### PR TITLE
[no jira] Change theme story to use BpkButton

### DIFF
--- a/native/packages/react-native-bpk-theming/package-lock.json
+++ b/native/packages/react-native-bpk-theming/package-lock.json
@@ -1,174 +1,283 @@
 {
-	"requires": true,
-	"lockfileVersion": 1,
-	"dependencies": {
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
-		"brcast": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
-			"integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
-		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-		},
-		"create-react-class": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
-			"integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
-			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
-			}
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "0.4.19"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.16",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-			"requires": {
-				"core-js": "1.2.7",
-				"isomorphic-fetch": "2.2.1",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"promise": "7.3.1",
-				"setimmediate": "1.0.5",
-				"ua-parser-js": "0.7.14"
-			}
-		},
-		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-		},
-		"is-function": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
-		},
-		"is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"requires": {
-				"isobject": "3.0.1"
-			}
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.3"
-			}
-		},
-		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-		},
-		"loose-envify": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"requires": {
-				"js-tokens": "3.0.2"
-			}
-		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
-			}
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "2.0.6"
-			}
-		},
-		"prop-types": {
-			"version": "15.6.0",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-			"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
-			}
-		},
-		"react": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-			"integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
-			"requires": {
-				"create-react-class": "15.6.2",
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
-			}
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-		},
-		"theming": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/theming/-/theming-1.1.0.tgz",
-			"integrity": "sha512-YRhQV+eqeuef70eqfMGKGR+3DBXoWJ4lsrSSuj8dzrv0/EsnVuDmZAjIifESvJARtuP1KbMpdl8qbXdLAz4t/w==",
-			"requires": {
-				"brcast": "2.0.2",
-				"is-function": "1.0.1",
-				"is-plain-object": "2.0.4",
-				"prop-types": "15.6.0",
-				"react": "15.6.2"
-			}
-		},
-		"ua-parser-js": {
-			"version": "0.7.14",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
-			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
-		},
-		"whatwg-fetch": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-		}
-	}
+  "name": "react-native-bpk-theming",
+  "version": "1.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "bpk-tokens": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-26.4.0.tgz",
+      "integrity": "sha512-j820mnbxzQ5UyEjGkiaVe2xTGu1beqLNS0PB0bbi5vcw6lcR1uXo3KNIp9migjuGvWKINLkwKN8D5ujP9092/w==",
+      "dev": true,
+      "requires": {
+        "color": "2.0.0"
+      }
+    },
+    "brcast": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+      "integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
+    },
+    "color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-2.0.0.tgz",
+      "integrity": "sha1-4MmXLR6WmFcASxAeqlXOq1lh1n0=",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.0",
+        "color-string": "1.5.2"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "color-string": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3",
+        "simple-swizzle": "0.2.2"
+      }
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "create-react-class": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
+      "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.14"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "is-arrayish": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
+      "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0=",
+      "dev": true
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "react": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "requires": {
+        "create-react-class": "15.6.2",
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-native-bpk-component-button": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-bpk-component-button/-/react-native-bpk-component-button-3.1.0.tgz",
+      "integrity": "sha512-YjPwPpniYDEq11e9LyNR1rS6VhJKn7bVuuGv5+hr5+DbUWI2MedQfF/QvxnMl/hn8zRz0PL/aj3Zc5PPlcORYQ==",
+      "dev": true,
+      "requires": {
+        "bpk-tokens": "26.4.0",
+        "lodash": "4.17.4",
+        "prop-types": "15.6.0",
+        "react-native-bpk-component-text": "2.1.10",
+        "react-native-bpk-theming": "1.0.3",
+        "react-native-linear-gradient": "2.3.0"
+      }
+    },
+    "react-native-bpk-component-text": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/react-native-bpk-component-text/-/react-native-bpk-component-text-2.1.10.tgz",
+      "integrity": "sha512-SptaBAS/cZwyyTUrjrQeJlW7UPBCRfILgS6bAXYKrmJgvED3TlHQ0rtYONF51d2HZUcMEPKnwCjB6GLDSDldbg==",
+      "dev": true,
+      "requires": {
+        "bpk-tokens": "26.4.0",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-native-bpk-theming": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-bpk-theming/-/react-native-bpk-theming-1.0.3.tgz",
+      "integrity": "sha512-/raKBcJYtE+Ty0G+GpMbPZAoCGNvm4McQ0sFXZ/+QwF/f7u02m5dZWA3AKPjOiHWE5fZZya3rQGTFr/Af77Taw==",
+      "dev": true,
+      "requires": {
+        "theming": "1.1.0"
+      }
+    },
+    "react-native-linear-gradient": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.3.0.tgz",
+      "integrity": "sha512-34z/F/0XxqF/9Jt8zsWENiYehj8xywRpZOfUDfanshSSAZkStLHThScyagvOAzkkCxrUV1K5sWS5Hxu6iR6VTA==",
+      "dev": true,
+      "requires": {
+        "prop-types": "15.6.0"
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.3.1"
+      }
+    },
+    "theming": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/theming/-/theming-1.1.0.tgz",
+      "integrity": "sha512-YRhQV+eqeuef70eqfMGKGR+3DBXoWJ4lsrSSuj8dzrv0/EsnVuDmZAjIifESvJARtuP1KbMpdl8qbXdLAz4t/w==",
+      "requires": {
+        "brcast": "2.0.2",
+        "is-function": "1.0.1",
+        "is-plain-object": "2.0.4",
+        "prop-types": "15.6.0",
+        "react": "15.6.2"
+      }
+    },
+    "ua-parser-js": {
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
+      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    }
+  }
 }

