### PR TITLE
[BPK-1019] Add theming support for secondary button

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
   - iOS & Android radii tokens
 
 - react-native-bpk-component-button
-  - Added theming support
+  - Primary and secondary buttons can now be themed.
 
 **Fixed:**
 - bpk-tokens:

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
@@ -173,12 +173,22 @@ const themeMappings = {
   text: {
     color: {
       primary: 'buttonPrimaryTextColor',
+      secondary: 'buttonSecondaryTextColor',
+    },
+  },
+  button: {
+    borderColor: {
+      secondary: 'buttonSecondaryBorderColor',
     },
   },
   gradient: {
     primary: {
       startColor: 'buttonPrimaryGradientStartColor',
       endColor: 'buttonPrimaryGradientEndColor',
+    },
+    secondary: {
+      startColor: 'buttonSecondaryBackgroundColor',
+      endColor: 'buttonSecondaryBackgroundColor',
     },
   },
 };

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
@@ -125,6 +125,25 @@ const commonTests = () => {
         iconOnly: true,
       }, 'icon', 'BpkButton').toString()).toEqual('Error: Invalid prop `icon` supplied to `BpkButton`. When `iconOnly` is enabled, `icon` must be supplied.'); // eslint-disable-line max-len
     });
+
+    it('should reject theme property when some theme attributes are omitted', () => { // eslint-disable-line max-len
+      expect(propTypes.theme({
+        type: 'primary',
+        theme: {},
+      }, 'theme', 'BpkButton').toString()).toEqual('Error: Invalid prop `theme` supplied to `BpkButton`. For buttons of type `primary`, the `theme` prop must include `buttonPrimaryTextColor, buttonPrimaryGradientStartColor, buttonPrimaryGradientEndColor`'); // eslint-disable-line max-len
+    });
+
+    it('should accept theme property when correct attributes are supplied', () => { // eslint-disable-line max-len
+      expect(propTypes.theme({
+        type: 'primary',
+        theme: {
+          buttonPrimaryGradientStartColor: 'red',
+          buttonPrimaryGradientEndColor: 'green',
+          buttonPrimaryTextColor: 'blue',
+        },
+      }, 'theme', 'BpkButton')).toBeFalsy();
+    });
+
     it('should throw an error for invalid button type', () => {
       jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
       expect(() => renderer.create(
@@ -138,15 +157,14 @@ const commonTests = () => {
   });
 
   describe('BpkButtonThemed', () => {
-    const themeAttributes = {
-      gradientStartColor: '#CE93D8',
-      gradientEndColor: '#AB47BC',
-      textColor: 'rgba(255, 255, 255, 0.8)',
-    };
-
     it('should render correctly', () => {
+      const theme = {
+        buttonPrimaryTextColor: 'red',
+        buttonPrimaryGradientStartColor: 'green',
+        buttonPrimaryGradientEndColor: 'blue',
+      };
       const tree = renderer.create(
-        <BpkThemeProvider theme={themeAttributes}>
+        <BpkThemeProvider theme={theme}>
           <BpkButton title="Lorem ipsum" type="primary" onPress={onPressFn} />
         </BpkThemeProvider>,
       ).toJSON();

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
@@ -49,14 +49,17 @@ exports[`Android BpkButton should render correctly 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -160,22 +163,25 @@ exports[`Android BpkButton should render correctly with type="destructive" 1`] =
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "rgb(230, 228, 235)",
-            "borderWidth": 2,
-            "paddingBottom": 6,
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "paddingTop": 6,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingBottom": 6,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 6,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -282,14 +288,17 @@ exports[`Android BpkButton should render correctly with type="featured" 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -393,14 +402,17 @@ exports[`Android BpkButton should render correctly with type="primary" 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -504,22 +516,25 @@ exports[`Android BpkButton should render correctly with type="secondary" 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "rgb(230, 228, 235)",
-            "borderWidth": 2,
-            "paddingBottom": 6,
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "paddingTop": 6,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingBottom": 6,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 6,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -627,15 +642,18 @@ exports[`Android BpkButton should support having an icon as well as a title 1`] 
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          undefined,
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            undefined,
+          ],
+          Object {},
         ],
       ]
     }
@@ -751,15 +769,18 @@ exports[`Android BpkButton should support having only an icon 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          undefined,
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            undefined,
+          ],
+          Object {},
         ],
       ]
     }
@@ -838,14 +859,17 @@ exports[`Android BpkButton should support overwriting styles 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -951,17 +975,20 @@ exports[`Android BpkButton should support the "disabled" property 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "transparent",
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1073,20 +1100,23 @@ exports[`Android BpkButton should support the "icon" and "large" property 1`] = 
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "minHeight": 48,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-          },
-          undefined,
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "minHeight": 48,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            undefined,
+          ],
+          Object {},
         ],
       ]
     }
@@ -1204,20 +1234,23 @@ exports[`Android BpkButton should support the "iconOnly" and "large" property 1`
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "minHeight": 48,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-          },
-          undefined,
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "minHeight": 48,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            undefined,
+          ],
+          Object {},
         ],
       ]
     }
@@ -1294,27 +1327,30 @@ exports[`Android BpkButton should support the "large" and secondary property 1`]
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "rgb(230, 228, 235)",
-            "borderWidth": 2,
-            "paddingBottom": 6,
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "paddingTop": 6,
-          },
-          Object {
-            "minHeight": 48,
-            "paddingLeft": 14,
-            "paddingRight": 14,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingBottom": 6,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 6,
+            },
+            Object {
+              "minHeight": 48,
+              "paddingLeft": 14,
+              "paddingRight": 14,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1426,19 +1462,22 @@ exports[`Android BpkButton should support the "large" property 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "minHeight": 48,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "minHeight": 48,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1545,17 +1584,20 @@ exports[`Android BpkButton should support the "selected" property 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "transparent",
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1618,8 +1660,8 @@ exports[`Android BpkButtonThemed should render correctly 1`] = `
 <BVLinearGradient
   colors={
     Array [
-      -16722059,
-      -16728728,
+      -16744448,
+      -16776961,
     ]
   }
   end={undefined}
@@ -1663,14 +1705,17 @@ exports[`Android BpkButtonThemed should render correctly 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1713,7 +1758,9 @@ exports[`Android BpkButtonThemed should render correctly 1`] = `
                   "color": "rgb(255, 255, 255)",
                 },
               ],
-              Object {},
+              Object {
+                "color": "red",
+              },
             ],
           ]
         }

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -49,14 +49,17 @@ exports[`iOS BpkButton should render correctly 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -160,22 +163,25 @@ exports[`iOS BpkButton should render correctly with type="destructive" 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "rgb(230, 228, 235)",
-            "borderWidth": 2,
-            "paddingBottom": 6,
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "paddingTop": 6,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingBottom": 6,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 6,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -282,14 +288,17 @@ exports[`iOS BpkButton should render correctly with type="featured" 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -393,14 +402,17 @@ exports[`iOS BpkButton should render correctly with type="primary" 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -504,22 +516,25 @@ exports[`iOS BpkButton should render correctly with type="secondary" 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "rgb(230, 228, 235)",
-            "borderWidth": 2,
-            "paddingBottom": 6,
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "paddingTop": 6,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingBottom": 6,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 6,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -627,15 +642,18 @@ exports[`iOS BpkButton should support having an icon as well as a title 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          undefined,
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            undefined,
+          ],
+          Object {},
         ],
       ]
     }
@@ -751,15 +769,18 @@ exports[`iOS BpkButton should support having only an icon 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          undefined,
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            undefined,
+          ],
+          Object {},
         ],
       ]
     }
@@ -838,14 +859,17 @@ exports[`iOS BpkButton should support overwriting styles 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -951,17 +975,20 @@ exports[`iOS BpkButton should support the "disabled" property 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "transparent",
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1073,20 +1100,23 @@ exports[`iOS BpkButton should support the "icon" and "large" property 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "minHeight": 48,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-          },
-          undefined,
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "minHeight": 48,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            undefined,
+          ],
+          Object {},
         ],
       ]
     }
