### PR TITLE
[NO-JIRA] docs pluralisation

### DIFF
--- a/packages/bpk-docs/src/constants/redirect-routes.js
+++ b/packages/bpk-docs/src/constants/redirect-routes.js
@@ -56,4 +56,5 @@ export default {
   '/components/molecules/fieldsets': ROUTES.FIELDSETS,
   '/components/molecules/barcharts': ROUTES.BARCHARTS,
   '/components/molecules/star-rating': ROUTES.STAR_RATING,
+  '/components/native/button': ROUTES.NATIVE_BUTTONS,
 };

--- a/packages/bpk-docs/src/constants/redirect-routes.js
+++ b/packages/bpk-docs/src/constants/redirect-routes.js
@@ -57,4 +57,5 @@ export default {
   '/components/molecules/barcharts': ROUTES.BARCHARTS,
   '/components/molecules/star-rating': ROUTES.STAR_RATING,
   '/components/native/button': ROUTES.NATIVE_BUTTONS,
+  '/components/native/text-input': ROUTES.NATIVE_INPUTS,
 };

--- a/packages/bpk-docs/src/constants/routes.js
+++ b/packages/bpk-docs/src/constants/routes.js
@@ -71,7 +71,7 @@ export const HORIZONTAL_GRID = '/components/web/horizontal-grid';
 
 // components/native/
 export const NATIVE_COMPONENTS = '/components/native';
-export const NATIVE_INPUT = '/components/native/text-input';
+export const NATIVE_INPUTS = '/components/native/text-inputs';
 export const NATIVE_TEXT = '/components/native/text';
 export const NATIVE_BUTTONS = '/components/native/buttons';
 

--- a/packages/bpk-docs/src/constants/routes.js
+++ b/packages/bpk-docs/src/constants/routes.js
@@ -73,7 +73,7 @@ export const HORIZONTAL_GRID = '/components/web/horizontal-grid';
 export const NATIVE_COMPONENTS = '/components/native';
 export const NATIVE_INPUT = '/components/native/text-input';
 export const NATIVE_TEXT = '/components/native/text';
-export const NATIVE_BUTTON = '/components/native/button';
+export const NATIVE_BUTTONS = '/components/native/buttons';
 
 // components/utilities/
 export const UTILITIES = '/components/utilities';

