### PR TITLE
Bpk 937 touchable highlight

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@
   - Android elevation tokens
   - iOS touchable highlight underlay tokens
 
+**Fixed:**
+- bpk-tokens:
+  - Fixed package meta data to point to correct entry file
+    i.e. `"main": "index.js",` instead of `"main": "tokens/base.default.scss",`
+
 ## 2017-10-06 - React Native Icon Component
 - react-native-bpk-component-icon: 0.0.4 => 1.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - bpk-tokens:
   - iOS & Android border size tokens
   - Android elevation tokens
+  - iOS touchable highlight underlay tokens
 
 ## 2017-10-06 - React Native Icon Component
 - react-native-bpk-component-icon: 0.0.4 => 1.0.0

--- a/native/package.json
+++ b/native/package.json
@@ -28,6 +28,9 @@
     "preset": "react-native",
     "verbose": true,
     "testRegex": ".*-test(\\.ios)?(\\.android)?\\.js$",
+    "transformIgnorePatterns": [
+      "node_modules/(?!react-native|bpk)"
+    ],
     "coverageThreshold": {
       "global": {
         "statements": 75,

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
@@ -16,15 +16,19 @@
  * limitations under the License.
  */
 
+import { setOpacity } from 'bpk-tokens';
 import { Platform, StyleSheet } from 'react-native';
 
-const tokens = Platform.OS === 'ios' ?
-  require('bpk-tokens/tokens/ios/base.react.native.common.js') :
-  require('bpk-tokens/tokens/android/base.react.native.common.js')
-;
+const tokens = Platform.select({
+  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
+  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
+})();
 
 // Slight darkness to use when buttons are pressed in.
-const underlayColor = 'rgba(0, 0, 0, 0.15)';
+const underlayColor = Platform.select({
+  ios: () => setOpacity(tokens.underlayColor, tokens.underlayOpacity),
+  android: () => null,
+})();
 
 // A high number used as a borderRadius value produces circular corners.
 const roundedBorderRadius = 100;

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
@@ -124,6 +124,7 @@ const commonTests = () => {
       }, 'icon', 'BpkButton').toString()).toEqual('Error: Invalid prop `icon` supplied to `BpkButton`. When `iconOnly` is enabled, `icon` must be supplied.'); // eslint-disable-line max-len
     });
     it('should throw an error for invalid button type', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
       expect(() => renderer.create(
         <BpkButton
           title="Lorem ipsum"

--- a/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.common.js
+++ b/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.common.js
@@ -36,6 +36,7 @@ const commonTests = () => {
     });
 
     it('should error when theme is not provided', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
       expect(() => renderer.create(
         <BpkThemeProvider>
           <Text>Lorem ipsum</Text>

--- a/packages/bpk-tokens/package.json
+++ b/packages/bpk-tokens/package.json
@@ -2,7 +2,7 @@
   "name": "bpk-tokens",
   "version": "26.3.0",
   "description": "Backpack design tokens for colors, spacing, font, etc.",
-  "main": "tokens/base.default.scss",
+  "main": "index.js",
   "scripts": {
     "tokens": "gulp"
   },

--- a/packages/bpk-tokens/src/ios/base.json
+++ b/packages/bpk-tokens/src/ios/base.json
@@ -3,6 +3,7 @@
     "./base/borders.json",
     "./base/colors.json",
     "./base/spacing.json",
+    "./base/touchables.json",
     "./base/typography.json"
   ]
 }

--- a/packages/bpk-tokens/src/ios/base/touchables.json
+++ b/packages/bpk-tokens/src/ios/base/touchables.json
@@ -1,0 +1,15 @@
+{
+  "global": {
+    "category": "touchables"
+  },
+  "props": {
+    "UNDERLAY_COLOR": {
+      "value": "{!GRAY_900}",
+      "type": "color"
+    },
+    "UNDERLAY_OPACITY": {
+      "value": "0.15",
+      "type": "number"
+    }
+  }
+}

--- a/packages/bpk-tokens/src/react-native-output-test.js
+++ b/packages/bpk-tokens/src/react-native-output-test.js
@@ -31,7 +31,7 @@ const ANDROID_ONLY_PROPS = [
   'ELEVATION_LG',
   'ELEVATION_XL',
 ];
-const IOS_ONLY_PROPS = [];
+const IOS_ONLY_PROPS = ['UNDERLAY_COLOR', 'UNDERLAY_OPACITY'];
 
 describe('React Native output', () => {
   it('Produces the same output for Android and iOS', () => {

--- a/packages/bpk-tokens/tokens/ios/base.ios.json
+++ b/packages/bpk-tokens/tokens/ios/base.ios.json
@@ -631,6 +631,21 @@
       "name": "spacingXxl"
     },
     {
+      "category": "touchables",
+      "value": "#252033ff",
+      "type": "color",
+      ".alias": {
+        "value": "#252033"
+      },
+      "name": "underlayColor"
+    },
+    {
+      "category": "touchables",
+      "value": "0.15",
+      "type": "number",
+      "name": "underlayOpacity"
+    },
+    {
       "value": "\"System\"",
       "type": "font",
       "category": "typesettings",

--- a/packages/bpk-tokens/tokens/ios/base.raw.json
+++ b/packages/bpk-tokens/tokens/ios/base.raw.json
@@ -893,6 +893,21 @@
       },
       "name": "SPACING_XXL"
     },
+    "UNDERLAY_COLOR": {
+      "category": "touchables",
+      "value": "#252033ff",
+      "type": "color",
+      ".alias": {
+        "value": "#252033"
+      },
+      "name": "UNDERLAY_COLOR"
+    },
+    "UNDERLAY_OPACITY": {
+      "category": "touchables",
+      "value": "0.15",
+      "type": "number",
+      "name": "UNDERLAY_OPACITY"
+    },
     "FONT_FAMILY": {
       "value": "\"System\"",
       "type": "font",
@@ -1253,6 +1268,8 @@
     "SPACING_LG",
     "SPACING_XL",
     "SPACING_XXL",
+    "UNDERLAY_COLOR",
+    "UNDERLAY_OPACITY",
     "FONT_FAMILY",
     "FONT_SIZE_XS",
     "FONT_SIZE_SM",

--- a/packages/bpk-tokens/tokens/ios/base.react.native.common.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.common.js
@@ -89,6 +89,8 @@ module.exports = {
   spacingLg: 24,
   spacingXl: 32,
   spacingXxl: 40,
+  underlayColor: "rgb(37, 32, 51)",
+  underlayOpacity: 0.15,
   fontFamily: "System",
   fontSizeXs: 11,
   fontSizeSm: 13,

--- a/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
@@ -87,6 +87,8 @@ export const spacingBase = 16;
 export const spacingLg = 24;
 export const spacingXl = 32;
 export const spacingXxl = 40;
+export const underlayColor = "rgb(37, 32, 51)";
+export const underlayOpacity = 0.15;
 export const fontFamily = "System";
 export const fontSizeXs = 11;
 export const fontSizeSm = 13;
@@ -194,6 +196,10 @@ spacingBase,
 spacingLg,
 spacingXl,
 spacingXxl,
+};
+export const touchables = {
+underlayColor,
+underlayOpacity,
 };
 export const typesettings = {
 fontFamily,


### PR DESCRIPTION
Added iOS only `UNDERLAY_COLOR` & `UNDERLAY_OPACITY` tokens and consumed them in the button component.