### PR TITLE
[BPK-863] Set displayName of alignment HOC

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,8 +11,11 @@
 **Fixed:**
 - bpk-component-table:
   - `BpkTableRow` now accepts arbitrary props
-
-_Nothing yet_
+- bpk-component-icon:
+  - Fixed displayName of `withAlignment` HOC
+    **NOTE:** This may break your snapshot tests and thus your build. This is nothing to worry about and the
+    snapshots can safely be updated. Just make sure to perform the update in isolation so that all the
+    snapshot updates relate to this issue and don't introduce unrelated regressions.
 
 ## 2017-08-15 - Added new token outputs for iOS and Android (native and React Native)
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -356,8 +356,7 @@
     "asap": {
       "version": "2.0.5",
       "from": "asap@>=2.0.3 <2.1.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
     },
     "asn1": {
       "version": "0.2.3",
@@ -2096,6 +2095,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "dev": true
     },
+    "change-emitter": {
+      "version": "0.1.6",
+      "from": "change-emitter@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz"
+    },
     "cheerio": {
       "version": "0.22.0",
       "from": "cheerio@>=0.22.0 <0.23.0",
@@ -3318,8 +3322,7 @@
     "encoding": {
       "version": "0.1.12",
       "from": "encoding@>=0.1.11 <0.2.0",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
     },
     "end-of-stream": {
       "version": "0.1.5",
@@ -3908,13 +3911,11 @@
       "version": "0.8.12",
       "from": "fbjs@>=0.8.4 <0.9.0",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-      "dev": true,
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
           "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
         }
       }
     },
