### PR TITLE
[BPK-1094] BpkFieldset validation tweak

### DIFF
--- a/packages/bpk-component-fieldset/readme.md
+++ b/packages/bpk-component-fieldset/readme.md
@@ -59,10 +59,10 @@ class FieldsetContainer extends Component {
 | Property          | PropType | Required | Default Value |
 | ----------------- | -------- | -------- | ------------- |
 | children          | node     | true     | -             |
+| label             | string   | true     | -             |
 | className         | string   | false    | null          |
 | disabled          | bool     | false    | false         |
 | isCheckbox        | bool     | false    | false         |
-| label             | string   | false    | null          |
 | required          | bool     | false    | false         |
 | valid             | bool     | false    | null          |
 | validationMessage | string   | false    | null          |

--- a/packages/bpk-component-fieldset/src/BpkFieldset-test.js
+++ b/packages/bpk-component-fieldset/src/BpkFieldset-test.js
@@ -197,4 +197,20 @@ describe('BpkFieldset', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should reject label property when label is omitted', () => {
+    expect(BpkFieldset.propTypes.label(
+      {},
+      'label',
+      'BpkFieldset',
+    ).toString()).toEqual('Error: `label` is required when `isCheckbox` is false.'); // eslint-disable-line max-len
+  });
+
+  it('should accept no label property when label is omitted but isCheckbox is included', () => {
+    expect(BpkFieldset.propTypes.label(
+      { isCheckbox: true },
+      'label',
+      'BpkFieldset',
+    ).toString()).toEqual('false');
+  });
 });

--- a/packages/bpk-component-fieldset/src/BpkFieldset.js
+++ b/packages/bpk-component-fieldset/src/BpkFieldset.js
@@ -95,10 +95,18 @@ const BpkFieldset = (props) => {
   );
 };
 
+const labelPropType = (props, propName) => {
+  const { isCheckbox, label } = props;
+  if (!label && !isCheckbox) {
+    return new Error(`\`${propName}\` is required when \`isCheckbox\` is false.`); // eslint-disable-line max-len
+  }
+  return false;
+};
+
 BpkFieldset.propTypes = {
   children: PropTypes.node.isRequired,
+  label: labelPropType,
   disabled: PropTypes.bool,
-  label: PropTypes.string,
   valid: PropTypes.bool,
   required: PropTypes.bool,
   className: PropTypes.string,
@@ -108,8 +116,8 @@ BpkFieldset.propTypes = {
 };
 
 BpkFieldset.defaultProps = {
-  disabled: false,
   label: null,
+  disabled: false,
   valid: null,
   required: false,
   className: null,


### PR DESCRIPTION
If BpkFieldset doesn't have a label, it will no longer include an empty BpkLabel component.