### PR TITLE
Export focusStore and focusScope from a single package

### DIFF
--- a/packages/bpk-component-popover/package-lock.json
+++ b/packages/bpk-component-popover/package-lock.json
@@ -2,20 +2,6 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
-		"a11y-focus-scope": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/a11y-focus-scope/-/a11y-focus-scope-1.1.3.tgz",
-			"integrity": "sha1-95U4TU3UDM7BxKFg700TNx0BWug=",
-			"requires": {
-				"focusin": "2.0.0",
-				"tabbable": "1.1.0"
-			}
-		},
-		"a11y-focus-store": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/a11y-focus-store/-/a11y-focus-store-1.0.0.tgz",
-			"integrity": "sha1-rlJWHLhq5sKQTBpKvy5YIL9TBbA="
-		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",

--- a/packages/bpk-component-popover/package.json
+++ b/packages/bpk-component-popover/package.json
@@ -13,12 +13,11 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "a11y-focus-scope": "^1.1.3",
-    "a11y-focus-store": "^1.0.0",
     "bpk-component-close-button": "^1.0.29",
     "bpk-component-link": "^1.0.29",
     "bpk-mixins": "^17.0.11",
     "bpk-react-utils": "^2.3.7",
+    "bpk-scrim-utils": "^1.0.0",
     "bpk-tether": "^1.0.3",
     "prop-types": "^15.5.8"
   },

--- a/packages/bpk-component-popover/src/BpkPopoverPortal-test.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal-test.js
@@ -20,20 +20,17 @@ import React from 'react';
 import Shallow from 'react-test-renderer/shallow';
 import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
+import { storeFocus, restoreFocus, scopeFocus, unscopeFocus } from 'bpk-scrim-utils';
+
+import BpkPopoverPortal from './BpkPopoverPortal';
 
 jest.mock('bpk-tether');
