### PR TITLE
[WIP] [BPK-558] Upgrade theo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,25 @@
 
 ## UNRELEASED
 
-_Nothing yet..._
+**Breaking:**
+- bpk-tokens:
+  - Aliases in `.raw.json` format are now objects with a `value` property i.e.
+
+    ```json
+    "WHITE": {
+      "value": "#ffffff"
+    },
+    ```
+
+    ...instead of...
+
+    ```json
+    "WHITE": "#ffffff",
+    ```
+
+**Fixed:**
+- bpk-tokens:
+  - Android colours are now #AARRGGBB instead of #RRGGBBAA
 
 ## 2017-07-24 - Icon improvements and fixes
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12041,9 +12041,9 @@
       "dev": true
     },
     "theo": {
-      "version": "4.3.0",
-      "from": "theo@4.3.0",
-      "resolved": "https://registry.npmjs.org/theo/-/theo-4.3.0.tgz",
+      "version": "5.0.0",
+      "from": "theo@5.0.0",
+      "resolved": "https://registry.npmjs.org/theo/-/theo-5.0.0.tgz",
       "dev": true,
       "dependencies": {
         "through2": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "stylefmt": "^6.0.0",
     "stylelint": "^8.0.0",
     "stylelint-config-skyscanner": "^1.0.0",
-    "theo": "^4.3.0",
+    "theo": "^5.0.0",
     "tinycolor2": "^1.4.1",
     "webpack": "^2.6.1",
     "webpack-dev-server": "^2.6.1",

--- a/packages/bpk-tokens/tokens/b2b-widgets.android.xml
+++ b/packages/bpk-tokens/tokens/b2b-widgets.android.xml
@@ -24,19 +24,19 @@
   <property name="BUTTON_PADDING_X" category="buttons">20px</property>
   <color name="BUTTON_BACKGROUND_COLOR" category="buttons">#ffffffff</color>
   <property name="BUTTON_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_COLOR" category="buttons">#006982ff</color>
+  <color name="BUTTON_COLOR" category="buttons">#ff006982</color>
   <property name="BUTTON_BORDER_RADIUS" category="buttons">none</property>
   <property name="BUTTON_BOX_SHADOW" category="buttons">inset 0px 0px 0px 1px #006982</property>
-  <color name="BUTTON_HOVER_BACKGROUND_COLOR" category="buttons">#006982ff</color>
+  <color name="BUTTON_HOVER_BACKGROUND_COLOR" category="buttons">#ff006982</color>
   <color name="BUTTON_HOVER_COLOR" category="buttons">#ffffffff</color>
   <property name="BUTTON_HOVER_BOX_SHADOW" category="buttons">inset 0px 0px 0px 1px rgba(0, 105, 130, 0.33)</property>
   <color name="BUTTON_DISABLED_BACKGROUND_COLOR" category="buttons">#ffffffff</color>
-  <color name="BUTTON_DISABLED_COLOR" category="buttons">#00698255</color>
+  <color name="BUTTON_DISABLED_COLOR" category="buttons">#55006982</color>
   <property name="BUTTON_DISABLED_BOX_SHADOW" category="buttons">inset 0px 0px 0px 1px rgba(0, 105, 130, 0.33)</property>
   <color name="BUTTON_SELECTED_COLOR" category="buttons">#ffffffff</color>
-  <color name="BUTTON_SELECTED_BACKGROUND_COLOR" category="buttons">#006982ff</color>
+  <color name="BUTTON_SELECTED_BACKGROUND_COLOR" category="buttons">#ff006982</color>
   <property name="BUTTON_SELECTED_BACKGROUND_IMAGE" category="buttons">none</property>
   <color name="BUTTON_SELECTED_HOVER_COLOR" category="buttons">#ffffffff</color>
-  <color name="BUTTON_SELECTED_HOVER_BACKGROUND_COLOR" category="buttons">#006982ff</color>
-  <color name="BUTTON_ACTIVE_BACKGROUND_COLOR" category="buttons">#006982ff</color>
+  <color name="BUTTON_SELECTED_HOVER_BACKGROUND_COLOR" category="buttons">#ff006982</color>
+  <color name="BUTTON_ACTIVE_BACKGROUND_COLOR" category="buttons">#ff006982</color>
 </resources>

--- a/packages/bpk-tokens/tokens/base.android.xml
+++ b/packages/bpk-tokens/tokens/base.android.xml
@@ -24,11 +24,11 @@
   <property name="DURATION_SM" category="animations">200ms</property>
   <property name="DURATION_BASE" category="animations">400ms</property>
   <color name="AUTOSUGGEST_LIST_BACKGROUND_COLOR" category="autosuggest">#ffffffff</color>
-  <color name="AUTOSUGGEST_LIST_ITEM_ACTIVE_BACKGROUND_COLOR" category="autosuggest">#e6e4ebff</color>
-  <color name="AUTOSUGGEST_LIST_ITEM_HIGHLIGHTED_BACKGROUND_COLOR" category="autosuggest">#f3f2f5ff</color>
+  <color name="AUTOSUGGEST_LIST_ITEM_ACTIVE_BACKGROUND_COLOR" category="autosuggest">#ffe6e4eb</color>
+  <color name="AUTOSUGGEST_LIST_ITEM_HIGHLIGHTED_BACKGROUND_COLOR" category="autosuggest">#fff3f2f5</color>
   <property name="BADGE_PADDING_Y" category="badges">0</property>
   <property name="BADGE_PADDING_X" category="badges">6</property>
-  <color name="BADGE_BACKGROUND_COLOR" category="badges">#ffbb00ff</color>
+  <color name="BADGE_BACKGROUND_COLOR" category="badges">#ffffbb00</color>
   <property name="BADGE_CENTERED_VERTICAL_ALIGN" category="badges">text-bottom</property>
   <property name="BORDER_RADIUS_XS" category="radii">3</property>
   <property name="BORDER_RADIUS_SM" category="radii">6</property>
@@ -53,13 +53,13 @@
   <property name="BUTTON_PADDING_X_ICON_ONLY" category="buttons">9</property>
   <property name="BUTTON_BORDER_RADIUS" category="buttons">18</property>
   <property name="BUTTON_BORDER_RADIUS_LG" category="buttons">21</property>
-  <color name="BUTTON_BACKGROUND_COLOR" category="buttons">#00d775ff</color>
+  <color name="BUTTON_BACKGROUND_COLOR" category="buttons">#ff00d775</color>
   <property name="BUTTON_BACKGROUND_IMAGE" category="buttons">linear-gradient(-180deg, #00d775 0, #00bd68 1)</property>
-  <color name="BUTTON_HOVER_BACKGROUND_COLOR" category="buttons">#00bd68ff</color>
+  <color name="BUTTON_HOVER_BACKGROUND_COLOR" category="buttons">#ff00bd68</color>
   <property name="BUTTON_HOVER_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_ACTIVE_BACKGROUND_COLOR" category="buttons">#00a85dff</color>
+  <color name="BUTTON_ACTIVE_BACKGROUND_COLOR" category="buttons">#ff00a85d</color>
   <property name="BUTTON_ACTIVE_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_DISABLED_BACKGROUND_COLOR" category="buttons">#e6e4ebff</color>
+  <color name="BUTTON_DISABLED_BACKGROUND_COLOR" category="buttons">#ffe6e4eb</color>
   <property name="BUTTON_DISABLED_BACKGROUND_IMAGE" category="buttons">none</property>
   <color name="BUTTON_COLOR" category="buttons">#ffffffff</color>
   <color name="BUTTON_HOVER_COLOR" category="buttons">#ffffffff</color>
@@ -68,7 +68,7 @@
   <property name="BUTTON_HOVER_BOX_SHADOW" category="buttons">none</property>
   <property name="BUTTON_ACTIVE_BOX_SHADOW" category="buttons">none</property>
   <property name="BUTTON_DISABLED_BOX_SHADOW" category="buttons">none</property>
-  <color name="BUTTON_DISABLED_COLOR" category="buttons">#b2aebdff</color>
+  <color name="BUTTON_DISABLED_COLOR" category="buttons">#ffb2aebd</color>
   <property name="BUTTON_FONT_SIZE" category="buttons">16</property>
   <property name="BUTTON_FONT_WEIGHT" category="buttons">700</property>
   <property name="BUTTON_LINE_HEIGHT" category="buttons">24</property>
@@ -84,31 +84,31 @@
   <property name="BUTTON_SECONDARY_HOVER_BACKGROUND_IMAGE" category="buttons">none</property>
   <color name="BUTTON_SECONDARY_ACTIVE_BACKGROUND_COLOR" category="buttons">#ffffffff</color>
   <property name="BUTTON_SECONDARY_ACTIVE_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_SECONDARY_DISABLED_BACKGROUND_COLOR" category="buttons">#e6e4ebff</color>
+  <color name="BUTTON_SECONDARY_DISABLED_BACKGROUND_COLOR" category="buttons">#ffe6e4eb</color>
   <property name="BUTTON_SECONDARY_DISABLED_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_SECONDARY_COLOR" category="buttons">#00b2d6ff</color>
-  <color name="BUTTON_SECONDARY_HOVER_COLOR" category="buttons">#00b2d6ff</color>
-  <color name="BUTTON_SECONDARY_ACTIVE_COLOR" category="buttons">#00b2d6ff</color>
-  <color name="BUTTON_SECONDARY_DISABLED_COLOR" category="buttons">#b2aebdff</color>
+  <color name="BUTTON_SECONDARY_COLOR" category="buttons">#ff00b2d6</color>
+  <color name="BUTTON_SECONDARY_HOVER_COLOR" category="buttons">#ff00b2d6</color>
+  <color name="BUTTON_SECONDARY_ACTIVE_COLOR" category="buttons">#ff00b2d6</color>
+  <color name="BUTTON_SECONDARY_DISABLED_COLOR" category="buttons">#ffb2aebd</color>
   <property name="BUTTON_SECONDARY_BOX_SHADOW" category="buttons">0 0 0 2px #E6E4EB inset</property>
   <property name="BUTTON_SECONDARY_HOVER_BOX_SHADOW" category="buttons">0 0 0 2px #00b2d6 inset</property>
   <property name="BUTTON_SECONDARY_ACTIVE_BOX_SHADOW" category="buttons">0 0 0 3px #00b2d6 inset</property>
   <property name="BUTTON_SECONDARY_DISABLED_BOX_SHADOW" category="buttons">none</property>
-  <color name="BUTTON_DESTRUCTIVE_COLOR" category="buttons">#ff5452ff</color>
+  <color name="BUTTON_DESTRUCTIVE_COLOR" category="buttons">#ffff5452</color>
   <property name="BUTTON_DESTRUCTIVE_BOX_SHADOW" category="buttons">0 0 0 2px #E6E4EB inset</property>
-  <color name="BUTTON_DESTRUCTIVE_HOVER_COLOR" category="buttons">#ff5452ff</color>
+  <color name="BUTTON_DESTRUCTIVE_HOVER_COLOR" category="buttons">#ffff5452</color>
   <property name="BUTTON_DESTRUCTIVE_HOVER_BOX_SHADOW" category="buttons">0 0 0 2px #ff5452 inset</property>
-  <color name="BUTTON_DESTRUCTIVE_ACTIVE_COLOR" category="buttons">#ff5452ff</color>
+  <color name="BUTTON_DESTRUCTIVE_ACTIVE_COLOR" category="buttons">#ffff5452</color>
   <property name="BUTTON_DESTRUCTIVE_ACTIVE_BOX_SHADOW" category="buttons">0 0 0 3px #ff5452 inset</property>
-  <color name="BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_COLOR" category="buttons">#e6e4ebff</color>
+  <color name="BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_COLOR" category="buttons">#ffe6e4eb</color>
   <property name="BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_DESTRUCTIVE_DISABLED_COLOR" category="buttons">#b2aebdff</color>
+  <color name="BUTTON_DESTRUCTIVE_DISABLED_COLOR" category="buttons">#ffb2aebd</color>
   <property name="BUTTON_DESTRUCTIVE_DISABLED_BOX_SHADOW" category="buttons">none</property>
-  <color name="BUTTON_SELECTED_BACKGROUND_COLOR" category="buttons">#00b2d6ff</color>
+  <color name="BUTTON_SELECTED_BACKGROUND_COLOR" category="buttons">#ff00b2d6</color>
   <property name="BUTTON_SELECTED_BACKGROUND_IMAGE" category="buttons">linear-gradient(-180deg, #009dbd 0, #008ca8 1)</property>
-  <color name="BUTTON_SELECTED_HOVER_BACKGROUND_COLOR" category="buttons">#008ca8ff</color>
+  <color name="BUTTON_SELECTED_HOVER_BACKGROUND_COLOR" category="buttons">#ff008ca8</color>
   <property name="BUTTON_SELECTED_HOVER_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_SELECTED_ACTIVE_BACKGROUND_COLOR" category="buttons">#00758cff</color>
+  <color name="BUTTON_SELECTED_ACTIVE_BACKGROUND_COLOR" category="buttons">#ff00758c</color>
   <property name="BUTTON_SELECTED_ACTIVE_BACKGROUND_IMAGE" category="buttons">none</property>
   <color name="BUTTON_SELECTED_COLOR" category="buttons">#ffffffff</color>
   <color name="BUTTON_SELECTED_HOVER_COLOR" category="buttons">#ffffffff</color>
@@ -118,84 +118,84 @@
   <property name="BUTTON_SELECTED_ACTIVE_BOX_SHADOW" category="buttons">none</property>
   <property name="BUTTON_SELECTED_DISABLED_BOX_SHADOW" category="buttons">none</property>
   <property name="BUTTON_FEATURED_BACKGROUND_IMAGE" category="buttons">linear-gradient(-180deg, #FA488A 0, #D92B6B 1)</property>
-  <color name="BUTTON_FEATURED_HOVER_BACKGROUND_COLOR" category="buttons">#d92b6bff</color>
-  <color name="BUTTON_FEATURED_ACTIVE_BACKGROUND_COLOR" category="buttons">#c50f52ff</color>
+  <color name="BUTTON_FEATURED_HOVER_BACKGROUND_COLOR" category="buttons">#ffd92b6b</color>
+  <color name="BUTTON_FEATURED_ACTIVE_BACKGROUND_COLOR" category="buttons">#ffc50f52</color>
   <property name="BUTTON_FEATURED_ACTIVE_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_FEATURED_DISABLED_BACKGROUND_COLOR" category="buttons">#e6e4ebff</color>
+  <color name="BUTTON_FEATURED_DISABLED_BACKGROUND_COLOR" category="buttons">#ffe6e4eb</color>
   <property name="BUTTON_FEATURED_DISABLED_BACKGROUND_IMAGE" category="buttons">none</property>
   <property name="CALENDAR_PADDING" category="calendar">12</property>
   <property name="CALENDAR_DAY_SPACING" category="calendar">6</property>
   <property name="CALENDAR_DAY_SIZE" category="calendar">36</property>
-  <color name="CALENDAR_DAY_COLOR" category="calendar">#00b2d6ff</color>
+  <color name="CALENDAR_DAY_COLOR" category="calendar">#ff00b2d6</color>
   <color name="CALENDAR_DAY_BACKGROUND_COLOR" category="calendar">#ffffffff</color>
   <color name="CALENDAR_DAY_SELECTED_COLOR" category="calendar">#ffffffff</color>
-  <color name="CALENDAR_DAY_SELECTED_BACKGROUND_COLOR" category="calendar">#008ca8ff</color>
-  <color name="CALENDAR_DAY_HOVER_COLOR" category="calendar">#524c61ff</color>
-  <color name="CALENDAR_DAY_HOVER_BACKGROUND_COLOR" category="calendar">#f3f2f5ff</color>
-  <color name="CALENDAR_DAY_ACTIVE_COLOR" category="calendar">#252033ff</color>
-  <color name="CALENDAR_DAY_ACTIVE_BACKGROUND_COLOR" category="calendar">#e6e4ebff</color>
-  <color name="CALENDAR_DAY_DISABLED_COLOR" category="calendar">#e6e4ebff</color>
+  <color name="CALENDAR_DAY_SELECTED_BACKGROUND_COLOR" category="calendar">#ff008ca8</color>
+  <color name="CALENDAR_DAY_HOVER_COLOR" category="calendar">#ff524c61</color>
+  <color name="CALENDAR_DAY_HOVER_BACKGROUND_COLOR" category="calendar">#fff3f2f5</color>
+  <color name="CALENDAR_DAY_ACTIVE_COLOR" category="calendar">#ff252033</color>
+  <color name="CALENDAR_DAY_ACTIVE_BACKGROUND_COLOR" category="calendar">#ffe6e4eb</color>
+  <color name="CALENDAR_DAY_DISABLED_COLOR" category="calendar">#ffe6e4eb</color>
   <color name="CALENDAR_DAY_DISABLED_BACKGROUND_COLOR" category="calendar">#ffffffff</color>
-  <color name="CALENDAR_DAY_OUTSIDE_COLOR" category="calendar">#b2aebdff</color>
+  <color name="CALENDAR_DAY_OUTSIDE_COLOR" category="calendar">#ffb2aebd</color>
   <color name="CALENDAR_DAY_OUTSIDE_BACKGROUND_COLOR" category="calendar">#ffffffff</color>
-  <color name="CALENDAR_NAV_ICON_FILL" category="calendar">#00b2d6ff</color>
-  <color name="CALENDAR_NAV_ICON_HOVER_FILL" category="calendar">#009dbdff</color>
-  <color name="CALENDAR_NAV_ICON_ACTIVE_FILL" category="calendar">#008ca8ff</color>
-  <color name="CALENDAR_NAV_ICON_DISABLED_FILL" category="calendar">#e6e4ebff</color>
+  <color name="CALENDAR_NAV_ICON_FILL" category="calendar">#ff00b2d6</color>
+  <color name="CALENDAR_NAV_ICON_HOVER_FILL" category="calendar">#ff009dbd</color>
+  <color name="CALENDAR_NAV_ICON_ACTIVE_FILL" category="calendar">#ff008ca8</color>
+  <color name="CALENDAR_NAV_ICON_DISABLED_FILL" category="calendar">#ffe6e4eb</color>
   <color name="CARD_BACKGROUND_COLOR" category="cards">#ffffffff</color>
-  <color name="CARD_COLOR" category="cards">#524c61ff</color>
+  <color name="CARD_COLOR" category="cards">#ff524c61</color>
   <property name="CARD_PADDING" category="cards">12</property>
   <color name="COLOR_WHITE" category="colors">#ffffffff</color>
-  <color name="COLOR_BLUE_50" category="colors">#e1f4f8ff</color>
-  <color name="COLOR_BLUE_100" category="colors">#cbeef5ff</color>
-  <color name="COLOR_BLUE_200" category="colors">#b0e4eeff</color>
-  <color name="COLOR_BLUE_300" category="colors">#7fd7e8ff</color>
-  <color name="COLOR_BLUE_400" category="colors">#40c4dfff</color>
-  <color name="COLOR_BLUE_500" category="colors">#00b2d6ff</color>
-  <color name="COLOR_BLUE_600" category="colors">#009dbdff</color>
-  <color name="COLOR_BLUE_700" category="colors">#008ca8ff</color>
-  <color name="COLOR_BLUE_800" category="colors">#00758cff</color>
-  <color name="COLOR_BLUE_900" category="colors">#005567ff</color>
-  <color name="COLOR_GRAY_50" category="colors">#f3f2f5ff</color>
-  <color name="COLOR_GRAY_100" category="colors">#e6e4ebff</color>
-  <color name="COLOR_GRAY_200" category="colors">#ccc9d4ff</color>
-  <color name="COLOR_GRAY_300" category="colors">#b2aebdff</color>
-  <color name="COLOR_GRAY_400" category="colors">#9a95a7ff</color>
-  <color name="COLOR_GRAY_500" category="colors">#817b8fff</color>
-  <color name="COLOR_GRAY_600" category="colors">#696179ff</color>
-  <color name="COLOR_GRAY_700" category="colors">#524c61ff</color>
-  <color name="COLOR_GRAY_800" category="colors">#3b344bff</color>
-  <color name="COLOR_GRAY_900" category="colors">#252033ff</color>
-  <color name="COLOR_GREEN_50" category="colors">#dff7ecff</color>
-  <color name="COLOR_GREEN_100" category="colors">#cbf5e2ff</color>
-  <color name="COLOR_GREEN_200" category="colors">#afedd1ff</color>
-  <color name="COLOR_GREEN_300" category="colors">#80e8b9ff</color>
-  <color name="COLOR_GREEN_400" category="colors">#40de97ff</color>
-  <color name="COLOR_GREEN_500" category="colors">#00d775ff</color>
-  <color name="COLOR_GREEN_600" category="colors">#00bd68ff</color>
-  <color name="COLOR_GREEN_700" category="colors">#00a85dff</color>
-  <color name="COLOR_GREEN_800" category="colors">#008c4dff</color>
-  <color name="COLOR_GREEN_900" category="colors">#006638ff</color>
-  <color name="COLOR_RED_50" category="colors">#fcf2f2ff</color>
-  <color name="COLOR_RED_100" category="colors">#ffd6d5ff</color>
-  <color name="COLOR_RED_200" category="colors">#ffbbbaff</color>
-  <color name="COLOR_RED_300" category="colors">#ff9694ff</color>
-  <color name="COLOR_RED_400" category="colors">#fe7471ff</color>
-  <color name="COLOR_RED_500" category="colors">#ff5452ff</color>
-  <color name="COLOR_RED_600" category="colors">#eb423fff</color>
-  <color name="COLOR_RED_700" category="colors">#de322fff</color>
-  <color name="COLOR_RED_800" category="colors">#cc1f1dff</color>
-  <color name="COLOR_RED_900" category="colors">#a80300ff</color>
-  <color name="COLOR_YELLOW_50" category="colors">#fff9e6ff</color>
-  <color name="COLOR_YELLOW_100" category="colors">#fff3cfff</color>
-  <color name="COLOR_YELLOW_200" category="colors">#ffecb8ff</color>
-  <color name="COLOR_YELLOW_300" category="colors">#ffe18cff</color>
-  <color name="COLOR_YELLOW_400" category="colors">#ffcf4aff</color>
-  <color name="COLOR_YELLOW_500" category="colors">#ffbb00ff</color>
-  <color name="COLOR_YELLOW_600" category="colors">#f0b000ff</color>
-  <color name="COLOR_YELLOW_700" category="colors">#e1a500ff</color>
-  <color name="COLOR_YELLOW_800" category="colors">#c28e00ff</color>
-  <color name="COLOR_YELLOW_900" category="colors">#9c7200ff</color>
+  <color name="COLOR_BLUE_50" category="colors">#ffe1f4f8</color>
+  <color name="COLOR_BLUE_100" category="colors">#ffcbeef5</color>
+  <color name="COLOR_BLUE_200" category="colors">#ffb0e4ee</color>
+  <color name="COLOR_BLUE_300" category="colors">#ff7fd7e8</color>
+  <color name="COLOR_BLUE_400" category="colors">#ff40c4df</color>
+  <color name="COLOR_BLUE_500" category="colors">#ff00b2d6</color>
+  <color name="COLOR_BLUE_600" category="colors">#ff009dbd</color>
+  <color name="COLOR_BLUE_700" category="colors">#ff008ca8</color>
+  <color name="COLOR_BLUE_800" category="colors">#ff00758c</color>
+  <color name="COLOR_BLUE_900" category="colors">#ff005567</color>
+  <color name="COLOR_GRAY_50" category="colors">#fff3f2f5</color>
+  <color name="COLOR_GRAY_100" category="colors">#ffe6e4eb</color>
+  <color name="COLOR_GRAY_200" category="colors">#ffccc9d4</color>
+  <color name="COLOR_GRAY_300" category="colors">#ffb2aebd</color>
+  <color name="COLOR_GRAY_400" category="colors">#ff9a95a7</color>
+  <color name="COLOR_GRAY_500" category="colors">#ff817b8f</color>
+  <color name="COLOR_GRAY_600" category="colors">#ff696179</color>
+  <color name="COLOR_GRAY_700" category="colors">#ff524c61</color>
+  <color name="COLOR_GRAY_800" category="colors">#ff3b344b</color>
+  <color name="COLOR_GRAY_900" category="colors">#ff252033</color>
+  <color name="COLOR_GREEN_50" category="colors">#ffdff7ec</color>
+  <color name="COLOR_GREEN_100" category="colors">#ffcbf5e2</color>
+  <color name="COLOR_GREEN_200" category="colors">#ffafedd1</color>
+  <color name="COLOR_GREEN_300" category="colors">#ff80e8b9</color>
+  <color name="COLOR_GREEN_400" category="colors">#ff40de97</color>
+  <color name="COLOR_GREEN_500" category="colors">#ff00d775</color>
+  <color name="COLOR_GREEN_600" category="colors">#ff00bd68</color>
+  <color name="COLOR_GREEN_700" category="colors">#ff00a85d</color>
+  <color name="COLOR_GREEN_800" category="colors">#ff008c4d</color>
+  <color name="COLOR_GREEN_900" category="colors">#ff006638</color>
+  <color name="COLOR_RED_50" category="colors">#fffcf2f2</color>
+  <color name="COLOR_RED_100" category="colors">#ffffd6d5</color>
+  <color name="COLOR_RED_200" category="colors">#ffffbbba</color>
+  <color name="COLOR_RED_300" category="colors">#ffff9694</color>
+  <color name="COLOR_RED_400" category="colors">#fffe7471</color>
+  <color name="COLOR_RED_500" category="colors">#ffff5452</color>
+  <color name="COLOR_RED_600" category="colors">#ffeb423f</color>
+  <color name="COLOR_RED_700" category="colors">#ffde322f</color>
+  <color name="COLOR_RED_800" category="colors">#ffcc1f1d</color>
+  <color name="COLOR_RED_900" category="colors">#ffa80300</color>
+  <color name="COLOR_YELLOW_50" category="colors">#fffff9e6</color>
+  <color name="COLOR_YELLOW_100" category="colors">#fffff3cf</color>
+  <color name="COLOR_YELLOW_200" category="colors">#ffffecb8</color>
+  <color name="COLOR_YELLOW_300" category="colors">#ffffe18c</color>
+  <color name="COLOR_YELLOW_400" category="colors">#ffffcf4a</color>
+  <color name="COLOR_YELLOW_500" category="colors">#ffffbb00</color>
+  <color name="COLOR_YELLOW_600" category="colors">#fff0b000</color>
+  <color name="COLOR_YELLOW_700" category="colors">#ffe1a500</color>
+  <color name="COLOR_YELLOW_800" category="colors">#ffc28e00</color>
+  <color name="COLOR_YELLOW_900" category="colors">#ff9c7200</color>
   <property name="PRIMARY_GRADIENT" category="colors">linear-gradient(135deg, #00b2d6 0, #02DDD8 1)</property>
   <property name="INPUT_HEIGHT" category="forms">36</property>
   <property name="INPUT_PADDING_X" category="forms">12</property>
@@ -204,11 +204,11 @@
   <property name="INPUT_BORDER" category="forms">solid .0625rem #E6E4EB</property>
   <property name="INPUT_BORDER_RADIUS" category="forms">3</property>
   <property name="INPUT_BACKGROUND" category="forms">#ffffff</property>
-  <color name="INPUT_COLOR" category="forms">#524c61ff</color>
-  <color name="INPUT_PLACEHOLDER_COLOR" category="forms">#817b8fff</color>
+  <color name="INPUT_COLOR" category="forms">#ff524c61</color>
+  <color name="INPUT_PLACEHOLDER_COLOR" category="forms">#ff817b8f</color>
   <property name="INPUT_PLACEHOLDER_FONT_STYLE" category="forms">italic</property>
-  <color name="INPUT_DISABLED_BORDER_COLOR" category="forms">#f3f2f5ff</color>
-  <color name="INPUT_DISABLED_COLOR" category="forms">#b2aebdff</color>
+  <color name="INPUT_DISABLED_BORDER_COLOR" category="forms">#fff3f2f5</color>
+  <color name="INPUT_DISABLED_COLOR" category="forms">#ffb2aebd</color>
   <property name="INPUT_LARGE_HEIGHT" category="forms">42</property>
   <property name="SELECT_HEIGHT" category="forms">36</property>
   <property name="SELECT_PADDING_TOP" category="forms">6</property>
@@ -218,30 +218,30 @@
   <property name="SELECT_BORDER_WIDTH" category="forms">1</property>
   <property name="SELECT_BORDER" category="forms">solid .0625rem #E6E4EB</property>
   <property name="SELECT_BORDER_RADIUS" category="forms">3</property>
-  <color name="SELECT_COLOR" category="forms">#524c61ff</color>
-  <color name="SELECT_DISABLED_BORDER_COLOR" category="forms">#f3f2f5ff</color>
-  <color name="SELECT_DISABLED_COLOR" category="forms">#b2aebdff</color>
+  <color name="SELECT_COLOR" category="forms">#ff524c61</color>
+  <color name="SELECT_DISABLED_BORDER_COLOR" category="forms">#fff3f2f5</color>
+  <color name="SELECT_DISABLED_COLOR" category="forms">#ffb2aebd</color>
   <property name="SELECT_LARGE_HEIGHT" category="forms">42</property>
-  <color name="LABEL_COLOR" category="forms">#524c61ff</color>
-  <color name="LABEL_DISABLED_COLOR" category="forms">#b2aebdff</color>
+  <color name="LABEL_COLOR" category="forms">#ff524c61</color>
+  <color name="LABEL_DISABLED_COLOR" category="forms">#ffb2aebd</color>
   <property name="LABEL_FONT_SIZE" category="forms">12</property>
   <property name="LABEL_LINE_HEIGHT" category="forms">18</property>
   <property name="FORM_VALIDATION_MARGIN" category="forms">0</property>
   <property name="FORM_VALIDATION_PADDING_Y" category="forms">6</property>
   <property name="FORM_VALIDATION_PADDING_X" category="forms">12</property>
-  <color name="FORM_VALIDATION_BACKGROUND_COLOR" category="forms">#ff5452ff</color>
+  <color name="FORM_VALIDATION_BACKGROUND_COLOR" category="forms">#ffff5452</color>
   <color name="FORM_VALIDATION_COLOR" category="forms">#ffffffff</color>
   <property name="FORM_VALIDATION_ARROW_SIZE" category="forms">6</property>
   <property name="FORM_VALIDATION_CHECKBOX_ARROW_LEFT" category="forms">24</property>
   <property name="TEXTAREA_MIN_HEIGHT" category="forms">2.625rem * 2</property>
-  <color name="REQUIRED_COLOR" category="forms">#ff5452ff</color>
+  <color name="REQUIRED_COLOR" category="forms">#ffff5452</color>
   <property name="GRID_COLUMNS" category="grids">12</property>
   <property name="GRID_GUTTER" category="grids">24</property>
   <property name="GRID_CONTAINER_PADDING" category="grids">24</property>
   <property name="GRID_CONTAINER_MOBILE_PADDING" category="grids">12</property>
   <property name="ICON_SIZE_SM" category="icons">18</property>
   <property name="ICON_SIZE_LG" category="icons">24</property>
-  <color name="MODAL_SCRIM_BACKGROUND_COLOR" category="modals">#b2aebdff</color>
+  <color name="MODAL_SCRIM_BACKGROUND_COLOR" category="modals">#ffb2aebd</color>
   <property name="MODAL_SCRIM_INITIAL_OPACITY" category="modals">0</property>
   <property name="MODAL_SCRIM_OPACITY" category="modals">.7</property>
   <property name="MODAL_SCRIM_MOBILE_OPACITY" category="modals">1</property>
@@ -251,23 +251,23 @@
   <property name="MODAL_MAX_WIDTH" category="modals">516</property>
   <property name="MODAL_WIDE_MAX_WIDTH" category="modals">804</property>
   <property name="MODAL_HEADER_PADDING" category="modals">12</property>
-  <color name="MODAL_CLOSE_ICON_FILL" category="modals">#817b8fff</color>
-  <color name="MODAL_CLOSE_ICON_HOVER_FILL" category="modals">#524c61ff</color>
+  <color name="MODAL_CLOSE_ICON_FILL" category="modals">#ff817b8f</color>
+  <color name="MODAL_CLOSE_ICON_HOVER_FILL" category="modals">#ff524c61</color>
   <property name="MODAL_CONTENT_PADDING" category="modals">12</property>
   <color name="BANNER_ALERT_BACKGROUND_COLOR" category="notifications">#ffffffff</color>
   <property name="BANNER_ALERT_HEADER_PADDING_Y" category="notifications">6</property>
   <property name="BANNER_ALERT_HEADER_PADDING_X" category="notifications">12</property>
-  <color name="BANNER_ALERT_HEADER_EXPANDABLE_HOVER_BACKGROUND_COLOR" category="notifications">#f3f2f5ff</color>
-  <color name="BANNER_ALERT_HEADER_EXPANDABLE_ACTIVE_BACKGROUND_COLOR" category="notifications">#e6e4ebff</color>
-  <color name="BANNER_ALERT_SUCCESS_COLOR" category="notifications">#00d775ff</color>
-  <color name="BANNER_ALERT_WARN_COLOR" category="notifications">#ffbb00ff</color>
-  <color name="BANNER_ALERT_ERROR_COLOR" category="notifications">#ff5452ff</color>
-  <color name="BANNER_ALERT_EXPAND_ICON_FILL" category="notifications">#524c61ff</color>
+  <color name="BANNER_ALERT_HEADER_EXPANDABLE_HOVER_BACKGROUND_COLOR" category="notifications">#fff3f2f5</color>
+  <color name="BANNER_ALERT_HEADER_EXPANDABLE_ACTIVE_BACKGROUND_COLOR" category="notifications">#ffe6e4eb</color>
+  <color name="BANNER_ALERT_SUCCESS_COLOR" category="notifications">#ff00d775</color>
+  <color name="BANNER_ALERT_WARN_COLOR" category="notifications">#ffffbb00</color>
+  <color name="BANNER_ALERT_ERROR_COLOR" category="notifications">#ffff5452</color>
+  <color name="BANNER_ALERT_EXPAND_ICON_FILL" category="notifications">#ff524c61</color>
   <property name="BANNER_ALERT_CHILDREN_PADDING_Y" category="notifications">6</property>
   <property name="BANNER_ALERT_CHILDREN_PADDING_X" category="notifications">12</property>
-  <color name="BANNER_ALERT_CHILDREN_COLOR" category="notifications">#817b8fff</color>
+  <color name="BANNER_ALERT_CHILDREN_COLOR" category="notifications">#ff817b8f</color>
   <property name="PANEL_PADDING" category="panels">12</property>
-  <color name="PANEL_BORDER_COLOR" category="panels">#e6e4ebff</color>
+  <color name="PANEL_BORDER_COLOR" category="panels">#ffe6e4eb</color>
   <color name="PANEL_BACKGROUND_COLOR" category="panels">#ffffffff</color>
   <property name="SPACING_XS" category="spacings">6</property>
   <property name="SPACING_SM" category="spacings">12</property>
@@ -277,9 +277,9 @@
   <property name="SPACING_XL" category="spacings">36</property>
   <property name="SPACING_XXL" category="spacings">42</property>
   <property name="ONE_PIXEL_REM" category="spacings">1</property>
-  <color name="STATE_SELECTED_BACKGROUND_COLOR" category="colors">#008ca8ff</color>
+  <color name="STATE_SELECTED_BACKGROUND_COLOR" category="colors">#ff008ca8</color>
   <property name="FONT_FAMILY_BASE" category="typesettings">-apple-system, BlinkMacSystemFont, 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Arial', sans-serif</property>
-  <color name="FONT_COLOR_BASE" category="text-colors">#524c61ff</color>
+  <color name="FONT_COLOR_BASE" category="text-colors">#ff524c61</color>
   <property name="LINE_HEIGHT_SM" category="typesettings">18</property>
   <property name="LINE_HEIGHT_BASE" category="typesettings">24</property>
   <property name="LINE_HEIGHT_LG" category="typesettings">30</property>
@@ -320,15 +320,15 @@
   <property name="LIST_NESTED_MARGIN_BOTTOM" category="spacings">0</property>
   <property name="LIST_ITEM_MARGIN_TOP" category="spacings">0</property>
   <property name="LIST_ITEM_MARGIN_BOTTOM" category="spacings">0</property>
-  <color name="LINK_COLOR" category="text-colors">#00b2d6ff</color>
+  <color name="LINK_COLOR" category="text-colors">#ff00b2d6</color>
   <property name="LINK_TEXT_DECORATION" category="text-decorations">none</property>
-  <color name="LINK_HOVER_COLOR" category="text-colors">#524c61ff</color>
+  <color name="LINK_HOVER_COLOR" category="text-colors">#ff524c61</color>
   <property name="LINK_HOVER_TEXT_DECORATION" category="text-decorations">underline</property>
-  <color name="LINK_ACTIVE_COLOR" category="text-colors">#252033ff</color>
-  <color name="LINK_VISITED_COLOR" category="text-colors">#008ca8ff</color>
+  <color name="LINK_ACTIVE_COLOR" category="text-colors">#ff252033</color>
+  <color name="LINK_VISITED_COLOR" category="text-colors">#ff008ca8</color>
   <color name="LINK_WHITE_COLOR" category="text-colors">#ffffffff</color>
   <color name="LINK_WHITE_HOVER_COLOR" category="text-colors">#ffffffff</color>
-  <color name="LINK_WHITE_ACTIVE_COLOR" category="text-colors">#e6e4ebff</color>
+  <color name="LINK_WHITE_ACTIVE_COLOR" category="text-colors">#ffe6e4eb</color>
   <color name="LINK_WHITE_VISITED_COLOR" category="text-colors">#ffffffff</color>
   <property name="ZINDEX_AUTOSUGGEST" category="z-indices">900</property>
   <property name="ZINDEX_POPOVER" category="z-indices">900</property>

--- a/packages/bpk-tokens/tokens/base.ios.json
+++ b/packages/bpk-tokens/tokens/base.ios.json
@@ -22,18 +22,27 @@
       "category": "autosuggest",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "autosuggestListBackgroundColor"
     },
     {
       "category": "autosuggest",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "autosuggestListItemActiveBackgroundColor"
     },
     {
       "category": "autosuggest",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "autosuggestListItemHighlightedBackgroundColor"
     },
     {
@@ -46,12 +55,18 @@
       "category": "badges",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "badgePaddingX"
     },
     {
       "category": "badges",
       "value": "rgb(255, 187, 0)",
       "type": "color",
+      ".alias": {
+        "value": "#FFBB00"
+      },
       "name": "badgeBackgroundColor"
     },
     {
@@ -64,42 +79,63 @@
       "type": "size",
       "value": "3",
       "category": "radii",
+      ".alias": {
+        "value": ".1875rem"
+      },
       "name": "borderRadiusXs"
     },
     {
       "type": "size",
       "value": "6",
       "category": "radii",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "borderRadiusSm"
     },
     {
       "type": "size",
       "value": "18",
       "category": "radii",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "borderRadiusPill"
     },
     {
       "type": "size",
       "value": "21",
       "category": "radii",
+      ".alias": {
+        "value": "1.3125rem"
+      },
       "name": "borderRadiusPillLg"
     },
     {
       "type": "size",
       "value": "1px",
       "category": "borders",
+      ".alias": {
+        "value": "1px"
+      },
       "name": "borderSizeSm"
     },
     {
       "type": "size",
       "value": "2px",
       "category": "borders",
+      ".alias": {
+        "value": "2px"
+      },
       "name": "borderSizeLg"
     },
     {
       "type": "size",
       "value": "3px",
       "category": "borders",
+      ".alias": {
+        "value": "3px"
+      },
       "name": "borderSizeXl"
     },
     {
@@ -124,60 +160,90 @@
       "category": "breakpoints",
       "value": "516",
       "type": "size",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "breakpointMobile"
     },
     {
       "category": "breakpoints",
       "value": "804",
       "type": "size",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "breakpointTablet"
     },
     {
       "category": "breakpoints",
       "value": "1140",
       "type": "size",
+      ".alias": {
+        "value": "71.25rem"
+      },
       "name": "breakpointDesktop"
     },
     {
       "category": "breakpoints",
       "value": "(max-width: 32.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "breakpointQueryMobile"
     },
     {
       "category": "breakpoints",
       "value": "(max-width: 50.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "breakpointQueryTablet"
     },
     {
       "category": "breakpoints",
       "value": "(min-width: 32.3125rem) and (max-width: 50.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "breakpointQueryTabletOnly"
     },
     {
       "category": "breakpoints",
       "value": "(min-width: 32.3125rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "32.3125rem"
+      },
       "name": "breakpointQueryAboveMobile"
     },
     {
       "category": "breakpoints",
       "value": "(min-width: 50.3125rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.3125rem"
+      },
       "name": "breakpointQueryAboveTablet"
     },
     {
       "category": "buttons",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "buttonPaddingY"
     },
     {
       "category": "buttons",
       "value": "18",
       "type": "size",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "buttonPaddingX"
     },
     {
@@ -190,30 +256,45 @@
       "category": "buttons",
       "value": "18",
       "type": "size",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "buttonBorderRadius"
     },
     {
       "category": "buttons",
       "value": "21",
       "type": "size",
+      ".alias": {
+        "value": "1.3125rem"
+      },
       "name": "buttonBorderRadiusLg"
     },
     {
       "category": "buttons",
       "value": "rgb(0, 215, 117)",
       "type": "color",
+      ".alias": {
+        "value": "#00d775"
+      },
       "name": "buttonBackgroundColor"
     },
     {
       "category": "buttons",
       "value": "linear-gradient(-180deg, #00d775 0, #00bd68 1)",
       "type": "background-image",
+      ".alias": {
+        "value": "#00bd68"
+      },
       "name": "buttonBackgroundImage"
     },
     {
       "category": "buttons",
       "value": "rgb(0, 189, 104)",
       "type": "color",
+      ".alias": {
+        "value": "#00bd68"
+      },
       "name": "buttonHoverBackgroundColor"
     },
     {
@@ -226,6 +307,9 @@
       "category": "buttons",
       "value": "rgb(0, 168, 93)",
       "type": "color",
+      ".alias": {
+        "value": "#00a85d"
+      },
       "name": "buttonActiveBackgroundColor"
     },
     {
@@ -238,6 +322,9 @@
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "buttonDisabledBackgroundColor"
     },
     {
@@ -250,18 +337,27 @@
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "buttonColor"
     },
     {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "buttonHoverColor"
     },
     {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "buttonActiveColor"
     },
     {
@@ -292,12 +388,18 @@
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "buttonDisabledColor"
     },
     {
       "category": "buttons",
       "value": "16",
       "type": "size",
+      ".alias": {
+        "value": "1rem"
+      },
       "name": "buttonFontSize"
     },
     {
@@ -310,6 +412,9 @@
       "category": "buttons",
       "value": "24",
       "type": "number",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "buttonLineHeight"
     },
     {
@@ -322,12 +427,18 @@
       "category": "buttons",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "buttonLargePaddingY"
     },
     {
       "category": "buttons",
       "value": "24",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "buttonLargePaddingX"
     },
     {
@@ -340,18 +451,27 @@
       "category": "buttons",
       "value": "24",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "buttonLargeFontSize"
     },
     {
       "category": "buttons",
       "value": "30",
       "type": "number",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "buttonLargeLineHeight"
     },
     {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "buttonSecondaryBackgroundColor"
     },
     {
@@ -364,6 +484,9 @@
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "buttonSecondaryHoverBackgroundColor"
     },
     {
@@ -376,6 +499,9 @@
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "buttonSecondaryActiveBackgroundColor"
     },
     {
@@ -388,6 +514,9 @@
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "buttonSecondaryDisabledBackgroundColor"
     },
     {
@@ -400,42 +529,63 @@
       "category": "buttons",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "buttonSecondaryColor"
     },
     {
       "category": "buttons",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "buttonSecondaryHoverColor"
     },
     {
       "category": "buttons",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "buttonSecondaryActiveColor"
     },
     {
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "buttonSecondaryDisabledColor"
     },
     {
       "category": "buttons",
       "value": "0 0 0 2px #E6E4EB inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "buttonSecondaryBoxShadow"
     },
     {
       "category": "buttons",
       "value": "0 0 0 2px #00b2d6 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "buttonSecondaryHoverBoxShadow"
     },
     {
       "category": "buttons",
       "value": "0 0 0 3px #00b2d6 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "buttonSecondaryActiveBoxShadow"
     },
     {
@@ -448,42 +598,63 @@
       "category": "buttons",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "buttonDestructiveColor"
     },
     {
       "category": "buttons",
       "value": "0 0 0 2px #E6E4EB inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "buttonDestructiveBoxShadow"
     },
     {
       "category": "buttons",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "buttonDestructiveHoverColor"
     },
     {
       "category": "buttons",
       "value": "0 0 0 2px #ff5452 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "buttonDestructiveHoverBoxShadow"
     },
     {
       "category": "buttons",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "buttonDestructiveActiveColor"
     },
     {
       "category": "buttons",
       "value": "0 0 0 3px #ff5452 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "buttonDestructiveActiveBoxShadow"
     },
     {
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "buttonDestructiveDisabledBackgroundColor"
     },
     {
@@ -496,6 +667,9 @@
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "buttonDestructiveDisabledColor"
     },
     {
@@ -508,18 +682,27 @@
       "category": "buttons",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "buttonSelectedBackgroundColor"
     },
     {
       "category": "buttons",
       "value": "linear-gradient(-180deg, #009dbd 0, #008ca8 1)",
       "type": "background-image",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "buttonSelectedBackgroundImage"
     },
     {
       "category": "buttons",
       "value": "rgb(0, 140, 168)",
       "type": "color",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "buttonSelectedHoverBackgroundColor"
     },
     {
@@ -532,6 +715,9 @@
       "category": "buttons",
       "value": "rgb(0, 117, 140)",
       "type": "color",
+      ".alias": {
+        "value": "#00758c"
+      },
       "name": "buttonSelectedActiveBackgroundColor"
     },
     {
@@ -544,18 +730,27 @@
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "buttonSelectedColor"
     },
     {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "buttonSelectedHoverColor"
     },
     {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "buttonSelectedActiveColor"
     },
     {
@@ -586,18 +781,27 @@
       "category": "buttons",
       "value": "linear-gradient(-180deg, #FA488A 0, #D92B6B 1)",
       "type": "background-image",
+      ".alias": {
+        "value": "#D92B6B"
+      },
       "name": "buttonFeaturedBackgroundImage"
     },
     {
       "category": "buttons",
       "value": "rgb(217, 43, 107)",
       "type": "color",
+      ".alias": {
+        "value": "#D92B6B"
+      },
       "name": "buttonFeaturedHoverBackgroundColor"
     },
     {
       "category": "buttons",
       "value": "rgb(197, 15, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#C50F52"
+      },
       "name": "buttonFeaturedActiveBackgroundColor"
     },
     {
@@ -610,6 +814,9 @@
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "buttonFeaturedDisabledBackgroundColor"
     },
     {
@@ -622,498 +829,747 @@
       "category": "calendar",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "calendarPadding"
     },
     {
       "category": "calendar",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "calendarDaySpacing"
     },
     {
       "category": "calendar",
       "value": "36",
       "type": "size",
+      ".alias": {
+        "value": "2.250rem"
+      },
       "name": "calendarDaySize"
     },
     {
       "category": "calendar",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "calendarDayColor"
     },
     {
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "calendarDayBackgroundColor"
     },
     {
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "calendarDaySelectedColor"
     },
     {
       "category": "calendar",
       "value": "rgb(0, 140, 168)",
       "type": "color",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "calendarDaySelectedBackgroundColor"
     },
     {
       "category": "calendar",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "calendarDayHoverColor"
     },
     {
       "category": "calendar",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "calendarDayHoverBackgroundColor"
     },
     {
       "category": "calendar",
       "value": "rgb(37, 32, 51)",
       "type": "color",
+      ".alias": {
+        "value": "#252033"
+      },
       "name": "calendarDayActiveColor"
     },
     {
       "category": "calendar",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "calendarDayActiveBackgroundColor"
     },
     {
       "category": "calendar",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "calendarDayDisabledColor"
     },
     {
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "calendarDayDisabledBackgroundColor"
     },
     {
       "category": "calendar",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "calendarDayOutsideColor"
     },
     {
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "calendarDayOutsideBackgroundColor"
     },
     {
       "category": "calendar",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "calendarNavIconFill"
     },
     {
       "category": "calendar",
       "value": "rgb(0, 157, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#009dbd"
+      },
       "name": "calendarNavIconHoverFill"
     },
     {
       "category": "calendar",
       "value": "rgb(0, 140, 168)",
       "type": "color",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "calendarNavIconActiveFill"
     },
     {
       "category": "calendar",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "calendarNavIconDisabledFill"
     },
     {
       "category": "cards",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "cardBackgroundColor"
     },
     {
       "category": "cards",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "cardColor"
     },
     {
       "category": "cards",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "cardPadding"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 255, 255)",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "colorWhite"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(225, 244, 248)",
+      ".alias": {
+        "value": "#e1f4f8"
+      },
       "name": "colorBlue50"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(203, 238, 245)",
+      ".alias": {
+        "value": "#cbeef5"
+      },
       "name": "colorBlue100"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(176, 228, 238)",
+      ".alias": {
+        "value": "#b0e4ee"
+      },
       "name": "colorBlue200"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(127, 215, 232)",
+      ".alias": {
+        "value": "#7fd7e8"
+      },
       "name": "colorBlue300"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(64, 196, 223)",
+      ".alias": {
+        "value": "#40c4df"
+      },
       "name": "colorBlue400"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 178, 214)",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "colorBlue500"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 157, 189)",
