### PR TITLE
[BPK-999] Upgrade recompose to 0.26.x

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,10 @@
     - ticket
     - time
 
+**Fixed:**
+- bpk-react-utils
+ - Upgraded [recompose](https://github.com/acdlite/recompose) dependency to support React 16.
+
 ## 2017-10-12 - New React Native icon component installation instructions and simpler React Native button API
 
 **Breaking:**

--- a/packages/bpk-react-utils/package-lock.json
+++ b/packages/bpk-react-utils/package-lock.json
@@ -49,11 +49,6 @@
 				"ua-parser-js": "0.7.14"
 			}
 		},
-		"hoist-non-react-statics": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-			"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
-		},
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -130,14 +125,21 @@
 			}
 		},
 		"recompose": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.24.0.tgz",
-			"integrity": "sha512-7+UVym5Mfks/ukIDfcAiasrY61YGki8uIs4CmLTGU7UV2lm2ObbhOl913WrlsZKu8x8uA/sLJUOI5hxVga0dIA==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+			"integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
 			"requires": {
 				"change-emitter": "0.1.6",
 				"fbjs": "0.8.16",
-				"hoist-non-react-statics": "1.2.0",
+				"hoist-non-react-statics": "2.3.1",
 				"symbol-observable": "1.0.4"
+			},
+			"dependencies": {
+				"hoist-non-react-statics": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
+					"integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+				}
 			}
 		},
 		"setimmediate": {

--- a/packages/bpk-react-utils/package.json
+++ b/packages/bpk-react-utils/package.json
@@ -17,6 +17,6 @@
     "object-assign": "^4.1.1",
     "prop-types": "^15.5.8",
     "react-transition-group": "1.1.3",
-    "recompose": "^0.24.0"
+    "recompose": "^0.26.0"
   }
 }


### PR DESCRIPTION
This is so it'll work with React 16.x.

I'm not certain of what needed to be done here, so here's a summary of what I did:

- Searched for all `package.json` files that mention recompose. The only result was `bpk-react-utils'.
- Upgraded from 0.24.x to 0.26.x in `bpk-react-utils`.
- `npm run clean`
- `npm install`
- `npm run build`
- `npm test`