### PR TITLE
Ability to pass custom props to BpkTableRow component

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+**Fixed:**
+- bpk-component-table:
+  - `BpkTableRow` now accepts arbitrary props
+
 _Nothing yet_
 
 ## 2017-08-15 - Added new token outputs for iOS and Android (native and React Native)

--- a/packages/bpk-component-table/src/BpkTableRow-test.js
+++ b/packages/bpk-component-table/src/BpkTableRow-test.js
@@ -29,4 +29,13 @@ describe('BpkTableRow', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with custom props', () => {
+    const tree = renderer.create(
+      <BpkTableRow id="test" className="testing">
+        <td />
+      </BpkTableRow>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-table/src/BpkTableRow.js
+++ b/packages/bpk-component-table/src/BpkTableRow.js
@@ -19,7 +19,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const BpkTableRow = props => <tr>{props.children}</tr>;
+const BpkTableRow = (props) => {
+  const { children, ...rest } = props;
+  return (
+    <tr {...rest}>{children}</tr>
+  );
+};
 
 BpkTableRow.propTypes = {
   children: PropTypes.node.isRequired,

--- a/packages/bpk-component-table/src/__snapshots__/BpkTableRow-test.js.snap
+++ b/packages/bpk-component-table/src/__snapshots__/BpkTableRow-test.js.snap
@@ -5,3 +5,12 @@ exports[`BpkTableRow should render correctly 1`] = `
   <td />
 </tr>
 `;
+
+exports[`BpkTableRow should render correctly with custom props 1`] = `
+<tr
+  className="testing"
+  id="test"
+>
+  <td />
+</tr>
+`;


### PR DESCRIPTION
+ [X] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [X] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [X] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [X] If I've updated `npm-shrinkwrap.json` those changes are intentional.
