### PR TITLE
Fixed propType warning by updating react-responsive to the latest version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # Backpack changelog
 
 ## UNRELEASED
-_Nothing Yet!_
+- bpk-component-breakpoint
+ - Upgraded react-responsive to v3.0.0 to fix propType warning.
 
 ### 2017-10-18 - New neutral configuration for native and web banner alerts
 

--- a/packages/bpk-component-breakpoint/package-lock.json
+++ b/packages/bpk-component-breakpoint/package-lock.json
@@ -117,9 +117,9 @@
 			}
 		},
 		"react-responsive": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-1.3.4.tgz",
-			"integrity": "sha512-I2MvP3DvrKKVWWvciaxGcKvDoTlsE9zI/kPSOBrSiCo+6UvCVzPNJY0siMc676Eld1E67aLXb1UpiVQLxd6J3Q==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-3.0.0.tgz",
+			"integrity": "sha512-1w42433p6EvW6w3/IvIwG52ZrjPyZcZCV8wxnHTq7ZD3RiKp3IrAT/zInrYUUc2ipJEoR+4GARhwJNaIh+LD6Q==",
 			"requires": {
 				"hyphenate-style-name": "1.0.2",
 				"matchmediaquery": "0.2.1",

--- a/packages/bpk-component-breakpoint/package.json
+++ b/packages/bpk-component-breakpoint/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bpk-mixins": "^17.0.7",
     "prop-types": "^15.5.8",
-    "react-responsive": "^1.3.2"
+    "react-responsive": "^3.0.0"
   },
   "devDependencies": {
     "bpk-tokens": "^26.4.2"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1129383/31712577-67feaa86-b3f3-11e7-994c-7bcad5c0e035.png)
the browser warning above was fixed in the latest version of react-responsive. https://github.com/contra/react-responsive/commit/49919d09b7a4e984873b570132ada5554300f071