### PR TITLE
[BPK-925] Add API for setting opacity of colour tokens

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
 - react-native-bpk-component-card:
   - New component BpkCard
 
+- bpk-tokens:
+  - Color tokens can now be made opaque with `setOpacity`
+
 ## 2017-09-25 - Bar chart bars now have hooks for hover and touch events
 
 **Added:**

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
+    "color": "^2.0.0",
     "css-loader": "^0.28.4",
     "danger": "^1.2.0",
     "del": "^3.0.0",

--- a/packages/bpk-tokens/index.js
+++ b/packages/bpk-tokens/index.js
@@ -1,0 +1,22 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import setOpacity from './src/setOpacity';
+
+export { setOpacity };
+export default { setOpacity };

--- a/packages/bpk-tokens/package.json
+++ b/packages/bpk-tokens/package.json
@@ -11,5 +11,8 @@
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "color": "^2.0.0"
+  }
 }

--- a/packages/bpk-tokens/readme.md
+++ b/packages/bpk-tokens/readme.md
@@ -41,3 +41,16 @@ import { colors } from 'bpk-tokens/tokens/base.es6';
 
 console.log(colors.colorGray700);
 ```
+
+## Transparency
+
+It is possible to add opacity to Backpack color tokens as follows:
+
+```js
+import { colorBlue500 } from 'bpk-tokens/tokens/base.es6';
+import { setOpacity } from 'bpk-tokens';
+
+const transparentBlue500 = setOpacity(colorBlue500, 0.7);
+
+console.log(transparentBlue500);
+```

--- a/packages/bpk-tokens/src/setOpacity-test.js
+++ b/packages/bpk-tokens/src/setOpacity-test.js
@@ -1,0 +1,57 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import setOpacity from './setOpacity';
+
+describe('setOpacity', () => {
+  it('should set opacity on rgb', () => {
+    expect(setOpacity('rgb(119, 67, 206)', 0.7)).toEqual('rgba(119, 67, 206, 0.7)');
+  });
+
+  it('should set opacity on hex', () => {
+    expect(setOpacity('#7743CE', 0.7)).toEqual('rgba(119, 67, 206, 0.7)');
+  });
+
+  it('should error if opacity > 1', () => {
+    // eslint-disable-next-line max-len
+    expect(() => setOpacity('rgb(119, 67, 206)', 47)).toThrow('Invalid arg `opacity` of value `47` supplied to `setOpacity`, expected a value between 0.0 and 1.0.');
+  });
+
+  it('should error if opacity < 0', () => {
+    // eslint-disable-next-line max-len
+    expect(() => setOpacity('rgb(119, 67, 206)', -12)).toThrow('Invalid arg `opacity` of value `-12` supplied to `setOpacity`, expected a value between 0.0 and 1.0.');
+  });
+
+  it('should error if opacity is wrong type', () => {
+    // eslint-disable-next-line max-len
+    expect(() => setOpacity('rgb(119, 67, 206)', { opacity: 0.4 })).toThrow('Invalid arg `opacity` of type `object` supplied to `setOpacity`, expected a numeric value between 0.0 and 1.0.');
+  });
+
+  it('should error if opacity is null', () => {
+    // eslint-disable-next-line max-len
+    expect(() => setOpacity('rgb(119, 67, 206)', null)).toThrow('Invalid arg `opacity` of type `object` supplied to `setOpacity`, expected a numeric value between 0.0 and 1.0.');
+  });
+
+  it('should error if color token is invalid', () => {
+    expect(() => setOpacity('ASDFG', 0.5)).toThrow('Unable to parse color from string: ASDFG');
+  });
+
+  it('should default if color token is null', () => {
+    expect(setOpacity(null, 0.5)).toEqual('rgba(0, 0, 0, 0.5)');
+  });
+});

--- a/packages/bpk-tokens/src/setOpacity.js
+++ b/packages/bpk-tokens/src/setOpacity.js
@@ -1,0 +1,32 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Color from 'color';
+
+const setOpacity = (colorToken, opacity) => {
+  if (!parseFloat(opacity)) {
+    // eslint-disable-next-line max-len
+    throw new Error(`Invalid arg \`opacity\` of type \`${typeof (opacity)}\` supplied to \`setOpacity\`, expected a numeric value between 0.0 and 1.0.`);
+  } else if (opacity > 1.0 || opacity < 0.0) {
+    // eslint-disable-next-line max-len
+    throw new Error(`Invalid arg \`opacity\` of value \`${opacity}\` supplied to \`setOpacity\`, expected a value between 0.0 and 1.0.`);
+  }
+  return (new Color(colorToken)).alpha(opacity).string();
+};
+
+export default setOpacity;


### PR DESCRIPTION
<!-- Thanks for your PR. Please verify below that you've made all the necessary changes. -->
<!-- # Please remove this and the above line before submitting -->

+ [x] For any new web components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new native components I've made sure that the style can be extended by the consumer using a `style` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
