### PR TITLE
[BPK-817] Opt for css media queries over BpkBreakpoint

### DIFF
--- a/packages/bpk-docs/src/components/Heading/Heading.js
+++ b/packages/bpk-docs/src/components/Heading/Heading.js
@@ -18,158 +18,39 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import BpkText from 'bpk-component-text';
-import BpkBreakpoint, { BREAKPOINTS } from 'bpk-component-breakpoint';
-
-import { cssModules, withDefaultProps } from 'bpk-react-utils';
+import { cssModules } from 'bpk-react-utils';
 
 import STYLES from './Heading.scss';
 
 const getClassName = cssModules(STYLES);
-const className = getClassName('bpk-docs-heading');
 
-const HEADINGS = {
-  h1: {
-    mobile: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'xl',
-        tagName: 'h1',
-        bold: false,
-        className,
-      },
-    ),
-    other: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'xxl',
-        tagName: 'h1',
-        bold: false,
-        className,
-      },
-    ),
-  },
-  h2: {
-    mobile: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'lg',
-        tagName: 'h2',
-        bold: false,
-        className,
-      },
-    ),
-    other: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'xl',
-        tagName: 'h2',
-        bold: false,
-        className,
-      },
-    ),
-  },
-  h3: {
-    mobile: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'base',
-        tagName: 'h3',
-        bold: true,
-        className,
-      },
-    ),
-    other: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'lg',
-        tagName: 'h3',
-        bold: false,
-        className,
-      },
-    ),
-  },
-  h4: {
-    mobile: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'sm',
-        tagName: 'h4',
-        bold: true,
-        className,
-      },
-    ),
-    other: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'base',
-        tagName: 'h4',
-        bold: false,
-        className,
-      },
-    ),
-  },
-  h5: {
-    mobile: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'xs',
-        tagName: 'h5',
-        bold: true,
-        className,
-      },
-    ),
-    other: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'sm',
-        tagName: 'h5',
-        bold: false,
-        className,
-      },
-    ),
-  },
-  h6: {
-    mobile: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'xs',
-        tagName: 'h6',
-        bold: true,
-        className,
-      },
-    ),
-    other: withDefaultProps(
-      BpkText,
-      {
-        textStyle: 'sm',
-        tagName: 'h6',
-        bold: false,
-        className,
-      },
-    ),
-  },
+const HEADINGS_LEVELS = {
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  h5: 'h5',
+  h6: 'h6',
 };
 
 const Heading = (props) => {
-  const { level, ...rest } = props;
+  const { level: TagName, className, ...rest } = props;
 
-  const Component = HEADINGS[level];
+  const classNames = [getClassName('bpk-docs-heading')];
+  classNames.push(getClassName(`bpk-docs-heading--${TagName}`));
 
-  if (!Component) {
-    return null;
-  }
+  if (className) { classNames.push(className); }
 
-  return (
-    <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
-      {isMobile => Component[isMobile ? 'mobile' : 'other']({ ...rest })}
-    </BpkBreakpoint>
-  );
+  return <TagName className={classNames.join(' ')} {...rest} />;
 };
 
-
 Heading.propTypes = {
-  level: PropTypes.oneOf(Object.keys(HEADINGS)).isRequired,
+  level: PropTypes.oneOf(Object.keys(HEADINGS_LEVELS)).isRequired,
+  className: PropTypes.string,
+};
+
+Heading.defaultProps = {
+  className: null,
 };
 
 

--- a/packages/bpk-docs/src/components/Heading/Heading.scss
+++ b/packages/bpk-docs/src/components/Heading/Heading.scss
@@ -21,4 +21,56 @@
 .bpk-docs-heading {
   margin-top: 0;
   margin-bottom: $bpk-spacing-sm;
+
+  &--h1 {
+    @include bpk-text-xxl;
+
+    @include bpk-breakpoint-mobile {
+      @include bpk-text-xl;
+    }
+  }
+
+  &--h2 {
+    @include bpk-text-xl;
+
+    @include bpk-breakpoint-mobile {
+      @include bpk-text-lg;
+    }
+  }
+
+  &--h3 {
+    @include bpk-text-lg;
+
+    @include bpk-breakpoint-mobile {
+      @include bpk-text-base;
+      @include bpk-text-bold;
+    }
+  }
+
+  &--h4 {
+    @include bpk-text-base;
+
+    @include bpk-breakpoint-mobile {
+      @include bpk-text-sm;
+      @include bpk-text-bold;
+    }
+  }
+
+  &--h5 {
+    @include bpk-text-sm;
+
+    @include bpk-breakpoint-mobile {
+      @include bpk-text-xs;
+      @include bpk-text-bold;
+    }
+  }
+
+  &--h6 {
+    @include bpk-text-sm;
+
+    @include bpk-breakpoint-mobile {
+      @include bpk-text-xs;
+      @include bpk-text-bold;
+    }
+  }
 }


### PR DESCRIPTION
BpkBreakpoint uses `window.matchMedia` based mechanism to render "media queries" declaratively. We use SSR on the docs site an thus we need to media queries to work on first paint.