### PR TITLE
Rn code coverage

### DIFF
--- a/native/.gitignore
+++ b/native/.gitignore
@@ -38,3 +38,6 @@ yarn.lock
 buck-out/
 \.buckd/
 *.keystore
+
+#Jest
+coverage

--- a/native/package.json
+++ b/native/package.json
@@ -7,7 +7,7 @@
     "ios": "node node_modules/react-native/local-cli/cli.js run-ios",
     "android": "npm run android:emulator & node node_modules/react-native/local-cli/cli.js run-android",
     "android:emulator": "$ANDROID_HOME/tools/emulator -avd bpk-avd -dpi-device 420 -skin 1080x1920",
-    "test": "jest",
+    "test": "jest --coverage",
     "storybook": "storybook start -p 7007"
   },
   "devDependencies": {

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
@@ -16,96 +16,123 @@
  * limitations under the License.
  */
 
- import { Image } from 'react-native';
- import React from 'react';
- import renderer from 'react-test-renderer';
+import { Image } from 'react-native';
+import React from 'react';
+import renderer from 'react-test-renderer';
 
- import BpkButton, { BUTTON_TYPES } from './BpkButton';
+import BpkButton, { BUTTON_TYPES } from './BpkButton';
 
- const commonTests = () => {
-   jest.mock('Image', () => 'Image');
+const onPressFn = jest.fn();
+const commonTests = () => {
+  jest.mock('Image', () => 'Image');
 
-   describe('BpkButton', () => {
-     it('should render correctly', () => {
-       const tree = renderer.create(
-         <BpkButton title="Lorem ipsum" onPress={() => {}} />,
+  describe('BpkButton', () => {
+    it('should render correctly', () => {
+      const tree = renderer.create(
+        <BpkButton title="Lorem ipsum" onPress={onPressFn} />,
       ).toJSON();
-       expect(tree).toMatchSnapshot();
-     });
+      expect(tree).toMatchSnapshot();
+    });
 
-     it('should support the "large" property', () => {
-       const tree = renderer.create(
-         <BpkButton large title="Lorem ipsum" onPress={() => {}} />,
+    it('should support the "large" property', () => {
+      const tree = renderer.create(
+        <BpkButton large title="Lorem ipsum" onPress={onPressFn} />,
       ).toJSON();
-       expect(tree).toMatchSnapshot();
-     });
-
-     it('should support the "selected" property', () => {
-       const tree = renderer.create(
-         <BpkButton selected title="Lorem ipsum" onPress={() => {}} />,
+      expect(tree).toMatchSnapshot();
+    });
+    it('should support the "large" and secondary property', () => {
+      const tree = renderer.create(
+        <BpkButton large title="Lorem ipsum" type="secondary" onPress={onPressFn} />,
       ).toJSON();
-       expect(tree).toMatchSnapshot();
-     });
+      expect(tree).toMatchSnapshot();
+    });
 
-     it('should support the "disabled" property', () => {
-       const tree = renderer.create(
-         <BpkButton large title="Lorem ipsum" onPress={() => {}} />,
+    it('should support the "selected" property', () => {
+      const tree = renderer.create(
+        <BpkButton selected title="Lorem ipsum" onPress={onPressFn} />,
       ).toJSON();
-       expect(tree).toMatchSnapshot();
-     });
-
-     it('should support having an icon as well as a title', () => {
-       const tree = renderer.create(
-         <BpkButton
-           icon={<Image source="../rightarrow_360.png" />}
-           title="Lorem ipsum"
-           onPress={() => {}}
-         />,
+      expect(tree).toMatchSnapshot();
+    });
+    it('should support the "iconOnly" and "large" property', () => {
+      const tree = renderer.create(
+        <BpkButton iconOnly large icon title="Lorem ipsum" onPress={onPressFn} />,
       ).toJSON();
-       expect(tree).toMatchSnapshot();
-     });
-
-     it('should support having only an icon', () => {
-       const tree = renderer.create(
-         <BpkButton
-           title="Lorem ipsum"
-           icon={<Image source="../rightarrow_360.png" />}
-           iconOnly
-           onPress={() => {}}
-         />,
+      expect(tree).toMatchSnapshot();
+    });
+    it('should support the "icon" and "large" property', () => {
+      const tree = renderer.create(
+        <BpkButton icon large title="Lorem ipsum" onPress={onPressFn} />,
       ).toJSON();
-       expect(tree).toMatchSnapshot();
-     });
+      expect(tree).toMatchSnapshot();
+    });
 
-     it('should support overwriting styles', () => {
-       const tree = renderer.create(
-         <BpkButton title="Lorem ipsum" onPress={() => {}} style={{ width: 100 }} />,
+    it('should support the "disabled" property', () => {
+      const tree = renderer.create(
+        <BpkButton disabled title="Lorem ipsum" onPress={onPressFn} />,
       ).toJSON();
-       expect(tree).toMatchSnapshot();
-     });
+      expect(tree).toMatchSnapshot();
+    });
 
-     BUTTON_TYPES.forEach((buttonType) => {
-       it(`should render correctly with type="${buttonType}"`, () => {
-         const tree = renderer.create(
-           <BpkButton type={buttonType} title="Lorem ipsum" onPress={() => {}} />,
+    it('should support having an icon as well as a title', () => {
+      const tree = renderer.create(
+        <BpkButton
+          icon={<Image source="../rightarrow_360.png" />}
+          title="Lorem ipsum"
+          onPress={onPressFn}
+        />,
+      ).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    it('should support having only an icon', () => {
+      const tree = renderer.create(
+        <BpkButton
+          title="Lorem ipsum"
+          icon={<Image source="../rightarrow_360.png" />}
+          iconOnly
+          onPress={onPressFn}
+        />,
+      ).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should support overwriting styles', () => {
+      const tree = renderer.create(
+        <BpkButton title="Lorem ipsum" onPress={onPressFn} style={{ width: 100 }} />,
+      ).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    BUTTON_TYPES.forEach((buttonType) => {
+      it(`should render correctly with type="${buttonType}"`, () => {
+        const tree = renderer.create(
+          <BpkButton type={buttonType} title="Lorem ipsum" onPress={onPressFn} />,
         ).toJSON();
-         expect(tree).toMatchSnapshot();
-       });
-     });
+        expect(tree).toMatchSnapshot();
+      });
+    });
 
-     it('should accept iconOnly prop when icon prop is supplied', () => {
-       expect(BpkButton.propTypes.icon({
-         iconOnly: true,
-         icon: <Image />,
-       }, 'icon', 'BpkButton')).toBeFalsy();
-     });
+    it('should accept iconOnly prop when icon prop is supplied', () => {
+      expect(BpkButton.propTypes.icon({
+        iconOnly: true,
+        icon: <Image />,
+      }, 'icon', 'BpkButton')).toBeFalsy();
+    });
 
-     it('should accept iconOnly prop when icon prop is supplied', () => {
-       expect(BpkButton.propTypes.icon({
-         iconOnly: true,
-       }, 'icon', 'BpkButton').toString()).toEqual('Error: Invalid prop `icon` supplied to `BpkButton`. When `iconOnly` is enabled, `icon` must be supplied.'); // eslint-disable-line max-len
-     });
-   });
- };
+    it('should accept iconOnly prop when icon prop is supplied', () => {
+      expect(BpkButton.propTypes.icon({
+        iconOnly: true,
+      }, 'icon', 'BpkButton').toString()).toEqual('Error: Invalid prop `icon` supplied to `BpkButton`. When `iconOnly` is enabled, `icon` must be supplied.'); // eslint-disable-line max-len
+    });
+    it('should throw an error for invalid button type', () => {
+      expect(() => renderer.create(
+        <BpkButton
+          title="Lorem ipsum"
+          type="silly"
+          onPress={onPressFn}
+        />,
+      )).toThrow('"silly" is not a valid button type. Valid types are primary, featured, secondary, destructive');
+    });
+  });
+};
 
- export default commonTests;
+export default commonTests;

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
@@ -883,8 +883,344 @@ exports[`Android BpkButton should support the "disabled" property 1`] = `
 <BVLinearGradient
   colors={
     Array [
+      -1645333,
+      -1645333,
+    ]
+  }
+  end={undefined}
+  locations={null}
+  start={undefined}
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        undefined,
+      ],
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+        "disabled",
+      ]
+    }
+    accessible={true}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        Array [
+          Object {
+            "borderRadius": 100,
+            "height": 32,
+            "paddingBottom": 8,
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 8,
+          },
+          Object {
+            "borderColor": "transparent",
+          },
+        ],
+      ]
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "sans-serif",
+              "fontSize": 14,
+              "fontWeight": undefined,
+              "lineHeight": 20,
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+              Object {
+                "color": "rgb(178, 174, 189)",
+              },
+            ],
+          ]
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>
+</BVLinearGradient>
+`;
+
+exports[`Android BpkButton should support the "icon" and "large" property 1`] = `
+<BVLinearGradient
+  colors={
+    Array [
       -16722059,
       -16728728,
+    ]
+  }
+  end={undefined}
+  locations={null}
+  start={undefined}
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "minHeight": 48,
+        },
+        undefined,
+      ],
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        Array [
+          Object {
+            "borderRadius": 100,
+            "height": 32,
+            "paddingBottom": 8,
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 8,
+          },
+          Object {
+            "minHeight": 48,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          undefined,
+        ],
+      ]
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          undefined,
+          Object {
+            "justifyContent": "space-between",
+          },
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "sans-serif",
+              "fontSize": 16,
+              "fontWeight": undefined,
+              "lineHeight": 24,
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+              undefined,
+              Object {
+                "marginRight": 4,
+              },
+            ],
+          ]
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>
+</BVLinearGradient>
+`;
+
+exports[`Android BpkButton should support the "iconOnly" and "large" property 1`] = `
+<BVLinearGradient
+  colors={
+    Array [
+      -16722059,
+      -16728728,
+    ]
+  }
+  end={undefined}
+  locations={null}
+  start={undefined}
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "minHeight": 48,
+        },
+        Object {
+          "width": 48,
+        },
+      ],
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        Array [
+          Object {
+            "borderRadius": 100,
+            "height": 32,
+            "paddingBottom": 8,
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 8,
+          },
+          Object {
+            "minHeight": 48,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          undefined,
+        ],
+      ]
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          undefined,
+          undefined,
+        ]
+      }
+    />
+  </View>
+</BVLinearGradient>
+`;
+
+exports[`Android BpkButton should support the "large" and secondary property 1`] = `
+<BVLinearGradient
+  colors={
+    Array [
+      -1,
+      -1,
     ]
   }
   end={undefined}
@@ -940,9 +1276,17 @@ exports[`Android BpkButton should support the "disabled" property 1`] = `
             "paddingTop": 8,
           },
           Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
+            "paddingBottom": 6,
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "paddingTop": 6,
+          },
+          Object {
             "minHeight": 48,
-            "paddingLeft": 16,
-            "paddingRight": 16,
+            "paddingLeft": 14,
+            "paddingRight": 14,
           },
         ],
       ]
@@ -984,6 +1328,9 @@ exports[`Android BpkButton should support the "disabled" property 1`] = `
               Object {
                 "backgroundColor": "transparent",
                 "color": "rgb(255, 255, 255)",
+              },
+              Object {
+                "color": "rgb(0, 178, 214)",
               },
               undefined,
             ],

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -883,8 +883,344 @@ exports[`iOS BpkButton should support the "disabled" property 1`] = `
 <BVLinearGradient
   colors={
     Array [
+      4293321963,
+      4293321963,
+    ]
+  }
+  end={undefined}
+  locations={null}
+  start={undefined}
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        undefined,
+      ],
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+        "disabled",
+      ]
+    }
+    accessible={true}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        Array [
+          Object {
+            "borderRadius": 100,
+            "height": 32,
+            "paddingBottom": 8,
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 8,
+          },
+          Object {
+            "borderColor": "transparent",
+          },
+        ],
+      ]
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "System",
+              "fontSize": 13,
+              "fontWeight": "400",
+              "lineHeight": 18,
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+              Object {
+                "color": "rgb(178, 174, 189)",
+              },
+            ],
+          ]
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>
+</BVLinearGradient>
+`;
+
+exports[`iOS BpkButton should support the "icon" and "large" property 1`] = `
+<BVLinearGradient
+  colors={
+    Array [
       4278245237,
       4278238568,
+    ]
+  }
+  end={undefined}
+  locations={null}
+  start={undefined}
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "minHeight": 48,
+        },
+        undefined,
+      ],
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        Array [
+          Object {
+            "borderRadius": 100,
+            "height": 32,
+            "paddingBottom": 8,
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 8,
+          },
+          Object {
+            "minHeight": 48,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          undefined,
+        ],
+      ]
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          undefined,
+          Object {
+            "justifyContent": "space-between",
+          },
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "System",
+              "fontSize": 17,
+              "fontWeight": "400",
+              "lineHeight": 22,
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+              undefined,
+              Object {
+                "marginRight": 4,
+              },
+            ],
+          ]
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>
+</BVLinearGradient>
+`;
+
+exports[`iOS BpkButton should support the "iconOnly" and "large" property 1`] = `
+<BVLinearGradient
+  colors={
+    Array [
+      4278245237,
+      4278238568,
+    ]
+  }
+  end={undefined}
+  locations={null}
+  start={undefined}
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 100,
+          "height": 32,
+        },
+        Object {
+          "minHeight": 48,
+        },
+        Object {
+          "width": 48,
+        },
+      ],
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        Array [
+          Object {
+            "borderRadius": 100,
+            "height": 32,
+            "paddingBottom": 8,
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 8,
+          },
+          Object {
+            "minHeight": 48,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          undefined,
+        ],
+      ]
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          undefined,
+          undefined,
+        ]
+      }
+    />
+  </View>
+</BVLinearGradient>
+`;
+
+exports[`iOS BpkButton should support the "large" and secondary property 1`] = `
+<BVLinearGradient
+  colors={
+    Array [
+      4294967295,
+      4294967295,
     ]
   }
   end={undefined}
