### PR TITLE
[BPK-784] Align postcss config across webpack configs

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,13 +1,12 @@
 const fs = require('fs');
 const path = require('path');
-const autoprefixer = require('autoprefixer');
-const sassFunctions = require('../packages/bpk-mixins/sass-functions');
-const postCssFlexbugsFixes = require('postcss-flexbugs-fixes');
 
-const BPK_TOKENS = process.env.BPK_TOKENS;
+const sassFunctions = require('./../packages/bpk-mixins/sass-functions');
+const postCssPlugins = require('./../scripts/webpack/postCssPlugins');
+
+const { BPK_TOKENS, ENABLE_CSS_MODULES } = process.env;
 const rootDir = path.resolve(__dirname, '../');
-const ENABLE_CSS_MODULES = process.env.ENABLE_CSS_MODULES !== 'false';
-
+const useCssModules = ENABLE_CSS_MODULES !== 'false';
 
 module.exports = {
   module: {
@@ -22,25 +21,14 @@ module.exports = {
             loader: 'css-loader',
             options: {
               importLoaders: 1,
-              modules: ENABLE_CSS_MODULES,
-              localIdentName: '[local]--[hash:base64:5]',
+              modules: useCssModules,
+              localIdentName: '[local]-[hash:base64:5]',
             },
           },
           {
             loader: 'postcss-loader',
             options: {
-              plugins: () => [
-                postCssFlexbugsFixes,
-                autoprefixer({
-                  browsers: [
-                    '>1%',
-                    'last 4 versions',
-                    'Firefox ESR',
-                    'not ie < 9',
-                  ],
-                  flexbox: 'no-2009',
-                }),
-              ],
+              plugins: postCssPlugins,
             },
           },
           {
@@ -49,39 +37,6 @@ module.exports = {
               data: BPK_TOKENS ?
                 fs.readFileSync(path.join(rootDir, `packages/bpk-tokens/tokens/${BPK_TOKENS}.scss`)) : '',
               functions: sassFunctions,
-            },
-          },
-        ],
-      },
-      {
-        test: /\.css$/,
-        use: [
-          {
-            loader: 'style-loader',
-          },
-          {
-            loader: 'css-loader',
-            options: {
-              importLoaders: 1,
-              modules: ENABLE_CSS_MODULES,
-              localIdentName: '[local]--[hash:base64:5]',
-            },
-          },
-          {
-            loader: 'postcss-loader',
-            options: {
-              plugins: () => [
-                postCssFlexbugsFixes,
-                autoprefixer({
-                  browsers: [
-                    '>1%',
-                    'last 4 versions',
-                    'Firefox ESR',
-                    'not ie < 9',
-                  ],
-                  flexbox: 'no-2009',
-                }),
-              ],
             },
           },
         ],

--- a/packages/bpk-stylesheets/webpack.config.babel.js
+++ b/packages/bpk-stylesheets/webpack.config.babel.js
@@ -16,13 +16,11 @@
  * limitations under the License.
  */
 
-import autoprefixer from 'autoprefixer';
-import ExtractTextPlugin from 'extract-text-webpack-plugin';
-
-import postCssFlexbugsFixes from 'postcss-flexbugs-fixes';
 import WrapperPlugin from 'wrapper-webpack-plugin';
-
+import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import { blockComment as licenseHeader } from 'bpk-tokens/formatters/license-header';
+
+import postCssPlugins from './../../scripts/webpack/postCssPlugins';
 
 module.exports = {
   entry: {
@@ -55,18 +53,7 @@ module.exports = {
             {
               loader: 'postcss-loader',
               options: {
-                plugins: () => [
-                  postCssFlexbugsFixes,
-                  autoprefixer({
-                    browsers: [
-                      '>1%',
-                      'last 4 versions',
-                      'Firefox ESR',
-                      'not ie < 9', // React doesn't support IE8 anyway
-                    ],
-                    flexbox: 'no-2009',
-                  }),
-                ],
+                plugins: postCssPlugins,
               },
             },
             {
@@ -90,18 +77,7 @@ module.exports = {
             {
               loader: 'postcss-loader',
               options: {
-                plugins: () => [
-                  postCssFlexbugsFixes,
-                  autoprefixer({
-                    browsers: [
-                      '>1%',
-                      'last 4 versions',
-                      'Firefox ESR',
-                      'not ie < 9', // React doesn't support IE8 anyway
-                    ],
-                    flexbox: 'no-2009',
-                  }),
-                ],
+                plugins: postCssPlugins,
               },
             },
           ],

--- a/scripts/webpack/postCssPlugins.js
+++ b/scripts/webpack/postCssPlugins.js
@@ -1,0 +1,15 @@
+const autoprefixer = require('autoprefixer');
+const postCssFlexbugsFixes = require('postcss-flexbugs-fixes');
+
+module.exports = () => [
+  postCssFlexbugsFixes,
+  autoprefixer({
+    browsers: [
+      '>1%',
+      'last 4 versions',
+      'Firefox ESR',
+      'not ie < 9',
+    ],
+    flexbox: 'no-2009',
+  }),
+];

--- a/scripts/webpack/postCssPlugins.js
+++ b/scripts/webpack/postCssPlugins.js
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const autoprefixer = require('autoprefixer');
 const postCssFlexbugsFixes = require('postcss-flexbugs-fixes');
 


### PR DESCRIPTION
Configs exist for docs site, storybook and base stylesheet.
Removed the `*.css` loader in the storybook config as this appears unused.

+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.