### PR TITLE
[skip ci] Licence link now points to one in repo

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -23,7 +23,7 @@ This document describes how to go about it. If you have any questions, get in to
 
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of the [APLv2](https://www.apache.org/licenses/LICENSE-2.0).
+By contributing your code, you agree to license your contribution under the terms of the [APLv2](./LICENSE).
 
 All files are released with the Apache 2.0 license.
 


### PR DESCRIPTION
+ [x] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.

@k0nserv I merged the previous PR around this before I saw your comment about using a relative link - this fixes that.