+      ".alias": {
+        "value": "#009dbd"
+      },
       "name": "colorBlue600"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 140, 168)",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "colorBlue700"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 117, 140)",
+      ".alias": {
+        "value": "#00758c"
+      },
       "name": "colorBlue800"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 85, 103)",
+      ".alias": {
+        "value": "#005567"
+      },
       "name": "colorBlue900"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(243, 242, 245)",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "colorGray50"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(230, 228, 235)",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "colorGray100"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(204, 201, 212)",
+      ".alias": {
+        "value": "#CCC9D4"
+      },
       "name": "colorGray200"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(178, 174, 189)",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "colorGray300"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(154, 149, 167)",
+      ".alias": {
+        "value": "#9A95A7"
+      },
       "name": "colorGray400"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(129, 123, 143)",
+      ".alias": {
+        "value": "#817B8F"
+      },
       "name": "colorGray500"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(105, 97, 121)",
+      ".alias": {
+        "value": "#696179"
+      },
       "name": "colorGray600"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(82, 76, 97)",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "colorGray700"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(59, 52, 75)",
+      ".alias": {
+        "value": "#3B344B"
+      },
       "name": "colorGray800"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(37, 32, 51)",
+      ".alias": {
+        "value": "#252033"
+      },
       "name": "colorGray900"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(223, 247, 236)",
