### PR TITLE
[BPK-970] Tidy up native dependencies

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -12,14 +12,10 @@
   },
   "devDependencies": {
     "@storybook/react-native": "^3.2.11",
-    "babel-jest": "20.0.3",
     "babel-preset-react-native": "3.0.2",
-    "bpk-tokens": "^24.2.0",
-    "jest": "20.0.4",
-    "prop-types": "^15.5.10",
-    "react-dom": "16.0.0-alpha.12",
-    "react-test-renderer": "16.0.0-alpha.12",
-    "react": "16.0.0-alpha.12",
+    "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.0.0",
+    "react": "^16.0.0",
     "react-native": "^0.47.0"
   },
   "jest": {

--- a/native/packages/react-native-bpk-component-button/package.json
+++ b/native/packages/react-native-bpk-component-button/package.json
@@ -14,7 +14,7 @@
     "react-native": ">= 0.47.0"
   },
   "dependencies": {
-    "bpk-tokens": "^24.2.0",
+    "bpk-tokens": "^26.2.0",
     "prop-types": "^15.5.8",
     "react-native-bpk-component-text": "^2.1.5",
     "react-native-linear-gradient": "^2.3.0"

--- a/native/packages/react-native-bpk-component-card/package.json
+++ b/native/packages/react-native-bpk-component-card/package.json
@@ -14,7 +14,7 @@
     "react-native": ">= 0.47.0"
   },
   "dependencies": {
-    "bpk-tokens": "^24.2.0",
+    "bpk-tokens": "^26.2.0",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {

--- a/native/packages/react-native-bpk-component-text-input/package.json
+++ b/native/packages/react-native-bpk-component-text-input/package.json
@@ -14,7 +14,7 @@
     "react-native": ">= 0.47.0"
   },
   "dependencies": {
-    "bpk-tokens": "^24.2.0",
+    "bpk-tokens": "^26.2.0",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {


### PR DESCRIPTION
I noticed that our `native/package.json` had extraneous dependencies (which are otherwise provided by our top level `package.json`). So i removed them.

I also noticed that `bpk-tokens` was a a few major versions behind in some of the native components - perhaps leading to some of the token issues we've been having.