### PR TITLE
add TouchableNativeFeedback for android

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,19 +4,46 @@
     "browser": true,
     "jest": true
   },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".js",
+          ".json",
+          ".android.js",
+          ".ios.js"
+        ]
+      }
+    }
+  },
   "rules": {
-    "max-len": [2, 120],
+    "max-len": [
+      2,
+      120
+    ],
     "react/jsx-filename-extension": 0,
     "import/no-extraneous-dependencies": 0,
-    "react/prefer-stateless-function": [2, { "ignorePureComponents": true }],
-
+    "react/prefer-stateless-function": [
+      2,
+      {
+        "ignorePureComponents": true
+      }
+    ],
     // See https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/282
-    "jsx-a11y/label-has-for": [ 2, {
-      "components": [ "Label" ],
-      "required": {
-          "some": [ "nesting", "id" ]
-      },
-      "allowChildren": false
-    }]
+    "jsx-a11y/label-has-for": [
+      2,
+      {
+        "components": [
+          "Label"
+        ],
+        "required": {
+          "some": [
+            "nesting",
+            "id"
+          ]
+        },
+        "allowChildren": false
+      }
+    ]
   }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 - react-native-bpk-component-ticket:
   - New component, see http://backpack.prod.aws.skyscnr.com/components/native/ticket
 
+**Fixed:**
+- react-native-bpk-component-card
+  - Add support for android.
+
 ## 2017-11-10 - New `withScrim` HOC, plus native horizontal nav and switch components
 
 **Added:**

--- a/native/packages/react-native-bpk-component-card/src/BpkCard-test.android.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard-test.android.js
@@ -24,9 +24,13 @@ jest.mock('react-native', () => {
     .spyOn(reactNative.Platform, 'select')
     .mockImplementation(obj => obj.android || obj.default);
   reactNative.Platform.OS = 'android';
-
+  reactNative.TouchableNativeFeedback.SelectableBackgroundBorderless = jest.fn();
   return reactNative;
 });
