### PR TITLE
[BPK-908] Fix lazy loading HOC not responding to div scroll events

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## UNRELEASED
 
-_Nothing yet..._
+**Fixed:**
+- bpk-component-image:
+  - Fixed issue where lazy-loading HOC would not detect scrolling within a div
 
 ## 2017-08-30 - Calendars/Datepickers can now set initally focused date / month
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 **Fixed:**
 - bpk-component-image:
   - Fixed issue where lazy-loading HOC would not detect scrolling within a div
+  - Image background color will now be removed after the image is shown
 
 ## 2017-08-30 - Calendars/Datepickers can now set initally focused date / month
 

--- a/packages/bpk-component-image/package.json
+++ b/packages/bpk-component-image/package.json
@@ -19,6 +19,7 @@
     "prop-types": "^15.5.8"
   },
   "devDependencies": {
+    "bpk-component-mobile-scroll-container": "^1.0.10",
     "bpk-component-text": "^1.0.8",
     "bpk-tokens": "^24.2.0"
   }

--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -51,6 +51,7 @@ class BpkImage extends React.Component {
     const aspectRatioPc = `${100 / aspectRatio}%`;
 
     if (!loading) {
+      classNames.push(getClassName('bpk-image--show'));
       spinnerClassNames.push(getClassName('bpk-image__spinner--hide'));
       imgClassNames.push(getClassName('bpk-image__image--show'));
     }

--- a/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
+++ b/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
@@ -9,7 +9,7 @@ exports[`BpkImage should accept userland className 1`] = `
   }
 >
   <div
-    className="bpk-image userland-classname"
+    className="bpk-image bpk-image--show userland-classname"
     style={
       Object {
         "height": 0,
@@ -123,7 +123,7 @@ exports[`BpkImage should accept userland styling 1`] = `
   }
 >
   <div
