### PR TITLE
[BPK-434] Add datatable component from react-virtualized

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -35,6 +35,7 @@ configure(() => {
   require('./../packages/bpk-component-code/stories');
   require('./../packages/bpk-component-content-container/stories');
   require('./../packages/bpk-component-datepicker/stories');
+  require('./../packages/bpk-component-datatable/stories');
   require('./../packages/bpk-component-fieldset/stories');
   require('./../packages/bpk-component-form-validation/stories');
   require('./../packages/bpk-component-grid/stories');

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@
 - react-native-bpk-component-button
   - Added theming support
 
+- New component `bpk-component-datatable`, from `react-virtualized`
+
 **Fixed:**
 - bpk-tokens:
   - Fixed package meta data to point to correct entry file

--- a/packages/bpk-component-datatable/index.js
+++ b/packages/bpk-component-datatable/index.js
@@ -15,9 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import BpkDataTable from './src/BpkDataTable';
 import { Column } from 'react-virtualized';
+import BpkDataTable from './src/BpkDataTable';
 
 const BpkColumn = Column;
 

--- a/packages/bpk-component-datatable/index.js
+++ b/packages/bpk-component-datatable/index.js
@@ -1,0 +1,24 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BpkDataTable from './src/BpkDataTable';
+import { Column } from 'react-virtualized';
+
+const BpkColumn = Column;
+
+export { BpkDataTable, BpkColumn };

--- a/packages/bpk-component-datatable/package-lock.json
+++ b/packages/bpk-component-datatable/package-lock.json
@@ -1,0 +1,187 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"classnames": {
+			"version": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+			"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+		},
+		"prop-types": {
+			"version": "15.6.0",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+			"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			},
+			"dependencies": {
+				"asap": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+				},
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"requires": {
+						"iconv-lite": "0.4.19"
+					}
+				},
+				"fbjs": {
+					"version": "0.8.16",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+					"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+					"requires": {
+						"core-js": "1.2.7",
+						"isomorphic-fetch": "2.2.1",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1",
+						"promise": "7.3.1",
+						"setimmediate": "1.0.5",
+						"ua-parser-js": "0.7.14"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"isomorphic-fetch": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+					"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+					"requires": {
+						"node-fetch": "1.7.3",
+						"whatwg-fetch": "2.0.3"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "0.1.12",
+						"is-stream": "1.1.0"
+					}
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "2.0.6"
+					}
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				},
+				"ua-parser-js": {
+					"version": "0.7.14",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
+					"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+				},
+				"whatwg-fetch": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+					"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+				}
+			}
+		},
+		"react-table": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/react-table/-/react-table-6.6.0.tgz",
+			"integrity": "sha512-6g5GKrmufyol9x9i0GwSK2GwMFFevhfLhoYi9fD+0NUD4ctY9iHiSMAHkZK8vgBe6cRQyl7ncdtBB9vhJPtmfw==",
+			"requires": {
+				"classnames": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
+			}
+		},
+		"react-virtualized": {
+			"version": "9.10.1",
+			"resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.10.1.tgz",
+			"integrity": "sha512-A58MfDt5hyy3FoIni+5HDZM1jihgvHG81Mzld34Auhi6X7tRYcN4OCYuRb9eH6w/6CAAKC2MHd+f9z7yeYDCqA==",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"classnames": "2.2.5",
+				"dom-helpers": "3.2.1",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.0"
+			},
+			"dependencies": {
+				"babel-runtime": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"requires": {
+						"core-js": "2.5.1",
+						"regenerator-runtime": "0.11.0"
+					}
+				},
+				"classnames": {
+					"version": "2.2.5",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+					"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+				},
+				"core-js": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+					"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+				},
+				"dom-helpers": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
+					"integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+					"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+				}
+			}
+		}
+	}
+}

--- a/packages/bpk-component-datatable/package.json
+++ b/packages/bpk-component-datatable/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bpk-component-datatable",
+  "version": "0.0.0",
+  "description": "Backpack datatable component.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0"
+  },
+  "dependencies": {
+    "bpk-mixins": "^17.0.1",
+    "bpk-react-utils": "^2.3.4",
+    "prop-types": "^15.5.8",
+    "react-table": "^6.6.0",
+    "react-virtualized": "^9.10.1"
+  }
+}

--- a/packages/bpk-component-datatable/package.json
+++ b/packages/bpk-component-datatable/package.json
@@ -13,8 +13,9 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "bpk-mixins": "^17.0.1",
-    "bpk-react-utils": "^2.3.4",
+    "bpk-component-input": "^3.2.32",
+    "bpk-mixins": "^17.0.5",
+    "bpk-react-utils": "^2.3.6",
     "prop-types": "^15.5.8",
     "react-table": "^6.6.0",
     "react-virtualized": "^9.10.1"

