### PR TITLE
[No Jira] Allow custom className and other arbitrary props for bpk-component-banner-alert

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## UNRELEASED
 
-_Nothing yet_
+**Fixed:**
+- bpk-component-banner-alert
+  - Added support for a custom className and other arbitrary props
 
 ## 2017-08-08 - Enhancements to Chip, bug fixed for popover and modal
 

--- a/packages/bpk-component-banner-alert/readme.md
+++ b/packages/bpk-component-banner-alert/readme.md
@@ -35,3 +35,4 @@ export default () => (
 | ariaLive          | ARIA_LIVE (one of)   | false    | 'assertive'   |
 | children          | node                 | false    | null          |
 | toggleButtonLabel | string               | false    | null          |
+| className         | string               | no       | null          |

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
@@ -61,4 +61,18 @@ describe('BpkBannerAlert', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with a custom class name', () => {
+    const tree = renderer.create(
+      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} className="custom-class" />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with arbitrary props', () => {
+    const tree = renderer.create(
+      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} id="custom-id" hidden="hidden" />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
@@ -97,38 +97,40 @@ class BpkBannerAlert extends Component {
   }
 
   render() {
+    const { children, className, type, ariaLive, message, toggleButtonLabel, ...rest } = this.props;
     const isExpanded = this.state.expanded;
-    const isExpandable = this.props.children;
+    const isExpandable = children;
     const showChildren = isExpandable && isExpanded;
 
     const headerClassNames = [getClassName('bpk-banner-alert__header')];
-    const sectionClassNames = ['bpk-banner-alert', `bpk-banner-alert--${this.props.type}`]
-      .map(className => getClassName(className));
+    const sectionClassNames = ['bpk-banner-alert', `bpk-banner-alert--${type}`]
+      .map(sectionClassName => getClassName(sectionClassName));
 
+    if (className) { sectionClassNames.push(className); }
     if (isExpandable) { headerClassNames.push(getClassName('bpk-banner-alert__header--expandable')); }
 
     /* eslint-disable jsx-a11y/no-static-element-interactions */
     return (
-      <section className={sectionClassNames.join(' ')}>
+      <section className={sectionClassNames.join(' ')} {...rest}>
         <header
           role="alert"
-          aria-live={this.props.ariaLive}
+          aria-live={ariaLive}
           className={headerClassNames.join(' ')}
           onClick={this.onExpand}
         >
-          <span className={getClassName('bpk-banner-alert__icon')}>{getIconForType(this.props.type)}</span>
+          <span className={getClassName('bpk-banner-alert__icon')}>{getIconForType(type)}</span>
           &nbsp;
-          <span className={getClassName('bpk-banner-alert__message')}>{this.props.message}</span>
+          <span className={getClassName('bpk-banner-alert__message')}>{message}</span>
           &nbsp;
           {isExpandable ? (
             <span className={getClassName('bpk-banner-alert__toggle')}>
-              <ToggleButton expanded={isExpanded} label={this.props.toggleButtonLabel} />
+              <ToggleButton expanded={isExpanded} label={toggleButtonLabel} />
             </span>
           ) : null}
         </header>
         {
           showChildren ?
-            <div className={getClassName('bpk-banner-alert__children-container')}>{this.props.children}</div>
+            <div className={getClassName('bpk-banner-alert__children-container')}>{children}</div>
             : null
         }
       </section>
@@ -151,12 +153,14 @@ BpkBannerAlert.propTypes = {
   ]),
   children: PropTypes.node,
   toggleButtonLabel: PropTypes.string,
+  className: PropTypes.string,
 };
 
 BpkBannerAlert.defaultProps = {
   ariaLive: ARIA_LIVE.ASSERTIVE,
   children: null,
   toggleButtonLabel: null,
+  className: null,
 };
 
 export default BpkBannerAlert;

--- a/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.js.snap
+++ b/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.js.snap
@@ -159,6 +159,59 @@ exports[`BpkBannerAlert should render correctly with "type" attribute equal to "
 </section>
 `;
 
+exports[`BpkBannerAlert should render correctly with a custom class name 1`] = `
+<section
+  className="bpk-banner-alert bpk-banner-alert--warn custom-class"
+>
+  <header
+    aria-live="assertive"
+    className="bpk-banner-alert__header"
+    onClick={[Function]}
+    role="alert"
+  >
+    <span
+      className="bpk-banner-alert__icon"
+    >
+      <span
+        style={
+          Object {
+            "display": "inline-block",
+            "lineHeight": "1.125rem",
+            "marginTop": "0.1875rem",
+            "verticalAlign": "top",
+          }
+        }
+      >
+        <svg
+          className="bpk-banner-alert__warn-icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm1.5 16.1c0 .5-.4.9-.9.9h-1.1c-.5 0-.9-.4-.9-.9V11c0-.5.4-.9.9-.9h1.1c.5 0 .9.4.9.9v7.1zm0-11.1c0 .5-.5 1-1 1h-1c-.5 0-1-.5-1-1V6c0-.5.5-1 1-1h1c.5 0 1 .5 1 1v1z"
+          />
+        </svg>
+      </span>
+    </span>
+     
+    <span
+      className="bpk-banner-alert__message"
+    >
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+    </span>
+     
+  </header>
+</section>
+`;
+
 exports[`BpkBannerAlert should render correctly with a element based message 1`] = `
 <section
   className="bpk-banner-alert bpk-banner-alert--success"
@@ -252,6 +305,61 @@ exports[`BpkBannerAlert should render correctly with a element based message 1`]
         </span>
       </button>
     </span>
+  </header>
+</section>
+`;
+
+exports[`BpkBannerAlert should render correctly with arbitrary props 1`] = `
+<section
+  className="bpk-banner-alert bpk-banner-alert--warn"
+  hidden="hidden"
+  id="custom-id"
+>
+  <header
+    aria-live="assertive"
+    className="bpk-banner-alert__header"
+    onClick={[Function]}
+    role="alert"
+  >
+    <span
+      className="bpk-banner-alert__icon"
+    >
+      <span
+        style={
+          Object {
+            "display": "inline-block",
+            "lineHeight": "1.125rem",
+            "marginTop": "0.1875rem",
+            "verticalAlign": "top",
+          }
+        }
+      >
+        <svg
+          className="bpk-banner-alert__warn-icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm1.5 16.1c0 .5-.4.9-.9.9h-1.1c-.5 0-.9-.4-.9-.9V11c0-.5.4-.9.9-.9h1.1c.5 0 .9.4.9.9v7.1zm0-11.1c0 .5-.5 1-1 1h-1c-.5 0-1-.5-1-1V6c0-.5.5-1 1-1h1c.5 0 1 .5 1 1v1z"
+          />
+        </svg>
+      </span>
+    </span>
+     
+    <span
+      className="bpk-banner-alert__message"
+    >
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+    </span>
+     
   </header>
 </section>
 `;


### PR DESCRIPTION
+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.

