### PR TITLE
[BPK-954] Add theming documentation

### DIFF
--- a/native/packages/react-native-bpk-component-button/readme.md
+++ b/native/packages/react-native-bpk-component-button/readme.md
@@ -65,4 +65,19 @@ export default class App extends Component {
 | icon                  | element                                                   | false    | null          |
 | iconOnly              | bool                                                      | false    | false         |
 | large                 | bool                                                      | false    | false         |
+| theme                 | See [Theme Props](#theme-props) below                     | false    | null          |
 | type                  | oneOf('primary', 'featured', 'secondary', 'destructive')  | false    | null          |
+
+## Theme Props
+
+### Primary
+
+* `buttonPrimaryTextColor`
+* `buttonPrimaryGradientStartColor`
+* `buttonPrimaryGradientEndColor`
+
+### Secondary
+
+* `buttonSecondaryTextColor`
+* `buttonSecondaryBackgroundColor`
+* `buttonSecondaryBorderColor`

--- a/native/packages/react-native-bpk-theming/readme.md
+++ b/native/packages/react-native-bpk-theming/readme.md
@@ -16,17 +16,24 @@ import { View } from 'react-native';
 import BpkThemeProvider from 'react-native-bpk-theming';
 
 import BpkButton from 'react-native-bpk-component-button';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+
+import { translationHelper } from 'translations';
 
 const theme = {
-  color: TOKENS.colorBlue500
+  buttonPrimaryGradientStartColor: '#fce134',
+  buttonPrimaryGradientEndColor: '#f8c42d',
+  buttonPrimaryTextColor: '#2d244c',
+  buttonSecondaryBackgroundColor: '#fff',
+  buttonSecondaryTextColor: '#2d244c',
+  buttonSecondaryBorderColor: '#2d244c',
 };
 
 export default class App extends Component {
   render() {
     return (
-      <BpkThemeProvider theme={themes}>
-        <BpkButton title="Book flight" onPress={() => {}}/>
+      <BpkThemeProvider theme={theme}>
+        <BpkButton type="primary" title={translationHelper.translate('BOOK_FLIGHT')} onPress={() => {}} />
+        <BpkButton type="secondary" title={translationHelper.translate('BOOK_FLIGHT')} onPress={() => {}} />
       </BpkThemeProvider>
     );
   }

--- a/packages/bpk-docs/package.json
+++ b/packages/bpk-docs/package.json
@@ -70,6 +70,7 @@
     "react-native-bpk-component-icon": "^1.0.1",
     "react-native-bpk-component-text": "^2.1.10",
     "react-native-bpk-component-text-input": "^1.0.11",
+    "react-native-bpk-theming": "^1.0.2",
     "uglify-loader": "^1.4.0"
   }
 }

--- a/packages/bpk-docs/src/constants/routes.js
+++ b/packages/bpk-docs/src/constants/routes.js
@@ -81,6 +81,7 @@ export const NATIVE_TEXT = '/components/native/text';
 // components/utilities/
 export const UTILITIES = '/components/utilities';
 export const ALIGNMENT = '/components/utilities/alignment';
+export const THEMING = '/components/utilities/theming';
 
 // MISC
 export const GRID_COLUMN_DEMO = '/grid-column-demo';

--- a/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
+++ b/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
@@ -91,6 +91,7 @@ const links = [
     sort: true,
     links: [
       { id: 'ALIGNMENT', route: routes.ALIGNMENT, children: 'Alignment' },
+      { id: 'THEMING', route: routes.THEMING, children: 'Theming' },
     ],
   },
 ];

--- a/packages/bpk-docs/src/pages/NativeButtonPage/NativeButtonPage.js
+++ b/packages/bpk-docs/src/pages/NativeButtonPage/NativeButtonPage.js
@@ -29,6 +29,8 @@ import Paragraph from './../../components/Paragraph';
 import DocsPageBuilder from './../../components/DocsPageBuilder';
 import androidEmpty from './../../static/android_empty.svg';
 
+import { THEMING } from './../../constants/routes';
+
 const reactNativeUrl = 'https://facebook.github.io/react-native/docs/touchablehighlight.html';
 
 const components = [
@@ -136,6 +138,9 @@ const NativeTextPage = () => <DocsPageBuilder
     </Paragraph>,
     <Paragraph>
       Buttons can be text or icon based.
+    </Paragraph>,
+    <Paragraph>
+      Primary and secondary buttons can be <BpkLink href={THEMING}>themed</BpkLink>.
     </Paragraph>,
   ]}
   components={components}

--- a/packages/bpk-docs/src/pages/ThemingPage/ThemingPage.js
+++ b/packages/bpk-docs/src/pages/ThemingPage/ThemingPage.js
@@ -1,0 +1,56 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import BpkLink from 'bpk-component-link';
+import BpkBlockquote from 'bpk-component-blockquote';
+import { BpkList, BpkListItem } from 'bpk-component-list';
+import readme from 'react-native-bpk-theming/readme.md';
+
+import Paragraph from './../../components/Paragraph';
+import DocsPageBuilder from './../../components/DocsPageBuilder';
+
+import { NATIVE_BUTTON } from './../../constants/routes';
+
+const NativeTextPage = () => <DocsPageBuilder
+  title="Theming"
+  blurb={[
+    <Paragraph>
+      Backpack has full theming support through its theme provider component.
+      This component provides a theme to all themeable components underneath itself via the context API.
+      In the render tree all themeable components will have access to the provided theme, even
+      when they are multiple levels deep.
+    </Paragraph>,
+    <Paragraph>
+      The following Backpack components are themeable
+      (each themeable component lists the theming properties it requires in its readme).
+    </Paragraph>,
+    <BpkList>
+      <BpkListItem>
+        <BpkLink href={NATIVE_BUTTON}>Button</BpkLink>
+      </BpkListItem>
+      <BpkListItem>More coming soon!</BpkListItem>
+    </BpkList>,
+    <BpkBlockquote>
+      <strong>Note:</strong> React Native is currently supported, with web coming soon.
+    </BpkBlockquote>,
+  ]}
+  readme={readme}
+/>;
+
+export default NativeTextPage;

--- a/packages/bpk-docs/src/pages/ThemingPage/index.js
+++ b/packages/bpk-docs/src/pages/ThemingPage/index.js
@@ -1,0 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import page from './ThemingPage';
+
+export default page;

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -73,6 +73,7 @@ import BarchartsPage from './../pages/BarchartsPage';
 import StarRatingPage from './../pages/StarRatingPage';
 
 import AlignmentPage from './../pages/AlignmentPage';
+import ThemingPage from './../pages/ThemingPage';
 
 import NativeButtonPage from './../pages/NativeButtonPage';
 import NativeCardsPage from './../pages/NativeCardsPage';
@@ -155,6 +156,7 @@ const Routes = (
       <Route path={ROUTES.UTILITIES}>
         <IndexRedirect to={ROUTES.ALIGNMENT} />
         <Route path={ROUTES.ALIGNMENT} component={AlignmentPage} />
+        <Route path={ROUTES.THEMING} component={ThemingPage} />
       </Route>
     </Route>
 


### PR DESCRIPTION
Adds theming info to native button, as well as a new theming page to the sidebar.

New page:
![localhost-8080-components-utilities-theming](https://user-images.githubusercontent.com/73652/31398676-a6928f8c-ade1-11e7-9773-9fdeb3b5e070.png)

Button page:
![localhost-8080-components-native-button](https://user-images.githubusercontent.com/73652/31398699-b3da6340-ade1-11e7-8cd4-2605c86bbde5.png)