@@ -1204,20 +1234,23 @@ exports[`iOS BpkButton should support the "iconOnly" and "large" property 1`] = 
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "minHeight": 48,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-          },
-          undefined,
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "minHeight": 48,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            undefined,
+          ],
+          Object {},
         ],
       ]
     }
@@ -1294,27 +1327,30 @@ exports[`iOS BpkButton should support the "large" and secondary property 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "rgb(230, 228, 235)",
-            "borderWidth": 2,
-            "paddingBottom": 6,
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "paddingTop": 6,
-          },
-          Object {
-            "minHeight": 48,
-            "paddingLeft": 14,
-            "paddingRight": 14,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingBottom": 6,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 6,
+            },
+            Object {
+              "minHeight": 48,
+              "paddingLeft": 14,
+              "paddingRight": 14,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1426,19 +1462,22 @@ exports[`iOS BpkButton should support the "large" property 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "minHeight": 48,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "minHeight": 48,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1545,17 +1584,20 @@ exports[`iOS BpkButton should support the "selected" property 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
-          Object {
-            "borderColor": "transparent",
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1618,8 +1660,8 @@ exports[`iOS BpkButtonThemed should render correctly 1`] = `
 <BVLinearGradient
   colors={
     Array [
-      4278245237,
-      4278238568,
+      4278222848,
+      4278190335,
     ]
   }
   end={undefined}
@@ -1663,14 +1705,17 @@ exports[`iOS BpkButtonThemed should render correctly 1`] = `
           "backgroundColor": "transparent",
         },
         Array [
-          Object {
-            "borderRadius": 40,
-            "height": 32,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-          },
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingBottom": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 8,
+            },
+          ],
+          Object {},
         ],
       ]
     }
@@ -1713,7 +1758,9 @@ exports[`iOS BpkButtonThemed should render correctly 1`] = `
                   "color": "rgb(255, 255, 255)",
                 },
               ],