+      ".alias": {
+        "value": "#dff7ec"
+      },
       "name": "colorGreen50"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(203, 245, 226)",
+      ".alias": {
+        "value": "#cbf5e2"
+      },
       "name": "colorGreen100"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(175, 237, 209)",
+      ".alias": {
+        "value": "#afedd1"
+      },
       "name": "colorGreen200"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(128, 232, 185)",
+      ".alias": {
+        "value": "#80e8b9"
+      },
       "name": "colorGreen300"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(64, 222, 151)",
+      ".alias": {
+        "value": "#40de97"
+      },
       "name": "colorGreen400"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 215, 117)",
+      ".alias": {
+        "value": "#00d775"
+      },
       "name": "colorGreen500"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 189, 104)",
+      ".alias": {
+        "value": "#00bd68"
+      },
       "name": "colorGreen600"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 168, 93)",
+      ".alias": {
+        "value": "#00a85d"
+      },
       "name": "colorGreen700"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 140, 77)",
+      ".alias": {
+        "value": "#008c4d"
+      },
       "name": "colorGreen800"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 102, 56)",
+      ".alias": {
+        "value": "#006638"
+      },
       "name": "colorGreen900"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(252, 242, 242)",
+      ".alias": {
+        "value": "#fcf2f2"
+      },
       "name": "colorRed50"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 214, 213)",
+      ".alias": {
+        "value": "#ffd6d5"
+      },
       "name": "colorRed100"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 187, 186)",
+      ".alias": {
+        "value": "#ffbbba"
+      },
       "name": "colorRed200"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 150, 148)",
+      ".alias": {
+        "value": "#ff9694"
+      },
       "name": "colorRed300"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(254, 116, 113)",
+      ".alias": {
+        "value": "#fe7471"
+      },
       "name": "colorRed400"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 84, 82)",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "colorRed500"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(235, 66, 63)",
+      ".alias": {
+        "value": "#eb423f"
+      },
       "name": "colorRed600"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(222, 50, 47)",
+      ".alias": {
+        "value": "#de322f"
+      },
       "name": "colorRed700"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(204, 31, 29)",
+      ".alias": {
+        "value": "#cc1f1d"
+      },
       "name": "colorRed800"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(168, 3, 0)",
+      ".alias": {
+        "value": "#a80300"
+      },
       "name": "colorRed900"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 249, 230)",
+      ".alias": {
+        "value": "#FFF9E6"
+      },
       "name": "colorYellow50"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 243, 207)",
+      ".alias": {
+        "value": "#FFF3CF"
+      },
       "name": "colorYellow100"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 236, 184)",
+      ".alias": {
+        "value": "#FFECB8"
+      },
       "name": "colorYellow200"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 225, 140)",
+      ".alias": {
+        "value": "#FFE18C"
+      },
       "name": "colorYellow300"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 207, 74)",
+      ".alias": {
+        "value": "#FFCF4A"
+      },
       "name": "colorYellow400"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 187, 0)",
+      ".alias": {
+        "value": "#FFBB00"
+      },
       "name": "colorYellow500"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(240, 176, 0)",
+      ".alias": {
+        "value": "#F0B000"
+      },
       "name": "colorYellow600"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(225, 165, 0)",
+      ".alias": {
+        "value": "#E1A500"
+      },
       "name": "colorYellow700"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(194, 142, 0)",
+      ".alias": {
+        "value": "#C28E00"
+      },
       "name": "colorYellow800"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(156, 114, 0)",
+      ".alias": {
+        "value": "#9C7200"
+      },
       "name": "colorYellow900"
     },
     {
       "type": "background-image",
       "category": "colors",
       "value": "linear-gradient(135deg, #00b2d6 0, #02DDD8 1)",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "primaryGradient"
     },
     {
       "category": "forms",
       "value": "36",
       "type": "size",
+      ".alias": {
+        "value": "2.250rem"
+      },
       "name": "inputHeight"
     },
     {
       "category": "forms",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "inputPaddingX"
     },
     {
       "category": "forms",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "inputPaddingY"
     },
     {
       "category": "forms",
       "value": "1",
       "type": "size",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "inputBorderWidth"
     },
     {
       "category": "forms",
       "value": "solid .0625rem #E6E4EB",
       "type": "border",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "inputBorder"
     },
     {
       "category": "forms",
       "value": "3",
       "type": "radius",
+      ".alias": {
+        "value": ".1875rem"
+      },
       "name": "inputBorderRadius"
     },
     {
       "category": "forms",
       "value": "#ffffff",
       "type": "background",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "inputBackground"
     },
     {
       "category": "forms",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "inputColor"
     },
     {
       "category": "forms",
       "value": "rgb(129, 123, 143)",
       "type": "color",
+      ".alias": {
+        "value": "#817B8F"
+      },
       "name": "inputPlaceholderColor"
     },
     {
@@ -1126,114 +1582,171 @@
       "category": "forms",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "inputDisabledBorderColor"
     },
     {
       "category": "forms",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "inputDisabledColor"
     },
     {
       "category": "forms",
       "value": "42",
       "type": "size",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "inputLargeHeight"
     },
     {
       "category": "forms",
       "value": "36",
       "type": "size",
+      ".alias": {
+        "value": "2.250rem"
+      },
       "name": "selectHeight"
     },
     {
       "category": "forms",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "selectPaddingTop"
     },
     {
       "category": "forms",
       "value": "30",
       "type": "size",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "selectPaddingRight"
     },
     {
       "category": "forms",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "selectPaddingBottom"
     },
     {
       "category": "forms",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "selectPaddingLeft"
     },
     {
       "category": "forms",
       "value": "1",
       "type": "size",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "selectBorderWidth"
     },
     {
       "category": "forms",
       "value": "solid .0625rem #E6E4EB",
       "type": "border",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "selectBorder"
     },
     {
       "category": "forms",
       "value": "3",
       "type": "radius",
+      ".alias": {
+        "value": ".1875rem"
+      },
       "name": "selectBorderRadius"
     },
     {
       "category": "forms",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "selectColor"
     },
     {
       "category": "forms",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "selectDisabledBorderColor"
     },
     {
       "category": "forms",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "selectDisabledColor"
     },
     {
       "category": "forms",
       "value": "42",
       "type": "size",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "selectLargeHeight"
     },
     {
       "category": "forms",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "labelColor"
     },
     {
       "category": "forms",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "labelDisabledColor"
     },
     {
       "category": "forms",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "labelFontSize"
     },
     {
       "category": "forms",
       "value": "18",
       "type": "number",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "labelLineHeight"
     },
     {
@@ -1246,48 +1759,72 @@
       "category": "forms",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "formValidationPaddingY"
     },
     {
       "category": "forms",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "formValidationPaddingX"
     },
     {
       "category": "forms",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "formValidationBackgroundColor"
     },
     {
       "category": "forms",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "formValidationColor"
     },
     {
       "category": "forms",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "formValidationArrowSize"
     },
     {
       "category": "forms",
       "value": "24",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "formValidationCheckboxArrowLeft"
     },
     {
       "category": "forms",
       "value": "2.625rem * 2",
       "type": "size",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "textareaMinHeight"
     },
     {
       "category": "forms",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "requiredColor"
     },
     {
@@ -1300,36 +1837,54 @@
       "category": "grids",
       "value": "24",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "gridGutter"
     },
     {
       "category": "grids",
       "value": "24",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "gridContainerPadding"
     },
     {
       "category": "grids",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "gridContainerMobilePadding"
     },
     {
       "type": "size",
       "category": "icons",
       "value": "18",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "iconSizeSm"
     },
     {
       "type": "size",
       "category": "icons",
       "value": "24",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "iconSizeLg"
     },
     {
       "category": "modals",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "modalScrimBackgroundColor"
     },
     {
@@ -1354,6 +1909,9 @@
       "category": "modals",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "modalBackgroundColor"
     },
     {
@@ -1372,180 +1930,270 @@
       "category": "modals",
       "value": "516",
       "type": "size",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "modalMaxWidth"
     },
     {
       "category": "modals",
       "value": "804",
       "type": "size",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "modalWideMaxWidth"
     },
     {
       "category": "modals",
       "value": "12",
       "type": "box-shadow",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "modalHeaderPadding"
     },
     {
       "category": "modals",
       "value": "rgb(129, 123, 143)",
       "type": "color",
+      ".alias": {
+        "value": "#817B8F"
+      },
       "name": "modalCloseIconFill"
     },
     {
       "category": "modals",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "modalCloseIconHoverFill"
     },
     {
       "category": "modals",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "modalContentPadding"
     },
     {
       "category": "notifications",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "bannerAlertBackgroundColor"
     },
     {
       "category": "notifications",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "bannerAlertHeaderPaddingY"
     },
     {
       "category": "notifications",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "bannerAlertHeaderPaddingX"
     },
     {
       "category": "notifications",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "bannerAlertHeaderExpandableHoverBackgroundColor"
     },
     {
       "category": "notifications",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "bannerAlertHeaderExpandableActiveBackgroundColor"
     },
     {
       "category": "notifications",
       "value": "rgb(0, 215, 117)",
       "type": "color",
+      ".alias": {
+        "value": "#00d775"
+      },
       "name": "bannerAlertSuccessColor"
     },
     {
       "category": "notifications",
       "value": "rgb(255, 187, 0)",
       "type": "color",
+      ".alias": {
+        "value": "#FFBB00"
+      },
       "name": "bannerAlertWarnColor"
     },
     {
       "category": "notifications",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "bannerAlertErrorColor"
     },
     {
       "category": "notifications",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "bannerAlertExpandIconFill"
     },
     {
       "category": "notifications",
       "value": "6",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "bannerAlertChildrenPaddingY"
     },
     {
       "category": "notifications",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "bannerAlertChildrenPaddingX"
     },
     {
       "category": "notifications",
       "value": "rgb(129, 123, 143)",
       "type": "color",
+      ".alias": {
+        "value": "#817B8F"
+      },
       "name": "bannerAlertChildrenColor"
     },
     {
       "category": "panels",
       "value": "12",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "panelPadding"
     },
     {
       "category": "panels",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "panelBorderColor"
     },
     {
       "category": "panels",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "panelBackgroundColor"
     },
     {
       "type": "size",
       "category": "spacings",
       "value": "6",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "spacingXs"
     },
     {
       "type": "size",
       "category": "spacings",
       "value": "12",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "spacingSm"
     },
     {
       "type": "size",
       "category": "spacings",
       "value": "18",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "spacingMd"
     },
     {
       "type": "size",
       "category": "spacings",
       "value": "24",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "spacingBase"
     },
     {
       "type": "size",
       "category": "spacings",
       "value": "30",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "spacingLg"
     },
     {
       "type": "size",
       "category": "spacings",
       "value": "36",
+      ".alias": {
+        "value": "2.250rem"
+      },
       "name": "spacingXl"
     },
     {
       "type": "size",
       "category": "spacings",
       "value": "42",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "spacingXxl"
     },
     {
       "type": "size",
       "category": "spacings",
       "value": "1",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "onePixelRem"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 140, 168)",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "stateSelectedBackgroundColor"
     },
     {
@@ -1558,30 +2206,45 @@
       "value": "rgb(82, 76, 97)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "fontColorBase"
     },
     {
       "value": "18",
       "type": "number",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "lineHeightSm"
     },
     {
       "value": "24",
       "type": "number",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "lineHeightBase"
     },
     {
       "value": "30",
       "type": "number",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "lineHeightLg"
     },
     {
       "value": "42",
       "type": "number",
       "category": "typesettings",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "lineHeightXl"
     },
     {
@@ -1600,96 +2263,144 @@
       "value": "12",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "fontSizeSm"
     },
     {
       "value": "16",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": "1rem"
+      },
       "name": "fontSizeBase"
     },
     {
       "value": "24",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "fontSizeLg"
     },
     {
       "value": "28",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.75rem"
+      },
       "name": "fontSizeXl"
     },
     {
       "value": "42",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "fontSizeXxl"
     },
     {
       "value": "12",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "h6FontSize"
     },
     {
       "value": "12",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "h5FontSize"
     },
     {
       "value": "16",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": "1rem"
+      },
       "name": "h4FontSize"
     },
     {
       "value": "24",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "h3FontSize"
     },
     {
       "value": "28",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": "1.75rem"
+      },
       "name": "h2FontSize"
     },
     {
       "value": "42",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "h1FontSize"
     },
     {
       "value": "18",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "h6LineHeight"
     },
     {
       "value": "18",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "h5LineHeight"
     },
     {
       "value": "24",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "h4LineHeight"
     },
     {
       "value": "30",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "h3LineHeight"
     },
     {
       "value": "42",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "h2LineHeight"
     },
     {
@@ -1744,12 +2455,18 @@
       "value": "12",
       "type": "size",
       "category": "spacings",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "headingMarginBottom"
     },
     {
       "value": "30",
       "type": "size",
       "category": "spacings",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "headingContentMarginTop"
     },
     {
@@ -1762,6 +2479,9 @@
       "value": "12",
       "type": "size",
       "category": "spacings",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "pMarginBottom"
     },
     {
@@ -1774,6 +2494,9 @@
       "value": "12",
       "type": "size",
       "category": "spacings",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "listMarginBottom"
     },
     {
@@ -1804,6 +2527,9 @@
       "value": "rgb(0, 178, 214)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "linkColor"
     },
     {
@@ -1816,6 +2542,9 @@
       "value": "rgb(82, 76, 97)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "linkHoverColor"
     },
     {
@@ -1828,66 +2557,99 @@
       "value": "rgb(37, 32, 51)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#252033"
+      },
       "name": "linkActiveColor"
     },
     {
       "value": "rgb(0, 140, 168)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "linkVisitedColor"
     },
     {
       "value": "rgb(255, 255, 255)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "linkWhiteColor"
     },
     {
       "value": "rgb(255, 255, 255)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "linkWhiteHoverColor"
     },
     {
       "value": "rgb(230, 228, 235)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "linkWhiteActiveColor"
     },
     {
       "value": "rgb(255, 255, 255)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "linkWhiteVisitedColor"
     },
     {
       "type": "number",
       "category": "z-indices",
       "value": "900",
+      ".alias": {
+        "value": "900"
+      },
       "name": "zindexAutosuggest"
     },
     {
       "type": "number",
       "category": "z-indices",
       "value": "900",
+      ".alias": {
+        "value": "900"
+      },
       "name": "zindexPopover"
     },
     {
       "type": "number",
       "category": "z-indices",
       "value": "900",
+      ".alias": {
+        "value": "900"
+      },
       "name": "zindexTooltip"
     },
     {
       "type": "number",
       "category": "z-indices",
       "value": "1000",
+      ".alias": {
+        "value": "1000"
+      },
       "name": "zindexModalScrim"
     },
     {
       "type": "number",
       "category": "z-indices",
       "value": "1100",
+      ".alias": {
+        "value": "1100"
+      },
       "name": "zindexModal"
     }
   ]

