### PR TITLE
[BPK-906] Separate layout docs into 3 pages

### DIFF
--- a/packages/bpk-docs/src/constants/routes.js
+++ b/packages/bpk-docs/src/constants/routes.js
@@ -65,6 +65,8 @@ export const HORIZONTAL_NAV = '/components/web/horizontal-nav';
 export const FIELDSETS = '/components/web/fieldsets';
 export const BARCHARTS = '/components/web/barcharts';
 export const STAR_RATING = '/components/web/star-rating';
+export const BREAKPOINTS = '/components/web/breakpoints';
+export const HORIZONTAL_GRID = '/components/web/horizontal-grid';
 
 // components/native/
 export const NATIVE_COMPONENTS = '/components/native';

--- a/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
+++ b/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
@@ -78,6 +78,8 @@ const links = [
       { id: 'NUMERICAL_RATING', route: null, children: 'Numerical rating' },
       { id: 'FLIGHT_ITINERARIES', route: null, children: 'Flight itinerary' },
       { id: 'FILTERS', route: null, children: 'Filters' },
+      { id: 'BREAKPOINTS', route: routes.BREAKPOINTS, children: 'Breakpoints' },
+      { id: 'HORIZONTAL_GRID', route: routes.HORIZONTAL_GRID, children: 'Horizontal grid' },
     ],
   },
   {

--- a/packages/bpk-docs/src/pages/BreakpointsPage/BreakpointsPage.js
+++ b/packages/bpk-docs/src/pages/BreakpointsPage/BreakpointsPage.js
@@ -1,0 +1,80 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import BpkBreakpoint, { BREAKPOINTS } from 'bpk-component-breakpoint';
+import { cssModules } from 'bpk-react-utils';
+import breakpointReadme from 'bpk-component-breakpoint/readme.md';
+
+import DocsPageBuilder from './../../components/DocsPageBuilder';
+import Paragraph from './../../components/Paragraph';
+import STYLES from './breakpoints-page.scss';
+
+const getClassName = cssModules(STYLES);
+
+const MediaQueryStatus = (props) => {
+  const className = getClassName(props.isActive ? 'bpk-breakpoints-demo--active' : 'bpk-breakpoints-demo--inactive');
+
+  return <div className={className}>{props.children}</div>;
+};
+
+MediaQueryStatus.propTypes = {
+  isActive: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+const components = [
+  {
+    id: 'default',
+    title: 'Default',
+    examples: [
+      <div className={getClassName('bpk-breakpoints-demo')}>
+        <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
+          {isActive => <MediaQueryStatus isActive={isActive}>MOBILE</MediaQueryStatus>}
+        </BpkBreakpoint>
+        <BpkBreakpoint query={BREAKPOINTS.TABLET}>
+          {isActive => <MediaQueryStatus isActive={isActive}>TABLET</MediaQueryStatus>}
+        </BpkBreakpoint>
+        <BpkBreakpoint query={BREAKPOINTS.TABLET_ONLY}>
+          {isActive => <MediaQueryStatus isActive={isActive}>TABLET ONLY</MediaQueryStatus>}
+        </BpkBreakpoint>
+        <BpkBreakpoint query={BREAKPOINTS.ABOVE_MOBILE}>
+          {isActive => <MediaQueryStatus isActive={isActive}>ABOVE MOBILE</MediaQueryStatus>}
+        </BpkBreakpoint>
+        <BpkBreakpoint query={BREAKPOINTS.ABOVE_TABLET}>
+          {isActive => <MediaQueryStatus isActive={isActive}>ABOVE TABLET</MediaQueryStatus>}
+        </BpkBreakpoint>
+      </div>,
+    ],
+  },
+];
+
+const BreakpointsPage = () => <DocsPageBuilder
+  title="Breakpoints"
+  blurb={[
+    <Paragraph>
+      To simplify things, Backpack uses only three breakpoints optimised for mobile, tablet and desktop viewports.
+    </Paragraph>,
+  ]}
+  components={components}
+  readme={breakpointReadme}
+  sassdocId="breakpoints"
+/>;
+
+export default BreakpointsPage;

--- a/packages/bpk-docs/src/pages/BreakpointsPage/breakpoints-page.scss
+++ b/packages/bpk-docs/src/pages/BreakpointsPage/breakpoints-page.scss
@@ -1,0 +1,35 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins/index';
+
+.bpk-breakpoints-demo {
+  border-radius: $bpk-border-radius-xs;
+  overflow: hidden;
+
+  &--active {
+    padding: $bpk-spacing-base;
+    background-color: $bpk-color-blue-500;
+    color: $bpk-color-white;
+  }
+
+  &--inactive {
+    padding: $bpk-spacing-base;
+    background-color: $bpk-color-gray-100;
+  }
+}

--- a/packages/bpk-docs/src/pages/BreakpointsPage/index.js
+++ b/packages/bpk-docs/src/pages/BreakpointsPage/index.js
@@ -1,0 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import page from './BreakpointsPage';
+
+export default page;

--- a/packages/bpk-docs/src/pages/HorizontalGridPage/HorizontalGridPage.js
+++ b/packages/bpk-docs/src/pages/HorizontalGridPage/HorizontalGridPage.js
@@ -1,0 +1,75 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { BpkCode } from 'bpk-component-code';
+import BpkBlockquote from 'bpk-component-blockquote';
+import BpkRouterLink from 'bpk-component-router-link';
+
+import gridReadme from 'bpk-component-grid/readme.md';
+
+import * as routes from './../../constants/routes';
+import DocsPageBuilder from './../../components/DocsPageBuilder';
+import Paragraph from './../../components/Paragraph';
+
+const HorizontalGridPage = () => <DocsPageBuilder
+  title="Horizontal grid"
+  blurb={[
+    <Paragraph>
+      Backpack uses a 12 column responsive grid to compose and layout pages. Grids are composed using three basic
+      building blocks: containers, rows and columns. Containers are used to encapsulate the entire layout (all rows).
+      Rows are used to act as container to columns and columns are used to horizontally layout content.
+    </Paragraph>,
+    <BpkBlockquote extraSpace>
+      <strong>Note:</strong> The Backpack grid is intended to be used for overall page layout as opposed to spacing
+      out atom or molecule level components. Please stick to flexbox based techniques for more intricate
+      layouts (or <BpkCode>display: table;</BpkCode> for browsers which lack support), just be sure to use the spacing
+      values above in order to achieve consistency.
+    </BpkBlockquote>,
+    <Paragraph>
+      <strong>Columns</strong>
+    </Paragraph>,
+    <Paragraph>
+      The grid makes use of 12 percentage based columns, which means your layouts will scale no matter the browser
+      size. Columns are separated by fixed width gutters and margins.
+    </Paragraph>,
+    <Paragraph>
+      <BpkRouterLink to={routes.GRID_COLUMN_DEMO}>View demo.</BpkRouterLink>
+    </Paragraph>,
+    <Paragraph>
+      <strong>Offsets</strong>
+    </Paragraph>,
+    <Paragraph>
+      Offsets allow you to shift columns to the right. Depending on their size, columns can be offset by 1 through 11.
+    </Paragraph>,
+    <Paragraph>
+      <BpkRouterLink to={routes.GRID_OFFSET_DEMO}>View demo.</BpkRouterLink>
+    </Paragraph>,
+    <Paragraph>
+      <strong>Responsive behaviour</strong>
+    </Paragraph>,
+    <Paragraph>
+      The grid works in conjunction with the breakpoints listed above and can be used to position content differently
+      based on these viewports by specifying different widths and offsets.
+    </Paragraph>,
+  ]}
+  readme={gridReadme}
+  sassdocId="grids"
+/>;
+
+export default HorizontalGridPage;

--- a/packages/bpk-docs/src/pages/HorizontalGridPage/index.js
+++ b/packages/bpk-docs/src/pages/HorizontalGridPage/index.js
@@ -1,0 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import page from './HorizontalGridPage';
+
+export default page;

--- a/packages/bpk-docs/src/pages/LayoutPage/LayoutPage.js
+++ b/packages/bpk-docs/src/pages/LayoutPage/LayoutPage.js
@@ -19,19 +19,10 @@
 import React from 'react';
 import pickBy from 'lodash/pickBy';
 import includes from 'lodash/includes';
-import { BpkCode } from 'bpk-component-code';
 import TOKENS from 'bpk-tokens/tokens/base.common';
-import BpkBlockquote from 'bpk-component-blockquote';
-import BpkRouterLink from 'bpk-component-router-link';
 
-import gridReadme from 'bpk-component-grid/readme.md';
-import breakpointReadme from 'bpk-component-breakpoint/readme.md';
-
-import * as routes from './../../constants/routes';
 import DocsPageBuilder from './../../components/DocsPageBuilder';
 import Paragraph from './../../components/Paragraph';
-
-const breakpoints = pickBy(TOKENS, (value, key) => includes(key, 'breakpoint') && !includes(key, 'breakpointQuery'));
 
 const components = [
   {
@@ -60,65 +51,6 @@ const components = [
       <Paragraph>You can preview this by switching on the grid at the bottom of the page.</Paragraph>,
     ],
     examples: [],
-  },
-  {
-    id: 'breakpoints',
-    title: 'Breakpoints',
-    blurb: [
-      <Paragraph>
-        To simplify things, Backpack uses only three breakpoints optimised for mobile, tablet and desktop viewports.
-      </Paragraph>,
-    ],
-    examples: [],
-    tokenMap: breakpoints,
-    readme: breakpointReadme,
-    sassdocId: 'breakpoints',
-  },
-  {
-    id: 'horizontal-grid',
-    title: 'Horizontal grid',
-    blurb: [
-      <Paragraph>
-        Backpack uses a 12 column responsive grid to compose and layout pages. Grids are composed using three basic
-        building blocks: containers, rows and columns. Containers are used to encapsulate the entire layout (all rows).
-        Rows are used to act as container to columns and columns are used to horizontally layout content.
-      </Paragraph>,
-      <BpkBlockquote extraSpace>
-        <strong>Note:</strong> The Backpack grid is intended to be used for overall page layout as opposed to spacing
-        out atom or molecule level components. Please stick to flexbox based techniques for more intricate
-        layouts (or <BpkCode>display: table;</BpkCode> for browsers which lack support), just be sure to use the spacing
-        values above in order to achieve consistency.
-      </BpkBlockquote>,
-      <Paragraph>
-        <strong>Columns</strong>
-      </Paragraph>,
-      <Paragraph>
-        The grid makes use of 12 percentage based columns, which means your layouts will scale no matter the browser
-        size. Columns are separated by fixed width gutters and margins.
-      </Paragraph>,
-      <Paragraph>
-        <BpkRouterLink to={routes.GRID_COLUMN_DEMO}>View demo.</BpkRouterLink>
-      </Paragraph>,
-      <Paragraph>
-        <strong>Offsets</strong>
-      </Paragraph>,
-      <Paragraph>
-        Offsets allow you to shift columns to the right. Depending on their size, columns can be offset by 1 through 11.
-      </Paragraph>,
-      <Paragraph>
-        <BpkRouterLink to={routes.GRID_OFFSET_DEMO}>View demo.</BpkRouterLink>
-      </Paragraph>,
-      <Paragraph>
-        <strong>Responsive behaviour</strong>
-      </Paragraph>,
-      <Paragraph>
-        The grid works in conjunction with the breakpoints listed above and can be used to position content differently
-        based on these viewports by specifying different widths and offsets.
-      </Paragraph>,
-    ],
-    examples: [],
-    readme: gridReadme,
-    sassdocId: 'grids',
   },
 ];
 

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -40,6 +40,8 @@ import RadiiPage from './../pages/RadiiPage';
 import ShadowsPage from './../pages/ShadowsPage';
 import BordersPage from './../pages/BordersPage';
 import LayoutPage from './../pages/LayoutPage';
+import BreakpointsPage from './../pages/BreakpointsPage';
+import HorizontalGridPage from './../pages/HorizontalGridPage';
 import AnimationPage from './../pages/AnimationPage';
 
 import TypographyPage from './../pages/TypographyPage';
@@ -131,6 +133,8 @@ const Routes = (
         <Route path={ROUTES.FIELDSETS} component={FieldsetsPage} />
         <Route path={ROUTES.BARCHARTS} component={BarchartsPage} />
         <Route path={ROUTES.STAR_RATING} component={StarRatingPage} />
+        <Route path={ROUTES.BREAKPOINTS} component={BreakpointsPage} />
+        <Route path={ROUTES.HORIZONTAL_GRID} component={HorizontalGridPage} />
       </Route>
       <Route path={ROUTES.NATIVE_COMPONENTS}>
         <IndexRedirect to={ROUTES.NATIVE_TEXT} />


### PR DESCRIPTION
<!-- Thanks for your PR. Please verify below that you've made all the necessary changes. -->
<!-- # Please remove this and the above line before submitting -->

+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