-              Object {},
+              Object {
+                "color": "red",
+              },
             ],
           ]
         }

--- a/native/packages/react-native-bpk-component-button/stories.js
+++ b/native/packages/react-native-bpk-component-button/stories.js
@@ -101,10 +101,22 @@ ArrowImage.defaultProps = {
   type: '',
 };
 
+const theme = {
+  contentColor: '#2d244c',
+  backgroundColor: '#fff',
+  brandColors: {
+    gradientStart: '#fce134',
+    gradientEnd: '#f8c42d',
+  },
+};
+
 const themeAttributes = {
-  buttonPrimaryGradientStartColor: '#fce134',
-  buttonPrimaryGradientEndColor: '#f8c42d',
-  buttonPrimaryTextColor: '#2d244c',
+  buttonPrimaryGradientStartColor: theme.brandColors.gradientStart,
+  buttonPrimaryGradientEndColor: theme.brandColors.gradientEnd,
+  buttonPrimaryTextColor: theme.contentColor,
+  buttonSecondaryBackgroundColor: theme.backgroundColor,
+  buttonSecondaryTextColor: theme.contentColor,
+  buttonSecondaryBorderColor: theme.contentColor,
 };
 
 const generateButtonStoryForType = type => (
@@ -227,6 +239,8 @@ storiesOf('BpkButton', module)
       <View>
         <BpkText textStyle="xxl">Primary</BpkText>
         {generateButtonStoryForType('primary')}
+        <BpkText textStyle="xxl">Secondary</BpkText>
+        {generateButtonStoryForType('secondary')}
       </View>
     </BpkThemeProvider>
   ))


### PR DESCRIPTION
![screen shot 2017-10-09 at 13 44 33](https://user-images.githubusercontent.com/73652/31338634-ffebf70c-acf7-11e7-84e1-cc3fca699edd.png)

In addition to secondary theming, this PR also includes better propTypes validation, so that a warning will be printed if:

a) The user is trying to theme an unthemeable button type
b) The user hasn't included all the necessary theme attributes for the type of button they're trying to theme.