### PR TITLE
[BPK-231] Fix for lazy loading with SSR

### DIFF
--- a/packages/bpk-component-image/readme.md
+++ b/packages/bpk-component-image/readme.md
@@ -19,8 +19,8 @@ import BpkImage from 'bpk-component-image';
 export default () => (
   <BpkImage
     altText="image description"
-    maxWidth={816}
-    maxHeight={544}
+    width={816}
+    height={544}
     src="./path/to/image.jpg"
   />
 );
@@ -71,8 +71,8 @@ const FadingLazyLoadedImage = withLoadingBehavior(withLazyLoading(BpkImage, docu
 export default () => (
   <FadingLazyLoadedImage
     altText="image description"
-    maxWidth={816}
-    maxHeight={544}
+    width={816}
+    height={544}
     src="./path/to/image.jpg"
   />
 );

--- a/packages/bpk-component-image/src/BpkBackgroundImage.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.js
@@ -80,6 +80,11 @@ class BpkBackgroundImage extends React.Component {
       contentClassNames.push(imageClassName);
     }
 
+    const contentClassNamesNoScript = [
+      getClassName('bpk-background-image__content'),
+      getClassName('bpk-background-image__content--show'),
+    ];
+
     return (
       <div
         className={classNames.join(' ')}
@@ -94,6 +99,18 @@ class BpkBackgroundImage extends React.Component {
         >
           {!loading && children}
         </div>
+        {(typeof window === 'undefined' && (!inView || loading)) &&
+          <noscript
+            className={contentClassNamesNoScript.join(' ')}
+            style={imageStyle}
+          >
+            <div
+              style={{ backgroundImage: `url(${src})`, ...imageStyle }}
+            >
+              {children}
+            </div>
+          </noscript>
+        }
       </div>
     );
   }

--- a/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
+++ b/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
@@ -1,12 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BpkImage should accept userland className 1`] = `
-<div>
+<div
+  style={
+    Object {
+      "maxHeight": 544,
+      "maxWidth": 816,
+    }
+  }
+>
   <div
     className="bpk-image userland-classname"
     style={
       Object {
         "height": 0,
+        "paddingBottom": "66.66666666666667%",
         "width": 500,
       }
     }
@@ -101,29 +109,28 @@ exports[`BpkImage should accept userland className 1`] = `
     <img
       alt="image description"
       className="bpk-image__image bpk-image__image--show"
-      height={0}
       onLoad={[Function]}
       src="./path/to/image.jpg"
-      width={null}
     />
   </div>
-  <noscript>
-    <img
-      alt="image description"
-      src="./path/to/image.jpg"
-      width="100%"
-    />
-  </noscript>
 </div>
 `;
 
 exports[`BpkImage should accept userland styling 1`] = `
-<div>
+<div
+  style={
+    Object {
+      "maxHeight": 544,
+      "maxWidth": 816,
+    }
+  }
+>
   <div
     className="bpk-image"
     style={
       Object {
         "height": 0,
+        "paddingBottom": "66.66666666666667%",
         "width": 500,
       }
     }
@@ -218,29 +225,28 @@ exports[`BpkImage should accept userland styling 1`] = `
     <img
       alt="image description"
       className="bpk-image__image bpk-image__image--show"
-      height={0}
       onLoad={[Function]}
       src="./path/to/image.jpg"
-      width={null}
     />
   </div>
-  <noscript>
-    <img
-      alt="image description"
-      src="./path/to/image.jpg"
-      width="100%"
-    />
-  </noscript>
 </div>
 `;
 
 exports[`BpkImage should have inView behavior 1`] = `
-<div>
+<div
+  style={
+    Object {
+      "maxHeight": 544,
+      "maxWidth": 816,
+    }
+  }
+>
   <div
     className="bpk-image"
     style={
       Object {
         "height": 0,
+        "paddingBottom": "66.66666666666667%",
       }
     }
   >
@@ -332,23 +338,24 @@ exports[`BpkImage should have inView behavior 1`] = `
       </svg>
     </div>
   </div>
-  <noscript>
-    <img
-      alt="image description"
-      src="./path/to/image.jpg"
-      width="100%"
-    />
-  </noscript>
 </div>
 `;
 
 exports[`BpkImage should have loading behavior 1`] = `
-<div>
+<div
+  style={
+    Object {
+      "maxHeight": 544,
+      "maxWidth": 816,
+    }
+  }
+>
   <div
     className="bpk-image"
     style={
       Object {
         "height": 0,
+        "paddingBottom": "66.66666666666667%",
       }
     }
   >
@@ -442,29 +449,28 @@ exports[`BpkImage should have loading behavior 1`] = `
     <img
       alt="image description"
       className="bpk-image__image"
-      height={0}
       onLoad={[Function]}
       src="./path/to/image.jpg"
-      width={null}
     />
   </div>
-  <noscript>
-    <img
-      alt="image description"
-      src="./path/to/image.jpg"
-      width="100%"
-    />
-  </noscript>
 </div>
 `;
 
 exports[`BpkImage should render correctly 1`] = `
-<div>
+<div
+  style={
+    Object {
+      "maxHeight": 544,
+      "maxWidth": 816,
+    }
+  }
+>
   <div
     className="bpk-image"
     style={
       Object {
         "height": 0,
+        "paddingBottom": "66.66666666666667%",
       }
     }
   >
@@ -558,18 +564,9 @@ exports[`BpkImage should render correctly 1`] = `
     <img
       alt="image description"
       className="bpk-image__image bpk-image__image--show"
-      height={0}
       onLoad={[Function]}
       src="./path/to/image.jpg"
-      width={null}
     />
   </div>
-  <noscript>
-    <img
-      alt="image description"
-      src="./path/to/image.jpg"
-      width="100%"
-    />
-  </noscript>
 </div>
 `;

--- a/packages/bpk-component-image/src/withLazyLoading.js
+++ b/packages/bpk-component-image/src/withLazyLoading.js
@@ -38,6 +38,8 @@ export default function withLazyLoading(Component, document) {
     componentDidMount() {
       const passiveArgs = this.supportsPassiveEvents() ? { passive: true } : false;
       document.addEventListener('scroll', this.checkInView, passiveArgs);
+      document.addEventListener('resize', this.checkInView);
+      document.addEventListener('fullscreenchange', this.checkInView);
       // call checkInView immediately incase the
       // component is already in view prior to scrolling
       this.checkInView();
@@ -56,6 +58,8 @@ export default function withLazyLoading(Component, document) {
 
     removeEventListeners() {
       document.removeEventListener('scroll', this.checkInView);
+      document.removeEventListener('resize', this.checkInView);
+      document.removeEventListener('fullscreenchange', this.checkInView);
     }
 
     checkInView() {

--- a/packages/bpk-docs/src/pages/ImagesPage/ImagesPage.js
+++ b/packages/bpk-docs/src/pages/ImagesPage/ImagesPage.js
@@ -163,7 +163,7 @@ const ImagesPage = () => <DocsPageBuilder
       <BpkCode>BpkBackgroundImage</BpkCode> will place a <BpkCode>div</BpkCode> tag in the DOM.
       Images will only be loaded when the inView prop is set to true. Using the <BpkCode>withLazyLoading</BpkCode> HOC
       will ensure that this only happens once the image is in view, saving user`s data and providing a smoother
-      experience. Similarly, the <BpkCode>withLoadingBehavior</BpkCode> HOC will allow a spinner to be shown until
+      experience. The <BpkCode>withLoadingBehavior</BpkCode> HOC will allow a spinner to be shown until
       the image gently fades in on load.
       By default, images will have a <BpkCode>width 100%</BpkCode>, but this can be prevented by setting
       <BpkCode>fullWidth</BpkCode> false.

--- a/packages/bpk-mixins/src/mixins/_images.scss
+++ b/packages/bpk-mixins/src/mixins/_images.scss
@@ -34,6 +34,7 @@
   display: block;
   max-width: 100%;
   background-color: $bpk-color-gray-100;
+  overflow: hidden;
 }
 
 /// Image content. Should be applied to the image element.
@@ -44,6 +45,8 @@
 ///   }
 
 @mixin bpk-image__content {
+  position: absolute;
+  width: 100%;
   transition: opacity $bpk-duration-base ease-in-out;
   opacity: 0;
 }


### PR DESCRIPTION
+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
