### PR TITLE
[BPK-966] Make Dangerfile more opinionated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ install:
   - npm install
   - npm run build
 script:
+  - npm run danger
   - npm test
   - npm run docs:dist:gzip
   - test -e dist/index.html
   - test -e dist/sassdoc/index.html
-  - npm run danger
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
Danger will now run at the beginning of a build, before tests run.
If a package source files have changed but snapshots haven't, Danger
will post a warning.

+ [x] For any new web components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new native components I've made sure that the style can be extended by the consumer using a `style` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.