### PR TITLE
[BPK-1092] horizontal nav animation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+**Breaking:**
+- react-native-bpk-component-horizontal-nav:
+ - `BpkHorizontalNavItem` no longer supports the `selected` prop. Instead, add an `id` prop to `BpkHorizontalNavItem` and a `selectedId` prop to `BpkHorizontalNav`. This allows the selected indicator line to animate when the `selectedId` prop changes. See http://backpack.prod.aws.skyscnr.com/components/native/horizontal-nav for an example.
+
 **Added:**
 - react-native-bpk-component-ticket:
   - New component, see http://backpack.prod.aws.skyscnr.com/components/native/ticket

--- a/native/packages/react-native-bpk-component-horizontal-nav/readme.md
+++ b/native/packages/react-native-bpk-component-horizontal-nav/readme.md
@@ -28,10 +28,10 @@ export default class App extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <BpkHorizontalNav>
-          <BpkHorizontalNavItem selected title="Item One" onPress={() => {}} />
-          <BpkHorizontalNavItem title="Item Two" onPress={() => {}} />
-          <BpkHorizontalNavItem title="Item Three" onPress={() => {}} />
+        <BpkHorizontalNav selectedId="nav-1">
+          <BpkHorizontalNavItem id="nav-0" title="Item One" onPress={() => {}} />
+          <BpkHorizontalNavItem id="nav-1" title="Item Two" onPress={() => {}} />
+          <BpkHorizontalNavItem id="nav-2" title="Item Three" onPress={() => {}} />
         </BpkHorizontalNav>
       </View >
     );
