### PR TITLE
pass correct arguments to onClick in BpkButton

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## UNRELEASED
 
-__Nothing yet...__
+**Fixed:**
+- bpk-component-button:
+  - Fixed SyntheticEvent not being passed to the onClick handler.
 
 ## 2017-08-17 (2) - Fix a missing dependency in several components
 

--- a/packages/bpk-component-button/src/BpkButton.js
+++ b/packages/bpk-component-button/src/BpkButton.js
@@ -71,9 +71,9 @@ const BpkButton = (props) => {
 
   // Due to React bug in Chrome, the onClick event fires even if the button is disabled.
   // Pull request is being worked on (as of 2016-12-22): https://github.com/facebook/react/pull/8329
-  const onClickWrapper = onClick ? () => {
+  const onClickWrapper = onClick ? (...args) => {
     if (!disabled) {
-      onClick(...arguments);
+      onClick(...args);
     }
   } : null;
 


### PR DESCRIPTION
Came across this while trying to stop event propagation. The `...arguments` parameter is actually that of the `BpkButton` class rather the function, so the onClick handler being passed was receiving garbage. This fixes it. Not sure the best method of testing it, I wasn't able to import a SyntheticEvent from react to assert the type. Open to suggestions.

<!-- Thanks for your PR. Please verify below that you've made all the necessary changes. -->
<!-- # Please remove this and the above line before submitting -->

+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
