### PR TITLE
[BPK-231] Fix for lazy loading with SSR 3

### DIFF
--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -64,14 +64,17 @@ class BpkImage extends React.Component {
       getClassName('bpk-image__image--show'),
     ];
 
-    const fullWidthLimitingStyle = { maxWidth: width, maxHeight: height };
+    const nonFullWidthDimensions =
+      fullWidth
+        ? {}
+        : { maxWidth: width, maxHeight: height };
 
     // wraps a div with maxWidth and maxHeight set iff full-width is no required.
     // This ensures that the css / html do not reserve too much spacing
     // when width 100% is not being used
     return (
       <div
-        style={fullWidth && fullWidthLimitingStyle}
+        style={nonFullWidthDimensions}
       >
         <div
           ref={(div) => { this.placeholder = div; }}

--- a/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
+++ b/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
@@ -2,12 +2,7 @@
 
 exports[`BpkImage should accept userland className 1`] = `
 <div
-  style={
-    Object {
-      "maxHeight": 544,
-      "maxWidth": 816,
-    }
-  }
+  style={Object {}}
 >
   <div
     className="bpk-image userland-classname"
@@ -118,12 +113,7 @@ exports[`BpkImage should accept userland className 1`] = `
 
 exports[`BpkImage should accept userland styling 1`] = `
 <div
-  style={
-    Object {
-      "maxHeight": 544,
-      "maxWidth": 816,
-    }
-  }
+  style={Object {}}
 >
   <div
     className="bpk-image"
@@ -234,12 +224,7 @@ exports[`BpkImage should accept userland styling 1`] = `
 
 exports[`BpkImage should have inView behavior 1`] = `
 <div
-  style={
-    Object {
-      "maxHeight": 544,
-      "maxWidth": 816,
-    }
-  }
+  style={Object {}}
 >
   <div
     className="bpk-image"
@@ -343,12 +328,7 @@ exports[`BpkImage should have inView behavior 1`] = `
 
 exports[`BpkImage should have loading behavior 1`] = `
 <div
-  style={
-    Object {
-      "maxHeight": 544,
-      "maxWidth": 816,
-    }
-  }
+  style={Object {}}
 >
   <div
     className="bpk-image"
@@ -458,12 +438,7 @@ exports[`BpkImage should have loading behavior 1`] = `
 
 exports[`BpkImage should render correctly 1`] = `
 <div
-  style={
-    Object {
-      "maxHeight": 544,
-      "maxWidth": 816,
-    }
-  }
+  style={Object {}}
 >
   <div
     className="bpk-image"


### PR DESCRIPTION
+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
