### PR TITLE
[BPK-903] Add correct unit formatting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,12 @@
 
 ## UNRELEASED
 
-_Nothing Yet!_
+**Fixed:**
+- bpk-tokens:
+  - Fixed various `type` values for web, ios and android tokens e.g:
+    - `LINE_HEIGHT_XS`'s type was `font-size` but is now `size`
+    - `FONT_SIZE_XS`'s type was `size` but is now `font-size`
+    - etc
 
 ## 2017-09-27 - Image loading spinner will now be removed from DOM after fading
 

--- a/packages/bpk-docs/src/components/DocsPageBuilder/TokenSwitcher.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/TokenSwitcher.js
@@ -21,7 +21,7 @@ import React, { Component } from 'react';
 import BpkHorizontalNav, { BpkHorizontalNavItem } from 'bpk-component-horizontal-nav';
 import { BpkTable, BpkTableHead, BpkTableBody, BpkTableRow, BpkTableHeadCell, BpkTableCell } from 'bpk-component-table';
 
-import { formatTokenName, formatTokenValue } from './../../helpers/tokens-helper';
+import { formatTokenName, getTokenValue } from './../../helpers/tokens-helper';
 
 const platforms = {
   web: {
@@ -57,14 +57,16 @@ class TokenSwitcher extends Component {
 
   render() {
     const { tokens } = this.props;
+    const { selectedPlatform } = this.state;
 
-    const selectedTokens = tokens[this.state.selectedPlatform] || {};
+    const selectedTokens = tokens[selectedPlatform] || {};
 
     return (
       <div>
         <BpkHorizontalNav>
           {Object.keys(platforms).map((platform) => {
             const { id, name } = platforms[platform];
+
             return (
               <BpkHorizontalNavItem
                 key={id}
@@ -85,12 +87,16 @@ class TokenSwitcher extends Component {
             </BpkTableRow>
           </BpkTableHead>
           <BpkTableBody>
-            {Object.keys(selectedTokens).map(token => (
-              <BpkTableRow key={formatTokenName(token)}>
-                <BpkTableCell>{formatTokenName(token)}</BpkTableCell>
-                <BpkTableCell>{formatTokenValue(selectedTokens[token])}</BpkTableCell>
-              </BpkTableRow>
-            ))}
+            {Object.keys(selectedTokens).map((tokenName) => {
+              const token = selectedTokens[tokenName];
+
+              return (
+                <BpkTableRow key={tokenName}>
+                  <BpkTableCell>{formatTokenName(tokenName)}</BpkTableCell>
+                  <BpkTableCell>{getTokenValue(token, selectedPlatform)}</BpkTableCell>
+                </BpkTableRow>
+              );
+            })}
           </BpkTableBody>
         </BpkTable>
       </div>

--- a/packages/bpk-docs/src/helpers/tokens-helper.js
+++ b/packages/bpk-docs/src/helpers/tokens-helper.js
@@ -19,10 +19,14 @@
 import union from 'lodash/union';
 import kebabCase from 'lodash/kebabCase';
 
+// We don't set the root font size in the backpack base stylesheet, which means that the root font size falls back to
+// the browser default - typically 16px;
+const ROOT_FONT_SIZE = 16;
+
 export const formatTokenName = name => kebabCase(name);
 
 export const toPx = (value) => {
-  const parsed = parseFloat(value) * 16;
+  const parsed = parseFloat(value) * ROOT_FONT_SIZE;
   return parsed ? `${parsed}px` : null;
 };
 

--- a/packages/bpk-docs/src/helpers/tokens-helper.js
+++ b/packages/bpk-docs/src/helpers/tokens-helper.js
@@ -19,32 +19,56 @@
 import union from 'lodash/union';
 import kebabCase from 'lodash/kebabCase';
 
+export const formatTokenName = name => kebabCase(name);
+
 export const toPx = (value) => {
-  let parsed = null;
-
-  if (/rem$/.test(value)) {
-    parsed = parseFloat(value.replace(/rem/, '')) * 16;
-  }
-
-  if (/%$/.test(value)) {
-    parsed = parseFloat((value.replace(/%/, '')) / 100) * 16;
-  }
-
+  const parsed = parseFloat(value) * 16;
   return parsed ? `${parsed}px` : null;
 };
 
-export const formatTokenName = name => kebabCase(name);
+const TOKEN_FORMAT_MAP = {
+  web: {
+    size: (value) => {
+      if (/rem$/.test(value)) {
+        return `${value} (${toPx(value)})`;
+      }
+      return value;
+    },
+    'font-size': (value) => {
+      if (/rem$/.test(value)) {
+        return `${value} (${toPx(value)})`;
+      }
+      if (/%$/.test(value)) {
+        return `${value} (${toPx(parseFloat(value) / 100)})`;
+      }
+      return value;
+    },
+  },
+  ios: {
+    size: value => (value ? `${value}pt` : value),
+    'font-size': value => (value ? `${value}pt` : value),
+  },
+  android: {
+    size: value => (value ? `${value}dp` : value),
+    'font-size': value => (value ? `${value}sp` : value),
+  },
+};
 
-export const formatTokenValue = (value) => {
-  const pxValue = toPx(value);
-  const formatted = pxValue ? `${value} (${pxValue})` : value;
-  return formatted || '-';
+export const getTokenValue = (token, platform) => {
+  const { value, type } = token || {};
+  const formats = TOKEN_FORMAT_MAP[platform] || {};
+
+  if (formats[type]) {
+    return formats[type](value);
+  }
+
+  return value || '-';
 };
 
 export const getTokens = (tokens, keys = null) => {
   const outTokens = {};
   (keys || Object.keys(tokens)).forEach((key) => {
-    outTokens[key] = (tokens[key] || {}).value || null;
+    outTokens[key] = tokens[key] || null;
   });
   return outTokens;
 };

--- a/packages/bpk-docs/src/helpers/tokens.helper-test.js
+++ b/packages/bpk-docs/src/helpers/tokens.helper-test.js
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { getTokenValue } from './tokens-helper';
 
 describe('tokens-helper', () => {

--- a/packages/bpk-docs/src/helpers/tokens.helper-test.js
+++ b/packages/bpk-docs/src/helpers/tokens.helper-test.js
@@ -1,0 +1,64 @@
+import { getTokenValue } from './tokens-helper';
+
+describe('tokens-helper', () => {
+  describe('getTokenValue', () => {
+    describe('web', () => {
+      describe('size', () => {
+        it('should format rem token values to pixels', () => {
+          expect(getTokenValue({ value: '1rem', type: 'size' }, 'web')).toEqual('1rem (16px)');
+        });
+
+        it('should not format pixel token values', () => {
+          expect(getTokenValue({ value: '16px', type: 'size' }, 'web')).toEqual('16px');
+        });
+
+        it('should not format percentage token values', () => {
+          expect(getTokenValue({ value: '100%', type: 'size' }, 'web')).toEqual('100%');
+        });
+      });
+
+      describe('font-size', () => {
+        it('should format rem token values to pixels', () => {
+          expect(getTokenValue({ value: '1rem', type: 'font-size' }, 'web')).toEqual('1rem (16px)');
+        });
+
+        it('should format percentage token values to pixels', () => {
+          expect(getTokenValue({ value: '100%', type: 'font-size' }, 'web')).toEqual('100% (16px)');
+        });
+
+        it('should not format pixel token values', () => {
+          expect(getTokenValue({ value: '16px', type: 'font-size' }, 'web')).toEqual('16px');
+        });
+      });
+    });
+
+    describe('iOS', () => {
+      describe('size', () => {
+        it('should format token values to points', () => {
+          expect(getTokenValue({ value: '4', type: 'size' }, 'ios')).toEqual('4pt');
+        });
+      });
+
+      describe('font-size', () => {
+        it('should format token values to points', () => {
+          expect(getTokenValue({ value: '4', type: 'font-size' }, 'ios')).toEqual('4pt');
+        });
+      });
+    });
+
+
+    describe('Android', () => {
+      describe('size', () => {
+        it('should format token values to density independant pixels', () => {
+          expect(getTokenValue({ value: '4', type: 'size' }, 'android')).toEqual('4dp');
+        });
+      });
+
+      describe('font-size', () => {
+        it('should format token values to scale independant pixels', () => {
+          expect(getTokenValue({ value: '4', type: 'font-size' }, 'android')).toEqual('4sp');
+        });
+      });
+    });
+  });
+});

--- a/packages/bpk-tokens/src/android/base/typography.json
+++ b/packages/bpk-tokens/src/android/base/typography.json
@@ -35,32 +35,32 @@
     },
     "LINE_HEIGHT_XS": {
       "value": "{!LINE_HEIGHT_XS}",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_SM": {
       "value": "{!LINE_HEIGHT_SM}",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_BASE": {
       "value": "{!LINE_HEIGHT_BASE}",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_LG": {
       "value": "{!LINE_HEIGHT_LG}",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_XL": {
       "value": "{!LINE_HEIGHT_XL}",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_XXL": {
       "value": "{!LINE_HEIGHT_XXL}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "TEXT_XS_FONT_SIZE": {
@@ -75,7 +75,7 @@
     },
     "TEXT_XS_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XS}",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_SM_FONT_SIZE": {
@@ -90,7 +90,7 @@
     },
     "TEXT_SM_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_SM}",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_BASE_FONT_SIZE": {
@@ -105,7 +105,7 @@
     },
     "TEXT_BASE_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_BASE}",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_LG_FONT_SIZE": {
@@ -120,7 +120,7 @@
     },
     "TEXT_LG_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_LG}",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_XL_FONT_SIZE": {
@@ -135,7 +135,7 @@
     },
     "TEXT_XL_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XL}",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_XXL_FONT_SIZE": {
@@ -150,7 +150,7 @@
     },
     "TEXT_XXL_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XXL}",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_EMPHASIZED_FONT_WEIGHT": {

--- a/packages/bpk-tokens/src/ios/base/typography.json
+++ b/packages/bpk-tokens/src/ios/base/typography.json
@@ -5,67 +5,67 @@
   "props": {
     "FONT_SIZE_XS": {
       "value": "{!FONT_SIZE_XS}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_SM": {
       "value": "{!FONT_SIZE_SM}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_BASE": {
       "value": "{!FONT_SIZE_BASE}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_LG": {
       "value": "{!FONT_SIZE_LG}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_XL": {
       "value": "{!FONT_SIZE_XL}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_XXL": {
       "value": "{!FONT_SIZE_XXL}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_XS": {
       "value": "{!LINE_HEIGHT_XS}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_SM": {
       "value": "{!LINE_HEIGHT_SM}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_BASE": {
       "value": "{!LINE_HEIGHT_BASE}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_LG": {
       "value": "{!LINE_HEIGHT_LG}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_XL": {
       "value": "{!LINE_HEIGHT_XL}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_XXL": {
       "value": "{!LINE_HEIGHT_XXL}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "TEXT_XS_FONT_SIZE": {
       "value": "{!FONT_SIZE_XS}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_XS_FONT_WEIGHT": {
@@ -75,12 +75,12 @@
     },
     "TEXT_XS_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XS}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_SM_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_SM_FONT_WEIGHT": {
@@ -90,12 +90,12 @@
     },
     "TEXT_SM_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_SM}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_BASE_FONT_SIZE": {
       "value": "{!FONT_SIZE_BASE}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_BASE_FONT_WEIGHT": {
@@ -105,12 +105,12 @@
     },
     "TEXT_BASE_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_BASE}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_LG_FONT_SIZE": {
       "value": "{!FONT_SIZE_LG}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_LG_FONT_WEIGHT": {
@@ -120,12 +120,12 @@
     },
     "TEXT_LG_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_LG}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_XL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XL}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_XL_FONT_WEIGHT": {
@@ -135,12 +135,12 @@
     },
     "TEXT_XL_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XL}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_XXL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXL}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_XXL_FONT_WEIGHT": {
@@ -150,7 +150,7 @@
     },
     "TEXT_XXL_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XXL}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_EMPHASIZED_FONT_WEIGHT": {

--- a/packages/bpk-tokens/src/web/base/typography.json
+++ b/packages/bpk-tokens/src/web/base/typography.json
@@ -15,22 +15,22 @@
     },
     "LINE_HEIGHT_SM": {
       "value": "{!SPACING_MD}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_BASE": {
       "value": "{!SPACING_BASE}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_LG": {
       "value": "{!SPACING_LG}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_XL": {
       "value": "{!SPACING_XXL}",
-      "type": "number",
+      "type": "size",
       "category": "typesettings"
     },
     "LINE_HEIGHT_XXL": {
@@ -40,92 +40,92 @@
     },
     "FONT_SIZE_ROOT": {
       "value": "100%",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_SM": {
       "value": "{!FONT_SIZE_SM}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_BASE": {
       "value": "{!FONT_SIZE_BASE}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_LG": {
       "value": "{!FONT_SIZE_LG}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_XL": {
       "value": "{!FONT_SIZE_XL}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_SIZE_XXL": {
       "value": "{!FONT_SIZE_XXL}",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings"
     },
     "FONT_WEIGHT_BOLD": {
       "value": "{!FONT_WEIGHT_BOLD}",
-      "type": "size",
+      "type": "string",
       "category": "font-weights"
     },
     "H6_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "H5_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "H4_FONT_SIZE": {
       "value": "{!FONT_SIZE_BASE}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "H3_FONT_SIZE": {
       "value": "{!FONT_SIZE_LG}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "H2_FONT_SIZE": {
       "value": "{!FONT_SIZE_XL}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "H1_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXL}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "H6_LINE_HEIGHT": {
       "value": "{!SPACING_MD}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "H5_LINE_HEIGHT": {
       "value": "{!SPACING_MD}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "H4_LINE_HEIGHT": {
       "value": "{!SPACING_BASE}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "H3_LINE_HEIGHT": {
       "value": "{!SPACING_LG}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "H2_LINE_HEIGHT": {
       "value": "{!SPACING_XXL}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "H1_LINE_HEIGHT": {
@@ -135,32 +135,32 @@
     },
     "H6_FONT_WEIGHT": {
       "value": "700",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "H5_FONT_WEIGHT": {
       "value": "700",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "H4_FONT_WEIGHT": {
       "value": "700",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "H3_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "H2_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "H1_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "HEADING_MARGIN_TOP": {
@@ -270,17 +270,17 @@
     },
     "TEXT_XS_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_XS_LINE_HEIGHT": {
       "value": "{!SPACING_MD}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_XS_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "TEXT_XS_LETTER_SPACING": {
@@ -290,17 +290,17 @@
     },
     "TEXT_SM_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_SM_LINE_HEIGHT": {
       "value": "{!SPACING_MD}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_SM_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "TEXT_SM_LETTER_SPACING": {
@@ -310,17 +310,17 @@
     },
     "TEXT_BASE_FONT_SIZE": {
       "value": "{!FONT_SIZE_BASE}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_BASE_LINE_HEIGHT": {
       "value": "{!SPACING_BASE}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_BASE_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "TEXT_BASE_LETTER_SPACING": {
@@ -330,17 +330,17 @@
     },
     "TEXT_LG_FONT_SIZE": {
       "value": "{!FONT_SIZE_LG}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_LG_LINE_HEIGHT": {
       "value": "{!SPACING_LG}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_LG_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "TEXT_LG_LETTER_SPACING": {
@@ -350,17 +350,17 @@
     },
     "TEXT_XL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XL}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_XL_LINE_HEIGHT": {
       "value": "{!SPACING_XXL}",
-      "type": "number",
+      "type": "size",
       "category": "line-heights"
     },
     "TEXT_XL_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "TEXT_XL_LETTER_SPACING": {
@@ -370,7 +370,7 @@
     },
     "TEXT_XXL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXL}",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes"
     },
     "TEXT_XXL_LINE_HEIGHT": {
@@ -380,7 +380,7 @@
     },
     "TEXT_XXL_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights"
     },
     "TEXT_XXL_LETTER_SPACING": {

--- a/packages/bpk-tokens/tokens/android/base.android.xml
+++ b/packages/bpk-tokens/tokens/android/base.android.xml
@@ -93,29 +93,29 @@
   <property name="FONT_SIZE_LG" category="typesettings">16sp</property>
   <property name="FONT_SIZE_XL" category="typesettings">20sp</property>
   <property name="FONT_SIZE_XXL" category="typesettings">24sp</property>
-  <property name="LINE_HEIGHT_XS" category="typesettings">16sp</property>
-  <property name="LINE_HEIGHT_SM" category="typesettings">20sp</property>
-  <property name="LINE_HEIGHT_BASE" category="typesettings">24sp</property>
-  <property name="LINE_HEIGHT_LG" category="typesettings">24sp</property>
-  <property name="LINE_HEIGHT_XL" category="typesettings">28sp</property>
-  <property name="LINE_HEIGHT_XXL" category="typesettings">32</property>
+  <property name="LINE_HEIGHT_XS" category="typesettings">16dp</property>
+  <property name="LINE_HEIGHT_SM" category="typesettings">20dp</property>
+  <property name="LINE_HEIGHT_BASE" category="typesettings">24dp</property>
+  <property name="LINE_HEIGHT_LG" category="typesettings">24dp</property>
+  <property name="LINE_HEIGHT_XL" category="typesettings">28dp</property>
+  <property name="LINE_HEIGHT_XXL" category="typesettings">32dp</property>
   <property name="TEXT_XS_FONT_SIZE" category="font-sizes">12sp</property>
   <property name="TEXT_XS_FONT_WEIGHT" category="font-weights">400</property>
-  <property name="TEXT_XS_LINE_HEIGHT" category="line-heights">16sp</property>
+  <property name="TEXT_XS_LINE_HEIGHT" category="line-heights">16dp</property>
   <property name="TEXT_SM_FONT_SIZE" category="font-sizes">14sp</property>
   <property name="TEXT_SM_FONT_WEIGHT" category="font-weights">400</property>
-  <property name="TEXT_SM_LINE_HEIGHT" category="line-heights">20sp</property>
+  <property name="TEXT_SM_LINE_HEIGHT" category="line-heights">20dp</property>
   <property name="TEXT_BASE_FONT_SIZE" category="font-sizes">14sp</property>
   <property name="TEXT_BASE_FONT_WEIGHT" category="font-weights">500</property>
-  <property name="TEXT_BASE_LINE_HEIGHT" category="line-heights">24sp</property>
+  <property name="TEXT_BASE_LINE_HEIGHT" category="line-heights">24dp</property>
   <property name="TEXT_LG_FONT_SIZE" category="font-sizes">16sp</property>
   <property name="TEXT_LG_FONT_WEIGHT" category="font-weights">400</property>
-  <property name="TEXT_LG_LINE_HEIGHT" category="line-heights">24sp</property>
+  <property name="TEXT_LG_LINE_HEIGHT" category="line-heights">24dp</property>
   <property name="TEXT_XL_FONT_SIZE" category="font-sizes">20sp</property>
   <property name="TEXT_XL_FONT_WEIGHT" category="font-weights">500</property>
-  <property name="TEXT_XL_LINE_HEIGHT" category="line-heights">28sp</property>
+  <property name="TEXT_XL_LINE_HEIGHT" category="line-heights">28dp</property>
   <property name="TEXT_XXL_FONT_SIZE" category="font-sizes">24sp</property>
   <property name="TEXT_XXL_FONT_WEIGHT" category="font-weights">400</property>
-  <property name="TEXT_XXL_LINE_HEIGHT" category="line-heights">32sp</property>
+  <property name="TEXT_XXL_LINE_HEIGHT" category="line-heights">32dp</property>
   <property name="TEXT_EMPHASIZED_FONT_WEIGHT" category="font-weights">500</property>
 </resources>

--- a/packages/bpk-tokens/tokens/android/base.raw.json
+++ b/packages/bpk-tokens/tokens/android/base.raw.json
@@ -910,7 +910,7 @@
     },
     "LINE_HEIGHT_XS": {
       "value": "16",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 16
@@ -919,7 +919,7 @@
     },
     "LINE_HEIGHT_SM": {
       "value": "20",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 20
@@ -928,7 +928,7 @@
     },
     "LINE_HEIGHT_BASE": {
       "value": "24",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 24
@@ -937,7 +937,7 @@
     },
     "LINE_HEIGHT_LG": {
       "value": "24",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 24
@@ -946,7 +946,7 @@
     },
     "LINE_HEIGHT_XL": {
       "value": "28",
-      "type": "font-size",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 28
@@ -955,7 +955,7 @@
     },
     "LINE_HEIGHT_XXL": {
       "value": "32",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 32
@@ -982,7 +982,7 @@
     },
     "TEXT_XS_LINE_HEIGHT": {
       "value": "16",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 16
@@ -1009,7 +1009,7 @@
     },
     "TEXT_SM_LINE_HEIGHT": {
       "value": "20",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 20
@@ -1036,7 +1036,7 @@
     },
     "TEXT_BASE_LINE_HEIGHT": {
       "value": "24",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 24
@@ -1063,7 +1063,7 @@
     },
     "TEXT_LG_LINE_HEIGHT": {
       "value": "24",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 24
@@ -1090,7 +1090,7 @@
     },
     "TEXT_XL_LINE_HEIGHT": {
       "value": "28",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 28
@@ -1117,7 +1117,7 @@
     },
     "TEXT_XXL_LINE_HEIGHT": {
       "value": "32",
-      "type": "font-size",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 32

--- a/packages/bpk-tokens/tokens/base.raw.json
+++ b/packages/bpk-tokens/tokens/base.raw.json
@@ -2491,7 +2491,7 @@
     },
     "LINE_HEIGHT_SM": {
       "value": "1.125rem",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": "1.125rem"
@@ -2500,7 +2500,7 @@
     },
     "LINE_HEIGHT_BASE": {
       "value": "1.5rem",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": "1.5rem"
@@ -2509,7 +2509,7 @@
     },
     "LINE_HEIGHT_LG": {
       "value": "1.875rem",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": "1.875rem"
@@ -2518,7 +2518,7 @@
     },
     "LINE_HEIGHT_XL": {
       "value": "2.625rem",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": "2.625rem"
@@ -2533,13 +2533,13 @@
     },
     "FONT_SIZE_ROOT": {
       "value": "100%",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       "name": "FONT_SIZE_ROOT"
     },
     "FONT_SIZE_SM": {
       "value": ".75rem",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": ".75rem"
@@ -2548,7 +2548,7 @@
     },
     "FONT_SIZE_BASE": {
       "value": "1rem",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": "1rem"
@@ -2557,7 +2557,7 @@
     },
     "FONT_SIZE_LG": {
       "value": "1.5rem",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": "1.5rem"
@@ -2566,7 +2566,7 @@
     },
     "FONT_SIZE_XL": {
       "value": "1.75rem",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": "1.75rem"
@@ -2575,7 +2575,7 @@
     },
     "FONT_SIZE_XXL": {
       "value": "2.625rem",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": "2.625rem"
@@ -2584,7 +2584,7 @@
     },
     "FONT_WEIGHT_BOLD": {
       "value": "700",
-      "type": "size",
+      "type": "string",
       "category": "font-weights",
       ".alias": {
         "value": "700"
@@ -2593,7 +2593,7 @@
     },
     "H6_FONT_SIZE": {
       "value": ".75rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": ".75rem"
@@ -2602,7 +2602,7 @@
     },
     "H5_FONT_SIZE": {
       "value": ".75rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": ".75rem"
@@ -2611,7 +2611,7 @@
     },
     "H4_FONT_SIZE": {
       "value": "1rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": "1rem"
@@ -2620,7 +2620,7 @@
     },
     "H3_FONT_SIZE": {
       "value": "1.5rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": "1.5rem"
@@ -2629,7 +2629,7 @@
     },
     "H2_FONT_SIZE": {
       "value": "1.75rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": "1.75rem"
@@ -2638,7 +2638,7 @@
     },
     "H1_FONT_SIZE": {
       "value": "2.625rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": "2.625rem"
@@ -2647,7 +2647,7 @@
     },
     "H6_LINE_HEIGHT": {
       "value": "1.125rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "1.125rem"
@@ -2656,7 +2656,7 @@
     },
     "H5_LINE_HEIGHT": {
       "value": "1.125rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "1.125rem"
@@ -2665,7 +2665,7 @@
     },
     "H4_LINE_HEIGHT": {
       "value": "1.5rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "1.5rem"
@@ -2674,7 +2674,7 @@
     },
     "H3_LINE_HEIGHT": {
       "value": "1.875rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "1.875rem"
@@ -2683,7 +2683,7 @@
     },
     "H2_LINE_HEIGHT": {
       "value": "2.625rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "2.625rem"
@@ -2698,37 +2698,37 @@
     },
     "H6_FONT_WEIGHT": {
       "value": "700",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "H6_FONT_WEIGHT"
     },
     "H5_FONT_WEIGHT": {
       "value": "700",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "H5_FONT_WEIGHT"
     },
     "H4_FONT_WEIGHT": {
       "value": "700",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "H4_FONT_WEIGHT"
     },
     "H3_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "H3_FONT_WEIGHT"
     },
     "H2_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "H2_FONT_WEIGHT"
     },
     "H1_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "H1_FONT_WEIGHT"
     },
@@ -2896,7 +2896,7 @@
     },
     "TEXT_XS_FONT_SIZE": {
       "value": ".75rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": ".75rem"
@@ -2905,7 +2905,7 @@
     },
     "TEXT_XS_LINE_HEIGHT": {
       "value": "1.125rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "1.125rem"
@@ -2914,7 +2914,7 @@
     },
     "TEXT_XS_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "TEXT_XS_FONT_WEIGHT"
     },
@@ -2926,7 +2926,7 @@
     },
     "TEXT_SM_FONT_SIZE": {
       "value": ".75rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": ".75rem"
@@ -2935,7 +2935,7 @@
     },
     "TEXT_SM_LINE_HEIGHT": {
       "value": "1.125rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "1.125rem"
@@ -2944,7 +2944,7 @@
     },
     "TEXT_SM_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "TEXT_SM_FONT_WEIGHT"
     },
@@ -2956,7 +2956,7 @@
     },
     "TEXT_BASE_FONT_SIZE": {
       "value": "1rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": "1rem"
@@ -2965,7 +2965,7 @@
     },
     "TEXT_BASE_LINE_HEIGHT": {
       "value": "1.5rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "1.5rem"
@@ -2974,7 +2974,7 @@
     },
     "TEXT_BASE_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "TEXT_BASE_FONT_WEIGHT"
     },
@@ -2986,7 +2986,7 @@
     },
     "TEXT_LG_FONT_SIZE": {
       "value": "1.5rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": "1.5rem"
@@ -2995,7 +2995,7 @@
     },
     "TEXT_LG_LINE_HEIGHT": {
       "value": "1.875rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "1.875rem"
@@ -3004,7 +3004,7 @@
     },
     "TEXT_LG_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "TEXT_LG_FONT_WEIGHT"
     },
@@ -3016,7 +3016,7 @@
     },
     "TEXT_XL_FONT_SIZE": {
       "value": "1.75rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": "1.75rem"
@@ -3025,7 +3025,7 @@
     },
     "TEXT_XL_LINE_HEIGHT": {
       "value": "2.625rem",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": "2.625rem"
@@ -3034,7 +3034,7 @@
     },
     "TEXT_XL_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "TEXT_XL_FONT_WEIGHT"
     },
@@ -3046,7 +3046,7 @@
     },
     "TEXT_XXL_FONT_SIZE": {
       "value": "2.625rem",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": "2.625rem"
@@ -3061,7 +3061,7 @@
     },
     "TEXT_XXL_FONT_WEIGHT": {
       "value": "400",
-      "type": "number",
+      "type": "string",
       "category": "font-weights",
       "name": "TEXT_XXL_FONT_WEIGHT"
     },

--- a/packages/bpk-tokens/tokens/ios/base.ios.json
+++ b/packages/bpk-tokens/tokens/ios/base.ios.json
@@ -605,7 +605,7 @@
     },
     {
       "value": "11",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 11
@@ -614,7 +614,7 @@
     },
     {
       "value": "13",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 13
@@ -623,7 +623,7 @@
     },
     {
       "value": "15",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 15
@@ -632,7 +632,7 @@
     },
     {
       "value": "17",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 17
@@ -641,7 +641,7 @@
     },
     {
       "value": "20",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 20
@@ -650,7 +650,7 @@
     },
     {
       "value": "34",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 34
@@ -659,7 +659,7 @@
     },
     {
       "value": "13",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 13
@@ -668,7 +668,7 @@
     },
     {
       "value": "18",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 18
@@ -677,7 +677,7 @@
     },
     {
       "value": "20",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 20
@@ -686,7 +686,7 @@
     },
     {
       "value": "22",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 22
@@ -695,7 +695,7 @@
     },
     {
       "value": "24",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 24
@@ -704,7 +704,7 @@
     },
     {
       "value": "41",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 41
@@ -713,7 +713,7 @@
     },
     {
       "value": "11",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 11
@@ -731,7 +731,7 @@
     },
     {
       "value": "13",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 13
@@ -740,7 +740,7 @@
     },
     {
       "value": "13",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 13
@@ -758,7 +758,7 @@
     },
     {
       "value": "18",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 18
@@ -767,7 +767,7 @@
     },
     {
       "value": "15",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 15
@@ -785,7 +785,7 @@
     },
     {
       "value": "20",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 20
@@ -794,7 +794,7 @@
     },
     {
       "value": "17",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 17
@@ -812,7 +812,7 @@
     },
     {
       "value": "22",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 22
@@ -821,7 +821,7 @@
     },
     {
       "value": "20",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 20
@@ -839,7 +839,7 @@
     },
     {
       "value": "24",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 24
@@ -848,7 +848,7 @@
     },
     {
       "value": "34",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 34
@@ -866,7 +866,7 @@
     },
     {
       "value": "41",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 41

--- a/packages/bpk-tokens/tokens/ios/base.raw.json
+++ b/packages/bpk-tokens/tokens/ios/base.raw.json
@@ -856,7 +856,7 @@
     },
     "FONT_SIZE_XS": {
       "value": "11",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 11
@@ -865,7 +865,7 @@
     },
     "FONT_SIZE_SM": {
       "value": "13",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 13
@@ -874,7 +874,7 @@
     },
     "FONT_SIZE_BASE": {
       "value": "15",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 15
@@ -883,7 +883,7 @@
     },
     "FONT_SIZE_LG": {
       "value": "17",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 17
@@ -892,7 +892,7 @@
     },
     "FONT_SIZE_XL": {
       "value": "20",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 20
@@ -901,7 +901,7 @@
     },
     "FONT_SIZE_XXL": {
       "value": "34",
-      "type": "size",
+      "type": "font-size",
       "category": "typesettings",
       ".alias": {
         "value": 34
@@ -910,7 +910,7 @@
     },
     "LINE_HEIGHT_XS": {
       "value": "13",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 13
@@ -919,7 +919,7 @@
     },
     "LINE_HEIGHT_SM": {
       "value": "18",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 18
@@ -928,7 +928,7 @@
     },
     "LINE_HEIGHT_BASE": {
       "value": "20",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 20
@@ -937,7 +937,7 @@
     },
     "LINE_HEIGHT_LG": {
       "value": "22",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 22
@@ -946,7 +946,7 @@
     },
     "LINE_HEIGHT_XL": {
       "value": "24",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 24
@@ -955,7 +955,7 @@
     },
     "LINE_HEIGHT_XXL": {
       "value": "41",
-      "type": "number",
+      "type": "size",
       "category": "typesettings",
       ".alias": {
         "value": 41
@@ -964,7 +964,7 @@
     },
     "TEXT_XS_FONT_SIZE": {
       "value": "11",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 11
@@ -982,7 +982,7 @@
     },
     "TEXT_XS_LINE_HEIGHT": {
       "value": "13",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 13
@@ -991,7 +991,7 @@
     },
     "TEXT_SM_FONT_SIZE": {
       "value": "13",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 13
@@ -1009,7 +1009,7 @@
     },
     "TEXT_SM_LINE_HEIGHT": {
       "value": "18",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 18
@@ -1018,7 +1018,7 @@
     },
     "TEXT_BASE_FONT_SIZE": {
       "value": "15",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 15
@@ -1036,7 +1036,7 @@
     },
     "TEXT_BASE_LINE_HEIGHT": {
       "value": "20",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 20
@@ -1045,7 +1045,7 @@
     },
     "TEXT_LG_FONT_SIZE": {
       "value": "17",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 17
@@ -1063,7 +1063,7 @@
     },
     "TEXT_LG_LINE_HEIGHT": {
       "value": "22",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 22
@@ -1072,7 +1072,7 @@
     },
     "TEXT_XL_FONT_SIZE": {
       "value": "20",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 20
@@ -1090,7 +1090,7 @@
     },
     "TEXT_XL_LINE_HEIGHT": {
       "value": "24",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 24
@@ -1099,7 +1099,7 @@
     },
     "TEXT_XXL_FONT_SIZE": {
       "value": "34",
-      "type": "size",
+      "type": "font-size",
       "category": "font-sizes",
       ".alias": {
         "value": 34
@@ -1117,7 +1117,7 @@
     },
     "TEXT_XXL_LINE_HEIGHT": {
       "value": "41",
-      "type": "number",
+      "type": "size",
       "category": "line-heights",
       ".alias": {
         "value": 41


### PR DESCRIPTION
We now rely on token meta data to apply correct formatting on the docs site. This requires that the token `type` is actually correct. Some were not, so i fixed them.

<!-- Thanks for your PR. Please verify below that you've made all the necessary changes. -->
<!-- # Please remove this and the above line before submitting -->

+ [ ] For any new web components I've made sure that the style can be extended by the consumer using a `className` override.
+ [ ] For any new native components I've made sure that the style can be extended by the consumer using a `style` override.
+ [ ] For any new files I've included the [Apache 2.0 License header](https://github.com/Skyscanner/backpack/blob/master/packages/bpk-tokens/formatters/license-header.js#L2-L16) at the top of the file.
+ [ ] I've updated `changelog.md` for any changes that need to be highlighted in the changelog.
+ [ ] If I've updated `npm-shrinkwrap.json` those changes are intentional.