--- a/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
+++ b/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
@@ -75,7 +75,7 @@ const links = [
     links: [
       { id: 'NATIVE_INPUT', route: routes.NATIVE_INPUT, children: 'Text input' },
       { id: 'NATIVE_TEXT', route: routes.NATIVE_TEXT, children: 'Text' },
-      { id: 'NATIVE_BUTTON', route: routes.NATIVE_BUTTON, children: 'Button' },
+      { id: 'NATIVE_BUTTONS', route: routes.NATIVE_BUTTONS, children: 'Buttons' },
     ],
   },
   {

--- a/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
+++ b/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
@@ -73,7 +73,7 @@ const links = [
     category: 'Native components',
     sort: true,
     links: [
-      { id: 'NATIVE_INPUT', route: routes.NATIVE_INPUT, children: 'Text input' },
+      { id: 'NATIVE_INPUTS', route: routes.NATIVE_INPUTS, children: 'Text inputs' },
       { id: 'NATIVE_TEXT', route: routes.NATIVE_TEXT, children: 'Text' },
       { id: 'NATIVE_BUTTONS', route: routes.NATIVE_BUTTONS, children: 'Buttons' },
     ],

--- a/packages/bpk-docs/src/pages/NativeButtonsPage/NativeButtonsPage.js
+++ b/packages/bpk-docs/src/pages/NativeButtonsPage/NativeButtonsPage.js
@@ -122,7 +122,7 @@ const components = [
   },
 ];
 
-const NativeTextPage = () => <DocsPageBuilder
+const NativeButtonsPage = () => <DocsPageBuilder
   title="Buttons"
   blurb={[
     <Paragraph>
@@ -143,4 +143,4 @@ const NativeTextPage = () => <DocsPageBuilder
   showMenu
 />;
 
-export default NativeTextPage;
+export default NativeButtonsPage;

--- a/packages/bpk-docs/src/pages/NativeButtonsPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeButtonsPage/index.js
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
 
-import page from './NativeButtonPage';
+import page from './NativeButtonsPage';
 
 export default page;

--- a/packages/bpk-docs/src/pages/NativeTextInputsPage/NativeTextInputsPage.js
+++ b/packages/bpk-docs/src/pages/NativeTextInputsPage/NativeTextInputsPage.js
@@ -52,8 +52,8 @@ const components = [
   },
 ];
 
-const NativeInputPage = () => <DocsPageBuilder
-  title="Text input"
+const NativeTextInputsPage = () => <DocsPageBuilder
+  title="Text inputs"
   blurb={[
     <Paragraph>
       The Backpack input is a wrapper around
@@ -67,4 +67,4 @@ const NativeInputPage = () => <DocsPageBuilder
   showMenu={false}
 />;
 
-export default NativeInputPage;
+export default NativeTextInputsPage;

--- a/packages/bpk-docs/src/pages/NativeTextInputsPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeTextInputsPage/index.js
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
 
-import page from './NativeTextInputPage';
+import page from './NativeTextInputsPage';
 
 export default page;

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -76,7 +76,7 @@ import AlignmentPage from './../pages/AlignmentPage';
 
 import NativeInputPage from './../pages/NativeTextInputPage';
 import NativeTextPage from './../pages/NativeTextPage';
-import NativeButtonPage from './../pages/NativeButtonPage';
+import NativeButtonsPage from './../pages/NativeButtonsPage';
 
 import ResourcesPage from './../pages/ResourcesPage';
 
@@ -145,7 +145,7 @@ const Routes = (
         <IndexRedirect to={ROUTES.NATIVE_TEXT} />
         <Route path={ROUTES.NATIVE_INPUT} component={NativeInputPage} />
         <Route path={ROUTES.NATIVE_TEXT} component={NativeTextPage} />
-        <Route path={ROUTES.NATIVE_BUTTON} component={NativeButtonPage} />
+        <Route path={ROUTES.NATIVE_BUTTONS} component={NativeButtonsPage} />
       </Route>
       <Route path={ROUTES.UTILITIES}>
         <IndexRedirect to={ROUTES.ALIGNMENT} />

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -74,7 +74,7 @@ import StarRatingPage from './../pages/StarRatingPage';
 
 import AlignmentPage from './../pages/AlignmentPage';
 
-import NativeInputPage from './../pages/NativeTextInputPage';
+import NativeInputsPage from './../pages/NativeTextInputsPage';
 import NativeTextPage from './../pages/NativeTextPage';
 import NativeButtonsPage from './../pages/NativeButtonsPage';
 
@@ -143,7 +143,7 @@ const Routes = (
       </Route>
       <Route path={ROUTES.NATIVE_COMPONENTS}>
         <IndexRedirect to={ROUTES.NATIVE_TEXT} />
-        <Route path={ROUTES.NATIVE_INPUT} component={NativeInputPage} />
+        <Route path={ROUTES.NATIVE_INPUTS} component={NativeInputsPage} />
         <Route path={ROUTES.NATIVE_TEXT} component={NativeTextPage} />
         <Route path={ROUTES.NATIVE_BUTTONS} component={NativeButtonsPage} />
       </Route>


### PR DESCRIPTION
At the moment our docs use inconsistent singlular / plural names for components. I thought we should make RN pages be consistent before we get too stuck in!



+ [ ] For any new web components I've made sure that the style can be extended by the consumer using a `className` override.
+ [ ] For any new native components I've made sure that the style can be extended by the consumer using a `style` override.
+ [ ] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [ ] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [ ] If I've updated `npm-shrinkwrap.json` those changes are intentional.