--- a/packages/bpk-tokens/tokens/base.raw.json
+++ b/packages/bpk-tokens/tokens/base.raw.json
@@ -1,96 +1,278 @@
 {
   "aliases": {
-    "WHITE": "#ffffff",
-    "BLUE_50": "#e1f4f8",
-    "BLUE_100": "#cbeef5",
-    "BLUE_200": "#b0e4ee",
-    "BLUE_300": "#7fd7e8",
-    "BLUE_400": "#40c4df",
-    "BLUE_500": "#00b2d6",
-    "BLUE_600": "#009dbd",
-    "BLUE_700": "#008ca8",
-    "BLUE_800": "#00758c",
-    "BLUE_900": "#005567",
-    "GRAY_50": "#F3F2F5",
-    "GRAY_100": "#E6E4EB",
-    "GRAY_200": "#CCC9D4",
-    "GRAY_300": "#B2AEBD",
-    "GRAY_400": "#9A95A7",
-    "GRAY_500": "#817B8F",
-    "GRAY_600": "#696179",
-    "GRAY_700": "#524C61",
-    "GRAY_800": "#3B344B",
-    "GRAY_900": "#252033",
-    "GREEN_50": "#dff7ec",
-    "GREEN_100": "#cbf5e2",
-    "GREEN_200": "#afedd1",
-    "GREEN_300": "#80e8b9",
-    "GREEN_400": "#40de97",
-    "GREEN_500": "#00d775",
-    "GREEN_600": "#00bd68",
-    "GREEN_700": "#00a85d",
-    "GREEN_800": "#008c4d",
-    "GREEN_900": "#006638",
-    "RED_50": "#fcf2f2",
-    "RED_100": "#ffd6d5",
-    "RED_200": "#ffbbba",
-    "RED_300": "#ff9694",
-    "RED_400": "#fe7471",
-    "RED_500": "#ff5452",
-    "RED_600": "#eb423f",
-    "RED_700": "#de322f",
-    "RED_800": "#cc1f1d",
-    "RED_900": "#a80300",
-    "YELLOW_50": "#FFF9E6",
-    "YELLOW_100": "#FFF3CF",
-    "YELLOW_200": "#FFECB8",
-    "YELLOW_300": "#FFE18C",
-    "YELLOW_400": "#FFCF4A",
-    "YELLOW_500": "#FFBB00",
-    "YELLOW_600": "#F0B000",
-    "YELLOW_700": "#E1A500",
-    "YELLOW_800": "#C28E00",
-    "YELLOW_900": "#9C7200",
-    "PINK_50": "#FDE4ED",
-    "PINK_100": "#FFBFD7",
-    "PINK_200": "#FF94BB",
-    "PINK_300": "#FF73A6",
-    "PINK_400": "#FF619B",
-    "PINK_500": "#FA488A",
-    "PINK_600": "#D92B6B",
-    "PINK_700": "#C50F52",
-    "PINK_800": "#B00C48",
-    "PINK_900": "#94053A",
-    "FONT_SIZE_SM": ".75rem",
-    "FONT_SIZE_BASE": "1rem",
-    "FONT_SIZE_LG": "1.5rem",
-    "FONT_SIZE_XL": "1.75rem",
-    "FONT_SIZE_XXL": "2.625rem",
-    "SPACING_XS": ".375rem",
-    "SPACING_SM": ".75rem",
-    "SPACING_MD": "1.125rem",
-    "SPACING_BASE": "1.5rem",
-    "SPACING_LG": "1.875rem",
-    "SPACING_XL": "2.250rem",
-    "SPACING_XXL": "2.625rem",
-    "BORDER_RADIUS_XS": ".1875rem",
-    "BORDER_RADIUS_SM": ".375rem",
-    "BORDER_RADIUS_PILL": "1.125rem",
-    "BORDER_RADIUS_PILL_LG": "1.3125rem",
-    "BORDER_SIZE_SM": "1px",
-    "BORDER_SIZE_LG": "2px",
-    "BORDER_SIZE_XL": "3px",
-    "BREAKPOINT_MOBILE": "32.25rem",
-    "BREAKPOINT_ABOVE_MOBILE": "32.3125rem",
-    "BREAKPOINT_TABLET": "50.25rem",
-    "BREAKPOINT_ABOVE_TABLET": "50.3125rem",
-    "BREAKPOINT_DESKTOP": "71.25rem",
-    "ONE_PIXEL_REM": ".0625rem",
-    "ZINDEX_AUTOSUGGEST": "900",
-    "ZINDEX_POPOVER": "900",
-    "ZINDEX_TOOLTIP": "900",
-    "ZINDEX_MODAL_SCRIM": "1000",
-    "ZINDEX_MODAL": "1100"
+    "WHITE": {
+      "value": "#ffffff"
+    },
+    "BLUE_50": {
+      "value": "#e1f4f8"
+    },
+    "BLUE_100": {
+      "value": "#cbeef5"
+    },
+    "BLUE_200": {
+      "value": "#b0e4ee"
+    },
+    "BLUE_300": {
+      "value": "#7fd7e8"
+    },
+    "BLUE_400": {
+      "value": "#40c4df"
+    },
+    "BLUE_500": {
+      "value": "#00b2d6"
+    },
+    "BLUE_600": {
+      "value": "#009dbd"
+    },
+    "BLUE_700": {
+      "value": "#008ca8"
+    },
+    "BLUE_800": {
+      "value": "#00758c"
+    },
+    "BLUE_900": {
+      "value": "#005567"
+    },
+    "GRAY_50": {
+      "value": "#F3F2F5"
+    },
+    "GRAY_100": {
+      "value": "#E6E4EB"
+    },
+    "GRAY_200": {
+      "value": "#CCC9D4"
+    },
+    "GRAY_300": {
+      "value": "#B2AEBD"
+    },
+    "GRAY_400": {
+      "value": "#9A95A7"
+    },
+    "GRAY_500": {
+      "value": "#817B8F"
+    },
+    "GRAY_600": {
+      "value": "#696179"
+    },
+    "GRAY_700": {
+      "value": "#524C61"
+    },
+    "GRAY_800": {
+      "value": "#3B344B"
+    },
+    "GRAY_900": {
+      "value": "#252033"
+    },
+    "GREEN_50": {
+      "value": "#dff7ec"
+    },
+    "GREEN_100": {
+      "value": "#cbf5e2"
+    },
+    "GREEN_200": {
+      "value": "#afedd1"
+    },
+    "GREEN_300": {
+      "value": "#80e8b9"
+    },
+    "GREEN_400": {
+      "value": "#40de97"
+    },
+    "GREEN_500": {
+      "value": "#00d775"
+    },
+    "GREEN_600": {
+      "value": "#00bd68"
+    },
+    "GREEN_700": {
+      "value": "#00a85d"
+    },
+    "GREEN_800": {
+      "value": "#008c4d"
+    },
+    "GREEN_900": {
+      "value": "#006638"
+    },
+    "RED_50": {
+      "value": "#fcf2f2"
+    },
+    "RED_100": {
+      "value": "#ffd6d5"
+    },
+    "RED_200": {
+      "value": "#ffbbba"
+    },
+    "RED_300": {
+      "value": "#ff9694"
+    },
+    "RED_400": {
+      "value": "#fe7471"
+    },
+    "RED_500": {
+      "value": "#ff5452"
+    },
+    "RED_600": {
+      "value": "#eb423f"
+    },
+    "RED_700": {
+      "value": "#de322f"
+    },
+    "RED_800": {
+      "value": "#cc1f1d"
+    },
+    "RED_900": {
+      "value": "#a80300"
+    },
+    "YELLOW_50": {
+      "value": "#FFF9E6"
+    },
+    "YELLOW_100": {
+      "value": "#FFF3CF"
+    },
+    "YELLOW_200": {
+      "value": "#FFECB8"
+    },
+    "YELLOW_300": {
+      "value": "#FFE18C"
+    },
+    "YELLOW_400": {
+      "value": "#FFCF4A"
+    },
+    "YELLOW_500": {
+      "value": "#FFBB00"
+    },
+    "YELLOW_600": {
+      "value": "#F0B000"
+    },
+    "YELLOW_700": {
+      "value": "#E1A500"
+    },
+    "YELLOW_800": {
+      "value": "#C28E00"
+    },
+    "YELLOW_900": {
+      "value": "#9C7200"
+    },
+    "PINK_50": {
+      "value": "#FDE4ED"
+    },
+    "PINK_100": {
+      "value": "#FFBFD7"
+    },
+    "PINK_200": {
+      "value": "#FF94BB"
+    },
+    "PINK_300": {
+      "value": "#FF73A6"
+    },
+    "PINK_400": {
+      "value": "#FF619B"
+    },
+    "PINK_500": {
+      "value": "#FA488A"
+    },
+    "PINK_600": {
+      "value": "#D92B6B"
+    },
+    "PINK_700": {
+      "value": "#C50F52"
+    },
+    "PINK_800": {
+      "value": "#B00C48"
+    },
+    "PINK_900": {
+      "value": "#94053A"
+    },
+    "FONT_SIZE_SM": {
+      "value": ".75rem"
+    },
+    "FONT_SIZE_BASE": {
+      "value": "1rem"
+    },
+    "FONT_SIZE_LG": {
+      "value": "1.5rem"
+    },
+    "FONT_SIZE_XL": {
+      "value": "1.75rem"
+    },
+    "FONT_SIZE_XXL": {
+      "value": "2.625rem"
+    },
+    "SPACING_XS": {
+      "value": ".375rem"
+    },
+    "SPACING_SM": {
+      "value": ".75rem"
+    },
+    "SPACING_MD": {
+      "value": "1.125rem"
+    },
+    "SPACING_BASE": {
+      "value": "1.5rem"
+    },
+    "SPACING_LG": {
+      "value": "1.875rem"
+    },
+    "SPACING_XL": {
+      "value": "2.250rem"
+    },
+    "SPACING_XXL": {
+      "value": "2.625rem"
+    },
+    "BORDER_RADIUS_XS": {
+      "value": ".1875rem"
+    },
+    "BORDER_RADIUS_SM": {
+      "value": ".375rem"
+    },
+    "BORDER_RADIUS_PILL": {
+      "value": "1.125rem"
+    },
+    "BORDER_RADIUS_PILL_LG": {
+      "value": "1.3125rem"
+    },
+    "BORDER_SIZE_SM": {
+      "value": "1px"
+    },
+    "BORDER_SIZE_LG": {
+      "value": "2px"
+    },
+    "BORDER_SIZE_XL": {
+      "value": "3px"
+    },
+    "BREAKPOINT_MOBILE": {
+      "value": "32.25rem"
+    },
+    "BREAKPOINT_ABOVE_MOBILE": {
+      "value": "32.3125rem"
+    },
+    "BREAKPOINT_TABLET": {
+      "value": "50.25rem"
+    },
+    "BREAKPOINT_ABOVE_TABLET": {
+      "value": "50.3125rem"
+    },
+    "BREAKPOINT_DESKTOP": {
+      "value": "71.25rem"
+    },
+    "ONE_PIXEL_REM": {
+      "value": ".0625rem"
+    },
+    "ZINDEX_AUTOSUGGEST": {
+      "value": "900"
+    },
+    "ZINDEX_POPOVER": {
+      "value": "900"
+    },
+    "ZINDEX_TOOLTIP": {
+      "value": "900"
+    },
+    "ZINDEX_MODAL_SCRIM": {
+      "value": "1000"
+    },
+    "ZINDEX_MODAL": {
+      "value": "1100"
+    }
   },
   "props": {
     "DURATION_XS": {
@@ -115,18 +297,27 @@
       "category": "autosuggest",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "AUTOSUGGEST_LIST_BACKGROUND_COLOR"
     },
     "AUTOSUGGEST_LIST_ITEM_ACTIVE_BACKGROUND_COLOR": {
       "category": "autosuggest",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "AUTOSUGGEST_LIST_ITEM_ACTIVE_BACKGROUND_COLOR"
     },
     "AUTOSUGGEST_LIST_ITEM_HIGHLIGHTED_BACKGROUND_COLOR": {
       "category": "autosuggest",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "AUTOSUGGEST_LIST_ITEM_HIGHLIGHTED_BACKGROUND_COLOR"
     },
     "BADGE_PADDING_Y": {
@@ -139,12 +330,18 @@
       "category": "badges",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "BADGE_PADDING_X"
     },
     "BADGE_BACKGROUND_COLOR": {
       "category": "badges",
       "value": "rgb(255, 187, 0)",
       "type": "color",
+      ".alias": {
+        "value": "#FFBB00"
+      },
       "name": "BADGE_BACKGROUND_COLOR"
     },
     "BADGE_CENTERED_VERTICAL_ALIGN": {
@@ -157,42 +354,63 @@
       "type": "size",
       "value": ".1875rem",
       "category": "radii",
+      ".alias": {
+        "value": ".1875rem"
+      },
       "name": "BORDER_RADIUS_XS"
     },
     "BORDER_RADIUS_SM": {
       "type": "size",
       "value": ".375rem",
       "category": "radii",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "BORDER_RADIUS_SM"
     },
     "BORDER_RADIUS_PILL": {
       "type": "size",
       "value": "1.125rem",
       "category": "radii",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "BORDER_RADIUS_PILL"
     },
     "BORDER_RADIUS_PILL_LG": {
       "type": "size",
       "value": "1.3125rem",
       "category": "radii",
+      ".alias": {
+        "value": "1.3125rem"
+      },
       "name": "BORDER_RADIUS_PILL_LG"
     },
     "BORDER_SIZE_SM": {
       "type": "size",
       "value": "1px",
       "category": "borders",
+      ".alias": {
+        "value": "1px"
+      },
       "name": "BORDER_SIZE_SM"
     },
     "BORDER_SIZE_LG": {
       "type": "size",
       "value": "2px",
       "category": "borders",
+      ".alias": {
+        "value": "2px"
+      },
       "name": "BORDER_SIZE_LG"
     },
     "BORDER_SIZE_XL": {
       "type": "size",
       "value": "3px",
       "category": "borders",
+      ".alias": {
+        "value": "3px"
+      },
       "name": "BORDER_SIZE_XL"
     },
     "BOX_SHADOW_SM": {
@@ -217,60 +435,90 @@
       "category": "breakpoints",
       "value": "32.25rem",
       "type": "size",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "BREAKPOINT_MOBILE"
     },
     "BREAKPOINT_TABLET": {
       "category": "breakpoints",
       "value": "50.25rem",
       "type": "size",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "BREAKPOINT_TABLET"
     },
     "BREAKPOINT_DESKTOP": {
       "category": "breakpoints",
       "value": "71.25rem",
       "type": "size",
+      ".alias": {
+        "value": "71.25rem"
+      },
       "name": "BREAKPOINT_DESKTOP"
     },
     "BREAKPOINT_QUERY_MOBILE": {
       "category": "breakpoints",
       "value": "(max-width: 32.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "BREAKPOINT_QUERY_MOBILE"
     },
     "BREAKPOINT_QUERY_TABLET": {
       "category": "breakpoints",
       "value": "(max-width: 50.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "BREAKPOINT_QUERY_TABLET"
     },
     "BREAKPOINT_QUERY_TABLET_ONLY": {
       "category": "breakpoints",
       "value": "(min-width: 32.3125rem) and (max-width: 50.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "BREAKPOINT_QUERY_TABLET_ONLY"
     },
     "BREAKPOINT_QUERY_ABOVE_MOBILE": {
       "category": "breakpoints",
       "value": "(min-width: 32.3125rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "32.3125rem"
+      },
       "name": "BREAKPOINT_QUERY_ABOVE_MOBILE"
     },
     "BREAKPOINT_QUERY_ABOVE_TABLET": {
       "category": "breakpoints",
       "value": "(min-width: 50.3125rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.3125rem"
+      },
       "name": "BREAKPOINT_QUERY_ABOVE_TABLET"
     },
     "BUTTON_PADDING_Y": {
       "category": "buttons",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "BUTTON_PADDING_Y"
     },
     "BUTTON_PADDING_X": {
       "category": "buttons",
       "value": "1.125rem",
       "type": "size",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "BUTTON_PADDING_X"
     },
     "BUTTON_PADDING_X_ICON_ONLY": {
@@ -283,30 +531,45 @@
       "category": "buttons",
       "value": "1.125rem",
       "type": "size",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "BUTTON_BORDER_RADIUS"
     },
     "BUTTON_BORDER_RADIUS_LG": {
       "category": "buttons",
       "value": "1.3125rem",
       "type": "size",
+      ".alias": {
+        "value": "1.3125rem"
+      },
       "name": "BUTTON_BORDER_RADIUS_LG"
     },
     "BUTTON_BACKGROUND_COLOR": {
       "category": "buttons",
       "value": "rgb(0, 215, 117)",
       "type": "color",
+      ".alias": {
+        "value": "#00d775"
+      },
       "name": "BUTTON_BACKGROUND_COLOR"
     },
     "BUTTON_BACKGROUND_IMAGE": {
       "category": "buttons",
       "value": "linear-gradient(-180deg, #00d775 0%, #00bd68 100%)",
       "type": "background-image",
+      ".alias": {
+        "value": "#00bd68"
+      },
       "name": "BUTTON_BACKGROUND_IMAGE"
     },
     "BUTTON_HOVER_BACKGROUND_COLOR": {
       "category": "buttons",
       "value": "rgb(0, 189, 104)",
       "type": "color",
+      ".alias": {
+        "value": "#00bd68"
+      },
       "name": "BUTTON_HOVER_BACKGROUND_COLOR"
     },
     "BUTTON_HOVER_BACKGROUND_IMAGE": {
@@ -319,6 +582,9 @@
       "category": "buttons",
       "value": "rgb(0, 168, 93)",
       "type": "color",
+      ".alias": {
+        "value": "#00a85d"
+      },
       "name": "BUTTON_ACTIVE_BACKGROUND_COLOR"
     },
     "BUTTON_ACTIVE_BACKGROUND_IMAGE": {
@@ -331,6 +597,9 @@
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "BUTTON_DISABLED_BACKGROUND_COLOR"
     },
     "BUTTON_DISABLED_BACKGROUND_IMAGE": {
@@ -343,18 +612,27 @@
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BUTTON_COLOR"
     },
     "BUTTON_HOVER_COLOR": {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BUTTON_HOVER_COLOR"
     },
     "BUTTON_ACTIVE_COLOR": {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BUTTON_ACTIVE_COLOR"
     },
     "BUTTON_BOX_SHADOW": {
@@ -385,12 +663,18 @@
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "BUTTON_DISABLED_COLOR"
     },
     "BUTTON_FONT_SIZE": {
       "category": "buttons",
       "value": "1rem",
       "type": "size",
+      ".alias": {
+        "value": "1rem"
+      },
       "name": "BUTTON_FONT_SIZE"
     },
     "BUTTON_FONT_WEIGHT": {
@@ -403,6 +687,9 @@
       "category": "buttons",
       "value": "1.5rem",
       "type": "number",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "BUTTON_LINE_HEIGHT"
     },
     "BUTTON_TEXT_ALIGN": {
@@ -415,12 +702,18 @@
       "category": "buttons",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "BUTTON_LARGE_PADDING_Y"
     },
     "BUTTON_LARGE_PADDING_X": {
       "category": "buttons",
       "value": "1.5rem",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "BUTTON_LARGE_PADDING_X"
     },
     "BUTTON_LARGE_PADDING_X_ICON_ONLY": {
@@ -433,18 +726,27 @@
       "category": "buttons",
       "value": "1.5rem",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "BUTTON_LARGE_FONT_SIZE"
     },
     "BUTTON_LARGE_LINE_HEIGHT": {
       "category": "buttons",
       "value": "1.875rem",
       "type": "number",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "BUTTON_LARGE_LINE_HEIGHT"
     },
     "BUTTON_SECONDARY_BACKGROUND_COLOR": {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BUTTON_SECONDARY_BACKGROUND_COLOR"
     },
     "BUTTON_SECONDARY_BACKGROUND_IMAGE": {
@@ -457,6 +759,9 @@
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BUTTON_SECONDARY_HOVER_BACKGROUND_COLOR"
     },
     "BUTTON_SECONDARY_HOVER_BACKGROUND_IMAGE": {
@@ -469,6 +774,9 @@
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BUTTON_SECONDARY_ACTIVE_BACKGROUND_COLOR"
     },
     "BUTTON_SECONDARY_ACTIVE_BACKGROUND_IMAGE": {
@@ -481,6 +789,9 @@
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "BUTTON_SECONDARY_DISABLED_BACKGROUND_COLOR"
     },
     "BUTTON_SECONDARY_DISABLED_BACKGROUND_IMAGE": {
@@ -493,42 +804,63 @@
       "category": "buttons",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "BUTTON_SECONDARY_COLOR"
     },
     "BUTTON_SECONDARY_HOVER_COLOR": {
       "category": "buttons",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "BUTTON_SECONDARY_HOVER_COLOR"
     },
     "BUTTON_SECONDARY_ACTIVE_COLOR": {
       "category": "buttons",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "BUTTON_SECONDARY_ACTIVE_COLOR"
     },
     "BUTTON_SECONDARY_DISABLED_COLOR": {
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "BUTTON_SECONDARY_DISABLED_COLOR"
     },
     "BUTTON_SECONDARY_BOX_SHADOW": {
       "category": "buttons",
       "value": "0 0 0 2px #E6E4EB inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "BUTTON_SECONDARY_BOX_SHADOW"
     },
     "BUTTON_SECONDARY_HOVER_BOX_SHADOW": {
       "category": "buttons",
       "value": "0 0 0 2px #00b2d6 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "BUTTON_SECONDARY_HOVER_BOX_SHADOW"
     },
     "BUTTON_SECONDARY_ACTIVE_BOX_SHADOW": {
       "category": "buttons",
       "value": "0 0 0 3px #00b2d6 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "BUTTON_SECONDARY_ACTIVE_BOX_SHADOW"
     },
     "BUTTON_SECONDARY_DISABLED_BOX_SHADOW": {
@@ -541,42 +873,63 @@
       "category": "buttons",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "BUTTON_DESTRUCTIVE_COLOR"
     },
     "BUTTON_DESTRUCTIVE_BOX_SHADOW": {
       "category": "buttons",
       "value": "0 0 0 2px #E6E4EB inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "BUTTON_DESTRUCTIVE_BOX_SHADOW"
     },
     "BUTTON_DESTRUCTIVE_HOVER_COLOR": {
       "category": "buttons",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "BUTTON_DESTRUCTIVE_HOVER_COLOR"
     },
     "BUTTON_DESTRUCTIVE_HOVER_BOX_SHADOW": {
       "category": "buttons",
       "value": "0 0 0 2px #ff5452 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "BUTTON_DESTRUCTIVE_HOVER_BOX_SHADOW"
     },
     "BUTTON_DESTRUCTIVE_ACTIVE_COLOR": {
       "category": "buttons",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "BUTTON_DESTRUCTIVE_ACTIVE_COLOR"
     },
     "BUTTON_DESTRUCTIVE_ACTIVE_BOX_SHADOW": {
       "category": "buttons",
       "value": "0 0 0 3px #ff5452 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "BUTTON_DESTRUCTIVE_ACTIVE_BOX_SHADOW"
     },
     "BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_COLOR": {
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_COLOR"
     },
     "BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_IMAGE": {
@@ -589,6 +942,9 @@
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "BUTTON_DESTRUCTIVE_DISABLED_COLOR"
     },
     "BUTTON_DESTRUCTIVE_DISABLED_BOX_SHADOW": {
@@ -601,18 +957,27 @@
       "category": "buttons",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "BUTTON_SELECTED_BACKGROUND_COLOR"
     },
     "BUTTON_SELECTED_BACKGROUND_IMAGE": {
       "category": "buttons",
       "value": "linear-gradient(-180deg, #009dbd 0%, #008ca8 100%)",
       "type": "background-image",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "BUTTON_SELECTED_BACKGROUND_IMAGE"
     },
     "BUTTON_SELECTED_HOVER_BACKGROUND_COLOR": {
       "category": "buttons",
       "value": "rgb(0, 140, 168)",
       "type": "color",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "BUTTON_SELECTED_HOVER_BACKGROUND_COLOR"
     },
     "BUTTON_SELECTED_HOVER_BACKGROUND_IMAGE": {
@@ -625,6 +990,9 @@
       "category": "buttons",
       "value": "rgb(0, 117, 140)",
       "type": "color",
+      ".alias": {
+        "value": "#00758c"
+      },
       "name": "BUTTON_SELECTED_ACTIVE_BACKGROUND_COLOR"
     },
     "BUTTON_SELECTED_ACTIVE_BACKGROUND_IMAGE": {
@@ -637,18 +1005,27 @@
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BUTTON_SELECTED_COLOR"
     },
     "BUTTON_SELECTED_HOVER_COLOR": {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BUTTON_SELECTED_HOVER_COLOR"
     },
     "BUTTON_SELECTED_ACTIVE_COLOR": {
       "category": "buttons",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BUTTON_SELECTED_ACTIVE_COLOR"
     },
     "BUTTON_SELECTED_BOX_SHADOW": {
@@ -679,18 +1056,27 @@
       "category": "buttons",
       "value": "linear-gradient(-180deg, #FA488A 0%, #D92B6B 100%)",
       "type": "background-image",
+      ".alias": {
+        "value": "#D92B6B"
+      },
       "name": "BUTTON_FEATURED_BACKGROUND_IMAGE"
     },
     "BUTTON_FEATURED_HOVER_BACKGROUND_COLOR": {
       "category": "buttons",
       "value": "rgb(217, 43, 107)",
       "type": "color",
+      ".alias": {
+        "value": "#D92B6B"
+      },
       "name": "BUTTON_FEATURED_HOVER_BACKGROUND_COLOR"
     },
     "BUTTON_FEATURED_ACTIVE_BACKGROUND_COLOR": {
       "category": "buttons",
       "value": "rgb(197, 15, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#C50F52"
+      },
       "name": "BUTTON_FEATURED_ACTIVE_BACKGROUND_COLOR"
     },
     "BUTTON_FEATURED_ACTIVE_BACKGROUND_IMAGE": {
@@ -703,6 +1089,9 @@
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "BUTTON_FEATURED_DISABLED_BACKGROUND_COLOR"
     },
     "BUTTON_FEATURED_DISABLED_BACKGROUND_IMAGE": {
@@ -715,498 +1104,747 @@
       "category": "calendar",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "CALENDAR_PADDING"
     },
     "CALENDAR_DAY_SPACING": {
       "category": "calendar",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "CALENDAR_DAY_SPACING"
     },
     "CALENDAR_DAY_SIZE": {
       "category": "calendar",
       "value": "2.250rem",
       "type": "size",
+      ".alias": {
+        "value": "2.250rem"
+      },
       "name": "CALENDAR_DAY_SIZE"
     },
     "CALENDAR_DAY_COLOR": {
       "category": "calendar",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "CALENDAR_DAY_COLOR"
     },
     "CALENDAR_DAY_BACKGROUND_COLOR": {
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "CALENDAR_DAY_BACKGROUND_COLOR"
     },
     "CALENDAR_DAY_SELECTED_COLOR": {
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "CALENDAR_DAY_SELECTED_COLOR"
     },
     "CALENDAR_DAY_SELECTED_BACKGROUND_COLOR": {
       "category": "calendar",
       "value": "rgb(0, 140, 168)",
       "type": "color",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "CALENDAR_DAY_SELECTED_BACKGROUND_COLOR"
     },
     "CALENDAR_DAY_HOVER_COLOR": {
       "category": "calendar",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "CALENDAR_DAY_HOVER_COLOR"
     },
     "CALENDAR_DAY_HOVER_BACKGROUND_COLOR": {
       "category": "calendar",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "CALENDAR_DAY_HOVER_BACKGROUND_COLOR"
     },
     "CALENDAR_DAY_ACTIVE_COLOR": {
       "category": "calendar",
       "value": "rgb(37, 32, 51)",
       "type": "color",
+      ".alias": {
+        "value": "#252033"
+      },
       "name": "CALENDAR_DAY_ACTIVE_COLOR"
     },
     "CALENDAR_DAY_ACTIVE_BACKGROUND_COLOR": {
       "category": "calendar",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "CALENDAR_DAY_ACTIVE_BACKGROUND_COLOR"
     },
     "CALENDAR_DAY_DISABLED_COLOR": {
       "category": "calendar",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "CALENDAR_DAY_DISABLED_COLOR"
     },
     "CALENDAR_DAY_DISABLED_BACKGROUND_COLOR": {
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "CALENDAR_DAY_DISABLED_BACKGROUND_COLOR"
     },
     "CALENDAR_DAY_OUTSIDE_COLOR": {
       "category": "calendar",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "CALENDAR_DAY_OUTSIDE_COLOR"
     },
     "CALENDAR_DAY_OUTSIDE_BACKGROUND_COLOR": {
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "CALENDAR_DAY_OUTSIDE_BACKGROUND_COLOR"
     },
     "CALENDAR_NAV_ICON_FILL": {
       "category": "calendar",
       "value": "rgb(0, 178, 214)",
       "type": "color",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "CALENDAR_NAV_ICON_FILL"
     },
     "CALENDAR_NAV_ICON_HOVER_FILL": {
       "category": "calendar",
       "value": "rgb(0, 157, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#009dbd"
+      },
       "name": "CALENDAR_NAV_ICON_HOVER_FILL"
     },
     "CALENDAR_NAV_ICON_ACTIVE_FILL": {
       "category": "calendar",
       "value": "rgb(0, 140, 168)",
       "type": "color",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "CALENDAR_NAV_ICON_ACTIVE_FILL"
     },
     "CALENDAR_NAV_ICON_DISABLED_FILL": {
       "category": "calendar",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "CALENDAR_NAV_ICON_DISABLED_FILL"
     },
     "CARD_BACKGROUND_COLOR": {
       "category": "cards",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "CARD_BACKGROUND_COLOR"
     },
     "CARD_COLOR": {
       "category": "cards",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "CARD_COLOR"
     },
     "CARD_PADDING": {
       "category": "cards",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "CARD_PADDING"
     },
     "COLOR_WHITE": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 255, 255)",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "COLOR_WHITE"
     },
     "COLOR_BLUE_50": {
       "type": "color",
       "category": "colors",
       "value": "rgb(225, 244, 248)",
+      ".alias": {
+        "value": "#e1f4f8"
+      },
       "name": "COLOR_BLUE_50"
     },
     "COLOR_BLUE_100": {
       "type": "color",
       "category": "colors",
       "value": "rgb(203, 238, 245)",
+      ".alias": {
+        "value": "#cbeef5"
+      },
       "name": "COLOR_BLUE_100"
     },
     "COLOR_BLUE_200": {
       "type": "color",
       "category": "colors",
       "value": "rgb(176, 228, 238)",
+      ".alias": {
+        "value": "#b0e4ee"
+      },
       "name": "COLOR_BLUE_200"
     },
     "COLOR_BLUE_300": {
       "type": "color",
       "category": "colors",
       "value": "rgb(127, 215, 232)",
+      ".alias": {
+        "value": "#7fd7e8"
+      },
       "name": "COLOR_BLUE_300"
     },
     "COLOR_BLUE_400": {
       "type": "color",
       "category": "colors",
       "value": "rgb(64, 196, 223)",
+      ".alias": {
+        "value": "#40c4df"
+      },
       "name": "COLOR_BLUE_400"
     },
     "COLOR_BLUE_500": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 178, 214)",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "COLOR_BLUE_500"
     },
     "COLOR_BLUE_600": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 157, 189)",
