### PR TITLE
[No jira] Expose recompose's wrapDisplayName in bpk-react-utils

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -356,7 +356,8 @@
     "asap": {
       "version": "2.0.5",
       "from": "asap@>=2.0.3 <2.1.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.3",
@@ -2095,11 +2096,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "dev": true
     },
-    "change-emitter": {
-      "version": "0.1.6",
-      "from": "change-emitter@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz"
-    },
     "cheerio": {
       "version": "0.22.0",
       "from": "cheerio@>=0.22.0 <0.23.0",
@@ -3322,7 +3318,8 @@
     "encoding": {
       "version": "0.1.12",
       "from": "encoding@>=0.1.11 <0.2.0",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "dev": true
     },
     "end-of-stream": {
       "version": "0.1.5",
@@ -3911,11 +3908,13 @@
       "version": "0.8.12",
       "from": "fbjs@>=0.8.4 <0.9.0",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+      "dev": true,
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
           "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "dev": true
         }
       }
     },
@@ -5864,7 +5863,8 @@
     "hoist-non-react-statics": {
       "version": "1.2.0",
       "from": "hoist-non-react-statics@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -6005,7 +6005,8 @@
     "iconv-lite": {
       "version": "0.4.13",
       "from": "iconv-lite@0.4.13",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+      "dev": true
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -6410,7 +6411,8 @@
     "is-stream": {
       "version": "1.1.0",
       "from": "is-stream@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
@@ -6493,7 +6495,8 @@
     "isomorphic-fetch": {
       "version": "2.2.1",
       "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -6827,7 +6830,8 @@
     "js-tokens": {
       "version": "3.0.1",
       "from": "js-tokens@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.8.2",
@@ -7823,7 +7827,8 @@
     "loose-envify": {
       "version": "1.3.1",
       "from": "loose-envify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -8224,7 +8229,8 @@
     "node-fetch": {
       "version": "1.6.3",
       "from": "node-fetch@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+      "dev": true
     },
     "node-forge": {
       "version": "0.6.33",
@@ -8395,7 +8401,8 @@
     "object-assign": {
       "version": "4.1.1",
       "from": "object-assign@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "dev": true
     },
     "object-is": {
       "version": "1.0.1",
@@ -9390,7 +9397,8 @@
     "promise": {
       "version": "7.1.1",
       "from": "promise@>=7.1.1 <8.0.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "dev": true
     },
     "prop-types": {
       "version": "15.5.10",
@@ -9803,11 +9811,6 @@
       "from": "rechoir@>=0.6.2 <0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "dev": true
-    },
-    "recompose": {
-      "version": "0.24.0",
-      "from": "recompose@latest",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.24.0.tgz"
     },
     "redent": {
       "version": "1.0.0",
@@ -10496,7 +10499,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "from": "setimmediate@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.0.3",
@@ -11919,7 +11923,8 @@
     "symbol-observable": {
       "version": "1.0.4",
       "from": "symbol-observable@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -12237,7 +12242,8 @@
     "ua-parser-js": {
       "version": "0.7.12",
       "from": "ua-parser-js@>=0.7.9 <0.8.0",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.7.5",
@@ -12813,7 +12819,8 @@
     "whatwg-fetch": {
       "version": "2.0.3",
       "from": "whatwg-fetch@>=0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "dev": true
     },
     "whatwg-url": {
       "version": "4.8.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,5 @@
       }
     }
   },
-  "dependencies": {
-    "recompose": "^0.24.0"
-  }
+  "dependencies": {}
 }

--- a/packages/bpk-component-accordion/src/withAccordionItemState.js
+++ b/packages/bpk-component-accordion/src/withAccordionItemState.js
@@ -19,7 +19,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import { wrapDisplayName } from 'bpk-react-utils';
 
 const withAccordionItemState = (ComposedComponent) => {
   class WithAccordionItemState extends Component {

--- a/packages/bpk-component-accordion/src/withSingleItemAccordionState.js
+++ b/packages/bpk-component-accordion/src/withSingleItemAccordionState.js
@@ -19,7 +19,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Children, cloneElement } from 'react';
 
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import { wrapDisplayName } from 'bpk-react-utils';
 
 const getInitiallyExpanded = (children) => {
   const accordionItems = Children.toArray(children);

--- a/packages/bpk-component-barchart/hocs.js
+++ b/packages/bpk-component-barchart/hocs.js
@@ -19,7 +19,7 @@
 import isEqual from 'lodash/isEqual';
 import React, { Component } from 'react';
 
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import { wrapDisplayName } from 'bpk-react-utils';
 
 // eslint-disable-next-line import/prefer-default-export
 export const withSelectedState = (ComposedComponent) => {

--- a/packages/bpk-component-icon/src/classNameModifierHOCFactory.js
+++ b/packages/bpk-component-icon/src/classNameModifierHOCFactory.js
@@ -19,7 +19,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import { wrapDisplayName } from 'bpk-react-utils';
 
 export default (displayName, classNamesToAdd = []) => (ComposedComponent) => {
   const ClassNameModifierHOC = (props) => {

--- a/packages/bpk-component-icon/src/withAlignment.js
+++ b/packages/bpk-component-icon/src/withAlignment.js
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import { wrapDisplayName } from 'bpk-react-utils';
 
 export default function withAlignment(Component, objectHeight, subjectHeight) {
   const WithAlignment = (props) => {

--- a/packages/bpk-component-input/src/withOpenEvents.js
+++ b/packages/bpk-component-input/src/withOpenEvents.js
@@ -19,8 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { cssModules } from 'bpk-react-utils';
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import { cssModules, wrapDisplayName } from 'bpk-react-utils';
 
 import STYLES from './bpk-input.scss';
 

--- a/packages/bpk-component-rtl-toggle/package.json
+++ b/packages/bpk-component-rtl-toggle/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "bpk-component-link": "^1.0.8",
+    "bpk-react-utils": "^2.2.2",
     "prop-types": "^15.5.8"
   }
 }

--- a/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange.js
+++ b/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange.js
@@ -18,7 +18,7 @@
 
 import React, { Component } from 'react';
 
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import { wrapDisplayName } from 'bpk-react-utils';
 
 import { getHtmlElement, DIRECTION_CHANGE_EVENT } from './utils';
 

--- a/packages/bpk-component-star-rating/src/withInteractiveStarRatingState.js
+++ b/packages/bpk-component-star-rating/src/withInteractiveStarRatingState.js
@@ -19,7 +19,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import { wrapDisplayName } from 'bpk-react-utils';
 
 const withInteractiveStarRatingState = (InteractiveStarRating) => {
   class EnhancedComponent extends Component {

--- a/packages/bpk-react-utils/index.js
+++ b/packages/bpk-react-utils/index.js
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
+import wrapDisplayName from 'recompose/wrapDisplayName';
 import Portal from './src/Portal';
 import cssModules from './src/cssModules';
 import TransitionInitialMount from './src/TransitionInitialMount';
 import withDefaultProps from './src/withDefaultProps';
 
-export { Portal, cssModules, TransitionInitialMount, withDefaultProps };
-export default { Portal, cssModules, TransitionInitialMount, withDefaultProps };
+export { Portal, cssModules, TransitionInitialMount, withDefaultProps, wrapDisplayName };
+export default { Portal, cssModules, TransitionInitialMount, withDefaultProps, wrapDisplayName };

--- a/packages/bpk-react-utils/package.json
+++ b/packages/bpk-react-utils/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.5.8",
-    "react-transition-group": "1.1.3"
+    "react-transition-group": "1.1.3",
+    "recompose": "^0.24.0"
   }
 }


### PR DESCRIPTION
+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
