### PR TITLE
[BPK-788] Updated block-quote scss to match Jon Hicks' design

### DIFF
--- a/packages/bpk-component-blockquote/readme.md
+++ b/packages/bpk-component-blockquote/readme.md
@@ -15,7 +15,7 @@ import React from 'react';
 import BpkBlockquote from 'bpk-component-blockquote';
 
 export default () => (
-  <BpkBlockquote>
+  <BpkBlockquote extraSpace>
     Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
     commodo ligula eget dolor. Aenean massa. Cum sociis natoque
     penatibus et magnis dis parturient montes, nascetur ridiculus mus.
@@ -25,6 +25,7 @@ export default () => (
 
 ## Props
 
-| Property  | PropType | Required | Default Value |
-| --------- | -------- | -------- | ------------- |
-| children  | -        | true     | -             |
+| Property    | PropType | Required | Default Value |
+| ----------- | -------- | -------- | ------------- |
+| children    | -        | true     | -             |
+| extraSpace  | bool     | false    | false         |

--- a/packages/bpk-component-blockquote/src/BpkBlockquote-test.js
+++ b/packages/bpk-component-blockquote/src/BpkBlockquote-test.js
@@ -30,5 +30,14 @@ describe('BpkBlockquote', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('should render correctly with additional spacing', () => {
+    const tree = renderer.create(
+      <BpkBlockquote extraSpace>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum
+        sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+      </BpkBlockquote>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });
 

--- a/packages/bpk-component-blockquote/src/BpkBlockquote.js
+++ b/packages/bpk-component-blockquote/src/BpkBlockquote.js
@@ -24,13 +24,31 @@ import STYLES from './bpk-blockquote.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkBlockquote = props => <blockquote className={getClassName('bpk-blockquote')}>{props.children}</blockquote>;
+const BpkBlockquote = (props) => {
+  const classNames = [getClassName('bpk-blockquote')];
+  if (props.extraSpace) {
+    classNames.push(getClassName('bpk-blockquote--extra-spacing'));
+  }
+
+  return (
+    <blockquote
+      className={classNames.join(' ')}
+    >
+      {props.children}
+    </blockquote>
+  );
+};
 
 BpkBlockquote.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]).isRequired,
+  extraSpace: PropTypes.bool,
+};
+
+BpkBlockquote.defaultProps = {
+  extraSpace: false,
 };
 
 export default BpkBlockquote;

--- a/packages/bpk-component-blockquote/src/__snapshots__/BpkBlockquote-test.js.snap
+++ b/packages/bpk-component-blockquote/src/__snapshots__/BpkBlockquote-test.js.snap
@@ -7,3 +7,11 @@ exports[`BpkBlockquote should render correctly 1`] = `
   Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
 </blockquote>
 `;
+
+exports[`BpkBlockquote should render correctly with additional spacing 1`] = `
+<blockquote
+  className="bpk-blockquote bpk-blockquote--extra-spacing"
+>
+  Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+</blockquote>
+`;

--- a/packages/bpk-component-blockquote/src/bpk-blockquote.scss
+++ b/packages/bpk-component-blockquote/src/bpk-blockquote.scss
@@ -21,3 +21,7 @@
 .bpk-blockquote {
   @include bpk-blockquote;
 }
+
+.bpk-blockquote--extra-spacing {
+  @include bpk-blockquote--extra-spacing;
+}

--- a/packages/bpk-component-blockquote/stories.js
+++ b/packages/bpk-component-blockquote/stories.js
@@ -22,8 +22,14 @@ import { storiesOf } from '@storybook/react';
 import BpkBlockquote from './index';
 
 storiesOf('bpk-component-blockquote', module)
-  .add('Example', () => (
+  .add('Default example', () => (
     <BpkBlockquote>
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum
+      sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </BpkBlockquote>
+  ))
+  .add('Example with additional spacing (above and below)', () => (
+    <BpkBlockquote extraSpace>
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum
       sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
     </BpkBlockquote>

--- a/packages/bpk-docs/src/pages/BaseStylesheetPage/BaseStylesheetPage.js
+++ b/packages/bpk-docs/src/pages/BaseStylesheetPage/BaseStylesheetPage.js
@@ -65,7 +65,7 @@ const BaseStylesheetPage = () => (
         </BpkListItem>
         <BpkListItem>That&apos;s it!</BpkListItem>
       </BpkList>
-      <BpkBlockquote>
+      <BpkBlockquote extraSpace>
         <strong>Note:</strong> There is also a small amount of JavaScript that does
         &quot;<BpkLink href="https://modernizr.com/" blank>Modernizr</BpkLink> like&quot; feature detection (currently
         used to prevent hover effects on touch devices in downstream components) - make sure this is included in the

--- a/packages/bpk-docs/src/pages/GettingStartedPage/GettingStartedPage.js
+++ b/packages/bpk-docs/src/pages/GettingStartedPage/GettingStartedPage.js
@@ -68,7 +68,7 @@ ReactDom.render(myComponent, document.getElementById('react-mount'));
           </BpkCodeBlock>
         </BpkListItem>
       </BpkList>,
-      <BpkBlockquote>
+      <BpkBlockquote extraSpace>
         <strong>Note:</strong> If you are looking to integrate Backpack components into an existing project, be
         aware that components are published uncompiled which means you&apos;ll need to accommodate for this in your
         webpack config.
@@ -98,7 +98,7 @@ ReactDom.render(myComponent, document.getElementById('react-mount'));
   @include bpk-button;
 }`}
       </BpkCodeBlock>,
-      <BpkBlockquote>
+      <BpkBlockquote extraSpace>
         <strong>Note</strong>: <BpkCode>bpk-mixins</BpkCode> only
         supports <BpkLink href={nodeSassUrl} blank>node-sass</BpkLink> and makes extensive use
         of <BpkLink href={sassLoaderTildeUrl} blank>sass-loader&apos;s</BpkLink> tilde importing mechanism. If you are

--- a/packages/bpk-docs/src/pages/LayoutPage/LayoutPage.js
+++ b/packages/bpk-docs/src/pages/LayoutPage/LayoutPage.js
@@ -83,7 +83,7 @@ const components = [
         building blocks: containers, rows and columns. Containers are used to encapsulate the entire layout (all rows).
         Rows are used to act as container to columns and columns are used to horizontally layout content.
       </Paragraph>,
-      <BpkBlockquote>
+      <BpkBlockquote extraSpace>
         <strong>Note:</strong> The Backpack grid is intended to be used for overall page layout as opposed to spacing
         out atom or molecule level components. Please stick to flexbox based techniques for more intricate
         layouts (or <BpkCode>display: table;</BpkCode> for browsers which lack support), just be sure to use the spacing

--- a/packages/bpk-docs/src/pages/TypographyPage/TypographyPage.js
+++ b/packages/bpk-docs/src/pages/TypographyPage/TypographyPage.js
@@ -45,7 +45,7 @@ const components = [
         heading tags, a span or a paragraph. You can mix different text styles with the
         appropriate tag to achieve semantic markup while retaining control over how the text looks.
       </Paragraph>,
-      <BpkBlockquote>
+      <BpkBlockquote extraSpace>
         <BpkText bold>Note:</BpkText> Whilst <BpkCode>BpkText</BpkCode> allows for any combination of text size and
         heading levels, we recommend that visual hierarchy is maintained inline with the semantic structure.
       </BpkBlockquote>,
@@ -138,7 +138,7 @@ const components = [
     id: 'blockquotes',
     title: 'Blockquotes',
     examples: [
-      <BpkBlockquote>
+      <BpkBlockquote extraSpace>
         Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum
         sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
       </BpkBlockquote>,

--- a/packages/bpk-mixins/src/mixins/_typography.scss
+++ b/packages/bpk-mixins/src/mixins/_typography.scss
@@ -17,6 +17,7 @@
  */
 
 @import '../bonds';
+@import './borders';
 
 ////
 /// @group typography
@@ -663,17 +664,36 @@
 
 @mixin bpk-blockquote {
   margin: 0 0 $bpk-spacing-sm 0;
-  padding: $bpk-spacing-sm;
-  border-left: solid $bpk-spacing-sm $bpk-color-gray-50;
+  padding: $bpk-spacing-xs $bpk-spacing-xs $bpk-spacing-xs $bpk-spacing-md;
+  color: $bpk-color-gray-500;
+
+  @include bpk-border-left-lg($bpk-color-blue-500);
 
   @include bpk-rtl {
-    border-right: solid $bpk-spacing-sm $bpk-color-gray-50;
+    padding: $bpk-spacing-xs $bpk-spacing-md $bpk-spacing-xs $bpk-spacing-xs;
     border-left: 0;
+
+    @include bpk-border-right-lg($bpk-color-blue-500);
   }
 
   > *:last-child {
     margin-bottom: 0;
   }
+}
+
+/// Adds additional spacing above and below blockquotes. Modifies the bpk-blockquote mixin.
+///
+/// @require {mixin} bpk-blockquote
+///
+/// @example scss
+///   .selector {
+///     @include bpk-blockquote();
+///     @include bpk-blockquote--extra-spacing();
+///   }
+
+@mixin bpk-blockquote--extra-spacing {
+  margin-top: $bpk-spacing-lg;
+  margin-bottom: $bpk-spacing-lg;
 }
 
 /// Content container.


### PR DESCRIPTION
+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