+      ".alias": {
+        "value": "#009dbd"
+      },
       "name": "COLOR_BLUE_600"
     },
     "COLOR_BLUE_700": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 140, 168)",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "COLOR_BLUE_700"
     },
     "COLOR_BLUE_800": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 117, 140)",
+      ".alias": {
+        "value": "#00758c"
+      },
       "name": "COLOR_BLUE_800"
     },
     "COLOR_BLUE_900": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 85, 103)",
+      ".alias": {
+        "value": "#005567"
+      },
       "name": "COLOR_BLUE_900"
     },
     "COLOR_GRAY_50": {
       "type": "color",
       "category": "colors",
       "value": "rgb(243, 242, 245)",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "COLOR_GRAY_50"
     },
     "COLOR_GRAY_100": {
       "type": "color",
       "category": "colors",
       "value": "rgb(230, 228, 235)",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "COLOR_GRAY_100"
     },
     "COLOR_GRAY_200": {
       "type": "color",
       "category": "colors",
       "value": "rgb(204, 201, 212)",
+      ".alias": {
+        "value": "#CCC9D4"
+      },
       "name": "COLOR_GRAY_200"
     },
     "COLOR_GRAY_300": {
       "type": "color",
       "category": "colors",
       "value": "rgb(178, 174, 189)",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "COLOR_GRAY_300"
     },
     "COLOR_GRAY_400": {
       "type": "color",
       "category": "colors",
       "value": "rgb(154, 149, 167)",
+      ".alias": {
+        "value": "#9A95A7"
+      },
       "name": "COLOR_GRAY_400"
     },
     "COLOR_GRAY_500": {
       "type": "color",
       "category": "colors",
       "value": "rgb(129, 123, 143)",
+      ".alias": {
+        "value": "#817B8F"
+      },
       "name": "COLOR_GRAY_500"
     },
     "COLOR_GRAY_600": {
       "type": "color",
       "category": "colors",
       "value": "rgb(105, 97, 121)",
+      ".alias": {
+        "value": "#696179"
+      },
       "name": "COLOR_GRAY_600"
     },
     "COLOR_GRAY_700": {
       "type": "color",
       "category": "colors",
       "value": "rgb(82, 76, 97)",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "COLOR_GRAY_700"
     },
     "COLOR_GRAY_800": {
       "type": "color",
       "category": "colors",
       "value": "rgb(59, 52, 75)",
+      ".alias": {
+        "value": "#3B344B"
+      },
       "name": "COLOR_GRAY_800"
     },
     "COLOR_GRAY_900": {
       "type": "color",
       "category": "colors",
       "value": "rgb(37, 32, 51)",
+      ".alias": {
+        "value": "#252033"
+      },
       "name": "COLOR_GRAY_900"
     },
     "COLOR_GREEN_50": {
       "type": "color",
       "category": "colors",
       "value": "rgb(223, 247, 236)",
+      ".alias": {
+        "value": "#dff7ec"
+      },
       "name": "COLOR_GREEN_50"
     },
     "COLOR_GREEN_100": {
       "type": "color",
       "category": "colors",
       "value": "rgb(203, 245, 226)",
+      ".alias": {
+        "value": "#cbf5e2"
+      },
       "name": "COLOR_GREEN_100"
     },
     "COLOR_GREEN_200": {
       "type": "color",
       "category": "colors",
       "value": "rgb(175, 237, 209)",
+      ".alias": {
+        "value": "#afedd1"
+      },
       "name": "COLOR_GREEN_200"
     },
     "COLOR_GREEN_300": {
       "type": "color",
       "category": "colors",
       "value": "rgb(128, 232, 185)",
+      ".alias": {
+        "value": "#80e8b9"
+      },
       "name": "COLOR_GREEN_300"
     },
     "COLOR_GREEN_400": {
       "type": "color",
       "category": "colors",
       "value": "rgb(64, 222, 151)",
+      ".alias": {
+        "value": "#40de97"
+      },
       "name": "COLOR_GREEN_400"
     },
     "COLOR_GREEN_500": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 215, 117)",
+      ".alias": {
+        "value": "#00d775"
+      },
       "name": "COLOR_GREEN_500"
     },
     "COLOR_GREEN_600": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 189, 104)",
+      ".alias": {
+        "value": "#00bd68"
+      },
       "name": "COLOR_GREEN_600"
     },
     "COLOR_GREEN_700": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 168, 93)",
+      ".alias": {
+        "value": "#00a85d"
+      },
       "name": "COLOR_GREEN_700"
     },
     "COLOR_GREEN_800": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 140, 77)",
+      ".alias": {
+        "value": "#008c4d"
+      },
       "name": "COLOR_GREEN_800"
     },
     "COLOR_GREEN_900": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 102, 56)",
+      ".alias": {
+        "value": "#006638"
+      },
       "name": "COLOR_GREEN_900"
     },
     "COLOR_RED_50": {
       "type": "color",
       "category": "colors",
       "value": "rgb(252, 242, 242)",
+      ".alias": {
+        "value": "#fcf2f2"
+      },
       "name": "COLOR_RED_50"
     },
     "COLOR_RED_100": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 214, 213)",
+      ".alias": {
+        "value": "#ffd6d5"
+      },
       "name": "COLOR_RED_100"
     },
     "COLOR_RED_200": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 187, 186)",
+      ".alias": {
+        "value": "#ffbbba"
+      },
       "name": "COLOR_RED_200"
     },
     "COLOR_RED_300": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 150, 148)",
+      ".alias": {
+        "value": "#ff9694"
+      },
       "name": "COLOR_RED_300"
     },
     "COLOR_RED_400": {
       "type": "color",
       "category": "colors",
       "value": "rgb(254, 116, 113)",
+      ".alias": {
+        "value": "#fe7471"
+      },
       "name": "COLOR_RED_400"
     },
     "COLOR_RED_500": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 84, 82)",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "COLOR_RED_500"
     },
     "COLOR_RED_600": {
       "type": "color",
       "category": "colors",
       "value": "rgb(235, 66, 63)",
+      ".alias": {
+        "value": "#eb423f"
+      },
       "name": "COLOR_RED_600"
     },
     "COLOR_RED_700": {
       "type": "color",
       "category": "colors",
       "value": "rgb(222, 50, 47)",
+      ".alias": {
+        "value": "#de322f"
+      },
       "name": "COLOR_RED_700"
     },
     "COLOR_RED_800": {
       "type": "color",
       "category": "colors",
       "value": "rgb(204, 31, 29)",
+      ".alias": {
+        "value": "#cc1f1d"
+      },
       "name": "COLOR_RED_800"
     },
     "COLOR_RED_900": {
       "type": "color",
       "category": "colors",
       "value": "rgb(168, 3, 0)",
+      ".alias": {
+        "value": "#a80300"
+      },
       "name": "COLOR_RED_900"
     },
     "COLOR_YELLOW_50": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 249, 230)",
+      ".alias": {
+        "value": "#FFF9E6"
+      },
       "name": "COLOR_YELLOW_50"
     },
     "COLOR_YELLOW_100": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 243, 207)",
+      ".alias": {
+        "value": "#FFF3CF"
+      },
       "name": "COLOR_YELLOW_100"
     },
     "COLOR_YELLOW_200": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 236, 184)",
+      ".alias": {
+        "value": "#FFECB8"
+      },
       "name": "COLOR_YELLOW_200"
     },
     "COLOR_YELLOW_300": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 225, 140)",
+      ".alias": {
+        "value": "#FFE18C"
+      },
       "name": "COLOR_YELLOW_300"
     },
     "COLOR_YELLOW_400": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 207, 74)",
