### PR TITLE
[NOJIRA] Fix daysOfWeek example

### DIFF
--- a/packages/bpk-component-calendar/readme.md
+++ b/packages/bpk-component-calendar/readme.md
@@ -20,10 +20,10 @@ const formatDateFull = date => format(date, 'dddd, Do MMMM YYYY');
 const formatMonth = date => format(date, 'MMMM YYYY');
 const daysOfWeek = [
   {
-    "name": "Monday",
-    "nameAbbr": "Mon",
-    "index": 1,
-    "isWeekend": false
+    name: 'Sunday',
+    nameAbbr: 'Sun',
+    index: 0,
+    isWeekend: true,
   },
   // ...
 ];

--- a/packages/bpk-component-datepicker/readme.md
+++ b/packages/bpk-component-datepicker/readme.md
@@ -20,10 +20,10 @@ const formatDateFull = date => format(date, 'dddd, Do MMMM YYYY');
 const formatMonth = date => format(date, 'MMMM YYYY');
 const daysOfWeek = [
   {
-    "name": "Monday",
-    "nameAbbr": "Mon",
-    "index": 1,
-    "isWeekend": false
+    name: 'Sunday',
+    nameAbbr: 'Sun',
+    index: 0,
+    isWeekend: true,
   },
   // ...
 ];


### PR DESCRIPTION
~The order of the `daysOfWeek` array matters, Sunday should be at index 0 - our docs suggested otherwise.~

**Update:** The order of the `daysOfWeek` *does not* matter, however Sunday should have and `index` prop value of 0 - our docs confuse things by showing monday at index zero in the array. This change makes it clearer.

<!-- Thanks for your PR. Please verify below that you've made all the necessary changes. -->
<!-- # Please remove this and the above line before submitting -->

+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
