### PR TITLE
[skip-ci] [no-jira] Rename iPhone 7 to 8 in screenshot captions

### DIFF
--- a/packages/bpk-docs/src/pages/NativeButtonPage/NativeButtonPage.js
+++ b/packages/bpk-docs/src/pages/NativeButtonPage/NativeButtonPage.js
@@ -42,7 +42,7 @@ const components = [
         height: 1334,
         src: `/${iosScreenshotPrimary}`,
         altText: 'iOS Primary Button Component',
-        subText: '(iPhone 7 Simulator)',
+        subText: '(iPhone 8 Simulator)',
       },
       {
         title: 'Android',
@@ -64,7 +64,7 @@ const components = [
         height: 1334,
         src: `/${iosScreenshotSecondary}`,
         altText: 'iOS Secondary Button Component',
-        subText: '(iPhone 7 Simulator)',
+        subText: '(iPhone 8 Simulator)',
       },
       {
         title: 'Android',
@@ -86,7 +86,7 @@ const components = [
         height: 1334,
         src: `/${iosScreenshotDestructive}`,
         altText: 'iOS Destructive Button Component',
-        subText: '(iPhone 7 Simulator)',
+        subText: '(iPhone 8 Simulator)',
       },
       {
         title: 'Android',
@@ -108,7 +108,7 @@ const components = [
         height: 1334,
         src: `/${iosScreenshotFeatured}`,
         altText: 'iOS Featured Button Component',
-        subText: '(iPhone 7 Simulator)',
+        subText: '(iPhone 8 Simulator)',
       },
       {
         title: 'Android',

--- a/packages/bpk-docs/src/pages/NativeTextInputPage/NativeTextInputPage.js
+++ b/packages/bpk-docs/src/pages/NativeTextInputPage/NativeTextInputPage.js
@@ -38,7 +38,7 @@ const components = [
         height: 1334,
         src: `/${iosScreenshot}`,
         altText: 'iOS Default Text Input Component',
-        subText: '(iPhone 7 Simulator)',
+        subText: '(iPhone 8 Simulator)',
       },
       {
         title: 'Android',

--- a/packages/bpk-docs/src/pages/NativeTextPage/NativeTextPage.js
+++ b/packages/bpk-docs/src/pages/NativeTextPage/NativeTextPage.js
@@ -38,7 +38,7 @@ const components = [
         height: 1334,
         src: `/${iosScreenshot}`,
         altText: 'iOS Default Text Component',
-        subText: '(iPhone 7 Simulator)',
+        subText: '(iPhone 8 Simulator)',
       },
       {
         title: 'Android',


### PR DESCRIPTION
+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
