### PR TITLE
[BPK-551] Reduce number of travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ script:
 cache:
   directories:
   - node_modules
+# This causes builds for merges and direct pushes to master.
+# Other branches are pull requests and build are triggered via the
+# pull request hook
+branches:
+  only:
+    - master
 deploy:
   provider: s3
   on:


### PR DESCRIPTION
We need to enable builds triggered by both pushes and
pull request events. This should reduce the duplication
of pull request builds while still building merges and
direct pushes to master.

See: https://stackoverflow.com/questions/31882306/how-to-configure-travis-ci-to-build-pull-requests-merges-to-master-w-o-redunda