### PR TITLE
[EXPS-614]: Add className prop to BpkList and BpkListItem

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,14 @@
 ## UNRELEASED
 _Nothing Yet_
 
+
+## 2017-10-16 - Reack Lists and List Items can now have a className attribute added
+
+**Updated:**
+- bpk-component-list
+  - The `className` attribute has been added to BpkList and BpkListItem, mirroring functionality from other props that implement it
+
+
 ## 2017-10-13 - 17 new icons added and 5 existing icons changed
 
 **Added:**

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,9 @@
 # Backpack changelog
 
 ## UNRELEASED
-_Nothing Yet_
+### 2017-10-16 - React Lists and List Items can now have a className attribute added
 
-
-## 2017-10-16 - Reack Lists and List Items can now have a className attribute added
-
-**Updated:**
+**Added:**
 - bpk-component-list
   - The `className` attribute has been added to BpkList and BpkListItem, mirroring functionality from other props that implement it
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,11 @@
 # Backpack changelog
 
 ## UNRELEASED
-### 2017-10-16 - React Lists and List Items can now have a className attribute added
+### 2017-10-16 - React Lists and List Items can now have a className prop added
 
 **Added:**
 - bpk-component-list
-  - The `className` attribute has been added to BpkList and BpkListItem, mirroring functionality from other props that implement it
+  - The `className` prop has been added to BpkList and BpkListItem, mirroring functionality in other components that implement the prop
 
 
 ## 2017-10-13 - 17 new icons added and 5 existing icons changed

--- a/packages/bpk-component-badge/readme.md
+++ b/packages/bpk-component-badge/readme.md
@@ -25,3 +25,4 @@ export default () => (
 | --------- | --------------- | -------- | ------------- |
 | centered  | bool            | false    | null          |
 | docked    | 'left', 'right' | false    | null          |
+| className | string          | false    | null          |

--- a/packages/bpk-component-list/readme.md
+++ b/packages/bpk-component-list/readme.md
@@ -34,13 +34,15 @@ export default () => (
 
 ### BpkList
 
-| Property | PropType | Required | Default Value |
-| -------- | -------- | -------- | ------------- |
-| children | -        | true     | -             |
-| ordered  | bool     | false    | false         |
+| Property  | PropType | Required | Default Value |
+| --------- | -------- | -------- | ------------- |
+| children  | -        | true     | -             |
+| ordered   | bool     | false    | false         |
+| className | string   | false    | null          |
 
 ### BpkListItem
 
-| Property | PropType | Required | Default Value |
-| -------- | -------- | -------- | ------------- |
-| children | -        | true     | -             |
+| Property  | PropType | Required | Default Value |
+| --------- | -------- | -------- | ------------- |
+| children  | -        | true     | -             |
+| className | string   | false    | null          |

--- a/packages/bpk-component-list/src/BpkList-test.js
+++ b/packages/bpk-component-list/src/BpkList-test.js
@@ -38,4 +38,13 @@ describe('BpkList', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with a "className" attribute', () => {
+    const tree = renderer.create(
+      <BpkList className="test-list">
+        <li>list item</li>
+      </BpkList>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-list/src/BpkList.js
+++ b/packages/bpk-component-list/src/BpkList.js
@@ -26,8 +26,11 @@ const getClassName = cssModules(STYLES);
 
 const BpkList = (props) => {
   const TagName = props.ordered ? 'ol' : 'ul';
+  const classNames = [getClassName('bpk-list')];
 
-  return <TagName className={getClassName('bpk-list')}>{props.children}</TagName>;
+  if (props.className) { classNames.push(props.className); }
+
+  return <TagName className={classNames.join(' ')}>{props.children}</TagName>;
 };
 
 BpkList.propTypes = {
@@ -36,10 +39,12 @@ BpkList.propTypes = {
     PropTypes.node,
   ]).isRequired,
   ordered: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 BpkList.defaultProps = {
   ordered: false,
+  className: null,
 };
 
 export default (BpkList);

--- a/packages/bpk-component-list/src/BpkListItem-test.js
+++ b/packages/bpk-component-list/src/BpkListItem-test.js
@@ -26,5 +26,14 @@ describe('BpkListItem', () => {
     const tree = renderer.create(<BpkListItem>List item</BpkListItem>).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with a "className" attribute', () => {
+    const tree = renderer.create(
+      <BpkListItem className="test-list-item">
+        List item
+      </BpkListItem>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });
 

--- a/packages/bpk-component-list/src/BpkListItem.js
+++ b/packages/bpk-component-list/src/BpkListItem.js
@@ -24,13 +24,24 @@ import STYLES from './bpk-list.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkListItem = props => <li className={getClassName('bpk-list__item')}>{props.children}</li>;
+const BpkListItem = (props) => {
+  const classNames = [getClassName('bpk-list__item')];
+
+  if (props.className) { classNames.push(props.className); }
+
+  return (<li className={classNames.join(' ')}>{props.children}</li>);
+};
 
 BpkListItem.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]).isRequired,
+  className: PropTypes.string,
+};
+
+BpkListItem.defaultProps = {
+  className: null,
 };
 
 export default BpkListItem;

--- a/packages/bpk-component-list/src/__snapshots__/BpkList-test.js.snap
+++ b/packages/bpk-component-list/src/__snapshots__/BpkList-test.js.snap
@@ -10,6 +10,16 @@ exports[`BpkList should render correctly 1`] = `
 </ul>
 `;
 
+exports[`BpkList should render correctly with a "className" attribute 1`] = `
+<ul
+  className="bpk-list test-list"
+>
+  <li>
+    list item
+  </li>
+</ul>
+`;
+
 exports[`BpkList should render correctly with a "ordered" attribute 1`] = `
 <ol
   className="bpk-list"

--- a/packages/bpk-component-list/src/__snapshots__/BpkListItem-test.js.snap
+++ b/packages/bpk-component-list/src/__snapshots__/BpkListItem-test.js.snap
@@ -7,3 +7,11 @@ exports[`BpkListItem should render correctly 1`] = `
   List item
 </li>
 `;
+
+exports[`BpkListItem should render correctly with a "className" attribute 1`] = `
+<li
+  className="bpk-list__item test-list-item"
+>
+  List item
+</li>
+`;


### PR DESCRIPTION
Prop contains same functionality as it does elsewhere, using BpkText as an example of how to implement. Has no effect on tests. Has been linted.

Pull Request also contains update to the docs for List and Badge to include className prop, since I noticed it was missing from Badge last week.