### PR TITLE
[BPK-1096] Show weekend separator in IE and Edge.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@
   - New component `BpkSlider`. See http://backpack.prod.aws.skyscnr.com/components/web/sliders
   - **NOTE:** Don't release until we have fixed RTL support
 
+**Fixed:**
+- bpk-component-calendar:
+  - Fix for weekend separator not showing in Internet Explorer and Edge.
+
 ## 2017-11-02 - Popover fix for target element refocus
 
 **Fixed:**

--- a/packages/bpk-component-calendar/src/bpk-calendar-grid.scss
+++ b/packages/bpk-component-calendar/src/bpk-calendar-grid.scss
@@ -22,7 +22,7 @@
 .bpk-calendar-grid {
   display: table;
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
   border-spacing: 0;
   table-layout: fixed;
 


### PR DESCRIPTION
Weekend separator line is not showing in calendar for Internet Explorer and Edge due to `border-collapse: collapse` CSS rule preventing `box-shadow` from working.

This is how it looks currently:

![calendar_ie](https://user-images.githubusercontent.com/33334230/32370185-5dc8dfa0-c08c-11e7-8a1b-263a03cbb630.png)
