### PR TITLE
Allow bpk ticket stub to take custom props

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## UNRELEASED
 
-_Nothing yet..._
+**Added:**
+- react-native-bpk-component-card: 0.0.3 => 1.0.0
+  - New component BpkCard, see http://backpack.prod.aws.skyscnr.com/components/native/cards/
 
 ## 2017-09-26 - New native Card component
 

--- a/packages/bpk-component-ticket/readme.md
+++ b/packages/bpk-component-ticket/readme.md
@@ -25,10 +25,13 @@ export default () => (
 
 ## Props
 
-| Property  | PropType | Required | Default Value |
-| --------- | -------- | -------- | ------------- |
-| children  | node     | true     | -             |
-| stub      | node     | true     | -             |
-| href      | string   | false    | null          |
-| padded    | bool     | false    | true          |
-| vertical  | bool     | false    | false         |
+| Property      | PropType | Required | Default Value |
+| ------------- | -------- | -------- | ------------- |
+| children      | node     | true     | -             |
+| stub          | node     | true     | -             |
+| href          | string   | false    | null          |
+| padded        | bool     | false    | true          |
+| vertical      | bool     | false    | false         |
+| stubProps     | object   | false    | {}            |
+| stubClassName | string   | false    | null          |
+

--- a/packages/bpk-component-ticket/src/BpkTicket-test.js
+++ b/packages/bpk-component-ticket/src/BpkTicket-test.js
@@ -70,4 +70,27 @@ describe('BpkTicket', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with a "stubClassName" attribute', () => {
+    const tree = renderer.create(
+      <BpkTicket stub="Ticket stub" stubClassName="custom-class">
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum
+        sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+      </BpkTicket>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with a "stubProps" attribute', () => {
+    const stubProps = {
+      foo: 'bar',
+    };
+    const tree = renderer.create(
+      <BpkTicket stub="Ticket stub" stubClassName="custom-class" stubProps={stubProps}>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum
+        sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+      </BpkTicket>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-ticket/src/BpkTicket.js
+++ b/packages/bpk-component-ticket/src/BpkTicket.js
@@ -30,7 +30,7 @@ const isIE9 = () => {
 };
 
 const BpkTicket = (props) => {
-  const { children, href, padded, stub, vertical, className, ...rest } = props;
+  const { children, href, padded, stub, vertical, className, stubClassName, stubProps, ...rest } = props;
   const classNames = [getClassName('bpk-ticket')];
   const mainClassNames = ['bpk-ticket__paper', 'bpk-ticket__main'].map(getClassName);
   const stubClassNames = ['bpk-ticket__paper', 'bpk-ticket__stub'].map(getClassName);
@@ -40,6 +40,7 @@ const BpkTicket = (props) => {
   const fallback = isIE9();
 
   if (className) { classNames.push(className); }
+  if (stubClassName) { stubClassNames.push(stubClassName); }
   if (padded) {
     mainClassNames.push(getClassName('bpk-ticket__main--padded'));
     stubClassNames.push(getClassName('bpk-ticket__stub--padded'));
@@ -88,6 +89,7 @@ const BpkTicket = (props) => {
     <div
       key="stub"
       className={stubClassNames.join(' ')}
+      {...stubProps}
     >
       {stub}
     </div>,
@@ -115,6 +117,8 @@ BpkTicket.propTypes = {
   href: PropTypes.string,
   padded: PropTypes.bool,
   vertical: PropTypes.bool,
+  stubClassName: PropTypes.string,
+  stubProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 BpkTicket.defaultProps = {
@@ -122,6 +126,8 @@ BpkTicket.defaultProps = {
   href: null,
   padded: true,
   vertical: false,
+  stubClassName: null,
+  stubProps: {},
 };
 
 export default BpkTicket;

--- a/packages/bpk-component-ticket/src/__snapshots__/BpkTicket-test.js.snap
+++ b/packages/bpk-component-ticket/src/__snapshots__/BpkTicket-test.js.snap
@@ -90,6 +90,67 @@ exports[`BpkTicket should render correctly with a "className" attribute 1`] = `
 </div>
 `;
 
+exports[`BpkTicket should render correctly with a "stubClassName" attribute 1`] = `
+<div
+  className="bpk-ticket"
+  role="button"
+>
+  <div
+    className="bpk-ticket__paper bpk-ticket__main bpk-ticket__main--padded bpk-ticket__main--horizontal"
+  >
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+  </div>
+  <div
+    aria-hidden="true"
+    className="bpk-ticket__punchline bpk-ticket__punchline--vertical"
+    role="presentation"
+  >
+    <div
+      className="bpk-ticket__notch bpk-ticket__notch--top"
+    />
+    <div
+      className="bpk-ticket__notch bpk-ticket__notch--bottom"
+    />
+  </div>
+  <div
+    className="bpk-ticket__paper bpk-ticket__stub custom-class bpk-ticket__stub--padded bpk-ticket__stub--horizontal"
+  >
+    Ticket stub
+  </div>
+</div>
+`;
+
+exports[`BpkTicket should render correctly with a "stubProps" attribute 1`] = `
+<div
+  className="bpk-ticket"
+  role="button"
+>
+  <div
+    className="bpk-ticket__paper bpk-ticket__main bpk-ticket__main--padded bpk-ticket__main--horizontal"
+  >
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+  </div>
+  <div
+    aria-hidden="true"
+    className="bpk-ticket__punchline bpk-ticket__punchline--vertical"
+    role="presentation"
+  >
+    <div
+      className="bpk-ticket__notch bpk-ticket__notch--top"
+    />
+    <div
+      className="bpk-ticket__notch bpk-ticket__notch--bottom"
+    />
+  </div>
+  <div
+    className="bpk-ticket__paper bpk-ticket__stub custom-class bpk-ticket__stub--padded bpk-ticket__stub--horizontal"
+    foo="bar"
+  >
+    Ticket stub
+  </div>
+</div>
+`;
+
 exports[`BpkTicket should render correctly with a "vertical" attribute 1`] = `
 <div
   className="bpk-ticket bpk-ticket--vertical"


### PR DESCRIPTION
+ [x] For any new web components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new native components I've made sure that the style can be extended by the consumer using a `style` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.