@@ -940,9 +1276,17 @@ exports[`iOS BpkButton should support the "disabled" property 1`] = `
             "paddingTop": 8,
           },
           Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
+            "paddingBottom": 6,
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "paddingTop": 6,
+          },
+          Object {
             "minHeight": 48,
-            "paddingLeft": 16,
-            "paddingRight": 16,
+            "paddingLeft": 14,
+            "paddingRight": 14,
           },
         ],
       ]
@@ -984,6 +1328,9 @@ exports[`iOS BpkButton should support the "disabled" property 1`] = `
               Object {
                 "backgroundColor": "transparent",
                 "color": "rgb(255, 255, 255)",
+              },
+              Object {
+                "color": "rgb(0, 178, 214)",
               },
               undefined,
             ],

--- a/native/packages/react-native-bpk-component-card/src/BpkCard-test.common.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard-test.common.js
@@ -24,6 +24,7 @@ import BpkText from '../../react-native-bpk-component-text';
 import BpkCard from './BpkCard';
 
 const commonTests = () => {
+  const onPressFn = jest.fn();
   describe('BpkCard', () => {
     const cardContent = (
       <View>
@@ -36,13 +37,13 @@ const commonTests = () => {
     );
     it('should render correctly', () => {
       const tree = renderer.create(
-        <BpkCard onPress={() => null} accessibilityLabel="Example Card">{cardContent}</BpkCard>,
+        <BpkCard onPress={onPressFn} accessibilityLabel="Example Card">{cardContent}</BpkCard>,
       ).toJSON();
       expect(tree).toMatchSnapshot();
     });
     it('should render correctly without padding', () => {
       const tree = renderer.create(
-        <BpkCard onPress={() => null} padded={false} accessibilityLabel="Example Card">{cardContent}</BpkCard>,
+        <BpkCard onPress={onPressFn} padded={false} accessibilityLabel="Example Card">{cardContent}</BpkCard>,
       ).toJSON();
       expect(tree).toMatchSnapshot();
     });

--- a/native/packages/react-native-bpk-component-text/src/BpkText-test.common.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText-test.common.js
@@ -37,21 +37,21 @@ const commonTests = () => {
     it('should render correctly with `emphasize` prop', () => {
       const tree = renderer.create(
         <BpkText emphasize>
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
         commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus
         et magnis dis parturient montes, nascetur ridiculus mus.
       </BpkText>,
-    ).toJSON();
+      ).toJSON();
       expect(tree).toMatchSnapshot();
     });
 
     it('should support overwriting styles', () => {
       const tree = renderer.create(
         <BpkText style={{ color: 'red' }}>
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum
         sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
       </BpkText>,
-    ).toJSON();
+      ).toJSON();
       expect(tree).toMatchSnapshot();
     });
 
@@ -59,11 +59,11 @@ const commonTests = () => {
       it(`should render correctly with textStyle="${textStyle}"`, () => {
         const tree = renderer.create(
           <BpkText textStyle={textStyle}>
-          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
           ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
           dis parturient montes, nascetur ridiculus mus.
         </BpkText>,
-      ).toJSON();
+        ).toJSON();
         expect(tree).toMatchSnapshot();
       });
     });
@@ -107,6 +107,11 @@ const commonTests = () => {
           },
         }).breakingStyle,
       }, 'style', 'BpkText').toString()).toEqual('Error: Invalid prop `style` with `fontWeight` value `200` supplied to `BpkText`. Use `emphasize` prop instead.'); // eslint-disable-line max-len
+    });
+    it('should return false on undefined style', () => {
+      expect(BpkText.propTypes.style({
+        style: undefined,
+      }, 'style', 'BpkText')).toBeFalsy();
     });
   });
 };


### PR DESCRIPTION
+ [x] For any new web components I've made sure that the style can be extended by the consumer using a `className` override.
+ [x] For any new native components I've made sure that the style can be extended by the consumer using a `style` override.
+ [x] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [x] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [x] If I've updated `npm-shrinkwrap.json` those changes are intentional.

This brings the code coverage flag in and I've improved the coverage to 100% on RN components, the super annoying thing is: when testing errors, those are going to `console.error` and displayed in the console even if an error is expected, any way to prevent this?

the end result is quite lovely
![screen shot 2017-09-26 at 2 20 15 pm](https://user-images.githubusercontent.com/3579758/30862407-ddd4bc26-a2c5-11e7-9617-5c91270a1ab0.png)