--- a/native/packages/react-native-bpk-theming/package.json
+++ b/native/packages/react-native-bpk-theming/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "bpk-tokens": "^26.4.0",
-    "react-native-bpk-component-text": "^2.1.10"
+    "react-native-bpk-component-button": "^3.1.0"
   }
 }

--- a/native/packages/react-native-bpk-theming/stories.js
+++ b/native/packages/react-native-bpk-theming/stories.js
@@ -23,25 +23,38 @@ import {
   Platform,
   Picker,
 } from 'react-native';
+
 import { storiesOf } from '@storybook/react-native';
+import { action } from '@storybook/addon-actions';
 
-import BpkText from 'react-native-bpk-component-text';
+import BpkButton from 'react-native-bpk-component-button';
 
-import BpkThemeProvider, { withTheme } from './index';
+import BpkThemeProvider from './index';
 
 const tokens = Platform.OS === 'ios' ?
   require('bpk-tokens/tokens/ios/base.react.native.common.js') :
   require('bpk-tokens/tokens/android/base.react.native.common.js')
 ;
 
-// TODO when a themeable component is created, import and use that
-// instead of making one here.
-const BpkThemeableText = withTheme((props) => {
-  const { theme, style: outerStyle, ...rest } = props;
-  const innerStyle = {
-    color: theme.textOnPrimaryColor,
-  };
-  return <BpkText {...rest} style={[outerStyle, innerStyle]} />;
+const generateThemeAttributes = (gradientStartColor, gradientEndColor) => ({
+  buttonPrimaryTextColor: tokens.colorWhite,
+  buttonPrimaryGradientStartColor: gradientStartColor,
+  buttonPrimaryGradientEndColor: gradientEndColor,
+  buttonSecondaryTextColor: gradientEndColor,
+  buttonSecondaryBackgroundColor: tokens.colorWhite,
+  buttonSecondaryBorderColor: gradientEndColor,
+});
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingLeft: tokens.spacingMd,
+    paddingRight: tokens.spacingMd,
+  },
+  bottomMargin: {
+    marginBottom: tokens.spacingMd,
+  },
 });
 
 class BpkThemePicker extends Component {
@@ -49,15 +62,9 @@ class BpkThemePicker extends Component {
     super();
 
     this.themes = {
-      blue: {
-        textOnPrimaryColor: tokens.colorBlue500,
-      },
-      green: {
-        textOnPrimaryColor: tokens.colorGreen500,
-      },
-      red: {
-        textOnPrimaryColor: tokens.colorRed500,
-      },
+      blue: generateThemeAttributes(tokens.colorBlue400, tokens.colorBlue500),
+      yellow: generateThemeAttributes(tokens.colorYellow400, tokens.colorYellow500),
+      red: generateThemeAttributes(tokens.colorRed400, tokens.colorRed500),
     };
 
     this.state = {
@@ -83,32 +90,28 @@ class BpkThemePicker extends Component {
           onValueChange={this.switchTheme}
         >
           <Picker.Item label="Blue" value="blue" />
-          <Picker.Item label="Green" value="green" />
+          <Picker.Item label="Yellow" value="yellow" />
           <Picker.Item label="Red" value="red" />
         </Picker>
         <BpkThemeProvider theme={this.state.theme}>
           <View>
-            <BpkThemeableText textStyle="xxl">Flights to Edinburgh</BpkThemeableText>
-            <BpkThemeableText textStyle="xl">Flights to Edinburgh</BpkThemeableText>
-            <BpkThemeableText textStyle="lg">Flights to Edinburgh</BpkThemeableText>
-            <BpkThemeableText textStyle="base">Flights to Edinburgh</BpkThemeableText>
-            <BpkThemeableText textStyle="sm">Flights to Edinburgh</BpkThemeableText>
-            <BpkThemeableText textStyle="xs">Flights to Edinburgh</BpkThemeableText>
+            <BpkButton
+              type="primary"
+              title="Book hotel"
+              onPress={action('primary themed button pressed')}
+              style={styles.bottomMargin}
+            />
+            <BpkButton
+              type="secondary"
+              title="Go back"
+              onPress={action('secondary themed button pressed')}
+            />
           </View>
         </BpkThemeProvider>
       </View>
     );
   }
 }
-
-const styles = StyleSheet.create({
-  centered: {
-    flex: 1,
-    justifyContent: 'center',
-    paddingLeft: tokens.spacingMd,
-    paddingRight: tokens.spacingMd,
-  },
-});
 
 storiesOf('BpkTheming', module)
   .addDecorator(getStory =>


### PR DESCRIPTION
Previously the example used `BpkThemeableText`, which is something that was created especially for the storybook. Now that buttons are themeable, I've changed the storybook to use that instead.

I also changed the green example to yellow, as our standard button is green and the difference wasn't so apparent.

<img width="487" alt="screen shot 2017-10-11 at 14 40 32" src="https://user-images.githubusercontent.com/73652/31443716-28741376-ae92-11e7-86ff-e99a978fa077.png">
<img width="487" alt="screen shot 2017-10-11 at 14 37 15" src="https://user-images.githubusercontent.com/73652/31443700-1baee81e-ae92-11e7-87c7-bd580cbc7ae3.png">
<img width="487" alt="screen shot 2017-10-11 at 14 40 35" src="https://user-images.githubusercontent.com/73652/31443720-2b57222c-ae92-11e7-8f92-b45cee6191b3.png">
