### PR TITLE
[NOJIRA] Make sure RN styles can be extended in userland

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
 <!-- Thanks for your PR. Please verify below that you've made all the necessary changes. -->
 <!-- # Please remove this and the above line before submitting -->
 
-+ [ ] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
++ [ ] For any new web components I've made sure that the style can be extended by the consumer using a `className` override.
++ [ ] For any new native components I've made sure that the style can be extended by the consumer using a `style` override.
 + [ ] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
 + [ ] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
 + [ ] If I've updated `npm-shrinkwrap.json` those changes are intentional.


### PR DESCRIPTION
<!-- Thanks for your PR. Please verify below that you've made all the necessary changes. -->
<!-- # Please remove this and the above line before submitting -->

+ [ ] For any new components I've made sure that the style can be extended by the consumer using a `className` override.
+ [ ] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [ ] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [ ] If I've updated `npm-shrinkwrap.json` those changes are intentional.