@@ -5863,8 +5864,7 @@
     "hoist-non-react-statics": {
       "version": "1.2.0",
       "from": "hoist-non-react-statics@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -6005,8 +6005,7 @@
     "iconv-lite": {
       "version": "0.4.13",
       "from": "iconv-lite@0.4.13",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -6411,8 +6410,7 @@
     "is-stream": {
       "version": "1.1.0",
       "from": "is-stream@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-subset": {
       "version": "0.1.1",
@@ -6495,8 +6493,7 @@
     "isomorphic-fetch": {
       "version": "2.2.1",
       "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
     },
     "isstream": {
       "version": "0.1.2",
@@ -6830,8 +6827,7 @@
     "js-tokens": {
       "version": "3.0.1",
       "from": "js-tokens@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
     },
     "js-yaml": {
       "version": "3.8.2",
@@ -7827,8 +7823,7 @@
     "loose-envify": {
       "version": "1.3.1",
       "from": "loose-envify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -8229,8 +8224,7 @@
     "node-fetch": {
       "version": "1.6.3",
       "from": "node-fetch@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
     },
     "node-forge": {
       "version": "0.6.33",
@@ -8401,8 +8395,7 @@
     "object-assign": {
       "version": "4.1.1",
       "from": "object-assign@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
     },
     "object-is": {
       "version": "1.0.1",
@@ -9397,8 +9390,7 @@
     "promise": {
       "version": "7.1.1",
       "from": "promise@>=7.1.1 <8.0.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "prop-types": {
       "version": "15.5.10",
@@ -9811,6 +9803,11 @@
       "from": "rechoir@>=0.6.2 <0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "dev": true
+    },
+    "recompose": {
+      "version": "0.24.0",
+      "from": "recompose@latest",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.24.0.tgz"
     },
     "redent": {
       "version": "1.0.0",
@@ -10499,8 +10496,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "from": "setimmediate@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
     },
     "setprototypeof": {
       "version": "1.0.3",
@@ -11923,8 +11919,7 @@
     "symbol-observable": {
       "version": "1.0.4",
       "from": "symbol-observable@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -12242,8 +12237,7 @@
     "ua-parser-js": {
       "version": "0.7.12",
       "from": "ua-parser-js@>=0.7.9 <0.8.0",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "uglify-js": {
       "version": "2.7.5",
@@ -12819,8 +12813,7 @@
     "whatwg-fetch": {
       "version": "2.0.3",
       "from": "whatwg-fetch@>=0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
     },
     "whatwg-url": {
       "version": "4.8.0",

--- a/package.json
+++ b/package.json
@@ -126,5 +126,8 @@
         "lines": 75
       }
     }
+  },
+  "dependencies": {
+    "recompose": "^0.24.0"
   }
 }

--- a/packages/bpk-component-accordion/src/withAccordionItemState.js
+++ b/packages/bpk-component-accordion/src/withAccordionItemState.js
@@ -19,6 +19,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
+import wrapDisplayName from 'recompose/wrapDisplayName';
+
 const withAccordionItemState = (ComposedComponent) => {
   class WithAccordionItemState extends Component {
     constructor(props) {
@@ -56,9 +58,7 @@ const withAccordionItemState = (ComposedComponent) => {
     onClick: null,
   };
 
-  const composedComponentName = ComposedComponent.displayName || ComposedComponent.name || 'Component';
-
-  WithAccordionItemState.displayName = `withAccordionItemState(${composedComponentName})`;
+  WithAccordionItemState.displayName = wrapDisplayName(ComposedComponent, 'withAccordionItemState');
 
   return WithAccordionItemState;
 };

--- a/packages/bpk-component-accordion/src/withSingleItemAccordionState.js
+++ b/packages/bpk-component-accordion/src/withSingleItemAccordionState.js
@@ -19,6 +19,8 @@
 import PropTypes from 'prop-types';
 import React, { Component, Children, cloneElement } from 'react';
 
+import wrapDisplayName from 'recompose/wrapDisplayName';
+
 const getInitiallyExpanded = (children) => {
   const accordionItems = Children.toArray(children);
   const result = accordionItems.reduceRight((prev, item) => (item.props.initiallyExpanded ? item : prev), {});
@@ -64,9 +66,7 @@ const withSingleItemAccordionState = (ComposedComponent) => {
     children: PropTypes.node.isRequired,
   };
 
-  const composedComponentName = ComposedComponent.displayName || ComposedComponent.name || 'Component';
-
-  WithSingleItemAccordionState.displayName = `withSingleItemAccordionState(${composedComponentName})`;
+  WithSingleItemAccordionState.displayName = wrapDisplayName(ComposedComponent, 'withSingleItemAccordionState');
 
   return WithSingleItemAccordionState;
 };

--- a/packages/bpk-component-barchart/hocs.js
+++ b/packages/bpk-component-barchart/hocs.js
@@ -19,6 +19,8 @@
 import isEqual from 'lodash/isEqual';
 import React, { Component } from 'react';
 
+import wrapDisplayName from 'recompose/wrapDisplayName';
+
 // eslint-disable-next-line import/prefer-default-export
 export const withSelectedState = (ComposedComponent) => {
   class WithSelectedState extends Component {
@@ -57,9 +59,7 @@ export const withSelectedState = (ComposedComponent) => {
 
   }
 
-  const composedComponentName = ComposedComponent.displayName || ComposedComponent.name || 'Component';
-
-  WithSelectedState.displayName = `withSelectedState(${composedComponentName})`;
+  WithSelectedState.displayName = wrapDisplayName(ComposedComponent, 'withSelectedState');
 
   return WithSelectedState;
 };

--- a/packages/bpk-component-icon/src/__snapshots__/withAlignment-test.js.snap
+++ b/packages/bpk-component-icon/src/__snapshots__/withAlignment-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`withAlignment should keep wrapped-component syling 1`] = `
+exports[`withAlignment should keep wrapped-component styling 1`] = `
 <span
   style={
     Object {
@@ -224,4 +224,10 @@ exports[`withAlignment should render correctly 10`] = `
     1.5rem
   </div>
 </span>
+`;
+
+exports[`withAlignment should wrap the component display name 1`] = `
+<div>
+  <withAlignment(Component) />
+</div>
 `;

--- a/packages/bpk-component-icon/src/classNameModifierHOCFactory.js
+++ b/packages/bpk-component-icon/src/classNameModifierHOCFactory.js
@@ -19,6 +19,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import wrapDisplayName from 'recompose/wrapDisplayName';
+
 export default (displayName, classNamesToAdd = []) => (ComposedComponent) => {
   const ClassNameModifierHOC = (props) => {
     let classNames = [];
@@ -38,9 +40,7 @@ export default (displayName, classNamesToAdd = []) => (ComposedComponent) => {
     className: null,
   };
 
-  const composedComponentName = ComposedComponent.displayName || ComposedComponent.name || 'Component';
-
-  ClassNameModifierHOC.displayName = `${displayName}(${composedComponentName})`;
+  ClassNameModifierHOC.displayName = wrapDisplayName(ComposedComponent, displayName);
 
   return ClassNameModifierHOC;
 };

--- a/packages/bpk-component-icon/src/withAlignment-test.js
+++ b/packages/bpk-component-icon/src/withAlignment-test.js
@@ -18,6 +18,9 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
+import ReactShallowRenderer from 'react-test-renderer/shallow';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import withAlignment from './withAlignment';
 import {
   lineHeightSm, lineHeightBase, lineHeightLg, lineHeightXl, lineHeightXxl,
@@ -40,11 +43,20 @@ describe('withAlignment', () => {
     }
   });
 
-  it('should keep wrapped-component syling', () => {
+  it('should keep wrapped-component styling', () => {
     const FloatingComponent = props => <div {...props} >test lineHeight {lineHeightLg} and iconsSize {iconSizeSm}</div>;
     const AlignedFloatingComponent = withAlignment(FloatingComponent, lineHeightLg, iconSizeSm);
 
     const tree = renderer.create(<AlignedFloatingComponent style={{ float: 'right'}} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should wrap the component display name', () => {
+    const shallowRenderer = new ReactShallowRenderer();
+    const AlignedComponent = withAlignment(props => <div {...props} >test</div>, lineHeightLg, iconSizeSm);
+    const Wrapper = () => <div><AlignedComponent /></div>;
+
+    const tree = shallowRenderer.render(<Wrapper />);
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/bpk-component-icon/src/withAlignment.js
+++ b/packages/bpk-component-icon/src/withAlignment.js
@@ -17,9 +17,10 @@
  */
 
 import React from 'react';
+import wrapDisplayName from 'recompose/wrapDisplayName';
 
 export default function withAlignment(Component, objectHeight, subjectHeight) {
-  return (props) => {
+  const WithAlignment = (props) => {
     const { children, ...rest } = props;
     const objectHeightDecimal = `${objectHeight}`.replace('rem', '');
     const subjectHeightDecimal = `${subjectHeight}`.replace('rem', '');
@@ -37,5 +38,9 @@ export default function withAlignment(Component, objectHeight, subjectHeight) {
         <Component {...rest} >{children}</Component>
       </span>
     );
-  }
+  };
+
+  WithAlignment.displayName = wrapDisplayName(Component, 'withAlignment');
+
+  return WithAlignment;
 }

--- a/packages/bpk-component-input/src/withOpenEvents.js
+++ b/packages/bpk-component-input/src/withOpenEvents.js
@@ -18,7 +18,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { cssModules } from 'bpk-react-utils';
+import wrapDisplayName from 'recompose/wrapDisplayName';
 
 import STYLES from './bpk-input.scss';
 
@@ -158,8 +160,7 @@ const withOpenEvents = (InputComponent) => {
     onKeyUp: null,
   };
 
-  const inputDisplayName = InputComponent.displayName || InputComponent.name || 'Input';
-  WithOpenEvents.displayName = `withOpenEvents(${inputDisplayName})`;
+  WithOpenEvents.displayName = wrapDisplayName(InputComponent, 'withOpenEvents');
 
   return WithOpenEvents;
 };

--- a/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange.js
+++ b/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange.js
@@ -17,7 +17,11 @@
  */
 
 import React, { Component } from 'react';
+
+import wrapDisplayName from 'recompose/wrapDisplayName';
+
 import { getHtmlElement, DIRECTION_CHANGE_EVENT } from './utils';
+
 
 const updateOnDirectionChange = (EnhancedComponent) => {
   class UpdateOnDirectionChange extends Component {
@@ -43,9 +47,7 @@ const updateOnDirectionChange = (EnhancedComponent) => {
     }
   }
 
-  const enhancedComponentName = EnhancedComponent.displayName || EnhancedComponent.name || 'Component';
-
-  UpdateOnDirectionChange.displayName = `updateOnDirectionChange(${enhancedComponentName})`;
+  UpdateOnDirectionChange.displayName = wrapDisplayName(EnhancedComponent, 'updateOnDirectionChange');
 
   return UpdateOnDirectionChange;
 };

--- a/packages/bpk-component-star-rating/src/withInteractiveStarRatingState.js
+++ b/packages/bpk-component-star-rating/src/withInteractiveStarRatingState.js
@@ -19,6 +19,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
+import wrapDisplayName from 'recompose/wrapDisplayName';
+
 const withInteractiveStarRatingState = (InteractiveStarRating) => {
   class EnhancedComponent extends Component {
     constructor() {
@@ -78,9 +80,7 @@ const withInteractiveStarRatingState = (InteractiveStarRating) => {
     onRatingSelect: () => null,
   };
 
-  const enhancedComponentName = EnhancedComponent.displayName || EnhancedComponent.name || 'Component';
-
-  EnhancedComponent.displayName = `withInteractiveStarRatingState(${enhancedComponentName})`;
+  EnhancedComponent.displayName = wrapDisplayName(EnhancedComponent, 'withInteractiveStarRatingState');
 
   return EnhancedComponent;
 };

--- a/packages/bpk-react-utils/src/withDefaultProps.js
+++ b/packages/bpk-react-utils/src/withDefaultProps.js
@@ -19,6 +19,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import wrapDisplayName from 'recompose/wrapDisplayName';
+
 const withDefaultProps = (WrappedComponent, defaultProps) => {
   const { className: defaultClassName, ...defaultRest } = defaultProps;
 
@@ -47,8 +49,8 @@ const withDefaultProps = (WrappedComponent, defaultProps) => {
   component.defaultProps = {
     className: null,
   };
-  const inputDisplayName = WrappedComponent.displayName || WrappedComponent.name || 'Text';
-  component.displayName = `withDefaultProps(${inputDisplayName})`;
+
+  component.displayName = wrapDisplayName(WrappedComponent, 'withDefaultProps');
 
   return component;
 };


### PR DESCRIPTION
- Set the displayName of the `withAlignment` HOC to "withAlignment". This still breaks from the old `withLargeButtonAlignment` etc., but I think it's the correct thing to do since we've overhauled these HOCs.
- Added **recompose** and used the `wrapDisplayName` function across the board

+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