@@ -43,20 +43,21 @@ export default class App extends Component {
 
 ### BpkHorizontalNav
 
-| Property            | PropType                              | Required | Default Value |
-| -----------         | ------------------------------------- | -------- | ------------- |
-| children            | node                                  | true     | -             |
-| spaceAround         | bool                                  | false    | false         |
+| Property            | PropType                                                    | Required | Default Value |
+| -----------         | ----------------------------------------------------------- | -------- | ------------- |
+| children            | node                                                        | true     | -             |
+| selectedId          | string (matching `id` prop of `BpkHorizontalNavItem` child) | true     | -             |
+| spaceAround         | bool                                                        | false    | false         |
 
 ### BpkHorizontalNavItem
 
 | Property            | PropType                              | Required | Default Value |
 | -----------         | ------------------------------------- | -------- | ------------- |
+| id                  | string                                | true     | -             |
 | onPress             | func                                  | true     | -             |
 | title               | string                                | true     | -             |
 | accessibilityLabel  | string                                | false    | props.title   |
 | disabled            | bool                                  | false    | false         |
-| selected            | bool                                  | false    | false         |
 | theme               | See [Theme Props](#theme-props) below | false    | null          |
 
 

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.common.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.common.js
@@ -18,14 +18,28 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
+
 import BpkHorizontalNav from './BpkHorizontalNav';
+import BpkHorizontalNavItem from './BpkHorizontalNavItem';
+
+jest.mock('./BpkHorizontalNavItem', () => 'BpkHorizontalNavItem');
 
 const commonTests = () => {
   describe('BpkHorizontalNav', () => {
     it('should render correctly', () => {
       const tree = renderer.create(
-        <BpkHorizontalNav>
+        <BpkHorizontalNav selectedId="0">
           My nav content.
+        </BpkHorizontalNav>,
+      ).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with the "selected" prop', () => {
+      const tree = renderer.create(
+        <BpkHorizontalNav selectedId="0">
+          <BpkHorizontalNavItem id="0" />
+          <BpkHorizontalNavItem id="1" />
         </BpkHorizontalNav>,
       ).toJSON();
       expect(tree).toMatchSnapshot();
@@ -33,7 +47,7 @@ const commonTests = () => {
 
     it('should render correctly with custom "style" prop', () => {
       const tree = renderer.create(
-        <BpkHorizontalNav style={{ marginBottom: 10 }}>
+        <BpkHorizontalNav selectedId="0" style={{ marginBottom: 10 }}>
           My nav content.
         </BpkHorizontalNav>,
       ).toJSON();
@@ -42,7 +56,7 @@ const commonTests = () => {
 
     it('should render correctly with arbitrary props', () => {
       const tree = renderer.create(
-        <BpkHorizontalNav custom="custom-prop">
+        <BpkHorizontalNav selectedId="0" custom="custom-prop">
           My nav content.
         </BpkHorizontalNav>,
       ).toJSON();

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.common.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.common.js
@@ -26,7 +26,7 @@ const commonTests = () => {
   describe('BpkHorizontalNavItem', () => {
     it('should render correctly', () => {
       const tree = renderer.create(
-        <BpkHorizontalNavItem title="Nav" onPress={onPressFn}>
+        <BpkHorizontalNavItem id="0" title="Nav" onPress={onPressFn}>
           My nav content.
         </BpkHorizontalNavItem>,
       ).toJSON();
@@ -35,7 +35,7 @@ const commonTests = () => {
 
     it('should render correctly with "selected" prop', () => {
       const tree = renderer.create(
-        <BpkHorizontalNavItem title="Nav" onPress={onPressFn} selected>
+        <BpkHorizontalNavItem id="0" title="Nav" onPress={onPressFn} selected>
           My nav content.
         </BpkHorizontalNavItem>,
       ).toJSON();
@@ -44,7 +44,7 @@ const commonTests = () => {
 
     it('should render correctly with "spaceAround" prop', () => {
       const tree = renderer.create(
-        <BpkHorizontalNavItem title="Nav" onPress={onPressFn} spaceAround>
+        <BpkHorizontalNavItem id="0" title="Nav" onPress={onPressFn} spaceAround>
           My nav content.
         </BpkHorizontalNavItem>,
       ).toJSON();
@@ -53,7 +53,7 @@ const commonTests = () => {
 
     it('should render correctly with custom "style" prop', () => {
       const tree = renderer.create(
-        <BpkHorizontalNavItem title="Nav" onPress={onPressFn} style={{ marginBottom: 10 }}>
+        <BpkHorizontalNavItem id="0" title="Nav" onPress={onPressFn} style={{ marginBottom: 10 }}>
           My nav content.
         </BpkHorizontalNavItem>,
       ).toJSON();
@@ -62,7 +62,7 @@ const commonTests = () => {
 
     it('should render correctly with arbitrary props', () => {
       const tree = renderer.create(
-        <BpkHorizontalNavItem title="Nav" onPress={onPressFn} custom="custom-prop">
+        <BpkHorizontalNavItem id="0" title="Nav" onPress={onPressFn} custom="custom-prop">
           My nav content.
         </BpkHorizontalNavItem>,
       ).toJSON();
@@ -75,7 +75,7 @@ const commonTests = () => {
       };
       const tree = renderer.create(
         <BpkThemeProvider theme={theme}>
-          <BpkHorizontalNavItem title="Nav" onPress={onPressFn} custom="custom-prop">
+          <BpkHorizontalNavItem id="0" title="Nav" onPress={onPressFn} custom="custom-prop">
           My nav content.
           </BpkHorizontalNavItem>
         </BpkThemeProvider>,
@@ -86,7 +86,7 @@ const commonTests = () => {
     it('should reject theme property when required theme attributes are omitted', () => { // eslint-disable-line max-len
       expect(propTypes.theme({
         theme: {},
-      }, 'theme', 'BpkHorizontalNavItem').toString()).toEqual('Error: Invalid prop `theme` supplied to `BpkHorizontalNavItem`. To theme a BpkHorizontalNavItem, the `theme` prop must include `horizontalNavSelectedTextColor`'); // eslint-disable-line max-len
+      }, 'theme', 'BpkHorizontalNavItem').toString()).toEqual('Error: Invalid prop `theme` supplied to `BpkHorizontalNavItem`. To theme a `BpkHorizontalNavItem`, the `theme` prop must include `horizontalNavSelectedTextColor`'); // eslint-disable-line max-len
     });
   });
 };

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -31,14 +31,12 @@ import { setOpacity } from 'bpk-tokens';
 import BpkText from 'react-native-bpk-component-text';
 import { withTheme } from 'react-native-bpk-theming';
 
+import { THEMING_ATTRIBUTE, themePropType } from './theming';
+
 const tokens = Platform.select({
   ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
   android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
 })();
-
-// If theming is ever expanded to support other types, this should be changed
-// to something akin to BpkButton's theming functions.
-const THEMING_ATTRIBUTE = 'horizontalNavSelectedTextColor';
 
 const selectedColor = tokens.colorBlue700;
 const styles = StyleSheet.create({
@@ -53,22 +51,7 @@ const styles = StyleSheet.create({
   selectedText: {
     color: selectedColor,
   },
-  selectedIndicator: {
-    backgroundColor: selectedColor,
-    height: tokens.borderSizeLg,
-  },
 });
-
-const themePropType = (props, propName, componentName) => {
-  const { theme } = props;
-  if (!theme) {
-    return false;
-  }
-  if (!theme[THEMING_ATTRIBUTE]) {
-    return new Error(`Invalid prop \`${propName}\` supplied to \`${componentName}\`. To theme a BpkHorizontalNavItem, the \`theme\` prop must include \`${THEMING_ATTRIBUTE}\``); // eslint-disable-line max-len
-  }
-  return false;
-};
 
 const BpkHorizontalNavItem = (props) => {
   const {
@@ -83,7 +66,6 @@ const BpkHorizontalNavItem = (props) => {
 
   const accessibilityTraits = ['button'];
   const textStyles = [styles.text];
-  const indicatorStyles = [styles.selectedIndicator];
 
   if (disabled) {
     accessibilityTraits.push('disabled');
@@ -93,14 +75,10 @@ const BpkHorizontalNavItem = (props) => {
     if (theme && theme[THEMING_ATTRIBUTE]) {
       const themeStyles = {
         selectedText: {
-          color: theme.horizontalNavSelectedTextColor,
-        },
-        selectedIndicator: {
-          backgroundColor: theme.horizontalNavSelectedTextColor,
+          color: theme[THEMING_ATTRIBUTE],
         },
       };
       textStyles.push(themeStyles.selectedText);
-      indicatorStyles.push(themeStyles.selectedIndicator);
     }
   }
 
@@ -122,13 +100,13 @@ const BpkHorizontalNavItem = (props) => {
     >
       <View style={style}>
         <BpkText style={textStyles}>{formattedTitle}</BpkText>
-        { (selected && !disabled) && <View style={indicatorStyles} />}
       </View>
     </Touchable>
   );
 };
 
 const propTypes = {
+  id: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   accessibilityLabel: PropTypes.string,

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.android.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.android.js
@@ -1,0 +1,33 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkHorizontalNavSelectedIndicator-test.common';
+
+jest.mock('react-native', () => {
+  const reactNative = require.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+
+  return reactNative;
+});
+
+describe('Android', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.common.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.common.js
@@ -1,0 +1,53 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BpkThemeProvider from 'react-native-bpk-theming';
+
+import BpkHorizontalNavSelectedIndicator, { propTypes } from './BpkHorizontalNavSelectedIndicator';
+
+const commonTests = () => {
+  describe('BpkHorizontalNavSelectedIndicator', () => {
+    it('should render correctly', () => {
+      const tree = renderer.create(
+        <BpkHorizontalNavSelectedIndicator xOffset={0} width={100} />,
+      ).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should support theming', () => {
+      const theme = {
+        horizontalNavSelectedTextColor: 'red',
+      };
+      const tree = renderer.create(
+        <BpkThemeProvider theme={theme}>
+          <BpkHorizontalNavSelectedIndicator xOffset={0} width={100} />
+        </BpkThemeProvider>,
+      ).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should reject theme property when required theme attributes are omitted', () => { // eslint-disable-line max-len
+      expect(propTypes.theme({
+        theme: {},
+      }, 'theme', 'BpkHorizontalNavSelectedIndicator').toString()).toEqual('Error: Invalid prop `theme` supplied to `BpkHorizontalNavSelectedIndicator`. To theme a `BpkHorizontalNavSelectedIndicator`, the `theme` prop must include `horizontalNavSelectedTextColor`'); // eslint-disable-line max-len
+    });
+  });
+};
+export default commonTests;

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.ios.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.ios.js
@@ -1,0 +1,33 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkHorizontalNavSelectedIndicator-test.common';
+
+jest.mock('react-native', () => {
+  const reactNative = require.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.ios || obj.default);
+  reactNative.Platform.OS = 'ios';
+
+  return reactNative;
+});
+
+describe('iOS', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator.js
@@ -1,0 +1,70 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  Animated,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+import PropTypes from 'prop-types';
+import { withTheme } from 'react-native-bpk-theming';
+
+import { THEMING_ATTRIBUTE, themePropType } from './theming';
+
+const tokens = Platform.select({
+  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
+  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
+})();
+
+const styles = StyleSheet.create({
+  selectedIndicator: {
+    backgroundColor: tokens.colorBlue700,
+    height: tokens.borderSizeLg,
+  },
+});
+
+const BpkHorizontalNavSelectedIndicator = (props) => {
+  const { theme, xOffset, width } = props;
+  const style = [styles.selectedIndicator];
+  if (theme && theme[THEMING_ATTRIBUTE]) { style.push({ backgroundColor: theme[THEMING_ATTRIBUTE] }); }
+  const animationStyles = {
+    transform: [{
+      translateX: xOffset,
+    }],
+    width,
+  };
+  return <Animated.View style={[style, animationStyles]} />;
+};
+
+const propTypes = {
+  theme: themePropType,
+  xOffset: PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Object)]).isRequired,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Object)]).isRequired,
+};
+
+BpkHorizontalNavSelectedIndicator.propTypes = propTypes;
+
+BpkHorizontalNavSelectedIndicator.defaultProps = {
+  theme: null,
+};
+
+export default withTheme(BpkHorizontalNavSelectedIndicator);
+export {
+  propTypes,
+};

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNav-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNav-test.android.js.snap
@@ -10,7 +10,6 @@ exports[`Android BpkHorizontalNav should render correctly 1`] = `
           "borderBottomColor": "rgb(230, 228, 235)",
           "borderColor": "transparent",
           "borderWidth": 1,
-          "flexDirection": "row",
         },
       ],
       null,
@@ -20,7 +19,15 @@ exports[`Android BpkHorizontalNav should render correctly 1`] = `
   showsHorizontalScrollIndicator={false}
 >
   <View>
-    My nav content.
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    </View>
   </View>
 </RCTScrollView>
 `;
@@ -35,7 +42,6 @@ exports[`Android BpkHorizontalNav should render correctly with arbitrary props 1
           "borderBottomColor": "rgb(230, 228, 235)",
           "borderColor": "transparent",
           "borderWidth": 1,
-          "flexDirection": "row",
         },
       ],
       null,
@@ -46,7 +52,15 @@ exports[`Android BpkHorizontalNav should render correctly with arbitrary props 1
   showsHorizontalScrollIndicator={false}
 >
   <View>
-    My nav content.
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    </View>
   </View>
 </RCTScrollView>
 `;
@@ -61,7 +75,6 @@ exports[`Android BpkHorizontalNav should render correctly with custom "style" pr
           "borderBottomColor": "rgb(230, 228, 235)",
           "borderColor": "transparent",
           "borderWidth": 1,
-          "flexDirection": "row",
         },
       ],
       Object {
@@ -73,7 +86,58 @@ exports[`Android BpkHorizontalNav should render correctly with custom "style" pr
   showsHorizontalScrollIndicator={false}
 >
   <View>
-    My nav content.
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Android BpkHorizontalNav should render correctly with the "selected" prop 1`] = `
+<RCTScrollView
+  alwaysBounceHorizontal={false}
+  contentContainerStyle={
+    Array [
+      Array [
+        Object {
+          "borderBottomColor": "rgb(230, 228, 235)",
+          "borderColor": "transparent",
+          "borderWidth": 1,
+        },
+      ],
+      null,
+    ]
+  }
+  horizontal={true}
+  showsHorizontalScrollIndicator={false}
+>
+  <View>
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      >
+        <BpkHorizontalNavItem
+          id="0"
+          onLayout={[Function]}
+          selected={true}
+        />
+        <BpkHorizontalNavItem
+          id="1"
+          onLayout={[Function]}
+          selected={false}
+        />
+      </View>
+    </View>
   </View>
 </RCTScrollView>
 `;

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNav-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNav-test.ios.js.snap
@@ -10,7 +10,6 @@ exports[`iOS BpkHorizontalNav should render correctly 1`] = `
           "borderBottomColor": "rgb(230, 228, 235)",
           "borderColor": "transparent",
           "borderWidth": 1,
-          "flexDirection": "row",
         },
       ],
       null,
@@ -20,7 +19,15 @@ exports[`iOS BpkHorizontalNav should render correctly 1`] = `
   showsHorizontalScrollIndicator={false}
 >
   <View>
-    My nav content.
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    </View>
   </View>
 </RCTScrollView>
 `;
@@ -35,7 +42,6 @@ exports[`iOS BpkHorizontalNav should render correctly with arbitrary props 1`] =
           "borderBottomColor": "rgb(230, 228, 235)",
           "borderColor": "transparent",
           "borderWidth": 1,
-          "flexDirection": "row",
         },
       ],
       null,
@@ -46,7 +52,15 @@ exports[`iOS BpkHorizontalNav should render correctly with arbitrary props 1`] =
   showsHorizontalScrollIndicator={false}
 >
   <View>
-    My nav content.
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    </View>
   </View>
 </RCTScrollView>
 `;
@@ -61,7 +75,6 @@ exports[`iOS BpkHorizontalNav should render correctly with custom "style" prop 1
           "borderBottomColor": "rgb(230, 228, 235)",
           "borderColor": "transparent",
           "borderWidth": 1,
-          "flexDirection": "row",
         },
       ],
       Object {
@@ -73,7 +86,58 @@ exports[`iOS BpkHorizontalNav should render correctly with custom "style" prop 1
   showsHorizontalScrollIndicator={false}
 >
   <View>
-    My nav content.
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`iOS BpkHorizontalNav should render correctly with the "selected" prop 1`] = `
+<RCTScrollView
+  alwaysBounceHorizontal={false}
+  contentContainerStyle={
+    Array [
+      Array [
+        Object {
+          "borderBottomColor": "rgb(230, 228, 235)",
+          "borderColor": "transparent",
+          "borderWidth": 1,
+        },
+      ],
+      null,
+    ]
+  }
+  horizontal={true}
+  showsHorizontalScrollIndicator={false}
+>
+  <View>
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      >
+        <BpkHorizontalNavItem
+          id="0"
+          onLayout={[Function]}
+          selected={true}
+        />
+        <BpkHorizontalNavItem
+          id="1"
+          onLayout={[Function]}
+          selected={false}
+        />
+      </View>
+    </View>
   </View>
 </RCTScrollView>
 `;

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
@@ -129,16 +129,6 @@ exports[`iOS BpkHorizontalNavItem should render correctly with "selected" prop 1
     >
       Nav
     </Text>
-    <View
-      style={
-        Array [
-          Object {
-            "backgroundColor": "rgb(0, 140, 168)",
-            "height": 2,
-          },
-        ]
-      }
-    />
   </View>
 </View>
 `;

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavSelectedIndicator-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavSelectedIndicator-test.android.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkHorizontalNavSelectedIndicator should render correctly 1`] = `
+<View
+  collapsable={undefined}
+  style={
+    Object {
+      "backgroundColor": "rgb(0, 140, 168)",
+      "height": 2,
+      "transform": Array [
+        Object {
+          "translateX": 0,
+        },
+      ],
+      "width": 100,
+    }
+  }
+/>
+`;
+
+exports[`Android BpkHorizontalNavSelectedIndicator should support theming 1`] = `
+<View
+  collapsable={undefined}
+  style={
+    Object {
+      "backgroundColor": "red",
+      "height": 2,
+      "transform": Array [
+        Object {
+          "translateX": 0,
+        },
+      ],
+      "width": 100,
+    }
+  }
+/>
+`;

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavSelectedIndicator-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavSelectedIndicator-test.ios.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS BpkHorizontalNavSelectedIndicator should render correctly 1`] = `
+<View
+  collapsable={undefined}
+  style={
+    Object {
+      "backgroundColor": "rgb(0, 140, 168)",
+      "height": 2,
+      "transform": Array [
+        Object {
+          "translateX": 0,
+        },
+      ],
+      "width": 100,
+    }
+  }
+/>
+`;
+
+exports[`iOS BpkHorizontalNavSelectedIndicator should support theming 1`] = `
+<View
+  collapsable={undefined}
+  style={
+    Object {
+      "backgroundColor": "red",
+      "height": 2,
+      "transform": Array [
+        Object {
+          "translateX": 0,
+        },
+      ],
+      "width": 100,
+    }
+  }
+/>
+`;

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/theming.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/theming.js
@@ -1,0 +1,37 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// If theming is ever expanded to support other types, this should be changed
+// to something akin to BpkButton's theming functions.
+const THEMING_ATTRIBUTE = 'horizontalNavSelectedTextColor';
+
+const themePropType = (props, propName, componentName) => {
+  const { theme } = props;
+  if (!theme) {
+    return false;
+  }
+  if (!theme[THEMING_ATTRIBUTE]) {
+    return new Error(`Invalid prop \`${propName}\` supplied to \`${componentName}\`. To theme a \`${componentName}\`, the \`theme\` prop must include \`${THEMING_ATTRIBUTE}\``); // eslint-disable-line max-len
+  }
+  return false;
+};
+
+export {
+  THEMING_ATTRIBUTE,
+  themePropType,
+};

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/withAnimatedProps.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/withAnimatedProps.js
@@ -1,0 +1,64 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ Higher order component that takes a component and an array of property names,
+ then converts said properties into instances of Animated.Value, then adds
+ a componentWillReceiveProps listener so that when they change, they are updated
+ with an animation.
+
+ Sample usage:
+
+ const myComponent (props) = <Animated.View style={{ width: props.someProp }} />;
+ const animatedComponent = withAnimatedProps(myComponent, ['someProp']);
+
+ Now when `someProp` changes, it will be animated.
+ */
+
+import React from 'react';
+import { Animated } from 'react-native';
+
+const ANIMATION_DURATION = 200; // milliseconds.
+
+const withAnimatedProps = (Component, propsToMonitor) => class extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    propsToMonitor.forEach((prop) => {
+      this.state[prop] = new Animated.Value(props[prop]);
+    });
+  }
+  componentWillReceiveProps(nextProps) {
+    const animations = propsToMonitor.map(prop => (
+      Animated.timing(this.state[prop], {
+        toValue: nextProps[prop],
+        duration: ANIMATION_DURATION,
+      })
+    ));
+    Animated.parallel(animations).start();
+  }
+  render() {
+    const newProps = {};
+    propsToMonitor.forEach((prop) => {
+      newProps[prop] = this.state[prop];
+    });
+    return <Component {...this.props} {...newProps} />;
+  }
+};
+
+export default withAnimatedProps;

--- a/native/packages/react-native-bpk-component-horizontal-nav/stories.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/stories.js
@@ -22,6 +22,7 @@ import {
   Platform,
   StyleSheet,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import BpkThemeProvider from 'react-native-bpk-theming';
@@ -40,22 +41,61 @@ const styles = StyleSheet.create({
   },
 });
 
+class ManagedNav extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { selectedId: '2' };
+  }
+  render() {
+    return (
+      <BpkHorizontalNav selectedId={this.state.selectedId}>
+        <BpkHorizontalNavItem id="0" onPress={() => { this.setState({ selectedId: '0' }); }} title="One" />
+        <BpkHorizontalNavItem id="1" onPress={() => { this.setState({ selectedId: '1' }); }} title="Two (Long Title)" />
+        <BpkHorizontalNavItem id="2" onPress={() => { this.setState({ selectedId: '2' }); }} title="Three" />
+      </BpkHorizontalNav>
+    );
+  }
+}
+
+const StoryNav = (props) => {
+  const { items, ...rest } = props;
+  return (
+    <BpkHorizontalNav selectedId="1" {...rest}>
+      { [...Array(items)].map((_, index) => (
+        <BpkHorizontalNavItem
+          title="Item"
+          id={index.toString()}
+          key={index.toString()}
+          onPress={action(`Nav item ${index} pressed`)}
+        />
+      ))}
+      <BpkHorizontalNavItem title="Disabled Item" disabled id="disabled" onPress={() => {}} />
+    </BpkHorizontalNav>
+  );
+};
+StoryNav.propTypes = {
+  items: PropTypes.number,
+};
+StoryNav.defaultProps = {
+  items: 2,
+};
+
 storiesOf('BpkHorizontalNav', module)
   .add('docs:default', () => (
     <View style={styles.bottomMargin}>
-      <BpkHorizontalNav>
-        <BpkHorizontalNavItem title="Flights" onPress={action('Nav item one pressed')} />
-        <BpkHorizontalNavItem selected title="Hotels" onPress={action('Nav item two pressed')} />
-        <BpkHorizontalNavItem title="Car hire" onPress={action('Nav item three pressed')} />
+      <BpkHorizontalNav selectedId="1">
+        <BpkHorizontalNavItem title="Flights" id="0" onPress={action('Nav item one pressed')} />
+        <BpkHorizontalNavItem title="Hotels" id="1" onPress={action('Nav item two pressed')} />
+        <BpkHorizontalNavItem title="Car hire" id="2" onPress={action('Nav item three pressed')} />
       </BpkHorizontalNav>
     </View>
   ))
   .add('docs:spaceAround', () => (
     <View style={styles.bottomMargin}>
-      <BpkHorizontalNav spaceAround>
-        <BpkHorizontalNavItem title="Flights" onPress={action('Nav item one pressed')} />
-        <BpkHorizontalNavItem selected title="Hotels" onPress={action('Nav item two pressed')} />
-        <BpkHorizontalNavItem title="Car hire" onPress={action('Nav item three pressed')} />
+      <BpkHorizontalNav spaceAround selectedId="1">
+        <BpkHorizontalNavItem title="Flights" id="0" onPress={action('Nav item one pressed')} />
+        <BpkHorizontalNavItem title="Hotels" id="1" onPress={action('Nav item two pressed')} />
+        <BpkHorizontalNavItem title="Car hire" id="2" onPress={action('Nav item three pressed')} />
       </BpkHorizontalNav>
     </View>
   ))
@@ -63,51 +103,29 @@ storiesOf('BpkHorizontalNav', module)
     <View>
       <View style={styles.bottomMargin}>
         <StorySubheading>Default</StorySubheading>
-        <BpkHorizontalNav>
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item one pressed')} />
-          <BpkHorizontalNavItem selected title="Item" onPress={action('Nav item two pressed')} />
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item three pressed')} />
-        </BpkHorizontalNav>
+        <StoryNav />
       </View>
       <View style={styles.bottomMargin}>
         <StorySubheading>Space Around</StorySubheading>
-        <BpkHorizontalNav spaceAround>
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item one pressed')} />
-          <BpkHorizontalNavItem selected title="Item" onPress={action('Nav item two pressed')} />
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item three pressed')} />
-        </BpkHorizontalNav>
+        <StoryNav spaceAround />
       </View>
       <View style={styles.bottomMargin}>
         <StorySubheading>Overflowing</StorySubheading>
-        <BpkHorizontalNav spaceAround>
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item one pressed')} />
-          <BpkHorizontalNavItem selected title="Item" onPress={action('Nav item two pressed')} />
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item three pressed')} />
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item one pressed')} />
-          <BpkHorizontalNavItem disabled title="Item" onPress={action('Nav item two pressed')} />
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item three pressed')} />
-        </BpkHorizontalNav>
+        <StoryNav items={5} />
       </View>
       <View style={styles.bottomMargin}>
         <StorySubheading>Space Around, Overflowing</StorySubheading>
-        <BpkHorizontalNav spaceAround>
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item one pressed')} />
-          <BpkHorizontalNavItem selected title="Item" onPress={action('Nav item two pressed')} />
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item three pressed')} />
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item one pressed')} />
-          <BpkHorizontalNavItem disabled title="Item" onPress={action('Nav item two pressed')} />
-          <BpkHorizontalNavItem title="Item" onPress={action('Nav item three pressed')} />
-        </BpkHorizontalNav>
+        <StoryNav items={5} spaceAround />
       </View>
       <View style={styles.bottomMargin}>
         <StorySubheading>Themed</StorySubheading>
         <BpkThemeProvider theme={themeAttributes}>
-          <BpkHorizontalNav>
-            <BpkHorizontalNavItem title="Menu Item" onPress={action('Nav item one pressed')} />
-            <BpkHorizontalNavItem selected title="Menu Item" onPress={action('Nav item two pressed')} />
-            <BpkHorizontalNavItem title="Menu Item" onPress={action('Nav item three pressed')} />
-          </BpkHorizontalNav>
+          <StoryNav />
         </BpkThemeProvider>
+      </View>
+      <View style={styles.bottomMargin}>
+        <StorySubheading>In a state management wrapper, for testing animation</StorySubheading>
+        <ManagedNav />
       </View>
     </View>
   ));

--- a/packages/bpk-docs/src/pages/NativeHorizontalNavPage/NativeHorizontalNavPage.js
+++ b/packages/bpk-docs/src/pages/NativeHorizontalNavPage/NativeHorizontalNavPage.js
@@ -87,6 +87,9 @@ const NativeHorizontalNavPage = () => (<DocsPageBuilder
       to other pages or views within the page.
     </Paragraph>,
     <Paragraph>
+      It features an indicator line that animates automatically when the selected item changes.
+    </Paragraph>,
+    <Paragraph>
       The selected item can be <BpkLink href={THEMING}>themed</BpkLink>.
     </Paragraph>,
   ]}


### PR DESCRIPTION
**What does this PR do?**

Previously, consumers would handle the `selected` prop on `BpkHorizontalNavItem`. If a NavItem had this prop, the NavItem would get blue text and a blue indicator underneath.

Their code would look like this:

```
<BpkHorizontalNav>
    <BpkHorizontalNavItem title="One" />
    <BpkHorizontalNavItem title="Two" selected />
    <BpkHorizontalNavItem title="Three" />
</BpkHorizontalNav>
```

With this PR, consumers should add a `selectedId` prop to the container and `id` props to the children instead, like this:

```
<BpkHorizontalNav selectedId="1">
    <BpkHorizontalNavItem title="One" id="0" />
    <BpkHorizontalNavItem title="Two" id="1" />
    <BpkHorizontalNavItem title="Three" id="2" />
</BpkHorizontalNav>
```

**How does it do this?**
The indicator line has been pulled out of the individual NavItems and made part of the parent. To place the line correctly, the parent needs to know the x-position and the width of each NavItem, so it can give the line the correct width and position.

To get this information, each child element is given an [`onLayout`](https://facebook.github.io/react-native/docs/view.html#onlayout) prop, which adds its layout information to an array contained in the parent.

`onLayout` fires after `componentDidMount`, making it hard to hook into a time when all the children have been laid out (and we have all the layout data we need to position the indicator). 

To overcome this, when `onLayout` fires for each NavItem, we check if the NavItem in question is the initially selected one. If so, we know we have enough layout information to render the initial position of the indicator, and trigger a re-render with `this.setState`. In the background, the other NavItem layouts can come in asynchronously, ready for when `selected` changes.

The indicator can now be positioned correctly because our array of positions looks like this:

```
{
  '0': {width: 100, x: 0},
  '1': {width: 80, x: 100},
  '2': {width: 90, x: 180}
}
```

So if `selected={1}`, the indicator's style would include `{ translateX: 100, width: 80 }`.

**Advantages of this approach**
* Very minimal changes to the NavItem code (just removing the indicator).
* Works with NavItems of variable width and with the `spaceAround` property, unlike [`react-native-tab-view`](https://github.com/react-native-community/react-native-tab-view/tree/master/src).
* Uses the least amount of stateful code possible. No need for Redux etc.

**Disadvantages of this approach**
* We're manually triggering a re-render, although in our testing this isn't noticeable.