### PR TITLE
[BPK-967] Make BpkButton work properly with user styles

### DIFF
--- a/native/packages/react-native-bpk-component-button/src/BpkButton.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton.js
@@ -30,7 +30,7 @@
 
  const BUTTON_TYPES = ['primary', 'featured', 'secondary', 'destructive'];
 
- const getStyleForElement = (elementType, { type, title, icon, iconOnly, selected, large, disabled, style }) => {
+ const getStyleForElement = (elementType, { type, title, icon, iconOnly, selected, large, disabled }) => {
    // Start with base style.
    const styleForElement = [styles.base[elementType]];
 
@@ -59,11 +59,6 @@
    } else if (title && icon) {
      // If it has a title and icon, get the style for that.
      styleForElement.push(styles.modifiers[large ? 'textAndIconLarge' : 'textAndIcon'][elementType]);
-   }
-
-   // Userland styles.
-   if (style && style[elementType]) {
-     styleForElement.push(style[elementType]);
    }
 
    return styleForElement;
@@ -115,7 +110,7 @@
    // Note that TouchableHighlight isn't on Android, so TouchableFeedback
    // will need to be used to support it.
    return (
-     <LinearGradient style={getStyleForElement('container', props)} colors={getGradientColors(props)}>
+     <LinearGradient style={[getStyleForElement('container', props), style]} colors={getGradientColors(props)}>
        <TouchableHighlight
          style={getStyleForElement('button', props)}
          disabled={disabled}

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
@@ -13,10 +13,13 @@ exports[`Android BpkButton should render correctly 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -118,10 +121,13 @@ exports[`Android BpkButton should render correctly with type="destructive" 1`] =
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -234,10 +240,13 @@ exports[`Android BpkButton should render correctly with type="featured" 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -339,10 +348,13 @@ exports[`Android BpkButton should render correctly with type="primary" 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -444,10 +456,13 @@ exports[`Android BpkButton should render correctly with type="secondary" 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -560,11 +575,14 @@ exports[`Android BpkButton should support having an icon as well as a title 1`] 
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      undefined,
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        undefined,
+      ],
+      null,
     ]
   }
 >
@@ -676,13 +694,16 @@ exports[`Android BpkButton should support having only an icon 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      Object {
-        "width": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "width": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -761,9 +782,14 @@ exports[`Android BpkButton should support overwriting styles 1`] = `
   start={undefined}
   style={
     Array [
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
       Object {
-        "borderRadius": 100,
-        "height": 32,
+        "width": 100,
       },
     ]
   }
@@ -866,13 +892,16 @@ exports[`Android BpkButton should support the "disabled" property 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      Object {
-        "minHeight": 48,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "minHeight": 48,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -981,13 +1010,16 @@ exports[`Android BpkButton should support the "large" property 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      Object {
-        "minHeight": 48,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "minHeight": 48,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -1096,11 +1128,14 @@ exports[`Android BpkButton should support the "selected" property 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      undefined,
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        undefined,
+      ],
+      null,
     ]
   }
 >

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -13,10 +13,13 @@ exports[`iOS BpkButton should render correctly 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -118,10 +121,13 @@ exports[`iOS BpkButton should render correctly with type="destructive" 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -234,10 +240,13 @@ exports[`iOS BpkButton should render correctly with type="featured" 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -339,10 +348,13 @@ exports[`iOS BpkButton should render correctly with type="primary" 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -444,10 +456,13 @@ exports[`iOS BpkButton should render correctly with type="secondary" 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -560,11 +575,14 @@ exports[`iOS BpkButton should support having an icon as well as a title 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      undefined,
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        undefined,
+      ],
+      null,
     ]
   }
 >
@@ -676,13 +694,16 @@ exports[`iOS BpkButton should support having only an icon 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      Object {
-        "width": 32,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "width": 32,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -761,9 +782,14 @@ exports[`iOS BpkButton should support overwriting styles 1`] = `
   start={undefined}
   style={
     Array [
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+      ],
       Object {
-        "borderRadius": 100,
-        "height": 32,
+        "width": 100,
       },
     ]
   }
@@ -866,13 +892,16 @@ exports[`iOS BpkButton should support the "disabled" property 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      Object {
-        "minHeight": 48,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "minHeight": 48,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -981,13 +1010,16 @@ exports[`iOS BpkButton should support the "large" property 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      Object {
-        "minHeight": 48,
-      },
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "minHeight": 48,
+        },
+      ],
+      null,
     ]
   }
 >
@@ -1096,11 +1128,14 @@ exports[`iOS BpkButton should support the "selected" property 1`] = `
   start={undefined}
   style={
     Array [
-      Object {
-        "borderRadius": 100,
-        "height": 32,
-      },
-      undefined,
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        undefined,
+      ],
+      null,
     ]
   }
 >

--- a/native/packages/react-native-bpk-component-button/stories.js
+++ b/native/packages/react-native-bpk-component-button/stories.js
@@ -72,10 +72,7 @@ const styles = StyleSheet.create({
   bottomMargin: {
     marginBottom: tokens.spacingSm,
   },
-});
-
-const buttonStyles = StyleSheet.create({
-  container: {
+  buttonStyles: {
     marginBottom: tokens.spacingMd,
     marginRight: tokens.spacingMd,
   },
@@ -111,28 +108,28 @@ const generateButtonStoryForType = type => (
         type={type}
         title="Button"
         onPress={action(`${type} pressed`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         type={type}
         selected
         title="Selected"
         onPress={action(`${type} selected pressed`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         type={type}
         disabled
         title="Disabled"
         onPress={action(`${type} disabled pressed, somehow`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         type={type}
         title="With icon"
         icon={<ArrowImage type={type} />}
         onPress={action(`${type} with icon clicked`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         type={type}
@@ -140,7 +137,7 @@ const generateButtonStoryForType = type => (
         icon={<ArrowImage type={type} />}
         iconOnly
         onPress={action(`${type} icon only button clicked`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
     </View>
 
@@ -151,7 +148,7 @@ const generateButtonStoryForType = type => (
         type={type}
         title="Button"
         onPress={action(`${type} pressed`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         large
@@ -159,7 +156,7 @@ const generateButtonStoryForType = type => (
         selected
         title="Selected"
         onPress={action(`${type} selected pressed`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         large
@@ -167,7 +164,7 @@ const generateButtonStoryForType = type => (
         disabled
         title="Disabled"
         onPress={action(`${type} disabled pressed, somehow`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         large
@@ -175,7 +172,7 @@ const generateButtonStoryForType = type => (
         title="With icon"
         icon={<ArrowImage large type={type} />}
         onPress={action(`${type} with icon clicked`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         large
@@ -184,7 +181,7 @@ const generateButtonStoryForType = type => (
         icon={<ArrowImage large type={type} />}
         iconOnly
         onPress={action(`${type} icon only button clicked`)}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
     </View>
   </View>
@@ -233,21 +230,21 @@ storiesOf('BpkButton', module)
         type="primary"
         title="I have a really long title"
         onPress={action('Button with long title pressed')}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         large
         type="primary"
         title="I also have a really long title"
         onPress={action('Large button with long title pressed')}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         type="primary"
         title="I have an absurdly long title and an icon and may cause wrapping"
         icon={<ArrowImage />}
         onPress={action('Button with icon and long title pressed')}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
       <BpkButton
         large
@@ -255,7 +252,7 @@ storiesOf('BpkButton', module)
         title="I also have an absurdly long title and an icon and may cause wrapping"
         icon={<ArrowImage />}
         onPress={action('Large button with icon and long title pressed')}
-        style={buttonStyles}
+        style={styles.buttonStyles}
       />
     </View>
   ));


### PR DESCRIPTION
+ [x] For any new web components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new native components I've made sure that the style can be extended by the consumer using a `style` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.

Previously it used a strange object format, now it behaves normally.