+      ".alias": {
+        "value": "#FFCF4A"
+      },
       "name": "COLOR_YELLOW_400"
     },
     "COLOR_YELLOW_500": {
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 187, 0)",
+      ".alias": {
+        "value": "#FFBB00"
+      },
       "name": "COLOR_YELLOW_500"
     },
     "COLOR_YELLOW_600": {
       "type": "color",
       "category": "colors",
       "value": "rgb(240, 176, 0)",
+      ".alias": {
+        "value": "#F0B000"
+      },
       "name": "COLOR_YELLOW_600"
     },
     "COLOR_YELLOW_700": {
       "type": "color",
       "category": "colors",
       "value": "rgb(225, 165, 0)",
+      ".alias": {
+        "value": "#E1A500"
+      },
       "name": "COLOR_YELLOW_700"
     },
     "COLOR_YELLOW_800": {
       "type": "color",
       "category": "colors",
       "value": "rgb(194, 142, 0)",
+      ".alias": {
+        "value": "#C28E00"
+      },
       "name": "COLOR_YELLOW_800"
     },
     "COLOR_YELLOW_900": {
       "type": "color",
       "category": "colors",
       "value": "rgb(156, 114, 0)",
+      ".alias": {
+        "value": "#9C7200"
+      },
       "name": "COLOR_YELLOW_900"
     },
     "PRIMARY_GRADIENT": {
       "type": "background-image",
       "category": "colors",
       "value": "linear-gradient(135deg, #00b2d6 0%, #02DDD8 100%)",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "PRIMARY_GRADIENT"
     },
     "INPUT_HEIGHT": {
       "category": "forms",
       "value": "2.250rem",
       "type": "size",
+      ".alias": {
+        "value": "2.250rem"
+      },
       "name": "INPUT_HEIGHT"
     },
     "INPUT_PADDING_X": {
       "category": "forms",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "INPUT_PADDING_X"
     },
     "INPUT_PADDING_Y": {
       "category": "forms",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "INPUT_PADDING_Y"
     },
     "INPUT_BORDER_WIDTH": {
       "category": "forms",
       "value": ".0625rem",
       "type": "size",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "INPUT_BORDER_WIDTH"
     },
     "INPUT_BORDER": {
       "category": "forms",
       "value": "solid .0625rem #E6E4EB",
       "type": "border",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "INPUT_BORDER"
     },
     "INPUT_BORDER_RADIUS": {
       "category": "forms",
       "value": ".1875rem",
       "type": "radius",
+      ".alias": {
+        "value": ".1875rem"
+      },
       "name": "INPUT_BORDER_RADIUS"
     },
     "INPUT_BACKGROUND": {
       "category": "forms",
       "value": "#ffffff",
       "type": "background",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "INPUT_BACKGROUND"
     },
     "INPUT_COLOR": {
       "category": "forms",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "INPUT_COLOR"
     },
     "INPUT_PLACEHOLDER_COLOR": {
       "category": "forms",
       "value": "rgb(129, 123, 143)",
       "type": "color",
+      ".alias": {
+        "value": "#817B8F"
+      },
       "name": "INPUT_PLACEHOLDER_COLOR"
     },
     "INPUT_PLACEHOLDER_FONT_STYLE": {
@@ -1219,114 +1857,171 @@
       "category": "forms",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "INPUT_DISABLED_BORDER_COLOR"
     },
     "INPUT_DISABLED_COLOR": {
       "category": "forms",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "INPUT_DISABLED_COLOR"
     },
     "INPUT_LARGE_HEIGHT": {
       "category": "forms",
       "value": "2.625rem + .375rem",
       "type": "size",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "INPUT_LARGE_HEIGHT"
     },
     "SELECT_HEIGHT": {
       "category": "forms",
       "value": "2.250rem",
       "type": "size",
+      ".alias": {
+        "value": "2.250rem"
+      },
       "name": "SELECT_HEIGHT"
     },
     "SELECT_PADDING_TOP": {
       "category": "forms",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "SELECT_PADDING_TOP"
     },
     "SELECT_PADDING_RIGHT": {
       "category": "forms",
       "value": "1.875rem",
       "type": "size",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "SELECT_PADDING_RIGHT"
     },
     "SELECT_PADDING_BOTTOM": {
       "category": "forms",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "SELECT_PADDING_BOTTOM"
     },
     "SELECT_PADDING_LEFT": {
       "category": "forms",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "SELECT_PADDING_LEFT"
     },
     "SELECT_BORDER_WIDTH": {
       "category": "forms",
       "value": ".0625rem",
       "type": "size",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "SELECT_BORDER_WIDTH"
     },
     "SELECT_BORDER": {
       "category": "forms",
       "value": "solid .0625rem #E6E4EB",
       "type": "border",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "SELECT_BORDER"
     },
     "SELECT_BORDER_RADIUS": {
       "category": "forms",
       "value": ".1875rem",
       "type": "radius",
+      ".alias": {
+        "value": ".1875rem"
+      },
       "name": "SELECT_BORDER_RADIUS"
     },
     "SELECT_COLOR": {
       "category": "forms",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "SELECT_COLOR"
     },
     "SELECT_DISABLED_BORDER_COLOR": {
       "category": "forms",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "SELECT_DISABLED_BORDER_COLOR"
     },
     "SELECT_DISABLED_COLOR": {
       "category": "forms",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "SELECT_DISABLED_COLOR"
     },
     "SELECT_LARGE_HEIGHT": {
       "category": "forms",
       "value": "2.625rem + .375rem",
       "type": "size",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "SELECT_LARGE_HEIGHT"
     },
     "LABEL_COLOR": {
       "category": "forms",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "LABEL_COLOR"
     },
     "LABEL_DISABLED_COLOR": {
       "category": "forms",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "LABEL_DISABLED_COLOR"
     },
     "LABEL_FONT_SIZE": {
       "category": "forms",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "LABEL_FONT_SIZE"
     },
     "LABEL_LINE_HEIGHT": {
       "category": "forms",
       "value": "1.125rem",
       "type": "number",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "LABEL_LINE_HEIGHT"
     },
     "FORM_VALIDATION_MARGIN": {
@@ -1339,48 +2034,72 @@
       "category": "forms",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "FORM_VALIDATION_PADDING_Y"
     },
     "FORM_VALIDATION_PADDING_X": {
       "category": "forms",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "FORM_VALIDATION_PADDING_X"
     },
     "FORM_VALIDATION_BACKGROUND_COLOR": {
       "category": "forms",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "FORM_VALIDATION_BACKGROUND_COLOR"
     },
     "FORM_VALIDATION_COLOR": {
       "category": "forms",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "FORM_VALIDATION_COLOR"
     },
     "FORM_VALIDATION_ARROW_SIZE": {
       "category": "forms",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "FORM_VALIDATION_ARROW_SIZE"
     },
     "FORM_VALIDATION_CHECKBOX_ARROW_LEFT": {
       "category": "forms",
       "value": "1.5rem",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "FORM_VALIDATION_CHECKBOX_ARROW_LEFT"
     },
     "TEXTAREA_MIN_HEIGHT": {
       "category": "forms",
       "value": "2.625rem * 2",
       "type": "size",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "TEXTAREA_MIN_HEIGHT"
     },
     "REQUIRED_COLOR": {
       "category": "forms",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "REQUIRED_COLOR"
     },
     "GRID_COLUMNS": {
@@ -1393,36 +2112,54 @@
       "category": "grids",
       "value": "1.5rem",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "GRID_GUTTER"
     },
     "GRID_CONTAINER_PADDING": {
       "category": "grids",
       "value": "1.5rem",
       "type": "size",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "GRID_CONTAINER_PADDING"
     },
     "GRID_CONTAINER_MOBILE_PADDING": {
       "category": "grids",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "GRID_CONTAINER_MOBILE_PADDING"
     },
     "ICON_SIZE_SM": {
       "type": "size",
       "category": "icons",
       "value": "1.125rem",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "ICON_SIZE_SM"
     },
     "ICON_SIZE_LG": {
       "type": "size",
       "category": "icons",
       "value": "1.5rem",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "ICON_SIZE_LG"
     },
     "MODAL_SCRIM_BACKGROUND_COLOR": {
       "category": "modals",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "MODAL_SCRIM_BACKGROUND_COLOR"
     },
     "MODAL_SCRIM_INITIAL_OPACITY": {
@@ -1447,6 +2184,9 @@
       "category": "modals",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "MODAL_BACKGROUND_COLOR"
     },
     "MODAL_INITIAL_OPACITY": {
@@ -1465,180 +2205,270 @@
       "category": "modals",
       "value": "32.25rem",
       "type": "size",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "MODAL_MAX_WIDTH"
     },
     "MODAL_WIDE_MAX_WIDTH": {
       "category": "modals",
       "value": "50.25rem",
       "type": "size",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "MODAL_WIDE_MAX_WIDTH"
     },
     "MODAL_HEADER_PADDING": {
       "category": "modals",
       "value": ".75rem",
       "type": "box-shadow",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "MODAL_HEADER_PADDING"
     },
     "MODAL_CLOSE_ICON_FILL": {
       "category": "modals",
       "value": "rgb(129, 123, 143)",
       "type": "color",
+      ".alias": {
+        "value": "#817B8F"
+      },
       "name": "MODAL_CLOSE_ICON_FILL"
     },
     "MODAL_CLOSE_ICON_HOVER_FILL": {
       "category": "modals",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "MODAL_CLOSE_ICON_HOVER_FILL"
     },
     "MODAL_CONTENT_PADDING": {
       "category": "modals",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "MODAL_CONTENT_PADDING"
     },
     "BANNER_ALERT_BACKGROUND_COLOR": {
       "category": "notifications",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "BANNER_ALERT_BACKGROUND_COLOR"
     },
     "BANNER_ALERT_HEADER_PADDING_Y": {
       "category": "notifications",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "BANNER_ALERT_HEADER_PADDING_Y"
     },
     "BANNER_ALERT_HEADER_PADDING_X": {
       "category": "notifications",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "BANNER_ALERT_HEADER_PADDING_X"
     },
     "BANNER_ALERT_HEADER_EXPANDABLE_HOVER_BACKGROUND_COLOR": {
       "category": "notifications",
       "value": "rgb(243, 242, 245)",
       "type": "color",
+      ".alias": {
+        "value": "#F3F2F5"
+      },
       "name": "BANNER_ALERT_HEADER_EXPANDABLE_HOVER_BACKGROUND_COLOR"
     },
     "BANNER_ALERT_HEADER_EXPANDABLE_ACTIVE_BACKGROUND_COLOR": {
       "category": "notifications",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "BANNER_ALERT_HEADER_EXPANDABLE_ACTIVE_BACKGROUND_COLOR"
     },
     "BANNER_ALERT_SUCCESS_COLOR": {
       "category": "notifications",
       "value": "rgb(0, 215, 117)",
       "type": "color",
+      ".alias": {
+        "value": "#00d775"
+      },
       "name": "BANNER_ALERT_SUCCESS_COLOR"
     },
     "BANNER_ALERT_WARN_COLOR": {
       "category": "notifications",
       "value": "rgb(255, 187, 0)",
       "type": "color",
+      ".alias": {
+        "value": "#FFBB00"
+      },
       "name": "BANNER_ALERT_WARN_COLOR"
     },
     "BANNER_ALERT_ERROR_COLOR": {
       "category": "notifications",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "BANNER_ALERT_ERROR_COLOR"
     },
     "BANNER_ALERT_EXPAND_ICON_FILL": {
       "category": "notifications",
       "value": "rgb(82, 76, 97)",
       "type": "color",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "BANNER_ALERT_EXPAND_ICON_FILL"
     },
     "BANNER_ALERT_CHILDREN_PADDING_Y": {
       "category": "notifications",
       "value": ".375rem",
       "type": "size",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "BANNER_ALERT_CHILDREN_PADDING_Y"
     },
     "BANNER_ALERT_CHILDREN_PADDING_X": {
       "category": "notifications",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "BANNER_ALERT_CHILDREN_PADDING_X"
     },
     "BANNER_ALERT_CHILDREN_COLOR": {
       "category": "notifications",
       "value": "rgb(129, 123, 143)",
       "type": "color",
+      ".alias": {
+        "value": "#817B8F"
+      },
       "name": "BANNER_ALERT_CHILDREN_COLOR"
     },
     "PANEL_PADDING": {
       "category": "panels",
       "value": ".75rem",
       "type": "size",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "PANEL_PADDING"
     },
     "PANEL_BORDER_COLOR": {
       "category": "panels",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "PANEL_BORDER_COLOR"
     },
     "PANEL_BACKGROUND_COLOR": {
       "category": "panels",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "PANEL_BACKGROUND_COLOR"
     },
     "SPACING_XS": {
       "type": "size",
       "category": "spacings",
       "value": ".375rem",
+      ".alias": {
+        "value": ".375rem"
+      },
       "name": "SPACING_XS"
     },
     "SPACING_SM": {
       "type": "size",
       "category": "spacings",
       "value": ".75rem",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "SPACING_SM"
     },
     "SPACING_MD": {
       "type": "size",
       "category": "spacings",
       "value": "1.125rem",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "SPACING_MD"
     },
     "SPACING_BASE": {
       "type": "size",
       "category": "spacings",
       "value": "1.5rem",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "SPACING_BASE"
     },
     "SPACING_LG": {
       "type": "size",
       "category": "spacings",
       "value": "1.875rem",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "SPACING_LG"
     },
     "SPACING_XL": {
       "type": "size",
       "category": "spacings",
       "value": "2.250rem",
+      ".alias": {
+        "value": "2.250rem"
+      },
       "name": "SPACING_XL"
     },
     "SPACING_XXL": {
       "type": "size",
       "category": "spacings",
       "value": "2.625rem",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "SPACING_XXL"
     },
     "ONE_PIXEL_REM": {
       "type": "size",
       "category": "spacings",
       "value": ".0625rem",
+      ".alias": {
+        "value": ".0625rem"
+      },
       "name": "ONE_PIXEL_REM"
     },
     "STATE_SELECTED_BACKGROUND_COLOR": {
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 140, 168)",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "STATE_SELECTED_BACKGROUND_COLOR"
     },
     "FONT_FAMILY_BASE": {
@@ -1651,30 +2481,45 @@
       "value": "rgb(82, 76, 97)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "FONT_COLOR_BASE"
     },
     "LINE_HEIGHT_SM": {
       "value": "1.125rem",
       "type": "number",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "LINE_HEIGHT_SM"
     },
     "LINE_HEIGHT_BASE": {
       "value": "1.5rem",
       "type": "number",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "LINE_HEIGHT_BASE"
     },
     "LINE_HEIGHT_LG": {
       "value": "1.875rem",
       "type": "number",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "LINE_HEIGHT_LG"
     },
     "LINE_HEIGHT_XL": {
       "value": "2.625rem",
       "type": "number",
       "category": "typesettings",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "LINE_HEIGHT_XL"
     },
     "LINE_HEIGHT_XXL": {
@@ -1693,96 +2538,144 @@
       "value": ".75rem",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "FONT_SIZE_SM"
     },
     "FONT_SIZE_BASE": {
       "value": "1rem",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": "1rem"
+      },
       "name": "FONT_SIZE_BASE"
     },
     "FONT_SIZE_LG": {
       "value": "1.5rem",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "FONT_SIZE_LG"
     },
     "FONT_SIZE_XL": {
       "value": "1.75rem",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": "1.75rem"
+      },
       "name": "FONT_SIZE_XL"
     },
     "FONT_SIZE_XXL": {
       "value": "2.625rem",
       "type": "size",
       "category": "typesettings",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "FONT_SIZE_XXL"
     },
     "H6_FONT_SIZE": {
       "value": ".75rem",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "H6_FONT_SIZE"
     },
     "H5_FONT_SIZE": {
       "value": ".75rem",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "H5_FONT_SIZE"
     },
     "H4_FONT_SIZE": {
       "value": "1rem",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": "1rem"
+      },
       "name": "H4_FONT_SIZE"
     },
     "H3_FONT_SIZE": {
       "value": "1.5rem",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "H3_FONT_SIZE"
     },
     "H2_FONT_SIZE": {
       "value": "1.75rem",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": "1.75rem"
+      },
       "name": "H2_FONT_SIZE"
     },
     "H1_FONT_SIZE": {
       "value": "2.625rem",
       "type": "size",
       "category": "font-sizes",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "H1_FONT_SIZE"
     },
     "H6_LINE_HEIGHT": {
       "value": "1.125rem",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "H6_LINE_HEIGHT"
     },
     "H5_LINE_HEIGHT": {
       "value": "1.125rem",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "1.125rem"
+      },
       "name": "H5_LINE_HEIGHT"
     },
     "H4_LINE_HEIGHT": {
       "value": "1.5rem",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "1.5rem"
+      },
       "name": "H4_LINE_HEIGHT"
     },
     "H3_LINE_HEIGHT": {
       "value": "1.875rem",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "H3_LINE_HEIGHT"
     },
     "H2_LINE_HEIGHT": {
       "value": "2.625rem",
       "type": "number",
       "category": "line-heights",
+      ".alias": {
+        "value": "2.625rem"
+      },
       "name": "H2_LINE_HEIGHT"
     },
     "H1_LINE_HEIGHT": {
@@ -1837,12 +2730,18 @@
       "value": ".75rem",
       "type": "size",
       "category": "spacings",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "HEADING_MARGIN_BOTTOM"
     },
     "HEADING_CONTENT_MARGIN_TOP": {
       "value": "1.875rem",
       "type": "size",
       "category": "spacings",
+      ".alias": {
+        "value": "1.875rem"
+      },
       "name": "HEADING_CONTENT_MARGIN_TOP"
     },
     "P_MARGIN_TOP": {
@@ -1855,6 +2754,9 @@
       "value": ".75rem",
       "type": "size",
       "category": "spacings",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "P_MARGIN_BOTTOM"
     },
     "LIST_MARGIN_TOP": {
@@ -1867,6 +2769,9 @@
       "value": ".75rem",
       "type": "size",
       "category": "spacings",
+      ".alias": {
+        "value": ".75rem"
+      },
       "name": "LIST_MARGIN_BOTTOM"
     },
     "LIST_NESTED_MARGIN_TOP": {
@@ -1897,6 +2802,9 @@
       "value": "rgb(0, 178, 214)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#00b2d6"
+      },
       "name": "LINK_COLOR"
     },
     "LINK_TEXT_DECORATION": {
@@ -1909,6 +2817,9 @@
       "value": "rgb(82, 76, 97)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#524C61"
+      },
       "name": "LINK_HOVER_COLOR"
     },
     "LINK_HOVER_TEXT_DECORATION": {
@@ -1921,66 +2832,99 @@
       "value": "rgb(37, 32, 51)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#252033"
+      },
       "name": "LINK_ACTIVE_COLOR"
     },
     "LINK_VISITED_COLOR": {
       "value": "rgb(0, 140, 168)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#008ca8"
+      },
       "name": "LINK_VISITED_COLOR"
     },
     "LINK_WHITE_COLOR": {
       "value": "rgb(255, 255, 255)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "LINK_WHITE_COLOR"
     },
     "LINK_WHITE_HOVER_COLOR": {
       "value": "rgb(255, 255, 255)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "LINK_WHITE_HOVER_COLOR"
     },
     "LINK_WHITE_ACTIVE_COLOR": {
       "value": "rgb(230, 228, 235)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "LINK_WHITE_ACTIVE_COLOR"
     },
     "LINK_WHITE_VISITED_COLOR": {
       "value": "rgb(255, 255, 255)",
       "type": "color",
       "category": "text-colors",
+      ".alias": {
+        "value": "#ffffff"
+      },
       "name": "LINK_WHITE_VISITED_COLOR"
     },
     "ZINDEX_AUTOSUGGEST": {
       "type": "number",
       "category": "z-indices",
       "value": "900",
+      ".alias": {
+        "value": "900"
+      },
       "name": "ZINDEX_AUTOSUGGEST"
     },
     "ZINDEX_POPOVER": {
       "type": "number",
       "category": "z-indices",
       "value": "900",
+      ".alias": {
+        "value": "900"
+      },
       "name": "ZINDEX_POPOVER"
     },
     "ZINDEX_TOOLTIP": {
       "type": "number",
       "category": "z-indices",
       "value": "900",
+      ".alias": {
+        "value": "900"
+      },
       "name": "ZINDEX_TOOLTIP"
     },
     "ZINDEX_MODAL_SCRIM": {
       "type": "number",
       "category": "z-indices",
       "value": "1000",
+      ".alias": {
+        "value": "1000"
+      },
       "name": "ZINDEX_MODAL_SCRIM"
     },
     "ZINDEX_MODAL": {
       "type": "number",
       "category": "z-indices",
       "value": "1100",
+      ".alias": {
+        "value": "1100"
+      },
       "name": "ZINDEX_MODAL"
     }
   },

--- a/packages/bpk-tokens/tokens/breakpoints.ios.json
+++ b/packages/bpk-tokens/tokens/breakpoints.ios.json
@@ -4,48 +4,72 @@
       "category": "breakpoints",
       "value": "516",
       "type": "size",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "breakpointMobile"
     },
     {
       "category": "breakpoints",
       "value": "804",
       "type": "size",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "breakpointTablet"
     },
     {
       "category": "breakpoints",
       "value": "1140",
       "type": "size",
+      ".alias": {
+        "value": "71.25rem"
+      },
       "name": "breakpointDesktop"
     },
     {
       "category": "breakpoints",
       "value": "(max-width: 32.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "breakpointQueryMobile"
     },
     {
       "category": "breakpoints",
       "value": "(max-width: 50.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "breakpointQueryTablet"
     },
     {
       "category": "breakpoints",
       "value": "(min-width: 32.3125rem) and (max-width: 50.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "breakpointQueryTabletOnly"
     },
     {
       "category": "breakpoints",
       "value": "(min-width: 32.3125rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "32.3125rem"
+      },
       "name": "breakpointQueryAboveMobile"
     },
     {
       "category": "breakpoints",
       "value": "(min-width: 50.3125rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.3125rem"
+      },
       "name": "breakpointQueryAboveTablet"
     }
   ]

