### PR TITLE
Exposing BpkInput underlying DOM node ref to parent components

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,9 @@
 - react-native-bpk-component-banner-alert:
   - Fix icon color of success alert.
   - User style now takes precedence over encapsualted style.
+  
+- bpk-component-input:
+  - Expose BpkInput underlying DOM node ref to parent components.
 
 ## 2017-11-02 - Popover fix for target element refocus
 

--- a/packages/bpk-component-input/src/BpkInput-test.js
+++ b/packages/bpk-component-input/src/BpkInput-test.js
@@ -17,6 +17,7 @@
  */
 
 import React from 'react';
+import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 import BpkInput, { INPUT_TYPES } from './BpkInput';
 
@@ -150,5 +151,22 @@ describe('BpkInput', () => {
       />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('should expose input reference to parent components', () => {
+    let inputRef;
+    const storeInputReference = (ref) => {
+      inputRef = ref;
+    };
+    const tree = mount(
+      <BpkInput
+        id="test"
+        name="test"
+        value=""
+        inputRef={storeInputReference}
+      />,
+    );
+    const input = tree.find('input').at(0).instance();
+    expect(input).toEqual(inputRef);
   });
 });

--- a/packages/bpk-component-input/src/BpkInput.js
+++ b/packages/bpk-component-input/src/BpkInput.js
@@ -35,7 +35,7 @@ export const INPUT_TYPES = {
 const BpkInput = (props) => {
   const classNames = [getClassName('bpk-input')];
   const {
-    valid, large, docked, dockedFirst, dockedMiddle, dockedLast, className, ...rest
+    valid, large, docked, dockedFirst, dockedMiddle, dockedLast, className, inputRef, ...rest
   } = props;
 
   // Explicit check for false primitive value as undefined is
@@ -55,7 +55,7 @@ const BpkInput = (props) => {
   if (dockedLast) { classNames.push(getClassName('bpk-input--docked-last')); }
   if (className) { classNames.push(className); }
 
-  return <input className={classNames.join(' ')} aria-invalid={isInvalid} {...rest} />;
+  return <input className={classNames.join(' ')} ref={inputRef} aria-invalid={isInvalid} {...rest} />;
 };
 
 BpkInput.propTypes = {
@@ -76,6 +76,7 @@ BpkInput.propTypes = {
   dockedFirst: PropTypes.bool,
   dockedMiddle: PropTypes.bool,
   dockedLast: PropTypes.bool,
+  inputRef: PropTypes.func,
 };
 
 BpkInput.defaultProps = {
@@ -87,6 +88,7 @@ BpkInput.defaultProps = {
   dockedFirst: false,
   dockedMiddle: false,
   dockedLast: false,
+  inputRef: null,
 };
 
 export default BpkInput;


### PR DESCRIPTION
When using the component `BpkInput`, I would want to have access to the underlying `input` DOM node so that I can manage things like `focus` from a parent component.

The recommended way to do so in the React docs is by exposing a prop and attach it to the DOM node as a `ref` attribute: https://reactjs.org/docs/refs-and-the-dom.html#exposing-dom-refs-to-parent-components