### PR TITLE
[BPK-903] Move bonds to tokens section

### DIFF
--- a/packages/bpk-docs/src/components/Header/Header.js
+++ b/packages/bpk-docs/src/components/Header/Header.js
@@ -35,6 +35,7 @@ const getClassName = cssModules(STYLES);
 const headerLinks = [
   { to: ROUTES.USING_BACKPACK, children: 'Using Backpack' },
   { to: ROUTES.STYLE, children: 'Style' },
+  { to: ROUTES.TOKENS, children: 'Tokens' },
   { to: ROUTES.COMPONENTS, children: 'Components' },
   { to: ROUTES.RESOURCES, children: 'Resources' },
   { href: 'https://github.com/Skyscanner/backpack', children: 'Github', blank: true },

--- a/packages/bpk-docs/src/constants/redirect-routes.js
+++ b/packages/bpk-docs/src/constants/redirect-routes.js
@@ -20,6 +20,14 @@ import * as ROUTES from './routes';
 
 // Deprecated routes, kept here for redirects
 export default {
+  '/components/bonds': ROUTES.TOKENS,
+  '/components/bonds/colors': ROUTES.COLORS,
+  '/components/bonds/typesetting': ROUTES.TYPESETTING,
+  '/components/bonds/radii': ROUTES.RADII,
+  '/components/bonds/shadows': ROUTES.SHADOWS,
+  '/components/bonds/borders': ROUTES.BORDERS,
+  '/components/bonds/layout': ROUTES.LAYOUT,
+  '/components/bonds/animation': ROUTES.ANIMATION,
   '/components/atoms': ROUTES.WEB_COMPONENTS,
   '/components/atoms/typography': ROUTES.TYPOGRAPHY,
   '/components/atoms/buttons': ROUTES.BUTTONS,

--- a/packages/bpk-docs/src/constants/routes.js
+++ b/packages/bpk-docs/src/constants/routes.js
@@ -21,6 +21,7 @@ export const HOME = '/';
 // TOP LEVEL
 export const USING_BACKPACK = '/using';
 export const STYLE = '/style';
+export const TOKENS = '/tokens';
 export const COMPONENTS = '/components';
 export const RESOURCES = '/resources';
 
@@ -30,13 +31,13 @@ export const BACKPACK_REACT_SCRIPTS = '/using/backpack-react-scripts';
 export const BASE_STYLESHEET = '/using/base-stylesheet';
 
 // components/bonds/
-export const COLORS = '/components/bonds/colors';
-export const TYPESETTING = '/components/bonds/typesetting';
-export const RADII = '/components/bonds/radii';
-export const SHADOWS = '/components/bonds/shadows';
-export const BORDERS = '/components/bonds/borders';
-export const LAYOUT = '/components/bonds/layout';
-export const ANIMATION = '/components/bonds/animation';
+export const COLORS = '/tokens/colors';
+export const TYPESETTING = '/tokens/typesetting';
+export const RADII = '/tokens/radii';
+export const SHADOWS = '/tokens/shadows';
+export const BORDERS = '/tokens/borders';
+export const LAYOUT = '/tokens/layout';
+export const ANIMATION = '/tokens/animation';
 
 // components/web/
 export const WEB_COMPONENTS = '/components/web';

--- a/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
+++ b/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
@@ -24,20 +24,6 @@ import * as routes from './../../constants/routes';
 
 const links = [
   {
-    id: 'BONDS',
-    category: 'Bonds',
-    sort: true,
-    links: [
-      { id: 'COLORS', route: routes.COLORS, children: 'Colors' },
-      { id: 'TYPESETTING', route: routes.TYPESETTING, children: 'Typesetting' },
-      { id: 'LAYOUT', route: routes.LAYOUT, children: 'Layout' },
-      { id: 'RADII', route: routes.RADII, children: 'Radii' },
-      { id: 'SHADOWS', route: routes.SHADOWS, children: 'Shadows' },
-      { id: 'BORDERS', route: routes.BORDERS, children: 'Borders' },
-      { id: 'ANIMATION', route: routes.ANIMATION, children: 'Animation' },
-    ],
-  },
-  {
     id: 'COMPONENTS',
     category: 'Web components',
     sort: true,

--- a/packages/bpk-docs/src/layouts/TokensLayout/TokensLayout.js
+++ b/packages/bpk-docs/src/layouts/TokensLayout/TokensLayout.js
@@ -1,0 +1,48 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import SideNavLayout from './../SideNavLayout';
+import * as routes from './../../constants/routes';
+
+const links = [
+  {
+    id: 'Tokens',
+    category: 'Tokens',
+    sort: true,
+    links: [
+      { id: 'COLORS', route: routes.COLORS, children: 'Colors' },
+      { id: 'TYPESETTING', route: routes.TYPESETTING, children: 'Typesetting' },
+      { id: 'LAYOUT', route: routes.LAYOUT, children: 'Layout' },
+      { id: 'RADII', route: routes.RADII, children: 'Radii' },
+      { id: 'SHADOWS', route: routes.SHADOWS, children: 'Shadows' },
+      { id: 'BORDERS', route: routes.BORDERS, children: 'Borders' },
+      { id: 'ANIMATION', route: routes.ANIMATION, children: 'Animation' },
+    ],
+  },
+];
+
+const TokensLayout = ({ children, ...rest }) => <SideNavLayout links={links} {...rest}>{children}</SideNavLayout>;
+
+TokensLayout.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default TokensLayout;

--- a/packages/bpk-docs/src/layouts/TokensLayout/index.js
+++ b/packages/bpk-docs/src/layouts/TokensLayout/index.js
@@ -1,0 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import layout from './TokensLayout';
+
+export default layout;

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -24,6 +24,7 @@ import redirects from './../constants/redirect-routes';
 
 import DefaultLayout from './../layouts/DefaultLayout';
 import UsingLayout from './../layouts/UsingLayout';
+import TokensLayout from './../layouts/TokensLayout';
 import DocsLayout from './../layouts/DocsLayout';
 
 import HomePage from './../pages/HomePage';
@@ -97,15 +98,19 @@ const Routes = (
 
     <Route path={ROUTES.STYLE} component={StylePage} iconsSvgs={iconsSvgs} />
 
-    <Route path={ROUTES.COMPONENTS} component={DocsLayout}>
-      <IndexRedirect to={ROUTES.WEB_COMPONENTS} />
+    <Route path={ROUTES.TOKENS} component={TokensLayout}>
+      <IndexRedirect to={ROUTES.ANIMATION} />
+      <Route path={ROUTES.ANIMATION} component={AnimationPage} />
+      <Route path={ROUTES.BORDERS} component={BordersPage} />
       <Route path={ROUTES.COLORS} component={ColorsPage} />
-      <Route path={ROUTES.TYPESETTING} component={TypesettingPage} />
+      <Route path={ROUTES.LAYOUT} component={LayoutPage} />
       <Route path={ROUTES.RADII} component={RadiiPage} />
       <Route path={ROUTES.SHADOWS} component={ShadowsPage} />
-      <Route path={ROUTES.BORDERS} component={BordersPage} />
-      <Route path={ROUTES.LAYOUT} component={LayoutPage} />
-      <Route path={ROUTES.ANIMATION} component={AnimationPage} />
+      <Route path={ROUTES.TYPESETTING} component={TypesettingPage} />
+    </Route>
+
+    <Route path={ROUTES.COMPONENTS} component={DocsLayout}>
+      <IndexRedirect to={ROUTES.WEB_COMPONENTS} />
       <Route path={ROUTES.WEB_COMPONENTS}>
         <IndexRedirect to={ROUTES.ACCORDIONS} />
         <Route path={ROUTES.TYPOGRAPHY} component={TypographyPage} />


### PR DESCRIPTION
This is the first PR for moving the tokens pages to their own section. I will follow up with the restructure of the actual pages themselves in separate PR's

+ [x] For any new web components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new native components I've made sure that the style can be extended by the consumer using a `style` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