-    className="bpk-image"
+    className="bpk-image bpk-image--show"
     style={
       Object {
         "height": 0,
@@ -233,7 +233,7 @@ exports[`BpkImage should have !inView behavior 1`] = `
   style={Object {}}
 >
   <div
-    className="bpk-image"
+    className="bpk-image bpk-image--show"
     style={
       Object {
         "height": 0,
@@ -447,7 +447,7 @@ exports[`BpkImage should render correctly 1`] = `
   style={Object {}}
 >
   <div
-    className="bpk-image"
+    className="bpk-image bpk-image--show"
     style={
       Object {
         "height": 0,
@@ -557,7 +557,7 @@ exports[`BpkImage should support srcSet 1`] = `
   style={Object {}}
 >
   <div
-    className="bpk-image"
+    className="bpk-image bpk-image--show"
     style={
       Object {
         "height": 0,

--- a/packages/bpk-component-image/src/bpk-image.scss
+++ b/packages/bpk-component-image/src/bpk-image.scss
@@ -21,6 +21,10 @@
 .bpk-image {
   @include bpk-image;
 
+  &--show {
+    @include bpk-image--show;
+  }
+
   &__image {
     @include bpk-image__content;
 

--- a/packages/bpk-component-image/src/withLazyLoading-test.js
+++ b/packages/bpk-component-image/src/withLazyLoading-test.js
@@ -1,0 +1,74 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import withLazyLoading from './withLazyLoading';
+
+describe('withLazyLoading', () => {
+  it('should return the original component', () => {
+    const documentMock = jest.fn();
+    const MockImageComponent = () => (<div>Fake Image</div>);
+    const LazyLoadedImage = withLazyLoading(MockImageComponent, documentMock);
+
+    const lazyLoadedImage = shallow(<LazyLoadedImage />);
+    expect(lazyLoadedImage.first().is(MockImageComponent));
+  });
+
+  it('should add inView prop', () => {
+    const documentMock = jest.fn();
+    const MockImageComponent = () => (<div>Fake Image</div>);
+    const LazyLoadedImage = withLazyLoading(MockImageComponent, documentMock);
+
+    const lazyLoadedImage = shallow(<LazyLoadedImage />);
+    expect(lazyLoadedImage.hasOwnProperty('inView')); // eslint-disable-line no-prototype-builtins
+  });
+
+  it('scroll listener args should be correct when mounting', () => {
+    const documentMock = jest.fn();
+    documentMock.addEventListener = jest.fn();
+    documentMock.documentElement = jest.fn();
+    documentMock.documentElement.clientHeight = 450;
+
+    const MockImageComponent = () => (<div>Fake Image</div>);
+    const LazyLoadedImage = withLazyLoading(MockImageComponent, documentMock);
+
+    mount(<LazyLoadedImage />);
+
+    expect(documentMock.addEventListener.mock.calls.length).toBe(4);
+    expect(documentMock.addEventListener.mock.calls[0][0]).toEqual('scroll');
+    expect(documentMock.addEventListener.mock.calls[0][2]).toEqual({ capture: true });
+  });
+
+  it('scroll listener args should be correct when unmounting', () => {
+    const documentMock = jest.fn();
+    documentMock.addEventListener = jest.fn();
+    documentMock.removeEventListener = jest.fn();
+    documentMock.documentElement = jest.fn();
+    documentMock.documentElement.clientHeight = 450;
+
+    const MockImageComponent = () => (<div>Fake Image</div>);
+    const LazyLoadedImage = withLazyLoading(MockImageComponent, documentMock);
+
+    mount(<LazyLoadedImage />).unmount();
+
+    expect(documentMock.removeEventListener.mock.calls.length).toBe(4);
+    expect(documentMock.removeEventListener.mock.calls[0][0]).toEqual('scroll');
+    expect(documentMock.removeEventListener.mock.calls[0][2]).toEqual({ capture: true });
+  });
+});

--- a/packages/bpk-component-image/src/withLazyLoading.js
+++ b/packages/bpk-component-image/src/withLazyLoading.js
@@ -36,9 +36,10 @@ export default function withLazyLoading(Component, document) {
     }
 
     componentDidMount() {
-      const passiveArgs = this.supportsPassiveEvents() ? { passive: true } : false;
-      document.addEventListener('scroll', this.checkInView, passiveArgs);
+      const passiveArgs = this.supportsPassiveEvents() ? { passive: true } : {};
+      document.addEventListener('scroll', this.checkInView, { capture: true, ...passiveArgs });
       document.addEventListener('resize', this.checkInView);
+      document.addEventListener('orientationchange', this.checkInView);
       document.addEventListener('fullscreenchange', this.checkInView);
       // call checkInView immediately incase the
       // component is already in view prior to scrolling
@@ -57,8 +58,10 @@ export default function withLazyLoading(Component, document) {
     }
 
     removeEventListeners() {
-      document.removeEventListener('scroll', this.checkInView);
+      const passiveArgs = this.supportsPassiveEvents() ? { passive: true } : {};
+      document.removeEventListener('scroll', this.checkInView, { capture: true, ...passiveArgs });
       document.removeEventListener('resize', this.checkInView);
+      document.removeEventListener('orientationchange', this.checkInView);
       document.removeEventListener('fullscreenchange', this.checkInView);
     }
 

--- a/packages/bpk-component-image/stories.js
+++ b/packages/bpk-component-image/stories.js
@@ -20,6 +20,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import BpkText from 'bpk-component-text';
+import BpkMobileScrollContainer from 'bpk-component-mobile-scroll-container';
 import BpkImage, { BpkBackgroundImage, withLazyLoading, withLoadingBehavior } from './index';
 
 const image = 'https://content.skyscnr.com/96508dbac15a2895b0147dc7e7f9ad30/canadian-rockies-canada.jpg';
@@ -87,6 +88,35 @@ storiesOf('bpk-component-image', module)
       style={{ width: 612, height: 408 }}
       src={image}
     />
+  ))
+  .add('Within a scroll div', () => (
+    <BpkMobileScrollContainer >
+      <div
+        style={{ display: 'flex' }}
+      >
+        <FadingLazyLoadedImage
+          altText="image"
+          width={612}
+          height={408}
+          style={{ width: 612, height: 408 }}
+          src={image}
+        />
+        <FadingLazyLoadedImage
+          altText="image"
+          width={612}
+          height={408}
+          style={{ width: 612, height: 408 }}
+          src={image}
+        />
+        <FadingLazyLoadedImage
+          altText="image"
+          width={612}
+          height={408}
+          style={{ width: 612, height: 408 }}
+          src={image}
+        />
+      </div>
+    </BpkMobileScrollContainer>
   ))
   .add('Background Image', () => (
     <BpkBackgroundImage

--- a/packages/bpk-mixins/src/mixins/_images.scss
+++ b/packages/bpk-mixins/src/mixins/_images.scss
@@ -33,8 +33,14 @@
   position: relative;
   display: block;
   max-width: 100%;
+  transition: background-color $bpk-duration-base ease-in-out;
   background-color: $bpk-color-gray-100;
   overflow: hidden;
+  transition-delay: $bpk-duration-base;
+}
+
+@mixin bpk-image--show {
+  background-color: transparent;
 }
 
 /// Image content. Should be applied to the image element.


### PR DESCRIPTION
<!-- Thanks for your PR. Please verify below that you've made all the necessary changes. -->
<!-- # Please remove this and the above line before submitting -->

+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
