### PR TITLE
[BPK-231] Fix for lazy loading with SSR 2

### DIFF
--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -64,14 +64,17 @@ class BpkImage extends React.Component {
       getClassName('bpk-image__image--show'),
     ];
 
-    const fullWidthLimitingStyle = { maxWidth: width, maxHeight: height };
+    const nonFullWidthDimensions =
+      fullWidth
+        ? {}
+        : { maxWidth: width, maxHeight: height };
 
     // wraps a div with maxWidth and maxHeight set iff full-width is no required.
     // This ensures that the css / html do not reserve too much spacing
     // when width 100% is not being used
     return (
       <div
-        style={fullWidth && fullWidthLimitingStyle}
+        style={nonFullWidthDimensions}
       >
         <div
           ref={(div) => { this.placeholder = div; }}


### PR DESCRIPTION
+ [ ] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [ ] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [ ] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [ ] If I've updated `npm-shrinkwrap.json` those changes are intentional.