--- a/packages/bpk-tokens/tokens/breakpoints.raw.json
+++ b/packages/bpk-tokens/tokens/breakpoints.raw.json
@@ -1,144 +1,350 @@
 {
   "aliases": {
-    "WHITE": "#ffffff",
-    "BLUE_50": "#e1f4f8",
-    "BLUE_100": "#cbeef5",
-    "BLUE_200": "#b0e4ee",
-    "BLUE_300": "#7fd7e8",
-    "BLUE_400": "#40c4df",
-    "BLUE_500": "#00b2d6",
-    "BLUE_600": "#009dbd",
-    "BLUE_700": "#008ca8",
-    "BLUE_800": "#00758c",
-    "BLUE_900": "#005567",
-    "GRAY_50": "#F3F2F5",
-    "GRAY_100": "#E6E4EB",
-    "GRAY_200": "#CCC9D4",
-    "GRAY_300": "#B2AEBD",
-    "GRAY_400": "#9A95A7",
-    "GRAY_500": "#817B8F",
-    "GRAY_600": "#696179",
-    "GRAY_700": "#524C61",
-    "GRAY_800": "#3B344B",
-    "GRAY_900": "#252033",
-    "GREEN_50": "#dff7ec",
-    "GREEN_100": "#cbf5e2",
-    "GREEN_200": "#afedd1",
-    "GREEN_300": "#80e8b9",
-    "GREEN_400": "#40de97",
-    "GREEN_500": "#00d775",
-    "GREEN_600": "#00bd68",
-    "GREEN_700": "#00a85d",
-    "GREEN_800": "#008c4d",
-    "GREEN_900": "#006638",
-    "RED_50": "#fcf2f2",
-    "RED_100": "#ffd6d5",
-    "RED_200": "#ffbbba",
-    "RED_300": "#ff9694",
-    "RED_400": "#fe7471",
-    "RED_500": "#ff5452",
-    "RED_600": "#eb423f",
-    "RED_700": "#de322f",
-    "RED_800": "#cc1f1d",
-    "RED_900": "#a80300",
-    "YELLOW_50": "#FFF9E6",
-    "YELLOW_100": "#FFF3CF",
-    "YELLOW_200": "#FFECB8",
-    "YELLOW_300": "#FFE18C",
-    "YELLOW_400": "#FFCF4A",
-    "YELLOW_500": "#FFBB00",
-    "YELLOW_600": "#F0B000",
-    "YELLOW_700": "#E1A500",
-    "YELLOW_800": "#C28E00",
-    "YELLOW_900": "#9C7200",
-    "PINK_50": "#FDE4ED",
-    "PINK_100": "#FFBFD7",
-    "PINK_200": "#FF94BB",
-    "PINK_300": "#FF73A6",
-    "PINK_400": "#FF619B",
-    "PINK_500": "#FA488A",
-    "PINK_600": "#D92B6B",
-    "PINK_700": "#C50F52",
-    "PINK_800": "#B00C48",
-    "PINK_900": "#94053A",
-    "FONT_SIZE_SM": ".75rem",
-    "FONT_SIZE_BASE": "1rem",
-    "FONT_SIZE_LG": "1.5rem",
-    "FONT_SIZE_XL": "1.75rem",
-    "FONT_SIZE_XXL": "2.625rem",
-    "SPACING_XS": ".375rem",
-    "SPACING_SM": ".75rem",
-    "SPACING_MD": "1.125rem",
-    "SPACING_BASE": "1.5rem",
-    "SPACING_LG": "1.875rem",
-    "SPACING_XL": "2.250rem",
-    "SPACING_XXL": "2.625rem",
-    "BORDER_RADIUS_XS": ".1875rem",
-    "BORDER_RADIUS_SM": ".375rem",
-    "BORDER_RADIUS_PILL": "1.125rem",
-    "BORDER_RADIUS_PILL_LG": "1.3125rem",
-    "BORDER_SIZE_SM": "1px",
-    "BORDER_SIZE_LG": "2px",
-    "BORDER_SIZE_XL": "3px",
-    "BREAKPOINT_MOBILE": "32.25rem",
-    "BREAKPOINT_ABOVE_MOBILE": "32.3125rem",
-    "BREAKPOINT_TABLET": "50.25rem",
-    "BREAKPOINT_ABOVE_TABLET": "50.3125rem",
-    "BREAKPOINT_DESKTOP": "71.25rem",
-    "ONE_PIXEL_REM": ".0625rem",
-    "ZINDEX_AUTOSUGGEST": "900",
-    "ZINDEX_POPOVER": "900",
-    "ZINDEX_TOOLTIP": "900",
-    "ZINDEX_MODAL_SCRIM": "1000",
-    "ZINDEX_MODAL": "1100"
+    "WHITE": {
+      "value": "#ffffff"
+    },
+    "BLUE_50": {
+      "value": "#e1f4f8"
+    },
+    "BLUE_100": {
+      "value": "#cbeef5"
+    },
+    "BLUE_200": {
+      "value": "#b0e4ee"
+    },
+    "BLUE_300": {
+      "value": "#7fd7e8"
+    },
+    "BLUE_400": {
+      "value": "#40c4df"
+    },
+    "BLUE_500": {
+      "value": "#00b2d6"
+    },
+    "BLUE_600": {
+      "value": "#009dbd"
+    },
+    "BLUE_700": {
+      "value": "#008ca8"
+    },
+    "BLUE_800": {
+      "value": "#00758c"
+    },
+    "BLUE_900": {
+      "value": "#005567"
+    },
+    "GRAY_50": {
+      "value": "#F3F2F5"
+    },
+    "GRAY_100": {
+      "value": "#E6E4EB"
+    },
+    "GRAY_200": {
+      "value": "#CCC9D4"
+    },
+    "GRAY_300": {
+      "value": "#B2AEBD"
+    },
+    "GRAY_400": {
+      "value": "#9A95A7"
+    },
+    "GRAY_500": {
+      "value": "#817B8F"
+    },
+    "GRAY_600": {
+      "value": "#696179"
+    },
+    "GRAY_700": {
+      "value": "#524C61"
+    },
+    "GRAY_800": {
+      "value": "#3B344B"
+    },
+    "GRAY_900": {
+      "value": "#252033"
+    },
+    "GREEN_50": {
+      "value": "#dff7ec"
+    },
+    "GREEN_100": {
+      "value": "#cbf5e2"
+    },
+    "GREEN_200": {
+      "value": "#afedd1"
+    },
+    "GREEN_300": {
+      "value": "#80e8b9"
+    },
+    "GREEN_400": {
+      "value": "#40de97"
+    },
+    "GREEN_500": {
+      "value": "#00d775"
+    },
+    "GREEN_600": {
+      "value": "#00bd68"
+    },
+    "GREEN_700": {
+      "value": "#00a85d"
+    },
+    "GREEN_800": {
+      "value": "#008c4d"
+    },
+    "GREEN_900": {
+      "value": "#006638"
+    },
+    "RED_50": {
+      "value": "#fcf2f2"
+    },
+    "RED_100": {
+      "value": "#ffd6d5"
+    },
+    "RED_200": {
+      "value": "#ffbbba"
+    },
+    "RED_300": {
+      "value": "#ff9694"
+    },
+    "RED_400": {
+      "value": "#fe7471"
+    },
+    "RED_500": {
+      "value": "#ff5452"
+    },
+    "RED_600": {
+      "value": "#eb423f"
+    },
+    "RED_700": {
+      "value": "#de322f"
+    },
+    "RED_800": {
+      "value": "#cc1f1d"
+    },
+    "RED_900": {
+      "value": "#a80300"
+    },
+    "YELLOW_50": {
+      "value": "#FFF9E6"
+    },
+    "YELLOW_100": {
+      "value": "#FFF3CF"
+    },
+    "YELLOW_200": {
+      "value": "#FFECB8"
+    },
+    "YELLOW_300": {
+      "value": "#FFE18C"
+    },
+    "YELLOW_400": {
+      "value": "#FFCF4A"
+    },
+    "YELLOW_500": {
+      "value": "#FFBB00"
+    },
+    "YELLOW_600": {
+      "value": "#F0B000"
+    },
+    "YELLOW_700": {
+      "value": "#E1A500"
+    },
+    "YELLOW_800": {
+      "value": "#C28E00"
+    },
+    "YELLOW_900": {
+      "value": "#9C7200"
+    },
+    "PINK_50": {
+      "value": "#FDE4ED"
+    },
+    "PINK_100": {
+      "value": "#FFBFD7"
+    },
+    "PINK_200": {
+      "value": "#FF94BB"
+    },
+    "PINK_300": {
+      "value": "#FF73A6"
+    },
+    "PINK_400": {
+      "value": "#FF619B"
+    },
+    "PINK_500": {
+      "value": "#FA488A"
+    },
+    "PINK_600": {
+      "value": "#D92B6B"
+    },
+    "PINK_700": {
+      "value": "#C50F52"
+    },
+    "PINK_800": {
+      "value": "#B00C48"
+    },
+    "PINK_900": {
+      "value": "#94053A"
+    },
+    "FONT_SIZE_SM": {
+      "value": ".75rem"
+    },
+    "FONT_SIZE_BASE": {
+      "value": "1rem"
+    },
+    "FONT_SIZE_LG": {
+      "value": "1.5rem"
+    },
+    "FONT_SIZE_XL": {
+      "value": "1.75rem"
+    },
+    "FONT_SIZE_XXL": {
+      "value": "2.625rem"
+    },
+    "SPACING_XS": {
+      "value": ".375rem"
+    },
+    "SPACING_SM": {
+      "value": ".75rem"
+    },
+    "SPACING_MD": {
+      "value": "1.125rem"
+    },
+    "SPACING_BASE": {
+      "value": "1.5rem"
+    },
+    "SPACING_LG": {
+      "value": "1.875rem"
+    },
+    "SPACING_XL": {
+      "value": "2.250rem"
+    },
+    "SPACING_XXL": {
+      "value": "2.625rem"
+    },
+    "BORDER_RADIUS_XS": {
+      "value": ".1875rem"
+    },
+    "BORDER_RADIUS_SM": {
+      "value": ".375rem"
+    },
+    "BORDER_RADIUS_PILL": {
+      "value": "1.125rem"
+    },
+    "BORDER_RADIUS_PILL_LG": {
+      "value": "1.3125rem"
+    },
+    "BORDER_SIZE_SM": {
+      "value": "1px"
+    },
+    "BORDER_SIZE_LG": {
+      "value": "2px"
+    },
+    "BORDER_SIZE_XL": {
+      "value": "3px"
+    },
+    "BREAKPOINT_MOBILE": {
+      "value": "32.25rem"
+    },
+    "BREAKPOINT_ABOVE_MOBILE": {
+      "value": "32.3125rem"
+    },
+    "BREAKPOINT_TABLET": {
+      "value": "50.25rem"
+    },
+    "BREAKPOINT_ABOVE_TABLET": {
+      "value": "50.3125rem"
+    },
+    "BREAKPOINT_DESKTOP": {
+      "value": "71.25rem"
+    },
+    "ONE_PIXEL_REM": {
+      "value": ".0625rem"
+    },
+    "ZINDEX_AUTOSUGGEST": {
+      "value": "900"
+    },
+    "ZINDEX_POPOVER": {
+      "value": "900"
+    },
+    "ZINDEX_TOOLTIP": {
+      "value": "900"
+    },
+    "ZINDEX_MODAL_SCRIM": {
+      "value": "1000"
+    },
+    "ZINDEX_MODAL": {
+      "value": "1100"
+    }
   },
   "props": {
     "BREAKPOINT_MOBILE": {
       "category": "breakpoints",
       "value": "32.25rem",
       "type": "size",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "BREAKPOINT_MOBILE"
     },
     "BREAKPOINT_TABLET": {
       "category": "breakpoints",
       "value": "50.25rem",
       "type": "size",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "BREAKPOINT_TABLET"
     },
     "BREAKPOINT_DESKTOP": {
       "category": "breakpoints",
       "value": "71.25rem",
       "type": "size",
+      ".alias": {
+        "value": "71.25rem"
+      },
       "name": "BREAKPOINT_DESKTOP"
     },
     "BREAKPOINT_QUERY_MOBILE": {
       "category": "breakpoints",
       "value": "(max-width: 32.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "32.25rem"
+      },
       "name": "BREAKPOINT_QUERY_MOBILE"
     },
     "BREAKPOINT_QUERY_TABLET": {
       "category": "breakpoints",
       "value": "(max-width: 50.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "BREAKPOINT_QUERY_TABLET"
     },
     "BREAKPOINT_QUERY_TABLET_ONLY": {
       "category": "breakpoints",
       "value": "(min-width: 32.3125rem) and (max-width: 50.25rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.25rem"
+      },
       "name": "BREAKPOINT_QUERY_TABLET_ONLY"
     },
     "BREAKPOINT_QUERY_ABOVE_MOBILE": {
       "category": "breakpoints",
       "value": "(min-width: 32.3125rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "32.3125rem"
+      },
       "name": "BREAKPOINT_QUERY_ABOVE_MOBILE"
     },
     "BREAKPOINT_QUERY_ABOVE_TABLET": {
       "category": "breakpoints",
       "value": "(min-width: 50.3125rem)",
       "type": "media-query",
+      ".alias": {
+        "value": "50.3125rem"
+      },
       "name": "BREAKPOINT_QUERY_ABOVE_TABLET"
     }
   },

--- a/packages/bpk-tokens/tokens/travelpro.android.xml
+++ b/packages/bpk-tokens/tokens/travelpro.android.xml
@@ -24,17 +24,17 @@
   <property name="BUTTON_PADDING_X" category="buttons">24px</property>
   <property name="BUTTON_PADDING_X_ICON_ONLY" category="buttons">16</property>
   <property name="BUTTON_BORDER_RADIUS" category="buttons">3px</property>
-  <color name="BUTTON_BACKGROUND_COLOR" category="buttons">#34363dff</color>
+  <color name="BUTTON_BACKGROUND_COLOR" category="buttons">#ff34363d</color>
   <property name="BUTTON_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_HOVER_BACKGROUND_COLOR" category="buttons">#4d5059ff</color>
+  <color name="BUTTON_HOVER_BACKGROUND_COLOR" category="buttons">#ff4d5059</color>
   <property name="BUTTON_HOVER_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_ACTIVE_BACKGROUND_COLOR" category="buttons">#4d5059ff</color>
+  <color name="BUTTON_ACTIVE_BACKGROUND_COLOR" category="buttons">#ff4d5059</color>
   <property name="BUTTON_ACTIVE_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_DISABLED_BACKGROUND_COLOR" category="buttons">#00000080</color>
+  <color name="BUTTON_DISABLED_BACKGROUND_COLOR" category="buttons">#80000000</color>
   <property name="BUTTON_DISABLED_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_COLOR" category="buttons">#00ddeeff</color>
+  <color name="BUTTON_COLOR" category="buttons">#ff00ddee</color>
   <property name="BUTTON_FONT_WEIGHT" category="buttons">normal</property>
-  <color name="BUTTON_DISABLED_COLOR" category="buttons">#b2aebdff</color>
+  <color name="BUTTON_DISABLED_COLOR" category="buttons">#ffb2aebd</color>
   <property name="BUTTON_FONT_SIZE" category="buttons">14</property>
   <property name="BUTTON_LINE_HEIGHT" category="buttons">1.125em</property>
   <property name="BUTTON_TEXT_ALIGN" category="buttons">center</property>
@@ -44,17 +44,17 @@
   <property name="BUTTON_LARGE_FONT_SIZE" category="buttons">16</property>
   <property name="BUTTON_LARGE_LINE_HEIGHT" category="buttons">30</property>
   <property name="BUTTON_DISABLED_BOX_SHADOW" category="buttons">none</property>
-  <color name="BUTTON_SECONDARY_BACKGROUND_COLOR" category="buttons">#00000080</color>
+  <color name="BUTTON_SECONDARY_BACKGROUND_COLOR" category="buttons">#80000000</color>
   <property name="BUTTON_SECONDARY_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_SECONDARY_HOVER_BACKGROUND_COLOR" category="buttons">#00bbcc33</color>
+  <color name="BUTTON_SECONDARY_HOVER_BACKGROUND_COLOR" category="buttons">#3300bbcc</color>
   <property name="BUTTON_SECONDARY_HOVER_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_SECONDARY_ACTIVE_BACKGROUND_COLOR" category="buttons">#00bbcc33</color>
+  <color name="BUTTON_SECONDARY_ACTIVE_BACKGROUND_COLOR" category="buttons">#3300bbcc</color>
   <property name="BUTTON_SECONDARY_ACTIVE_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_SECONDARY_DISABLED_BACKGROUND_COLOR" category="buttons">#e6e4ebff</color>
+  <color name="BUTTON_SECONDARY_DISABLED_BACKGROUND_COLOR" category="buttons">#ffe6e4eb</color>
   <property name="BUTTON_SECONDARY_DISABLED_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_SECONDARY_COLOR" category="buttons">#34363dff</color>
-  <color name="BUTTON_SECONDARY_HOVER_COLOR" category="buttons">#34363dff</color>
-  <color name="BUTTON_SECONDARY_ACTIVE_COLOR" category="buttons">#34363dff</color>
+  <color name="BUTTON_SECONDARY_COLOR" category="buttons">#ff34363d</color>
+  <color name="BUTTON_SECONDARY_HOVER_COLOR" category="buttons">#ff34363d</color>
+  <color name="BUTTON_SECONDARY_ACTIVE_COLOR" category="buttons">#ff34363d</color>
   <property name="BUTTON_SECONDARY_BOX_SHADOW" category="buttons">none</property>
   <property name="BUTTON_SECONDARY_HOVER_BOX_SHADOW" category="buttons">none</property>
   <property name="BUTTON_SECONDARY_ACTIVE_BOX_SHADOW" category="buttons">none</property>
@@ -64,23 +64,23 @@
   <property name="BUTTON_SECONDARY_LINE_HEIGHT" category="buttons">20</property>
   <property name="BUTTON_DESTRUCTIVE_FONT_SIZE" category="buttons">14</property>
   <property name="BUTTON_DESTRUCTIVE_LINE_HEIGHT" category="buttons">20</property>
-  <color name="BUTTON_DESTRUCTIVE_COLOR" category="buttons">#c5000eff</color>
+  <color name="BUTTON_DESTRUCTIVE_COLOR" category="buttons">#ffc5000e</color>
   <property name="BUTTON_DESTRUCTIVE_BOX_SHADOW" category="buttons">none</property>
-  <color name="BUTTON_DESTRUCTIVE_HOVER_COLOR" category="buttons">#c5000eff</color>
+  <color name="BUTTON_DESTRUCTIVE_HOVER_COLOR" category="buttons">#ffc5000e</color>
   <property name="BUTTON_DESTRUCTIVE_HOVER_BOX_SHADOW" category="buttons">none</property>
-  <color name="BUTTON_DESTRUCTIVE_ACTIVE_COLOR" category="buttons">#ff5452ff</color>
+  <color name="BUTTON_DESTRUCTIVE_ACTIVE_COLOR" category="buttons">#ffff5452</color>
   <property name="BUTTON_DESTRUCTIVE_ACTIVE_BOX_SHADOW" category="buttons">0 0 0 3px #ff5452 inset</property>
-  <color name="BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_COLOR" category="buttons">#e6e4ebff</color>
+  <color name="BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_COLOR" category="buttons">#ffe6e4eb</color>
   <property name="BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_IMAGE" category="buttons">none</property>
-  <color name="BUTTON_DESTRUCTIVE_DISABLED_COLOR" category="buttons">#b2aebdff</color>
+  <color name="BUTTON_DESTRUCTIVE_DISABLED_COLOR" category="buttons">#ffb2aebd</color>
   <property name="BUTTON_DESTRUCTIVE_DISABLED_BOX_SHADOW" category="buttons">none</property>
   <property name="FONT_FAMILY_BASE" category="typesettings">'markweb', Helvetica, Arial, sans-serif</property>
-  <color name="LINK_COLOR" category="text-colors">#00bbccff</color>
+  <color name="LINK_COLOR" category="text-colors">#ff00bbcc</color>
   <property name="LINK_TEXT_DECORATION" category="text-decorations">none</property>
-  <color name="LINK_HOVER_COLOR" category="text-colors">#34363dff</color>
+  <color name="LINK_HOVER_COLOR" category="text-colors">#ff34363d</color>
   <property name="LINK_HOVER_TEXT_DECORATION" category="text-decorations">underline</property>
-  <color name="LINK_ACTIVE_COLOR" category="text-colors">#4d5059ff</color>
+  <color name="LINK_ACTIVE_COLOR" category="text-colors">#ff4d5059</color>
   <color name="LINK_WHITE_COLOR" category="text-colors">#ffffffff</color>
   <color name="LINK_WHITE_HOVER_COLOR" category="text-colors">#ffffffff</color>
-  <color name="LINK_WHITE_ACTIVE_COLOR" category="text-colors">#f7f7f7ff</color>
+  <color name="LINK_WHITE_ACTIVE_COLOR" category="text-colors">#fff7f7f7</color>
 </resources>

--- a/packages/bpk-tokens/tokens/travelpro.ios.json
+++ b/packages/bpk-tokens/tokens/travelpro.ios.json
@@ -28,6 +28,9 @@
       "category": "buttons",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "buttonBackgroundColor"
     },
     {
@@ -40,6 +43,9 @@
       "category": "buttons",
       "value": "rgb(77, 80, 89)",
       "type": "color",
+      ".alias": {
+        "value": "#4D5059"
+      },
       "name": "buttonHoverBackgroundColor"
     },
     {
@@ -52,6 +58,9 @@
       "category": "buttons",
       "value": "rgb(77, 80, 89)",
       "type": "color",
+      ".alias": {
+        "value": "#4D5059"
+      },
       "name": "buttonActiveBackgroundColor"
     },
     {
@@ -64,6 +73,9 @@
       "category": "buttons",
       "value": "rgba(0, 0, 0, 0.5)",
       "type": "color",
+      ".alias": {
+        "value": "rgba(0,0,0,0.5)"
+      },
       "name": "buttonDisabledBackgroundColor"
     },
     {
@@ -76,6 +88,9 @@
       "category": "buttons",
       "value": "rgb(0, 221, 238)",
       "type": "color",
+      ".alias": {
+        "value": "#00DDEE"
+      },
       "name": "buttonColor"
     },
     {
@@ -88,6 +103,9 @@
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "buttonDisabledColor"
     },
     {
@@ -148,6 +166,9 @@
       "category": "buttons",
       "value": "rgba(0, 0, 0, 0.5)",
       "type": "color",
+      ".alias": {
+        "value": "rgba(0,0,0,0.5)"
+      },
       "name": "buttonSecondaryBackgroundColor"
     },
     {
@@ -160,6 +181,9 @@
       "category": "buttons",
       "value": "rgba(0, 187, 204, 0.2)",
       "type": "color",
+      ".alias": {
+        "value": "rgba(0,187,204,0.2)"
+      },
       "name": "buttonSecondaryHoverBackgroundColor"
     },
     {
@@ -172,6 +196,9 @@
       "category": "buttons",
       "value": "rgba(0, 187, 204, 0.2)",
       "type": "color",
+      ".alias": {
+        "value": "rgba(0,187,204,0.2)"
+      },
       "name": "buttonSecondaryActiveBackgroundColor"
     },
     {
@@ -184,6 +211,9 @@
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "buttonSecondaryDisabledBackgroundColor"
     },
     {
@@ -196,18 +226,27 @@
       "category": "buttons",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "buttonSecondaryColor"
     },
     {
       "category": "buttons",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "buttonSecondaryHoverColor"
     },
     {
       "category": "buttons",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "buttonSecondaryActiveColor"
     },
     {
@@ -268,6 +307,9 @@
       "category": "buttons",
       "value": "rgb(197, 0, 14)",
       "type": "color",
+      ".alias": {
+        "value": "#C5000E"
+      },
       "name": "buttonDestructiveColor"
     },
     {
@@ -280,6 +322,9 @@
       "category": "buttons",
       "value": "rgb(197, 0, 14)",
       "type": "color",
+      ".alias": {
+        "value": "#C5000E"
+      },
       "name": "buttonDestructiveHoverColor"
     },
     {
@@ -292,18 +337,27 @@
       "category": "buttons",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "buttonDestructiveActiveColor"
     },
     {
       "category": "buttons",
       "value": "0 0 0 3px #ff5452 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "buttonDestructiveActiveBoxShadow"
     },
     {
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "buttonDestructiveDisabledBackgroundColor"
     },
     {
@@ -316,6 +370,9 @@
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "buttonDestructiveDisabledColor"
     },
     {
@@ -334,6 +391,9 @@
       "category": "text-colors",
       "value": "rgb(0, 187, 204)",
       "type": "color",
+      ".alias": {
+        "value": "#00BBCC"
+      },
       "name": "linkColor"
     },
     {
@@ -346,6 +406,9 @@
       "category": "text-colors",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "linkHoverColor"
     },
     {
@@ -358,24 +421,36 @@
       "category": "text-colors",
       "value": "rgb(77, 80, 89)",
       "type": "color",
+      ".alias": {
+        "value": "#4D5059"
+      },
       "name": "linkActiveColor"
     },
     {
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#FFFFFF"
+      },
       "name": "linkWhiteColor"
     },
     {
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#FFFFFF"
+      },
       "name": "linkWhiteHoverColor"
     },
     {
       "category": "text-colors",
       "value": "rgb(247, 247, 247)",
       "type": "color",
+      ".alias": {
+        "value": "#F7F7F7"
+      },
       "name": "linkWhiteActiveColor"
     }
   ]

