### PR TITLE
[BPK-937] Add ios & android border tokens

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## UNRELEASED
 
-_Nothing yet..._
+**Added:**
+- bpk-tokens:
+  - iOS & Android border size tokens
 
 ## 2017-10-06 - React Native Icon Component
 - react-native-bpk-component-icon: 0.0.4 => 1.0.0

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
@@ -32,7 +32,7 @@ const roundedBorderRadius = 100;
 // These should probably be their own tokens.
 // For now they are derived from existing tokens.
 const largeHeight = tokens.spacingSm * 12;
-const buttonBorderWidth = tokens.spacingSm / 2;
+const buttonBorderWidth = tokens.borderSizeLg;
 
 // The base styles that are initially applied to all buttons.
 const base = StyleSheet.create({

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
@@ -37,6 +37,7 @@ const tokens = Platform.select({
 })();
 
 const {
+  borderSizeSm,
   colorGray100,
   colorGray300,
   colorGray700,
@@ -61,13 +62,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     borderColor: colorGray100,
-      // TODO Replace with borderSm token once available
-    borderWidth: 1,
+    borderWidth: borderSizeSm,
       // TODO Replace with radiiSm token once available
     borderRadius: spacingSm,
     paddingLeft: spacingSm * 3,
     paddingRight: spacingSm * 3,
-      // TODO Replace '1' with borderSm token once available
     height: (spacingLg * 2) - (1 * 2),
   },
   text: {
@@ -83,7 +82,6 @@ const styles = StyleSheet.create({
   smallInput: {
     paddingLeft: spacingMd,
     paddingRight: spacingMd,
-      // TODO Replace '1' with borderSm token once available
     height: spacingXl - (1 * 2),
   },
   smallText: {

--- a/packages/bpk-tokens/src/android/base.json
+++ b/packages/bpk-tokens/src/android/base.json
@@ -1,5 +1,6 @@
 {
   "imports": [
+    "./base/borders.json",
     "./base/colors.json",
     "./base/spacing.json",
     "./base/typography.json"

--- a/packages/bpk-tokens/src/android/base/aliases.json
+++ b/packages/bpk-tokens/src/android/base/aliases.json
@@ -26,6 +26,9 @@
     "SPACING_BASE": 16,
     "SPACING_LG": 24,
     "SPACING_XL": 32,
-    "SPACING_XXL": 40
+    "SPACING_XXL": 40,
+    "BORDER_SIZE_SM": 1,
+    "BORDER_SIZE_LG": 2,
+    "BORDER_SIZE_XL": 3
   }
 }

--- a/packages/bpk-tokens/src/android/base/borders.json
+++ b/packages/bpk-tokens/src/android/base/borders.json
@@ -1,0 +1,17 @@
+{
+  "global": {
+    "type": "size",
+    "category": "borders"
+  },
+  "props": {
+    "BORDER_SIZE_SM": {
+      "value": "{!BORDER_SIZE_SM}"
+    },
+    "BORDER_SIZE_LG": {
+      "value": "{!BORDER_SIZE_LG}"
+    },
+    "BORDER_SIZE_XL": {
+      "value": "{!BORDER_SIZE_XL}"
+    }
+  }
+}

--- a/packages/bpk-tokens/src/ios/base.json
+++ b/packages/bpk-tokens/src/ios/base.json
@@ -1,5 +1,6 @@
 {
   "imports": [
+    "./base/borders.json",
     "./base/colors.json",
     "./base/spacing.json",
     "./base/typography.json"

--- a/packages/bpk-tokens/src/ios/base/aliases.json
+++ b/packages/bpk-tokens/src/ios/base/aliases.json
@@ -25,6 +25,9 @@
     "SPACING_BASE": 16,
     "SPACING_LG": 24,
     "SPACING_XL": 32,
-    "SPACING_XXL": 40
+    "SPACING_XXL": 40,
+    "BORDER_SIZE_SM": 1,
+    "BORDER_SIZE_LG": 2,
+    "BORDER_SIZE_XL": 3
   }
 }

--- a/packages/bpk-tokens/src/ios/base/borders.json
+++ b/packages/bpk-tokens/src/ios/base/borders.json
@@ -1,0 +1,17 @@
+{
+  "global": {
+    "type": "size",
+    "category": "borders"
+  },
+  "props": {
+    "BORDER_SIZE_SM": {
+      "value": "{!BORDER_SIZE_SM}"
+    },
+    "BORDER_SIZE_LG": {
+      "value": "{!BORDER_SIZE_LG}"
+    },
+    "BORDER_SIZE_XL": {
+      "value": "{!BORDER_SIZE_XL}"
+    }
+  }
+}

--- a/packages/bpk-tokens/tokens/android/base.android.xml
+++ b/packages/bpk-tokens/tokens/android/base.android.xml
@@ -20,6 +20,9 @@
   
 -->
 <resources>
+  <property name="BORDER_SIZE_SM" category="borders">1dp</property>
+  <property name="BORDER_SIZE_LG" category="borders">2dp</property>
+  <property name="BORDER_SIZE_XL" category="borders">3dp</property>
   <color name="COLOR_WHITE" category="colors">#ffffffff</color>
   <color name="COLOR_BLUE_50" category="colors">#ffe1f4f8</color>
   <color name="COLOR_BLUE_100" category="colors">#ffcbeef5</color>

--- a/packages/bpk-tokens/tokens/android/base.raw.json
+++ b/packages/bpk-tokens/tokens/android/base.raw.json
@@ -254,9 +254,45 @@
     },
     "SPACING_XXL": {
       "value": 40
+    },
+    "BORDER_SIZE_SM": {
+      "value": 1
+    },
+    "BORDER_SIZE_LG": {
+      "value": 2
+    },
+    "BORDER_SIZE_XL": {
+      "value": 3
     }
   },
   "props": {
+    "BORDER_SIZE_SM": {
+      "type": "size",
+      "category": "borders",
+      "value": "1",
+      ".alias": {
+        "value": 1
+      },
+      "name": "BORDER_SIZE_SM"
+    },
+    "BORDER_SIZE_LG": {
+      "type": "size",
+      "category": "borders",
+      "value": "2",
+      ".alias": {
+        "value": 2
+      },
+      "name": "BORDER_SIZE_LG"
+    },
+    "BORDER_SIZE_XL": {
+      "type": "size",
+      "category": "borders",
+      "value": "3",
+      ".alias": {
+        "value": 3
+      },
+      "name": "BORDER_SIZE_XL"
+    },
     "COLOR_WHITE": {
       "type": "color",
       "category": "colors",
@@ -1159,6 +1195,9 @@
     }
   },
   "propKeys": [
+    "BORDER_SIZE_SM",
+    "BORDER_SIZE_LG",
+    "BORDER_SIZE_XL",
     "COLOR_WHITE",
     "COLOR_BLUE_50",
     "COLOR_BLUE_100",

--- a/packages/bpk-tokens/tokens/android/base.react.native.common.js
+++ b/packages/bpk-tokens/tokens/android/base.react.native.common.js
@@ -19,6 +19,9 @@
  */
 
 module.exports = {
+  borderSizeSm: 1,
+  borderSizeLg: 2,
+  borderSizeXl: 3,
   colorWhite: "rgb(255, 255, 255)",
   colorBlue50: "rgb(225, 244, 248)",
   colorBlue100: "rgb(203, 238, 245)",

--- a/packages/bpk-tokens/tokens/android/base.react.native.es6.js
+++ b/packages/bpk-tokens/tokens/android/base.react.native.es6.js
@@ -17,6 +17,9 @@
  * limitations under the License.
  * 
  */
+export const borderSizeSm = 1;
+export const borderSizeLg = 2;
+export const borderSizeXl = 3;
 export const colorWhite = "rgb(255, 255, 255)";
 export const colorBlue50 = "rgb(225, 244, 248)";
 export const colorBlue100 = "rgb(203, 238, 245)";
@@ -117,6 +120,11 @@ export const textXxlFontSize = 24;
 export const textXxlFontWeight = "400";
 export const textXxlLineHeight = 32;
 export const textEmphasizedFontWeight = "500";
+export const borders = {
+borderSizeSm,
+borderSizeLg,
+borderSizeXl,
+};
 export const colors = {
 colorWhite,
 colorBlue50,

--- a/packages/bpk-tokens/tokens/ios/base.ios.json
+++ b/packages/bpk-tokens/tokens/ios/base.ios.json
@@ -1,6 +1,33 @@
 {
   "properties": [
     {
+      "type": "size",
+      "category": "borders",
+      "value": "1",
+      ".alias": {
+        "value": 1
+      },
+      "name": "borderSizeSm"
+    },
+    {
+      "type": "size",
+      "category": "borders",
+      "value": "2",
+      ".alias": {
+        "value": 2
+      },
+      "name": "borderSizeLg"
+    },
+    {
+      "type": "size",
+      "category": "borders",
+      "value": "3",
+      ".alias": {
+        "value": 3
+      },
+      "name": "borderSizeXl"
+    },
+    {
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",

--- a/packages/bpk-tokens/tokens/ios/base.raw.json
+++ b/packages/bpk-tokens/tokens/ios/base.raw.json
@@ -251,9 +251,45 @@
     },
     "SPACING_XXL": {
       "value": 40
+    },
+    "BORDER_SIZE_SM": {
+      "value": 1
+    },
+    "BORDER_SIZE_LG": {
+      "value": 2
+    },
+    "BORDER_SIZE_XL": {
+      "value": 3
     }
   },
   "props": {
+    "BORDER_SIZE_SM": {
+      "type": "size",
+      "category": "borders",
+      "value": "1",
+      ".alias": {
+        "value": 1
+      },
+      "name": "BORDER_SIZE_SM"
+    },
+    "BORDER_SIZE_LG": {
+      "type": "size",
+      "category": "borders",
+      "value": "2",
+      ".alias": {
+        "value": 2
+      },
+      "name": "BORDER_SIZE_LG"
+    },
+    "BORDER_SIZE_XL": {
+      "type": "size",
+      "category": "borders",
+      "value": "3",
+      ".alias": {
+        "value": 3
+      },
+      "name": "BORDER_SIZE_XL"
+    },
     "COLOR_WHITE": {
       "type": "color",
       "category": "colors",
@@ -1147,6 +1183,9 @@
     }
   },
   "propKeys": [
+    "BORDER_SIZE_SM",
+    "BORDER_SIZE_LG",
+    "BORDER_SIZE_XL",
     "COLOR_WHITE",
     "COLOR_BLUE_50",
     "COLOR_BLUE_100",

--- a/packages/bpk-tokens/tokens/ios/base.react.native.common.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.common.js
@@ -19,6 +19,9 @@
  */
 
 module.exports = {
+  borderSizeSm: 1,
+  borderSizeLg: 2,
+  borderSizeXl: 3,
   colorWhite: "rgb(255, 255, 255)",
   colorBlue50: "rgb(225, 244, 248)",
   colorBlue100: "rgb(203, 238, 245)",

--- a/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
@@ -17,6 +17,9 @@
  * limitations under the License.
  * 
  */
+export const borderSizeSm = 1;
+export const borderSizeLg = 2;
+export const borderSizeXl = 3;
 export const colorWhite = "rgb(255, 255, 255)";
 export const colorBlue50 = "rgb(225, 244, 248)";
 export const colorBlue100 = "rgb(203, 238, 245)";
@@ -116,6 +119,11 @@ export const textXxlFontSize = 34;
 export const textXxlFontWeight = "700";
 export const textXxlLineHeight = 41;
 export const textEmphasizedFontWeight = "600";
+export const borders = {
+borderSizeSm,
+borderSizeLg,
+borderSizeXl,
+};
 export const colors = {
 colorWhite,
 colorBlue50,


### PR DESCRIPTION
Added `BORDER_SIZE_SM`, `BORDER_SIZE_LG` & `BORDER_SIZE_XL` tokens and consumed them in places where `borderWidth` was set to a hard coded value (only two places, button and text input).

The names are important here - they match web and therefore show up on the docs page.