+
+jest.mock('./BpkCard', () => require.requireActual('./BpkCard.android.js'));
+jest.mock('TouchableNativeFeedback',
+  () => require.requireActual('./../../../node_modules/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android')); // eslint-disable-line max-len
 
 describe('Android', () => {
   commonTests();

--- a/native/packages/react-native-bpk-component-card/src/BpkCard-test.ios.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard-test.ios.js
@@ -28,6 +28,8 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('./BpkCard', () => require.requireActual('./BpkCard.ios.js'));
+
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-card/src/BpkCard.android.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard.android.js
@@ -20,8 +20,7 @@ import {
   View,
   Platform,
   StyleSheet,
-  TouchableHighlight,
-  PixelRatio,
+  TouchableNativeFeedback,
   ViewPropTypes,
 } from 'react-native';
 import React from 'react';
@@ -33,22 +32,11 @@ const tokens = Platform.select({
 })();
 
 const {
-  colorGray50,
   colorWhite,
   elevationXs,
   elevationLg,
   borderRadiusSm,
   spacingBase,
-  shadowSmColor,
-  shadowSmOffsetWidth,
-  shadowSmOffsetHeight,
-  shadowSmOpacity,
-  shadowSmRadius,
-  shadowXlColor,
-  shadowXlOffsetWidth,
-  shadowXlOffsetHeight,
-  shadowXlOpacity,
-  shadowXlRadius,
 } = tokens;
 
 /**
@@ -59,23 +47,12 @@ const styles = StyleSheet.create({
     backgroundColor: colorWhite,
     borderRadius: borderRadiusSm,
     elevation: elevationXs,
-    shadowColor: shadowSmColor,
-    shadowOffset: { width: shadowSmOffsetWidth, height: shadowSmOffsetHeight / PixelRatio.get() },
-    shadowOpacity: shadowSmOpacity,
-    shadowRadius: shadowSmRadius / PixelRatio.get(),
   },
   cardPadded: {
     padding: spacingBase,
   },
   cardFocused: {
     elevation: elevationLg,
-    shadowColor: shadowXlColor,
-    shadowOffset: { width: shadowXlOffsetWidth, height: shadowXlOffsetHeight / PixelRatio.get() },
-    shadowOpacity: shadowXlOpacity,
-    shadowRadius: shadowXlRadius / PixelRatio.get(),
-  },
-  cardInner: {
-    backgroundColor: 'transparent', // otherwise this view's corners would bleed outwith the outer container
   },
 });
 
@@ -94,14 +71,19 @@ const BpkCard = (props) => {
   if (userStyle) { style.push(userStyle); }
 
   return (
-    <TouchableHighlight
-      accessibilityComponentType="button"
-      underlayColor={colorGray50}
-      style={style}
-      {...rest}
-    >
-      <View style={styles.cardInner}>{children}</View>
-    </TouchableHighlight>
+
+    <View style={userStyle}>
+      <TouchableNativeFeedback
+        useForeground
+        accessibilityComponentType="button"
+        background={TouchableNativeFeedback.SelectableBackgroundBorderless()}
+        {...rest}
+      >
+        <View style={style}>
+          <View>{children}</View>
+        </View>
+      </TouchableNativeFeedback>
+    </View>
   );
 };
 

--- a/native/packages/react-native-bpk-component-card/src/BpkCard.ios.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard.ios.js
@@ -1,0 +1,114 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  PixelRatio,
+  Platform,
+  StyleSheet,
+  TouchableHighlight,
+  View,
+  ViewPropTypes,
+} from 'react-native';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const tokens = Platform.select({
+  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
+  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
+})();
+const {
+  colorGray50,
+  colorWhite,
+  borderRadiusSm,
+  spacingBase,
+  shadowSmColor,
+  shadowSmOffsetWidth,
+  shadowSmOffsetHeight,
+  shadowSmOpacity,
+  shadowSmRadius,
+  shadowXlColor,
+  shadowXlOffsetWidth,
+  shadowXlOffsetHeight,
+  shadowXlOpacity,
+  shadowXlRadius,
+} = tokens;
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colorWhite,
+    borderRadius: borderRadiusSm,
+    shadowColor: shadowSmColor,
+    shadowOffset: { width: shadowSmOffsetWidth, height: shadowSmOffsetHeight / PixelRatio.get() },
+    shadowOpacity: shadowSmOpacity,
+    shadowRadius: shadowSmRadius / PixelRatio.get(),
+  },
+  cardPadded: {
+    padding: spacingBase,
+  },
+  cardFocused: {
+    shadowColor: shadowXlColor,
+    shadowOffset: { width: shadowXlOffsetWidth, height: shadowXlOffsetHeight / PixelRatio.get() },
+    shadowOpacity: shadowXlOpacity,
+    shadowRadius: shadowXlRadius / PixelRatio.get(),
+  },
+  cardInner: {
+    backgroundColor: 'transparent', // otherwise this view's corners would bleed outwith the outer container
+  },
+});
+
+const BpkCard = (props) => {
+  const {
+    padded,
+    children,
+    focused,
+    style: userStyle,
+    ...rest
+  } = props;
+
+  const style = [styles.card];
+  if (padded) { style.push(styles.cardPadded); }
+  if (focused) { style.push(styles.cardFocused); }
+  if (userStyle) { style.push(userStyle); }
+
+  return (
+    <TouchableHighlight
+      accessibilityComponentType="button"
+      underlayColor={colorGray50}
+      style={style}
+      {...rest}
+    >
+      <View style={styles.cardInner}>{children}</View>
+    </TouchableHighlight>
+  );
+};
+
+BpkCard.propTypes = {
+  children: PropTypes.node.isRequired,
+  onPress: PropTypes.func.isRequired,
+  focused: PropTypes.bool,
+  padded: PropTypes.bool,
+  style: ViewPropTypes.style,
+};
+
+BpkCard.defaultProps = {
+  focused: false,
+  padded: true,
+  style: null,
+};
+
+export default BpkCard;

--- a/native/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.android.js.snap
@@ -2,307 +2,252 @@
 
 exports[`Android BpkCard should render correctly 1`] = `
 <View
-  accessibilityComponentType="button"
-  accessibilityLabel="Example Card"
-  accessibilityTraits={undefined}
-  accessible={true}
-  hasTVPreferredFocus={undefined}
-  hitSlop={undefined}
-  isTVSelectable={true}
-  nativeID={undefined}
-  onLayout={undefined}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Array [
+  style={null}
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Example Card"
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    nativeBackgroundAndroid={
       Object {
-        "backgroundColor": "transparent",
-      },
+        "attribute": "selectableItemBackground",
+        "type": "ThemeAttrAndroid",
+      }
+    }
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
       Array [
         Object {
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 2,
           "elevation": 2,
-          "shadowColor": undefined,
-          "shadowOffset": Object {
-            "height": NaN,
-            "width": undefined,
-          },
-          "shadowOpacity": undefined,
-          "shadowRadius": NaN,
         },
         Object {
           "padding": 16,
         },
-      ],
-    ]
-  }
-  testID={undefined}
-  tvParallaxProperties={undefined}
->
-  <View
-    style={
-      Object {
-        "backgroundColor": "transparent",
-      }
+      ]
     }
+    testID={undefined}
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      disabled={false}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "color": "rgb(82, 76, 97)",
-            "fontFamily": "sans-serif",
-            "fontSize": 16,
-            "fontWeight": "400",
-            "lineHeight": 24,
-          },
-          Object {},
-        ]
-      }
-    >
-      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-    </Text>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "sans-serif",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "lineHeight": 24,
+            },
+            Object {},
+          ]
+        }
+      >
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+      </Text>
+    </View>
   </View>
 </View>
 `;
 
 exports[`Android BpkCard should render correctly with arbitrary props 1`] = `
 <View
-  accessibilityComponentType="button"
-  accessibilityLabel="Example Card"
-  accessibilityTraits={undefined}
-  accessible={true}
-  hasTVPreferredFocus={undefined}
-  hitSlop={undefined}
-  isTVSelectable={true}
-  nativeID={undefined}
-  onLayout={undefined}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Array [
+  style={null}
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Example Card"
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    nativeBackgroundAndroid={
       Object {
-        "backgroundColor": "transparent",
-      },
+        "attribute": "selectableItemBackground",
+        "type": "ThemeAttrAndroid",
+      }
+    }
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
       Array [
         Object {
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 2,
           "elevation": 2,
-          "shadowColor": undefined,
-          "shadowOffset": Object {
-            "height": NaN,
-            "width": undefined,
-          },
-          "shadowOpacity": undefined,
-          "shadowRadius": NaN,
         },
         Object {
           "padding": 16,
         },
-      ],
-    ]
-  }
-  testID="arbitrary value"
-  tvParallaxProperties={undefined}
->
-  <View
-    style={
-      Object {
-        "backgroundColor": "transparent",
-      }
+      ]
     }
+    testID="arbitrary value"
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      disabled={false}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "color": "rgb(82, 76, 97)",
-            "fontFamily": "sans-serif",
-            "fontSize": 16,
-            "fontWeight": "400",
-            "lineHeight": 24,
-          },
-          Object {},
-        ]
-      }
-    >
-      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-    </Text>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "sans-serif",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "lineHeight": 24,
+            },
+            Object {},
+          ]
+        }
+      >
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+      </Text>
+    </View>
   </View>
 </View>
 `;
 
 exports[`Android BpkCard should render correctly with the "focused" state 1`] = `
 <View
-  accessibilityComponentType="button"
-  accessibilityLabel="Example Card"
-  accessibilityTraits={undefined}
-  accessible={true}
-  hasTVPreferredFocus={undefined}
-  hitSlop={undefined}
-  isTVSelectable={true}
-  nativeID={undefined}
-  onLayout={undefined}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Array [
+  style={null}
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Example Card"
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    nativeBackgroundAndroid={
       Object {
-        "backgroundColor": "transparent",
-      },
+        "attribute": "selectableItemBackground",
+        "type": "ThemeAttrAndroid",
+      }
+    }
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
       Array [
         Object {
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 2,
           "elevation": 2,
-          "shadowColor": undefined,
-          "shadowOffset": Object {
-            "height": NaN,
-            "width": undefined,
-          },
-          "shadowOpacity": undefined,
-          "shadowRadius": NaN,
         },
         Object {
           "padding": 16,
         },
         Object {
           "elevation": 16,
-          "shadowColor": undefined,
-          "shadowOffset": Object {
-            "height": NaN,
-            "width": undefined,
-          },
-          "shadowOpacity": undefined,
-          "shadowRadius": NaN,
         },
-      ],
-    ]
-  }
-  testID={undefined}
-  tvParallaxProperties={undefined}
->
-  <View
-    style={
-      Object {
-        "backgroundColor": "transparent",
-      }
+      ]
     }
+    testID={undefined}
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      disabled={false}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "color": "rgb(82, 76, 97)",
-            "fontFamily": "sans-serif",
-            "fontSize": 16,
-            "fontWeight": "400",
-            "lineHeight": 24,
-          },
-          Object {},
-        ]
-      }
-    >
-      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-    </Text>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "sans-serif",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "lineHeight": 24,
+            },
+            Object {},
+          ]
+        }
+      >
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+      </Text>
+    </View>
   </View>
 </View>
 `;
 
 exports[`Android BpkCard should render correctly without padding 1`] = `
 <View
-  accessibilityComponentType="button"
-  accessibilityLabel="Example Card"
-  accessibilityTraits={undefined}
-  accessible={true}
-  hasTVPreferredFocus={undefined}
-  hitSlop={undefined}
-  isTVSelectable={true}
-  nativeID={undefined}
-  onLayout={undefined}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Array [
+  style={null}
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Example Card"
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    nativeBackgroundAndroid={
       Object {
-        "backgroundColor": "transparent",
-      },
+        "attribute": "selectableItemBackground",
+        "type": "ThemeAttrAndroid",
+      }
+    }
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
       Array [
         Object {
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 2,
           "elevation": 2,
-          "shadowColor": undefined,
-          "shadowOffset": Object {
-            "height": NaN,
-            "width": undefined,
-          },
-          "shadowOpacity": undefined,
-          "shadowRadius": NaN,
         },
-      ],
-    ]
-  }
-  testID={undefined}
-  tvParallaxProperties={undefined}
->
-  <View
-    style={
-      Object {
-        "backgroundColor": "transparent",
-      }
+      ]
     }
+    testID={undefined}
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      disabled={false}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "color": "rgb(82, 76, 97)",
-            "fontFamily": "sans-serif",
-            "fontSize": 16,
-            "fontWeight": "400",
-            "lineHeight": 24,
-          },
-          Object {},
-        ]
-      }
-    >
-      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-    </Text>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "sans-serif",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "lineHeight": 24,
+            },
+            Object {},
+          ]
+        }
+      >
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+      </Text>
+    </View>
   </View>
 </View>
 `;

--- a/native/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.ios.js.snap
@@ -26,7 +26,6 @@ exports[`iOS BpkCard should render correctly 1`] = `
         Object {
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 4,
-          "elevation": undefined,
           "shadowColor": "rgb(37, 32, 51)",
           "shadowOffset": Object {
             "height": 0.5,
@@ -101,7 +100,6 @@ exports[`iOS BpkCard should render correctly with arbitrary props 1`] = `
         Object {
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 4,
-          "elevation": undefined,
           "shadowColor": "rgb(37, 32, 51)",
           "shadowOffset": Object {
             "height": 0.5,
@@ -176,7 +174,6 @@ exports[`iOS BpkCard should render correctly with the "focused" state 1`] = `
         Object {
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 4,
-          "elevation": undefined,
           "shadowColor": "rgb(37, 32, 51)",
           "shadowOffset": Object {
             "height": 0.5,
@@ -189,7 +186,6 @@ exports[`iOS BpkCard should render correctly with the "focused" state 1`] = `
           "padding": 16,
         },
         Object {
-          "elevation": undefined,
           "shadowColor": "rgb(37, 32, 51)",
           "shadowOffset": Object {
             "height": 6,
@@ -261,7 +257,6 @@ exports[`iOS BpkCard should render correctly without padding 1`] = `
         Object {
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 4,
-          "elevation": undefined,
           "shadowColor": "rgb(37, 32, 51)",
           "shadowOffset": Object {
             "height": 0.5,


### PR DESCRIPTION
added `TouchableNativeFeedback` for android, we'll now  ship two BPK cards: iOS and Android, the reason behind it is `TouchableNativeFeedback` and `TouchableHighlight` are very different so having them behaving in one file became a nightmare.

The main difference between the two (`TouchableNativeFeedback` and `TouchableHighlight`) is the `style` `TouchableNativeFeedback`does not accepts any styles therefore the Android version return a `View` wrapping it, in which userland style will be applied

Base Card
![screenshot_1510678069](https://user-images.githubusercontent.com/3579758/32792721-fa542096-c95b-11e7-92af-0309a47e6141.png)

Ripple animation start
![screenshot_1510678078](https://user-images.githubusercontent.com/3579758/32792723-fb29a43c-c95b-11e7-9094-accb8b25c254.png)

Ripple animation end
![screenshot_1510678084](https://user-images.githubusercontent.com/3579758/32792725-fb6817ee-c95b-11e7-87ff-f29956624fa0.png)

cc @jamesf3rguson  for the visual validation

iOS is unaffected by this changes 
