### PR TITLE
[No JIRA] Remove border-radius for nav items

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,10 @@
 ## UNRELEASED
 _Nothing Yet_
 
+**Fixed:**
+- bpk-component-horizontal-nav:
+  - Explicitly set the border radius to 0 for BpkHorizontalNavItem.
+
 ## 2017-10-24 - Android support for button component
 
 **Fixed:**

--- a/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav-item.scss
+++ b/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav-item.scss
@@ -34,6 +34,7 @@
     display: flex;
     padding: $bpk-spacing-sm $bpk-spacing-base;
     border: 0;
+    border-radius: 0;
     background: none;
     color: $bpk-link-color;
     text-decoration: none;


### PR DESCRIPTION
For BpkHorizontalNavItem we weren't explicitlly setting the border
radius to 0. In Chrome 62 changes to the default button style was
leaking through and causing visual glitches due to this.