--- a/packages/bpk-tokens/tokens/travelpro.raw.json
+++ b/packages/bpk-tokens/tokens/travelpro.raw.json
@@ -1,120 +1,350 @@
 {
   "aliases": {
-    "WHITE": "#FFFFFF",
-    "CLEAR": "#F0F0F0",
-    "FOG": "#F7F7F7",
-    "SPRINKLE": "#E7E7E8",
-    "MIST": "#C5CDCD",
-    "DRIZZLE": "A0A2A8",
-    "RAINY": "#878A95",
-    "DUSK": "#686B75",
-    "TURBULENCE": "#4D5059",
-    "THUNDER": "#3E4048",
-    "STORM": "#34363D",
-    "MIDNIGHT": "#232429",
-    "BLACK": "#000000",
-    "OVERCAST": "#00BBCC",
-    "SKY": "#00DDEE",
-    "WEED": "#22AA00",
-    "GRASS": "#66CC00",
-    "SUN": "#FFDE02",
-    "SUNSET": "#EE9900",
-    "FIRE": "#CC4400",
-    "RED": "#D0021B",
-    "BLOOD": "#C5000E",
-    "OVERCAST_TWENTY_PERCENT": "rgba(0,187,204,0.2)",
-    "OVERCAST_FIFTY_PERCENT": "rgba(0,187,204,0.5)",
-    "BLACK_FIFTY_PERCENT": "rgba(0,0,0,0.5)",
-    "BLUE_50": "#e1f4f8",
-    "BLUE_100": "#cbeef5",
-    "BLUE_200": "#b0e4ee",
-    "BLUE_300": "#7fd7e8",
-    "BLUE_400": "#40c4df",
-    "BLUE_500": "#00b2d6",
-    "BLUE_600": "#009dbd",
-    "BLUE_700": "#008ca8",
-    "BLUE_800": "#00758c",
-    "BLUE_900": "#005567",
-    "GRAY_50": "#F3F2F5",
-    "GRAY_100": "#E6E4EB",
-    "GRAY_200": "#CCC9D4",
-    "GRAY_300": "#B2AEBD",
-    "GRAY_400": "#9A95A7",
-    "GRAY_500": "#817B8F",
-    "GRAY_600": "#696179",
-    "GRAY_700": "#524C61",
-    "GRAY_800": "#3B344B",
-    "GRAY_900": "#252033",
-    "GREEN_50": "#dff7ec",
-    "GREEN_100": "#cbf5e2",
-    "GREEN_200": "#afedd1",
-    "GREEN_300": "#80e8b9",
-    "GREEN_400": "#40de97",
-    "GREEN_500": "#00d775",
-    "GREEN_600": "#00bd68",
-    "GREEN_700": "#00a85d",
-    "GREEN_800": "#008c4d",
-    "GREEN_900": "#006638",
-    "RED_50": "#fcf2f2",
-    "RED_100": "#ffd6d5",
-    "RED_200": "#ffbbba",
-    "RED_300": "#ff9694",
-    "RED_400": "#fe7471",
-    "RED_500": "#ff5452",
-    "RED_600": "#eb423f",
-    "RED_700": "#de322f",
-    "RED_800": "#cc1f1d",
-    "RED_900": "#a80300",
-    "YELLOW_50": "#FFF9E6",
-    "YELLOW_100": "#FFF3CF",
-    "YELLOW_200": "#FFECB8",
-    "YELLOW_300": "#FFE18C",
-    "YELLOW_400": "#FFCF4A",
-    "YELLOW_500": "#FFBB00",
-    "YELLOW_600": "#F0B000",
-    "YELLOW_700": "#E1A500",
-    "YELLOW_800": "#C28E00",
-    "YELLOW_900": "#9C7200",
-    "PINK_50": "#FDE4ED",
-    "PINK_100": "#FFBFD7",
-    "PINK_200": "#FF94BB",
-    "PINK_300": "#FF73A6",
-    "PINK_400": "#FF619B",
-    "PINK_500": "#FA488A",
-    "PINK_600": "#D92B6B",
-    "PINK_700": "#C50F52",
-    "PINK_800": "#B00C48",
-    "PINK_900": "#94053A",
-    "FONT_SIZE_SM": ".75rem",
-    "FONT_SIZE_BASE": "1rem",
-    "FONT_SIZE_LG": "1.5rem",
-    "FONT_SIZE_XL": "1.75rem",
-    "FONT_SIZE_XXL": "2.625rem",
-    "SPACING_XS": ".375rem",
-    "SPACING_SM": ".75rem",
-    "SPACING_MD": "1.125rem",
-    "SPACING_BASE": "1.5rem",
-    "SPACING_LG": "1.875rem",
-    "SPACING_XL": "2.250rem",
-    "SPACING_XXL": "2.625rem",
-    "BORDER_RADIUS_XS": ".1875rem",
-    "BORDER_RADIUS_SM": ".375rem",
-    "BORDER_RADIUS_PILL": "1.125rem",
-    "BORDER_RADIUS_PILL_LG": "1.3125rem",
-    "BORDER_SIZE_SM": "1px",
-    "BORDER_SIZE_LG": "2px",
-    "BORDER_SIZE_XL": "3px",
-    "BREAKPOINT_MOBILE": "32.25rem",
-    "BREAKPOINT_ABOVE_MOBILE": "32.3125rem",
-    "BREAKPOINT_TABLET": "50.25rem",
-    "BREAKPOINT_ABOVE_TABLET": "50.3125rem",
-    "BREAKPOINT_DESKTOP": "71.25rem",
-    "ONE_PIXEL_REM": ".0625rem",
-    "ZINDEX_AUTOSUGGEST": "900",
-    "ZINDEX_POPOVER": "900",
-    "ZINDEX_TOOLTIP": "900",
-    "ZINDEX_MODAL_SCRIM": "1000",
-    "ZINDEX_MODAL": "1100"
+    "WHITE": {
+      "value": "#FFFFFF"
+    },
+    "CLEAR": {
+      "value": "#F0F0F0"
+    },
+    "FOG": {
+      "value": "#F7F7F7"
+    },
+    "SPRINKLE": {
+      "value": "#E7E7E8"
+    },
+    "MIST": {
+      "value": "#C5CDCD"
+    },
+    "DRIZZLE": {
+      "value": "A0A2A8"
+    },
+    "RAINY": {
+      "value": "#878A95"
+    },
+    "DUSK": {
+      "value": "#686B75"
+    },
+    "TURBULENCE": {
+      "value": "#4D5059"
+    },
+    "THUNDER": {
+      "value": "#3E4048"
+    },
+    "STORM": {
+      "value": "#34363D"
+    },
+    "MIDNIGHT": {
+      "value": "#232429"
+    },
+    "BLACK": {
+      "value": "#000000"
+    },
+    "OVERCAST": {
+      "value": "#00BBCC"
+    },
+    "SKY": {
+      "value": "#00DDEE"
+    },
+    "WEED": {
+      "value": "#22AA00"
+    },
+    "GRASS": {
+      "value": "#66CC00"
+    },
+    "SUN": {
+      "value": "#FFDE02"
+    },
+    "SUNSET": {
+      "value": "#EE9900"
+    },
+    "FIRE": {
+      "value": "#CC4400"
+    },
+    "RED": {
+      "value": "#D0021B"
+    },
+    "BLOOD": {
+      "value": "#C5000E"
+    },
+    "OVERCAST_TWENTY_PERCENT": {
+      "value": "rgba(0,187,204,0.2)"
+    },
+    "OVERCAST_FIFTY_PERCENT": {
+      "value": "rgba(0,187,204,0.5)"
+    },
+    "BLACK_FIFTY_PERCENT": {
+      "value": "rgba(0,0,0,0.5)"
+    },
+    "BLUE_50": {
+      "value": "#e1f4f8"
+    },
+    "BLUE_100": {
+      "value": "#cbeef5"
+    },
+    "BLUE_200": {
+      "value": "#b0e4ee"
+    },
+    "BLUE_300": {
+      "value": "#7fd7e8"
+    },
+    "BLUE_400": {
+      "value": "#40c4df"
+    },
+    "BLUE_500": {
+      "value": "#00b2d6"
+    },
+    "BLUE_600": {
+      "value": "#009dbd"
+    },
+    "BLUE_700": {
+      "value": "#008ca8"
+    },
+    "BLUE_800": {
+      "value": "#00758c"
+    },
+    "BLUE_900": {
+      "value": "#005567"
+    },
+    "GRAY_50": {
+      "value": "#F3F2F5"
+    },
+    "GRAY_100": {
+      "value": "#E6E4EB"
+    },
+    "GRAY_200": {
+      "value": "#CCC9D4"
+    },
+    "GRAY_300": {
+      "value": "#B2AEBD"
+    },
+    "GRAY_400": {
+      "value": "#9A95A7"
+    },
+    "GRAY_500": {
+      "value": "#817B8F"
+    },
+    "GRAY_600": {
+      "value": "#696179"
+    },
+    "GRAY_700": {
+      "value": "#524C61"
+    },
+    "GRAY_800": {
+      "value": "#3B344B"
+    },
+    "GRAY_900": {
+      "value": "#252033"
+    },
+    "GREEN_50": {
+      "value": "#dff7ec"
+    },
+    "GREEN_100": {
+      "value": "#cbf5e2"
+    },
+    "GREEN_200": {
+      "value": "#afedd1"
+    },
+    "GREEN_300": {
+      "value": "#80e8b9"
+    },
+    "GREEN_400": {
+      "value": "#40de97"
+    },
+    "GREEN_500": {
+      "value": "#00d775"
+    },
+    "GREEN_600": {
+      "value": "#00bd68"
+    },
+    "GREEN_700": {
+      "value": "#00a85d"
+    },
+    "GREEN_800": {
+      "value": "#008c4d"
+    },
+    "GREEN_900": {
+      "value": "#006638"
+    },
+    "RED_50": {
+      "value": "#fcf2f2"
+    },
+    "RED_100": {
+      "value": "#ffd6d5"
+    },
+    "RED_200": {
+      "value": "#ffbbba"
+    },
+    "RED_300": {
+      "value": "#ff9694"
+    },
+    "RED_400": {
+      "value": "#fe7471"
+    },
+    "RED_500": {
+      "value": "#ff5452"
+    },
+    "RED_600": {
+      "value": "#eb423f"
+    },
+    "RED_700": {
+      "value": "#de322f"
+    },
+    "RED_800": {
+      "value": "#cc1f1d"
+    },
+    "RED_900": {
+      "value": "#a80300"
+    },
+    "YELLOW_50": {
+      "value": "#FFF9E6"
+    },
+    "YELLOW_100": {
+      "value": "#FFF3CF"
+    },
+    "YELLOW_200": {
+      "value": "#FFECB8"
+    },
+    "YELLOW_300": {
+      "value": "#FFE18C"
+    },
+    "YELLOW_400": {
+      "value": "#FFCF4A"
+    },
+    "YELLOW_500": {
+      "value": "#FFBB00"
+    },
+    "YELLOW_600": {
+      "value": "#F0B000"
+    },
+    "YELLOW_700": {
+      "value": "#E1A500"
+    },
+    "YELLOW_800": {
+      "value": "#C28E00"
+    },
+    "YELLOW_900": {
+      "value": "#9C7200"
+    },
+    "PINK_50": {
+      "value": "#FDE4ED"
+    },
+    "PINK_100": {
+      "value": "#FFBFD7"
+    },
+    "PINK_200": {
+      "value": "#FF94BB"
+    },
+    "PINK_300": {
+      "value": "#FF73A6"
+    },
+    "PINK_400": {
+      "value": "#FF619B"
+    },
+    "PINK_500": {
+      "value": "#FA488A"
+    },
+    "PINK_600": {
+      "value": "#D92B6B"
+    },
+    "PINK_700": {
+      "value": "#C50F52"
+    },
+    "PINK_800": {
+      "value": "#B00C48"
+    },
+    "PINK_900": {
+      "value": "#94053A"
+    },
+    "FONT_SIZE_SM": {
+      "value": ".75rem"
+    },
+    "FONT_SIZE_BASE": {
+      "value": "1rem"
+    },
+    "FONT_SIZE_LG": {
+      "value": "1.5rem"
+    },
+    "FONT_SIZE_XL": {
+      "value": "1.75rem"
+    },
+    "FONT_SIZE_XXL": {
+      "value": "2.625rem"
+    },
+    "SPACING_XS": {
+      "value": ".375rem"
+    },
+    "SPACING_SM": {
+      "value": ".75rem"
+    },
+    "SPACING_MD": {
+      "value": "1.125rem"
+    },
+    "SPACING_BASE": {
+      "value": "1.5rem"
+    },
+    "SPACING_LG": {
+      "value": "1.875rem"
+    },
+    "SPACING_XL": {
+      "value": "2.250rem"
+    },
+    "SPACING_XXL": {
+      "value": "2.625rem"
+    },
+    "BORDER_RADIUS_XS": {
+      "value": ".1875rem"
+    },
+    "BORDER_RADIUS_SM": {
+      "value": ".375rem"
+    },
+    "BORDER_RADIUS_PILL": {
+      "value": "1.125rem"
+    },
+    "BORDER_RADIUS_PILL_LG": {
+      "value": "1.3125rem"
+    },
+    "BORDER_SIZE_SM": {
+      "value": "1px"
+    },
+    "BORDER_SIZE_LG": {
+      "value": "2px"
+    },
+    "BORDER_SIZE_XL": {
+      "value": "3px"
+    },
+    "BREAKPOINT_MOBILE": {
+      "value": "32.25rem"
+    },
+    "BREAKPOINT_ABOVE_MOBILE": {
+      "value": "32.3125rem"
+    },
+    "BREAKPOINT_TABLET": {
+      "value": "50.25rem"
+    },
+    "BREAKPOINT_ABOVE_TABLET": {
+      "value": "50.3125rem"
+    },
+    "BREAKPOINT_DESKTOP": {
+      "value": "71.25rem"
+    },
+    "ONE_PIXEL_REM": {
+      "value": ".0625rem"
+    },
+    "ZINDEX_AUTOSUGGEST": {
+      "value": "900"
+    },
+    "ZINDEX_POPOVER": {
+      "value": "900"
+    },
+    "ZINDEX_TOOLTIP": {
+      "value": "900"
+    },
+    "ZINDEX_MODAL_SCRIM": {
+      "value": "1000"
+    },
+    "ZINDEX_MODAL": {
+      "value": "1100"
+    }
   },
   "props": {
     "BUTTON_PADDING_Y": {
@@ -145,6 +375,9 @@
       "category": "buttons",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "BUTTON_BACKGROUND_COLOR"
     },
     "BUTTON_BACKGROUND_IMAGE": {
@@ -157,6 +390,9 @@
       "category": "buttons",
       "value": "rgb(77, 80, 89)",
       "type": "color",
+      ".alias": {
+        "value": "#4D5059"
+      },
       "name": "BUTTON_HOVER_BACKGROUND_COLOR"
     },
     "BUTTON_HOVER_BACKGROUND_IMAGE": {
@@ -169,6 +405,9 @@
       "category": "buttons",
       "value": "rgb(77, 80, 89)",
       "type": "color",
+      ".alias": {
+        "value": "#4D5059"
+      },
       "name": "BUTTON_ACTIVE_BACKGROUND_COLOR"
     },
     "BUTTON_ACTIVE_BACKGROUND_IMAGE": {
@@ -181,6 +420,9 @@
       "category": "buttons",
       "value": "rgba(0, 0, 0, 0.5)",
       "type": "color",
+      ".alias": {
+        "value": "rgba(0,0,0,0.5)"
+      },
       "name": "BUTTON_DISABLED_BACKGROUND_COLOR"
     },
     "BUTTON_DISABLED_BACKGROUND_IMAGE": {
@@ -193,6 +435,9 @@
       "category": "buttons",
       "value": "rgb(0, 221, 238)",
       "type": "color",
+      ".alias": {
+        "value": "#00DDEE"
+      },
       "name": "BUTTON_COLOR"
     },
     "BUTTON_FONT_WEIGHT": {
@@ -205,6 +450,9 @@
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "BUTTON_DISABLED_COLOR"
     },
     "BUTTON_FONT_SIZE": {
@@ -265,6 +513,9 @@
       "category": "buttons",
       "value": "rgba(0, 0, 0, 0.5)",
       "type": "color",
+      ".alias": {
+        "value": "rgba(0,0,0,0.5)"
+      },
       "name": "BUTTON_SECONDARY_BACKGROUND_COLOR"
     },
     "BUTTON_SECONDARY_BACKGROUND_IMAGE": {
@@ -277,6 +528,9 @@
       "category": "buttons",
       "value": "rgba(0, 187, 204, 0.2)",
       "type": "color",
+      ".alias": {
+        "value": "rgba(0,187,204,0.2)"
+      },
       "name": "BUTTON_SECONDARY_HOVER_BACKGROUND_COLOR"
     },
     "BUTTON_SECONDARY_HOVER_BACKGROUND_IMAGE": {
@@ -289,6 +543,9 @@
       "category": "buttons",
       "value": "rgba(0, 187, 204, 0.2)",
       "type": "color",
+      ".alias": {
+        "value": "rgba(0,187,204,0.2)"
+      },
       "name": "BUTTON_SECONDARY_ACTIVE_BACKGROUND_COLOR"
     },
     "BUTTON_SECONDARY_ACTIVE_BACKGROUND_IMAGE": {
@@ -301,6 +558,9 @@
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "BUTTON_SECONDARY_DISABLED_BACKGROUND_COLOR"
     },
     "BUTTON_SECONDARY_DISABLED_BACKGROUND_IMAGE": {
@@ -313,18 +573,27 @@
       "category": "buttons",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "BUTTON_SECONDARY_COLOR"
     },
     "BUTTON_SECONDARY_HOVER_COLOR": {
       "category": "buttons",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "BUTTON_SECONDARY_HOVER_COLOR"
     },
     "BUTTON_SECONDARY_ACTIVE_COLOR": {
       "category": "buttons",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "BUTTON_SECONDARY_ACTIVE_COLOR"
     },
     "BUTTON_SECONDARY_BOX_SHADOW": {
@@ -385,6 +654,9 @@
       "category": "buttons",
       "value": "rgb(197, 0, 14)",
       "type": "color",
+      ".alias": {
+        "value": "#C5000E"
+      },
       "name": "BUTTON_DESTRUCTIVE_COLOR"
     },
     "BUTTON_DESTRUCTIVE_BOX_SHADOW": {
@@ -397,6 +669,9 @@
       "category": "buttons",
       "value": "rgb(197, 0, 14)",
       "type": "color",
+      ".alias": {
+        "value": "#C5000E"
+      },
       "name": "BUTTON_DESTRUCTIVE_HOVER_COLOR"
     },
     "BUTTON_DESTRUCTIVE_HOVER_BOX_SHADOW": {
@@ -409,18 +684,27 @@
       "category": "buttons",
       "value": "rgb(255, 84, 82)",
       "type": "color",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "BUTTON_DESTRUCTIVE_ACTIVE_COLOR"
     },
     "BUTTON_DESTRUCTIVE_ACTIVE_BOX_SHADOW": {
       "category": "buttons",
       "value": "0 0 0 3px #ff5452 inset",
       "type": "box-shadow",
+      ".alias": {
+        "value": "#ff5452"
+      },
       "name": "BUTTON_DESTRUCTIVE_ACTIVE_BOX_SHADOW"
     },
     "BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_COLOR": {
       "category": "buttons",
       "value": "rgb(230, 228, 235)",
       "type": "color",
+      ".alias": {
+        "value": "#E6E4EB"
+      },
       "name": "BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_COLOR"
     },
     "BUTTON_DESTRUCTIVE_DISABLED_BACKGROUND_IMAGE": {
@@ -433,6 +717,9 @@
       "category": "buttons",
       "value": "rgb(178, 174, 189)",
       "type": "color",
+      ".alias": {
+        "value": "#B2AEBD"
+      },
       "name": "BUTTON_DESTRUCTIVE_DISABLED_COLOR"
     },
     "BUTTON_DESTRUCTIVE_DISABLED_BOX_SHADOW": {
@@ -451,6 +738,9 @@
       "category": "text-colors",
       "value": "rgb(0, 187, 204)",
       "type": "color",
+      ".alias": {
+        "value": "#00BBCC"
+      },
       "name": "LINK_COLOR"
     },
     "LINK_TEXT_DECORATION": {
@@ -463,6 +753,9 @@
       "category": "text-colors",
       "value": "rgb(52, 54, 61)",
       "type": "color",
+      ".alias": {
+        "value": "#34363D"
+      },
       "name": "LINK_HOVER_COLOR"
     },
     "LINK_HOVER_TEXT_DECORATION": {
@@ -475,24 +768,36 @@
       "category": "text-colors",
       "value": "rgb(77, 80, 89)",
       "type": "color",
+      ".alias": {
+        "value": "#4D5059"
+      },
       "name": "LINK_ACTIVE_COLOR"
     },
     "LINK_WHITE_COLOR": {
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#FFFFFF"
+      },
       "name": "LINK_WHITE_COLOR"
     },
     "LINK_WHITE_HOVER_COLOR": {
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
       "type": "color",
+      ".alias": {
+        "value": "#FFFFFF"
+      },
       "name": "LINK_WHITE_HOVER_COLOR"
     },
     "LINK_WHITE_ACTIVE_COLOR": {
       "category": "text-colors",
       "value": "rgb(247, 247, 247)",
       "type": "color",
+      ".alias": {
+        "value": "#F7F7F7"
+      },
       "name": "LINK_WHITE_ACTIVE_COLOR"
     }
   },


### PR DESCRIPTION
Breaking changes from `theo@^4.0.0` => `theo@^5.0.0`:

- Breaking change: removed the color/hex8 transform. Instead, use color/hex8argb in Android, and color/hex8rgba in, for example, CSS level 4 values
- Breaking change: Node.js 6 and up is required
- Dropped support for Node.js v4
- Theo v5 is now compatible with Node.js v6.3 and up, dropping support for Node.js v4.
- Pointing to a non-existing alias now throws an error instead of failing silently.
- Lodash's implementation of kebabCase was dropped because it separated numbers as words:
-- Lodash: A1 -> a-1
-- Theo: A1 -> a1

(See https://github.com/salesforce-ux/theo/blob/master/CHANGELOG.md).