--- a/packages/bpk-component-datatable/readme.md
+++ b/packages/bpk-component-datatable/readme.md
@@ -1,0 +1,29 @@
+# bpk-component-datatable
+
+> Backpack datatable component.
+
+## Installation
+
+```sh
+npm install bpk-component-datatable --save-dev
+```
+
+## Usage
+
+```js
+import React from 'react';
+import BpkDataTable from 'bpk-component-datatable';
+
+export default () => (
+  
+);
+```
+
+## Props
+
+| Property   | PropType                | Required | Default Value |
+| ---------- | ----------------------- | -------- | ------------- |
+| onClose    | func                    | yes      | -             |
+| children   | node                    | yes      | -             |
+| className  | string                  | no       | -             |
+| closeLabel | oneOfType(string, func) | no       | -             |

--- a/packages/bpk-component-datatable/readme.md
+++ b/packages/bpk-component-datatable/readme.md
@@ -1,6 +1,6 @@
 # bpk-component-datatable
 
-> Backpack datatable component.
+> Backpack datatable component, which takes up the entire width of the parent.
 
 ## Installation
 
@@ -14,16 +14,44 @@ npm install bpk-component-datatable --save-dev
 import React from 'react';
 import BpkDataTable from 'bpk-component-datatable';
 
+const rows = [
+  { name: 'Jose', description: 'Software Engineer' },
+  { name: 'Rolf', description: 'Manager' }
+]
+
 export default () => (
-  
+  <BpkDataTable rows={rows} height={200} dir={'rtl'}>
+    <BpkColumn
+      label={'Name'}
+      dataKey={'name'}
+      width={100}
+    />
+    <BpkColumn
+      label={'Description'}
+      dataKey={'description'}
+      width={100}
+      flexGrow={1}
+    />
+  </BpkDataTable>
 );
 ```
 
 ## Props
 
-| Property   | PropType                | Required | Default Value |
-| ---------- | ----------------------- | -------- | ------------- |
-| onClose    | func                    | yes      | -             |
-| children   | node                    | yes      | -             |
-| className  | string                  | no       | -             |
-| closeLabel | oneOfType(string, func) | no       | -             |
+### BpkDataTable
+
+| Property   | PropType                | Required | Default Value |  
+| ---------- | ----------------------- | -------- | ------------- |  
+| rows       | arrayOf(Object)         | yes      | -             |  
+| children   | node                    | yes      | -             |  
+| height     | number                  | yes      | -             |  
+| dir        | string                  | no       | 'ltr'         |  
+
+### BpkColumn
+
+| Property   | PropType                | Required | Default Value |  
+| ---------- | ----------------------- | -------- | ------------- |  
+| label      | string                  | yes      | -             |  
+| dataKey    | string                  | yes      | -             |  
+| width      | number                  | yes      | -             |  
+| flexGrow   | number                  | no       | 0             |  

--- a/packages/bpk-component-datatable/src/BpkColumn.js
+++ b/packages/bpk-component-datatable/src/BpkColumn.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Column } from 'react-virtualized';
+import { cssModules } from 'bpk-react-utils';
+
+import STYLES from './bpk-column.scss';
+
+const getClassName = cssModules(STYLES);
+
+const BpkColumn = props => <Column className={getClassName('bpk-column')} {...props} />;
+
+export default BpkColumn;

--- a/packages/bpk-component-datatable/src/BpkColumn.js
+++ b/packages/bpk-component-datatable/src/BpkColumn.js
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { Column } from 'react-virtualized';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-component-datatable/src/BpkColumn.js
+++ b/packages/bpk-component-datatable/src/BpkColumn.js
@@ -26,4 +26,4 @@ const getClassName = cssModules(STYLES);
 
 const BpkColumn = props => <Column className={getClassName('bpk-column')} {...props} />;
 
-export default BpkColumn;
+export { BpkColumn, Column };

--- a/packages/bpk-component-datatable/src/BpkDataTable-test.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable-test.js
@@ -1,0 +1,106 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BpkDataTable from './BpkDataTable';
+import { Column as BpkColumn } from './BpkColumn';
+
+jest.mock('react-dom', () => ({
+  findDOMNode: () => ({}),
+}));
+
+const rows = [
+  { name: 'Jose', description: 'Software Engineer', bla: 'Bla' },
+  { name: 'Rolf', description: 'Some guy', bla: 'Bla' },
+];
+
+describe('BpkDataTable', () => {
+  it('should render correctly with multiple columns', () => {
+    const tree = renderer.create(
+      <BpkDataTable rows={rows} height={200}>
+        <BpkColumn
+          label={'Name'}
+          dataKey={'name'}
+          width={100}
+        />
+        <BpkColumn
+          label={'Description'}
+          dataKey={'description'}
+          width={100}
+          flexGrow={1}
+        />
+        <BpkColumn
+          label={'Bla'}
+          dataKey={'bla'}
+          width={100}
+        />
+      </BpkDataTable>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with no data; only headers', () => {
+    const tree = renderer.create(
+      <BpkDataTable rows={[]} height={200}>
+        <BpkColumn
+          label={'Name'}
+          dataKey={'name'}
+          width={100}
+        />
+        <BpkColumn
+          label={'Description'}
+          dataKey={'description'}
+          width={100}
+          flexGrow={1}
+        />
+        <BpkColumn
+          label={'Bla'}
+          dataKey={'bla'}
+          width={100}
+        />
+      </BpkDataTable>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly in RTL', () => {
+    const tree = renderer.create(
+      <BpkDataTable rows={rows} height={200} dir={'rtl'}>
+        <BpkColumn
+          label={'Name'}
+          dataKey={'name'}
+          width={100}
+        />
+        <BpkColumn
+          label={'Description'}
+          dataKey={'description'}
+          width={100}
+          flexGrow={1}
+        />
+        <BpkColumn
+          label={'Bla'}
+          dataKey={'bla'}
+          width={100}
+        />
+      </BpkDataTable>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -16,24 +16,32 @@
  * limitations under the License.
  */
 
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
-import { defaultTableRowRenderer, Column, Table, AutoSizer } from 'react-virtualized';
+import { Table, AutoSizer } from 'react-virtualized';
 import { cssModules } from 'bpk-react-utils';
 import _ from 'lodash';
 
 import STYLES from './bpk-data-table.scss';
-import BpkColumn from './BpkColumn';
+import { BpkColumn } from './BpkColumn';
 
 const getClassName = cssModules(STYLES);
 
-export default class BpkDataTable extends Component {
+const sortList = ({ sortBy, sortDirection, list }) => {
+  const sorted = _.sortBy(list, sortBy);
+  if (sortDirection === 'DESC') {
+    return _.reverse(sorted);
+  }
+  return sorted;
+};
+
+class BpkDataTable extends Component {
   constructor(props) {
     super(props);
 
     const sortBy = 'name';
     const sortDirection = 'ASC';
-    const sortedList = this._sortList({ sortBy, sortDirection, list: props.rows });
+    const sortedList = sortList({ sortBy, sortDirection, list: props.rows });
     let columns = _.cloneDeep(this.props.children);
 
     if (this.props.dir === 'rtl') {
@@ -46,17 +54,16 @@ export default class BpkDataTable extends Component {
       sortDirection,
       columns,
       rows: props.rows,
-      rowSelected: undefined
+      rowSelected: undefined,
     };
 
-    this.table = null;
     this.rowClicked = this.rowClicked.bind(this);
     this.rowStyle = this.rowStyle.bind(this);
-    this._sort = this._sort.bind(this);
+    this.sort = this.sort.bind(this);
   }
 
-  rowClicked({ event, index, rowData }) {
-    if (this.state.rowSelected == index) {
+  rowClicked({ index }) {
+    if (this.state.rowSelected === index) {
       this.setState({ rowSelected: undefined });
     } else {
       this.setState({ rowSelected: index });
@@ -65,59 +72,65 @@ export default class BpkDataTable extends Component {
 
   rowStyle({ index }) {
     const classNames = [getClassName('bpk-data-table__row')];
-    if (this.state.rowSelected == index) {
+    if (this.state.rowSelected === index) {
       classNames.push(getClassName('bpk-data-table__row--selected'));
-    };
-    if (index == -1) {
+    }
+    if (index === -1) {
       classNames.push(getClassName('bpk-data-table__headerRow'));
     }
     return classNames;
   }
 
-  _sort({ sortBy, sortDirection }) {
-    const sortedList = this._sortList({ sortBy, sortDirection, list: this.state.rows });
+  sort({ sortBy, sortDirection }) {
+    const sortedList = sortList({ sortBy, sortDirection, list: this.state.rows });
 
     this.setState({ sortBy, sortDirection, sortedList });
   }
 
-  _sortList({ sortBy, sortDirection, list }) {
-    const sorted = _.sortBy(list, sortBy);
-    if (sortDirection === 'DESC') {
-      return _.reverse(sorted);
-    }
-    return sorted;
-  }
-
   render() {
-    const { sortedList, sortDirection, sortBy } = this.state; 
+    const { sortedList, sortDirection, sortBy } = this.state;
+    const { height } = this.props;
 
     return (
       <AutoSizer disableHeight>
-      {({width}) =>
-        <Table
-          className={getClassName('bpk-data-table')}
-          ref={table => { this.table = table; }}
-          width={width}
-          height={300}
-          headerHeight={60}
-          rowHeight={60}
-          rowCount={sortedList.length}
-          rowGetter={({ index }) => sortedList[index]}
-          headerClassName={getClassName('bpk-data-table__headerColumn')}
-          rowClassName={this.rowStyle}
-          onRowClick={this.rowClicked}
-          sort={this._sort}
-          sortBy={sortBy}
-          sortDirection={sortDirection} 
-          gridStyle={{ direction: this.props.dir }}
-        >
-          {
-            this.state.columns.map((child, index) => (
-              BpkColumn({ ...child.props, key: index })
-            ))
-          }
-        </Table>}
+        {({ width }) =>
+          <Table
+            className={getClassName('bpk-data-table')}
+            width={width}
+            height={height}
+            headerHeight={60}
+            rowHeight={60}
+            rowCount={sortedList.length}
+            rowGetter={({ index }) => sortedList[index]}
+            headerClassName={getClassName('bpk-data-table__headerColumn')}
+            rowClassName={this.rowStyle}
+            onRowClick={this.rowClicked}
+            sort={this.sort}
+            sortBy={sortBy}
+            sortDirection={sortDirection}
+            gridStyle={{ direction: this.props.dir }}
+          >
+            {
+              this.state.columns.map((child, index) => (
+                BpkColumn({ ...child.props, key: index })
+              ))
+            }
+          </Table>
+        }
       </AutoSizer>
     );
   }
+}
+
+BpkDataTable.propTypes = {
+  rows: PropTypes.arrayOf(Object).isRequired,
+  children: PropTypes.element.isRequired,
+  height: PropTypes.number.isRequired,
+  dir: PropTypes.string,
 };
+
+BpkDataTable.defaultProps = {
+  dir: 'ltr',
+};
+
+export default BpkDataTable;

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -20,7 +20,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Table, AutoSizer } from 'react-virtualized';
 import { cssModules } from 'bpk-react-utils';
-import _ from 'lodash';
+import BpkInput, { INPUT_TYPES } from 'bpk-component-input';
+import { sortBy } from 'lodash';
 
 import STYLES from './bpk-data-table.scss';
 import { BpkColumn } from './BpkColumn';
@@ -28,12 +29,23 @@ import { BpkColumn } from './BpkColumn';
 const getClassName = cssModules(STYLES);
 
 const sortList = ({ sortBy, sortDirection, list }) => {
-  const sorted = _.sortBy(list, sortBy);
+  const sorted = sortBy(list, sortBy);
   if (sortDirection === 'DESC') {
-    return _.reverse(sorted);
+    return sorted.slice().reverse();
   }
   return sorted;
 };
+
+const SearchableHeaderRenderer = (props) => (
+  <div className={props.className} role="row" style={props.style}>
+    {props.columns.map(c => (
+      <div className={c.className} style={c.style}>
+        {c}
+        <BpkInput placeholder="Search..." type={INPUT_TYPES.TEXT} />
+      </div>
+    ))}
+  </div>
+);
 
 class BpkDataTable extends Component {
   constructor(props) {
@@ -42,10 +54,10 @@ class BpkDataTable extends Component {
     const sortBy = 'name';
     const sortDirection = 'ASC';
     const sortedList = sortList({ sortBy, sortDirection, list: props.rows });
-    let columns = _.cloneDeep(this.props.children);
+    let columns = this.props.children.slice();
 
     if (this.props.dir === 'rtl') {
-      columns = _.reverse(columns);
+      columns = columns.reverse();
     }
 
     this.state = {
@@ -87,6 +99,10 @@ class BpkDataTable extends Component {
     this.setState({ sortBy, sortDirection, sortedList });
   }
 
+  headerRenderer(args) {
+    return <SearchableHeaderRenderer {...args} />;
+  }
+
   render() {
     const { sortedList, sortDirection, sortBy } = this.state;
     const { height } = this.props;
@@ -98,7 +114,7 @@ class BpkDataTable extends Component {
             className={getClassName('bpk-data-table')}
             width={width}
             height={height}
-            headerHeight={60}
+            headerHeight={120}
             rowHeight={60}
             rowCount={sortedList.length}
             rowGetter={({ index }) => sortedList[index]}
@@ -109,6 +125,7 @@ class BpkDataTable extends Component {
             sortBy={sortBy}
             sortDirection={sortDirection}
             gridStyle={{ direction: this.props.dir }}
+            headerRowRenderer={this.headerRenderer}
           >
             {
               this.state.columns.map((child, index) => (
@@ -124,7 +141,7 @@ class BpkDataTable extends Component {
 
 BpkDataTable.propTypes = {
   rows: PropTypes.arrayOf(Object).isRequired,
-  children: PropTypes.element.isRequired,
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
   height: PropTypes.number.isRequired,
   dir: PropTypes.string,
 };

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -1,0 +1,105 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import { defaultTableRowRenderer, Column, Table, AutoSizer } from 'react-virtualized';
+import { cssModules } from 'bpk-react-utils';
+import _ from 'lodash';
+
+import STYLES from './bpk-data-table.scss';
+import BpkColumn from './BpkColumn';
+
+const getClassName = cssModules(STYLES);
+
+export default class BpkDataTable extends Component {
+  constructor(props) {
+    super(props);
+
+    const sortBy = 'name';
+    const sortDirection = 'ASC';
+    const sortedList = this._sortList({ sortBy, sortDirection, list: props.rows });
+    let columns = _.cloneDeep(this.props.children);
+
+    if (this.props.dir === 'rtl') {
+      columns = _.reverse(columns);
+    }
+
+    this.state = {
+      sortedList,
+      sortBy,
+      sortDirection,
+      columns,
+      rows: props.rows,
+      rowSelected: undefined
+    };
+
+    this.table = null;
+    this.rowClicked = this.rowClicked.bind(this);
+    this.rowStyle = this.rowStyle.bind(this);
+    this._sort = this._sort.bind(this);
+  }
+
+  rowClicked({ event, index, rowData }) {
+    if (this.state.rowSelected == index) {
+      this.setState({ rowSelected: undefined });
+    } else {
+      this.setState({ rowSelected: index });
+    }
+  }
+
+  rowStyle({ index }) {
+    const classNames = [getClassName('bpk-data-table__row')];
+    if (this.state.rowSelected == index) {
+      classNames.push(getClassName('bpk-data-table__row--selected'));
+    };
+    if (index == -1) {
+      classNames.push(getClassName('bpk-data-table__headerRow'));
+    }
+    return classNames;
+  }
+
+  _sort({ sortBy, sortDirection }) {
+    const sortedList = this._sortList({ sortBy, sortDirection, list: this.state.rows });
+
+    this.setState({ sortBy, sortDirection, sortedList });
+  }
+
+  _sortList({ sortBy, sortDirection, list }) {
+    const sorted = _.sortBy(list, sortBy);
+    if (sortDirection === 'DESC') {
+      return _.reverse(sorted);
+    }
+    return sorted;
+  }
+
+  render() {
+    const { sortedList, sortDirection, sortBy } = this.state; 
+
+    return (
+      <AutoSizer disableHeight>
+      {({width}) =>
+        <Table
+          className={getClassName('bpk-data-table')}
+          ref={table => { this.table = table; }}
+          width={width}
+          height={300}
+          headerHeight={60}
+          rowHeight={60}
+          rowCount={sortedList.length}
+          rowGetter={({ index }) => sortedList[index]}
+          headerClassName={getClassName('bpk-data-table__headerColumn')}
+          rowClassName={this.rowStyle}
+          onRowClick={this.rowClicked}
+          sort={this._sort}
+          sortBy={sortBy}
+          sortDirection={sortDirection} 
+          gridStyle={{ direction: this.props.dir }}
+        >
+          {
+            this.state.columns.map((child, index) => (
+              BpkColumn({ ...child.props, key: index })
+            ))
+          }
+        </Table>}
+      </AutoSizer>
+    );
+  }
+};

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { defaultTableRowRenderer, Column, Table, AutoSizer } from 'react-virtualized';

--- a/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
+++ b/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
@@ -1,0 +1,406 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkDataTable should render correctly in RTL 1`] = `
+<div
+  style={
+    Object {
+      "overflow": "visible",
+      "width": 0,
+    }
+  }
+>
+  <div
+    className="ReactVirtualized__Table bpk-data-table"
+    id={undefined}
+    role="grid"
+    style={Object {}}
+  >
+    <div
+      className="ReactVirtualized__Table__headerRow bpk-data-table__row bpk-data-table__headerRow"
+      role="row"
+      style={
+        Object {
+          "height": 60,
+          "overflow": "hidden",
+          "paddingRight": 0,
+          "width": 0,
+        }
+      }
+    >
+      <div
+        aria-label="Bla"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__headerColumn ReactVirtualized__Table__sortableHeaderColumn"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "0 1 100px",
+            "flex": "0 1 100px",
+            "msFlex": "0 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="ReactVirtualized__Table__headerTruncatedText"
+          title="Bla"
+        >
+          Bla
+        </span>
+      </div>
+      <div
+        aria-label="Description"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__headerColumn ReactVirtualized__Table__sortableHeaderColumn"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "1 1 100px",
+            "flex": "1 1 100px",
+            "msFlex": "1 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="ReactVirtualized__Table__headerTruncatedText"
+          title="Description"
+        >
+          Description
+        </span>
+      </div>
+      <div
+        aria-label="Name"
+        aria-sort="ascending"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__headerColumn ReactVirtualized__Table__sortableHeaderColumn"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "0 1 100px",
+            "flex": "0 1 100px",
+            "msFlex": "0 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="ReactVirtualized__Table__headerTruncatedText"
+          title="Name"
+        >
+          Name
+        </span>
+        <svg
+          className="ReactVirtualized__Table__sortableHeaderIcon ReactVirtualized__Table__sortableHeaderIcon--ASC"
+          height={18}
+          viewBox="0 0 24 24"
+          width={18}
+        >
+          <path
+            d="M7 14l5-5 5 5z"
+          />
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      aria-label="grid"
+      aria-readonly={true}
+      className="ReactVirtualized__Grid ReactVirtualized__Table__Grid"
+      id={undefined}
+      onScroll={[Function]}
+      role="rowgroup"
+      style={
+        Object {
+          "WebkitOverflowScrolling": "touch",
+          "boxSizing": "border-box",
+          "direction": "rtl",
+          "height": 140,
+          "overflowX": "hidden",
+          "overflowY": "hidden",
+          "position": "relative",
+          "width": 0,
+          "willChange": "transform",
+        }
+      }
+      tabIndex={0}
+    />
+  </div>
+</div>
+`;
+
+exports[`BpkDataTable should render correctly with multiple columns 1`] = `
+<div
+  style={
+    Object {
+      "overflow": "visible",
+      "width": 0,
+    }
+  }
+>
+  <div
+    className="ReactVirtualized__Table bpk-data-table"
+    id={undefined}
+    role="grid"
+    style={Object {}}
+  >
+    <div
+      className="ReactVirtualized__Table__headerRow bpk-data-table__row bpk-data-table__headerRow"
+      role="row"
+      style={
+        Object {
+          "height": 60,
+          "overflow": "hidden",
+          "paddingRight": 0,
+          "width": 0,
+        }
+      }
+    >
+      <div
+        aria-label="Name"
+        aria-sort="ascending"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__headerColumn ReactVirtualized__Table__sortableHeaderColumn"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "0 1 100px",
+            "flex": "0 1 100px",
+            "msFlex": "0 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="ReactVirtualized__Table__headerTruncatedText"
+          title="Name"
+        >
+          Name
+        </span>
+        <svg
+          className="ReactVirtualized__Table__sortableHeaderIcon ReactVirtualized__Table__sortableHeaderIcon--ASC"
+          height={18}
+          viewBox="0 0 24 24"
+          width={18}
+        >
+          <path
+            d="M7 14l5-5 5 5z"
+          />
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+        </svg>
+      </div>
+      <div
+        aria-label="Description"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__headerColumn ReactVirtualized__Table__sortableHeaderColumn"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "1 1 100px",
+            "flex": "1 1 100px",
+            "msFlex": "1 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="ReactVirtualized__Table__headerTruncatedText"
+          title="Description"
+        >
+          Description
+        </span>
+      </div>
+      <div
+        aria-label="Bla"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__headerColumn ReactVirtualized__Table__sortableHeaderColumn"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "0 1 100px",
+            "flex": "0 1 100px",
+            "msFlex": "0 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="ReactVirtualized__Table__headerTruncatedText"
+          title="Bla"
+        >
+          Bla
+        </span>
+      </div>
+    </div>
+    <div
+      aria-label="grid"
+      aria-readonly={true}
+      className="ReactVirtualized__Grid ReactVirtualized__Table__Grid"
+      id={undefined}
+      onScroll={[Function]}
+      role="rowgroup"
+      style={
+        Object {
+          "WebkitOverflowScrolling": "touch",
+          "boxSizing": "border-box",
+          "direction": "ltr",
+          "height": 140,
+          "overflowX": "hidden",
+          "overflowY": "hidden",
+          "position": "relative",
+          "width": 0,
+          "willChange": "transform",
+        }
+      }
+      tabIndex={0}
+    />
+  </div>
+</div>
+`;
+
+exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
+<div
+  style={
+    Object {
+      "overflow": "visible",
+      "width": 0,
+    }
+  }
+>
+  <div
+    className="ReactVirtualized__Table bpk-data-table"
+    id={undefined}
+    role="grid"
+    style={Object {}}
+  >
+    <div
+      className="ReactVirtualized__Table__headerRow bpk-data-table__row bpk-data-table__headerRow"
+      role="row"
+      style={
+        Object {
+          "height": 60,
+          "overflow": "hidden",
+          "paddingRight": 0,
+          "width": 0,
+        }
+      }
+    >
+      <div
+        aria-label="Name"
+        aria-sort="ascending"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__headerColumn ReactVirtualized__Table__sortableHeaderColumn"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "0 1 100px",
+            "flex": "0 1 100px",
+            "msFlex": "0 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="ReactVirtualized__Table__headerTruncatedText"
+          title="Name"
+        >
+          Name
+        </span>
+        <svg
+          className="ReactVirtualized__Table__sortableHeaderIcon ReactVirtualized__Table__sortableHeaderIcon--ASC"
+          height={18}
+          viewBox="0 0 24 24"
+          width={18}
+        >
+          <path
+            d="M7 14l5-5 5 5z"
+          />
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+        </svg>
+      </div>
+      <div
+        aria-label="Description"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__headerColumn ReactVirtualized__Table__sortableHeaderColumn"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "1 1 100px",
+            "flex": "1 1 100px",
+            "msFlex": "1 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="ReactVirtualized__Table__headerTruncatedText"
+          title="Description"
+        >
+          Description
+        </span>
+      </div>
+      <div
+        aria-label="Bla"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__headerColumn ReactVirtualized__Table__sortableHeaderColumn"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "0 1 100px",
+            "flex": "0 1 100px",
+            "msFlex": "0 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="ReactVirtualized__Table__headerTruncatedText"
+          title="Bla"
+        >
+          Bla
+        </span>
+      </div>
+    </div>
+    <div
+      aria-label="grid"
+      aria-readonly={true}
+      className="ReactVirtualized__Grid ReactVirtualized__Table__Grid"
+      id={undefined}
+      onScroll={[Function]}
+      role="rowgroup"
+      style={
+        Object {
+          "WebkitOverflowScrolling": "touch",
+          "boxSizing": "border-box",
+          "direction": "ltr",
+          "height": 140,
+          "overflowX": "hidden",
+          "overflowY": "hidden",
+          "position": "relative",
+          "width": 0,
+          "willChange": "transform",
+        }
+      }
+      tabIndex={0}
+    />
+  </div>
+</div>
+`;

--- a/packages/bpk-component-datatable/src/bpk-column.scss
+++ b/packages/bpk-component-datatable/src/bpk-column.scss
@@ -21,7 +21,6 @@
 .bpk-column {
   text-overflow: ellipsis;
   white-space: nowrap;
-  overflow: hidden;
 
   &:first-child {
     padding: 0 $bpk-spacing-base;

--- a/packages/bpk-component-datatable/src/bpk-column.scss
+++ b/packages/bpk-component-datatable/src/bpk-column.scss
@@ -1,0 +1,13 @@
+.bpk-column {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:first-child {
+    padding: 0 20px;
+  }
+
+  &:last-child {
+    padding: 0 20px;
+  }
+}

--- a/packages/bpk-component-datatable/src/bpk-column.scss
+++ b/packages/bpk-component-datatable/src/bpk-column.scss
@@ -16,16 +16,18 @@
  * limitations under the License.
  */
 
+@import '~bpk-mixins/index';
+
 .bpk-column {
+  text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
 
   &:first-child {
-    padding: 0 20px;
+    padding: 0 $bpk-spacing-base;
   }
 
   &:last-child {
-    padding: 0 20px;
+    padding: 0 $bpk-spacing-base;
   }
 }

--- a/packages/bpk-component-datatable/src/bpk-column.scss
+++ b/packages/bpk-component-datatable/src/bpk-column.scss
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .bpk-column {
   white-space: nowrap;
   overflow: hidden;

--- a/packages/bpk-component-datatable/src/bpk-data-table.scss
+++ b/packages/bpk-component-datatable/src/bpk-data-table.scss
@@ -56,11 +56,12 @@
     &:not(.bpk-data-table__headerRow):hover {
       background-color: $bpk-color-gray-50;
       cursor: pointer;
+      @include bpk-border-left-xl($bpk-color-blue-500);
     }
 
     &--selected {
       background-color: $bpk-color-gray-100;
-      font-weight: bold;
+      @include bpk-border-left-xl($bpk-color-blue-500);
     }
   }
 }

--- a/packages/bpk-component-datatable/src/bpk-data-table.scss
+++ b/packages/bpk-component-datatable/src/bpk-data-table.scss
@@ -16,23 +16,23 @@
  * limitations under the License.
  */
 
-@import '~bpk-mixins/index';
+@import '~bpk-mixins';
 
 .bpk-data-table {
   width: 100%;
 
   &__headerColumn {
     display: flex;
+    height: 100%;
     flex-direction: row;
     align-items: center;
-    height: 100%;
-    
+
     &:first-child {
-      padding: 0 20px;
+      padding: 0 $bpk-spacing-base;
     }
 
     &:last-child {
-      padding: 0 20px;
+      padding: 0 $bpk-spacing-base;
     }
 
     &:hover {
@@ -44,13 +44,13 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    border: 1px solid $bpk-color-gray-50;
+    border: $bpk-border-size-sm solid $bpk-color-gray-50;
     border-bottom: none;
     color: $bpk-color-gray-700;
     font-weight: normal;
 
     &:last-child {
-      border-bottom: 1px solid $bpk-color-gray-50;
+      border-bottom: $bpk-border-size-sm solid $bpk-color-gray-50;
     }
 
     &:not(.bpk-data-table__headerRow):hover {

--- a/packages/bpk-component-datatable/src/bpk-data-table.scss
+++ b/packages/bpk-component-datatable/src/bpk-data-table.scss
@@ -56,11 +56,13 @@
     &:not(.bpk-data-table__headerRow):hover {
       background-color: $bpk-color-gray-50;
       cursor: pointer;
+
       @include bpk-border-left-xl($bpk-color-blue-500);
     }
 
     &--selected {
       background-color: $bpk-color-gray-100;
+
       @include bpk-border-left-xl($bpk-color-blue-500);
     }
   }

--- a/packages/bpk-component-datatable/src/bpk-data-table.scss
+++ b/packages/bpk-component-datatable/src/bpk-data-table.scss
@@ -1,0 +1,48 @@
+@import '~bpk-mixins/index';
+
+.bpk-data-table {
+  width: 100%;
+
+  &__headerColumn {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 100%;
+    
+    &:first-child {
+      padding: 0 20px;
+    }
+
+    &:last-child {
+      padding: 0 20px;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  &__row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    border: 1px solid $bpk-color-gray-50;
+    border-bottom: none;
+    color: $bpk-color-gray-700;
+    font-weight: normal;
+
+    &:last-child {
+      border-bottom: 1px solid $bpk-color-gray-50;
+    }
+
+    &:not(.bpk-data-table__headerRow):hover {
+      background-color: $bpk-color-gray-50;
+      cursor: pointer;
+    }
+
+    &--selected {
+      background-color: $bpk-color-gray-100;
+      font-weight: bold;
+    }
+  }
+}

--- a/packages/bpk-component-datatable/src/bpk-data-table.scss
+++ b/packages/bpk-component-datatable/src/bpk-data-table.scss
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @import '~bpk-mixins/index';
 
 .bpk-data-table {

--- a/packages/bpk-component-datatable/stories.js
+++ b/packages/bpk-component-datatable/stories.js
@@ -44,6 +44,7 @@ storiesOf('bpk-component-datatable', module)
         label={'Bla'}
         dataKey={'bla'}
         width={100}
+        disableSort
       />
     </BpkDataTable>
   ));

--- a/packages/bpk-component-datatable/stories.js
+++ b/packages/bpk-component-datatable/stories.js
@@ -23,27 +23,26 @@ import { BpkDataTable, BpkColumn } from './index';
 
 const rows = [
   { name: 'Jose', description: 'Software Engineer', bla: 'Bla' },
-  { name: 'Rolf', description: 'Some guy', bla: 'Bla' }
+  { name: 'Rolf', description: 'Some guy', bla: 'Bla' },
 ];
 
 storiesOf('bpk-component-datatable', module)
   .add('Example', () => (
-    <BpkDataTable rows={rows} dir={document.querySelector('html').dir}>
+    <BpkDataTable rows={rows} height={300} dir={document.querySelector('html').dir}>
       <BpkColumn
-        label='Name'
-        dataKey='name'
+        label={'Name'}
+        dataKey={'name'}
         width={100}
       />
       <BpkColumn
-        label='Description'
-        dataKey='description'
+        label={'Description'}
+        dataKey={'description'}
         width={100}
         flexGrow={1}
       />
       <BpkColumn
-        label='Bla'
-        dataKey='bla'
-        disableSort
+        label={'Bla'}
+        dataKey={'bla'}
         width={100}
       />
     </BpkDataTable>

--- a/packages/bpk-component-datatable/stories.js
+++ b/packages/bpk-component-datatable/stories.js
@@ -1,0 +1,50 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { BpkDataTable, BpkColumn } from './index';
+
+const rows = [
+  { name: 'Jose', description: 'Software Engineer', bla: 'Bla' },
+  { name: 'Rolf', description: 'Some guy', bla: 'Bla' }
+];
+
+storiesOf('bpk-component-datatable', module)
+  .add('Example', () => (
+    <BpkDataTable rows={rows} dir={document.querySelector('html').dir}>
+      <BpkColumn
+        label='Name'
+        dataKey='name'
+        width={100}
+      />
+      <BpkColumn
+        label='Description'
+        dataKey='description'
+        width={100}
+        flexGrow={1}
+      />
+      <BpkColumn
+        label='Bla'
+        dataKey='bla'
+        disableSort
+        width={100}
+      />
+    </BpkDataTable>
+  ));


### PR DESCRIPTION
Added datatable with a subset of the suggested features:

- Sortable columns.
- RTL and accessibility support.
- Support for _many_ rows via react-virtualized.

Also includes a readme and example in the storybook.

![backpack-table-v0 2](https://user-images.githubusercontent.com/3788301/31392412-172acdba-add1-11e7-9dbe-6536fd48906c.gif)