-jest.mock('a11y-focus-store', () => ({
+jest.mock('bpk-scrim-utils', () => ({
   storeFocus: jest.fn(),
   restoreFocus: jest.fn(),
-}));
-jest.mock('a11y-focus-scope', () => ({
   scopeFocus: jest.fn(),
   unscopeFocus: jest.fn(),
 }));
-
-/* eslint-disable import/first */
-import BpkPopoverPortal from './BpkPopoverPortal';
-/* eslint-enable */
 
 describe('BpkPopoverPortal', () => {
   it('should render correctly', () => {
@@ -114,9 +111,6 @@ describe('BpkPopoverPortal', () => {
   });
 
   it('should trap and restore focus', (done) => {
-    const focusStore = require('a11y-focus-store'); // eslint-disable-line global-require
-    const focusScope = require('a11y-focus-scope'); // eslint-disable-line global-require
-
     const portal = mount(
       <BpkPopoverPortal
         id="my-popover"
@@ -131,18 +125,18 @@ describe('BpkPopoverPortal', () => {
     );
 
     expect(portal.instance().tether).toBeNull();
-    expect(focusStore.storeFocus).not.toHaveBeenCalled();
-    expect(focusScope.scopeFocus).not.toHaveBeenCalled();
-    expect(focusStore.restoreFocus).not.toHaveBeenCalled();
-    expect(focusScope.unscopeFocus).not.toHaveBeenCalled();
+    expect(storeFocus).not.toHaveBeenCalled();
+    expect(scopeFocus).not.toHaveBeenCalled();
+    expect(restoreFocus).not.toHaveBeenCalled();
+    expect(unscopeFocus).not.toHaveBeenCalled();
 
     portal.setProps({ isOpen: true }, () => {
-      expect(focusStore.storeFocus).toHaveBeenCalled();
-      expect(focusScope.scopeFocus).toHaveBeenCalled();
+      expect(storeFocus).toHaveBeenCalled();
+      expect(scopeFocus).toHaveBeenCalled();
 
       portal.setProps({ isOpen: false }, () => {
-        expect(focusStore.restoreFocus).toHaveBeenCalled();
-        expect(focusScope.unscopeFocus).toHaveBeenCalled();
+        expect(restoreFocus).toHaveBeenCalled();
+        expect(unscopeFocus).toHaveBeenCalled();
         done();
       });
     });

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -16,9 +16,8 @@
  * limitations under the License.
  */
 
-import focusStore from 'a11y-focus-store';
-import focusScope from 'a11y-focus-scope';
 import { Portal, cssModules } from 'bpk-react-utils';
+import { scopeFocus, unscopeFocus, restoreFocus, storeFocus } from 'bpk-scrim-utils';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Tether, { getArrowPositionCallback, applyRTLTransforms } from 'bpk-tether';
@@ -34,8 +33,8 @@ const onOpen = (popoverElement, targetElement) => {
   // Therefore we also shouldn't store and scope the focus
   if (targetElement) {
     targetElement.focus();
-    focusStore.storeFocus();
-    focusScope.scopeFocus(popoverElement);
+    storeFocus();
+    scopeFocus(popoverElement);
   }
 };
 
@@ -59,8 +58,8 @@ class BpkPopoverPortal extends Component {
       this.tether = null;
     }
 
-    focusScope.unscopeFocus();
-    focusStore.restoreFocus();
+    unscopeFocus();
+    restoreFocus();
 
     done();
   }

--- a/packages/bpk-scrim-utils/index.js
+++ b/packages/bpk-scrim-utils/index.js
@@ -16,10 +16,15 @@
  * limitations under the License.
  */
 
-
+import { scopeFocus, unscopeFocus } from 'a11y-focus-scope';
+import { restoreFocus, storeFocus } from 'a11y-focus-store';
 import withScrim from './src/withScrim';
 
-export { withScrim };
+export { withScrim, scopeFocus, unscopeFocus, restoreFocus, storeFocus };
 export default {
   withScrim,
+  scopeFocus,
+  unscopeFocus,
+  restoreFocus,
+  storeFocus,
 };

--- a/packages/bpk-scrim-utils/package-lock.json
+++ b/packages/bpk-scrim-utils/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "bpk-scrim-utils",
+  "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "a11y-focus-scope": {
       "version": "1.1.3",
@@ -8,7 +10,7 @@
       "integrity": "sha1-95U4TU3UDM7BxKFg700TNx0BWug=",
       "requires": {
         "focusin": "2.0.0",
-        "tabbable": "1.1.0"
+        "tabbable": "1.1.1"
       }
     },
     "a11y-focus-store": {
@@ -16,15 +18,135 @@
       "resolved": "https://registry.npmjs.org/a11y-focus-store/-/a11y-focus-store-1.0.0.tgz",
       "integrity": "sha1-rlJWHLhq5sKQTBpKvy5YIL9TBbA="
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        }
+      }
+    },
     "focusin": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/focusin/-/focusin-2.0.0.tgz",
       "integrity": "sha1-WMARgN+xlJ8D493u4GNzn8M7b/w="
     },
-    "tabbable": {
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-1.1.0.tgz",
-      "integrity": "sha512-35UF7YrX08Wj5+CFFwO5akQYE4UFICvOY/xQ7Dgduhxb5QW7IS/d0DeLO9DnRzwVyfyiz6vRPj3MYhPt/Zopiw=="
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "tabbable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-1.1.1.tgz",
+      "integrity": "sha512-YnbzANAozgzJtFN9aSk4A1Ya3Z+yMh2GkrBa9AT3Bi4SF9z+iHmT8MoY/5bJL1h1aDYo+CPbAUR7qMx+LSxQgA=="
+    },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     }
   }
 }

--- a/packages/bpk-scrim-utils/package.json
+++ b/packages/bpk-scrim-utils/package.json
@@ -13,6 +13,7 @@
     "a11y-focus-scope": "^1.1.3",
     "a11y-focus-store": "^1.0.0",
     "bpk-mixins": "^17.0.10",
-    "bpk-react-utils": "^2.3.7"
+    "bpk-react-utils": "^2.3.7",
+    "prop-types": "^15.6.0"
   }
 }

--- a/packages/bpk-scrim-utils/src/withScrim.js
+++ b/packages/bpk-scrim-utils/src/withScrim.js
@@ -15,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import focusScope from 'a11y-focus-scope';
-import focusStore from 'a11y-focus-store';
+import { scopeFocus, unscopeFocus } from 'a11y-focus-scope';
+import { restoreFocus, storeFocus } from 'a11y-focus-store';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { cssModules, wrapDisplayName } from 'bpk-react-utils';
@@ -57,9 +57,9 @@ const withScrim = (WrappedComponent) => {
         }
       }
 
-      focusStore.storeFocus();
+      storeFocus();
       if (this.dialogElement) {
-        focusScope.scopeFocus(this.dialogElement);
+        scopeFocus(this.dialogElement);
       }
     }
 
@@ -77,8 +77,8 @@ const withScrim = (WrappedComponent) => {
         }
       }
 
-      focusScope.unscopeFocus();
-      focusStore.restoreFocus();
+      unscopeFocus();
+      restoreFocus();
     }
 
     onContentMouseDown(e) {


### PR DESCRIPTION
In the spirit of re-exposing external dependencies that are re-used, I figure the new scrim-utils package is the best place for this to live.