### PR TITLE
[NOJIRA] - Make use of the platform specific bpk-token import everywhere

### DIFF
--- a/native/packages/react-native-bpk-component-animate-height/readme.md
+++ b/native/packages/react-native-bpk-component-animate-height/readme.md
@@ -13,19 +13,19 @@ npm install react-native-bpk-component-animate-height --save-dev
 ```js
 import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
-import BpkAnimateHeight from 'react-native-bpk-component-animate-height';
-import BpkButton from 'react-native-bpk-component-button';
 import BpkText from 'react-native-bpk-component-text';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import BpkButton from 'react-native-bpk-component-button';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
+import BpkAnimateHeight from 'react-native-bpk-component-animate-height';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   },
   animateHeight: {
-    marginBottom: TOKENS.spacingBase,
+    marginBottom: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.android.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.android.js
@@ -28,6 +28,9 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('./../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.common.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.common.js
@@ -26,9 +26,9 @@ const commonTests = () => {
   describe('BpkAnimateHeight', () => {
     const animateHeightContent = (
       <BpkText>
-          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
-          commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus
-          et magnis dis parturient montes, nascetur ridiculus mus.
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
+        commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus
+        et magnis dis parturient montes, nascetur ridiculus mus.
       </BpkText>
     );
 

--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.ios.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkAnimateHeight-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight.js
@@ -24,15 +24,7 @@ import {
 } from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-const {
-  animationDurationSm,
-} = tokens;
+import { animationDurationSm } from 'bpk-tokens/tokens/base.react.native';
 
 class BpkAnimateHeight extends React.Component {
   constructor() {

--- a/native/packages/react-native-bpk-component-animate-height/stories.js
+++ b/native/packages/react-native-bpk-component-animate-height/stories.js
@@ -19,20 +19,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react-native';
-import { StyleSheet, View, Platform } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import BpkText from 'react-native-bpk-component-text';
 import BpkButton from 'react-native-bpk-component-button';
+import { spacingBase, colorGray50 } from 'bpk-tokens/tokens/base.react.native';
+
 import BpkAnimateHeight from './index';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-const {
-  spacingBase,
-  colorGray50,
-} = tokens;
 
 const styles = StyleSheet.create({
   centered: {

--- a/native/packages/react-native-bpk-component-banner-alert/readme.md
+++ b/native/packages/react-native-bpk-component-banner-alert/readme.md
@@ -14,8 +14,8 @@ npm install react-native-bpk-component-banner-alert --save-dev
 import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
 import BpkText from 'react-native-bpk-component-text';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 import BpkBannerAlert, {ALERT_TYPES} from 'react-native-bpk-component-banner-alert';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
 
 import { translationHelper } from 'translations';
 
@@ -23,10 +23,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   },
   bannerAlert: {
-    marginBottom: TOKENS.spacingBase,
+    marginBottom: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.android.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.android.js
@@ -28,6 +28,12 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('./../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.ios.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkBannerAlert-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.js
@@ -26,24 +26,7 @@ import {
 import React from 'react';
 import PropTypes from 'prop-types';
 import { setOpacity } from 'bpk-tokens';
-import BpkText from 'react-native-bpk-component-text';
-import BpkIcon from 'react-native-bpk-component-icon';
-import BpkAnimateHeight from 'react-native-bpk-component-animate-height';
-
-import { dismissablePropType } from './customPropTypes';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-// Slight darkness to use when buttons are pressed in.
-const underlayColor = Platform.select({
-  ios: () => setOpacity(tokens.underlayColor, tokens.underlayOpacity),
-  android: () => null,
-})();
-
-const {
+import {
   borderRadiusSm,
   borderSizeSm,
   colorGray300,
@@ -56,7 +39,20 @@ const {
   spacingMd,
   spacingSm,
   spacingXl,
-} = tokens;
+  underlayColor,
+  underlayOpacity,
+} from 'bpk-tokens/tokens/base.react.native';
+import BpkText from 'react-native-bpk-component-text';
+import BpkIcon from 'react-native-bpk-component-icon';
+import BpkAnimateHeight from 'react-native-bpk-component-animate-height';
+
+import { dismissablePropType } from './customPropTypes';
+
+// Slight darkness to use when buttons are pressed in.
+const underlay = Platform.select({
+  ios: () => setOpacity(underlayColor, underlayOpacity),
+  android: () => null,
+})();
 
 export const ALERT_TYPES = {
   SUCCESS: 'success',
@@ -213,7 +209,7 @@ const BpkBannerAlert = (props) => {
           <TouchableHighlight
             accessibilityComponentType="button"
             onPress={onAction}
-            underlayColor={underlayColor}
+            underlayColor={underlay}
             accessibilityLabel={actionButtonLabel}
             style={styles.bannerContainer}
           >
@@ -224,7 +220,7 @@ const BpkBannerAlert = (props) => {
           <TouchableHighlight
             accessibilityComponentType="button"
             onPress={onAction}
-            underlayColor={underlayColor}
+            underlayColor={underlay}
             accessibilityLabel={actionButtonLabel}
             style={styles.closeButtonContainer}
           >

--- a/native/packages/react-native-bpk-component-banner-alert/stories.js
+++ b/native/packages/react-native-bpk-component-banner-alert/stories.js
@@ -17,17 +17,12 @@
  */
 
 import React from 'react';
+import { StyleSheet, View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
-import { StyleSheet, View, Platform } from 'react-native';
 import BpkText from 'react-native-bpk-component-text';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
+
 import BpkBannerAlert, { ALERT_TYPES } from './index';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-const { spacingBase } = tokens;
 
 const styles = StyleSheet.create({
   container: {

--- a/native/packages/react-native-bpk-component-button/readme.md
+++ b/native/packages/react-native-bpk-component-button/readme.md
@@ -26,7 +26,7 @@ pod 'BVLinearGradient', :path => '../node_modules/react-native-bpk-component-but
 import React, { Component } from 'react';
 import { View, Image } from 'react-native';
 import BpkButton from 'react-native-bpk-component-button';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 
 import { translationHelper } from 'translations';
 
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
@@ -17,79 +17,84 @@
  */
 
 import { setOpacity } from 'bpk-tokens';
+import {
+  colorWhite,
+  colorGray100,
+  colorGray300,
+  colorBlue500,
+  colorRed500,
+  colorGreen600,
+  colorGreen500,
+  colorPink500,
+  colorPink600,
+  buttonHeight,
+  buttonPaddingVertical,
+  buttonPaddingHorizontal,
+  buttonBorderWidth,
+  buttonLineHeightLarge,
+  lineHeightXs,
+  borderRadiusPill,
+  spacingSm,
+  spacingBase,
+  spacingXl,
+  underlayColor as underlayColorToken,
+  underlayOpacity,
+} from 'bpk-tokens/tokens/base.react.native';
 import { Platform, StyleSheet } from 'react-native';
 
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-// Slight darkness to use when buttons are pressed in.
 const underlayColor = Platform.select({
-  ios: () => setOpacity(tokens.underlayColor, tokens.underlayOpacity),
+  ios: () => setOpacity(underlayColorToken, underlayOpacity),
   android: () => null,
 })();
 
-// The base styles that are initially applied to all buttons.
 const base = StyleSheet.create({
-
-  // Applied to the outer LinearGradient element.
   container: {
-    borderRadius: tokens.borderRadiusPill,
-    height: tokens.buttonHeight,
+    borderRadius: borderRadiusPill,
+    height: buttonHeight,
   },
-
-  // Applied to the TouchableHighlight/TouchableNativeFeedback element.
   button: {
-    borderRadius: tokens.borderRadiusPill,
-    height: tokens.buttonHeight,
-    paddingVertical: tokens.buttonPaddingVertical,
-    paddingHorizontal: tokens.buttonPaddingHorizontal,
+    borderRadius: borderRadiusPill,
+    height: buttonHeight,
+    paddingVertical: buttonPaddingVertical,
+    paddingHorizontal: buttonPaddingHorizontal,
   },
-
-  // Applied to the View element that encloses the text and icon.
   view: {
     alignItems: 'center',
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'center',
   },
-
-  // Applied to the Text element.
   text: Platform.select({
     ios: () => ({
       backgroundColor: 'transparent',
-      color: tokens.colorWhite,
-
+      color: colorWhite,
     }),
     android: () => ({
       backgroundColor: 'transparent',
-      color: tokens.colorWhite,
-      lineHeight: tokens.lineHeightXs,
+      color: colorWhite,
+      lineHeight: lineHeightXs,
     }),
   })(),
 });
 
 const outlineButtonStyle = {
-  borderColor: tokens.colorGray100,
-  borderWidth: tokens.buttonBorderWidth,
-
-  // minus the borderWidth so it's the same size as other buttons.
-  paddingVertical: tokens.buttonPaddingVertical - tokens.buttonBorderWidth,
-  paddingHorizontal: tokens.buttonPaddingHorizontal - tokens.buttonBorderWidth,
+  borderColor: colorGray100,
+  borderWidth: buttonBorderWidth,
+  paddingVertical: buttonPaddingVertical - buttonBorderWidth,
+  paddingHorizontal: buttonPaddingHorizontal - buttonBorderWidth,
 };
 
 const types = {
   secondary: StyleSheet.create({
     button: outlineButtonStyle,
     text: {
-      color: tokens.colorBlue500,
+      color: colorBlue500,
     },
   }),
   destructive: StyleSheet.create({
     button: outlineButtonStyle,
     text: {
-      color: tokens.colorRed500,
+      color: colorRed500,
     },
   }),
 };
@@ -97,20 +102,20 @@ const types = {
 const modifiers = {
   large: StyleSheet.create({
     container: {
-      minHeight: tokens.buttonLineHeightLarge,
+      minHeight: buttonLineHeightLarge,
     },
     button: {
-      minHeight: tokens.buttonLineHeightLarge,
-      paddingHorizontal: tokens.spacingBase,
+      minHeight: buttonLineHeightLarge,
+      paddingHorizontal: spacingBase,
     },
   }),
   largeWithOutline: StyleSheet.create({
     container: {
-      minHeight: tokens.buttonLineHeightLarge,
+      minHeight: buttonLineHeightLarge,
     },
     button: {
-      minHeight: tokens.buttonLineHeightLarge,
-      paddingHorizontal: tokens.spacingBase - tokens.buttonBorderWidth,
+      minHeight: buttonLineHeightLarge,
+      paddingHorizontal: spacingBase - buttonBorderWidth,
     },
   }),
   disabled: StyleSheet.create({
@@ -118,12 +123,12 @@ const modifiers = {
       borderColor: 'transparent',
     },
     text: {
-      color: tokens.colorGray300,
+      color: colorGray300,
     },
   }),
   iconOnly: StyleSheet.create({
     container: {
-      width: tokens.spacingXl,
+      width: spacingXl,
     },
     button: {
       paddingHorizontal: 0,
@@ -131,7 +136,7 @@ const modifiers = {
   }),
   iconOnlyLarge: StyleSheet.create({
     container: {
-      width: tokens.buttonLineHeightLarge,
+      width: buttonLineHeightLarge,
     },
     button: {
       paddingHorizontal: 0,
@@ -142,7 +147,7 @@ const modifiers = {
       justifyContent: 'space-between',
     },
     text: {
-      marginRight: tokens.spacingSm,
+      marginRight: spacingSm,
     },
   }),
   textAndIconLarge: StyleSheet.create({
@@ -150,17 +155,17 @@ const modifiers = {
       justifyContent: 'space-between',
     },
     text: {
-      marginRight: tokens.spacingSm,
+      marginRight: spacingSm,
     },
   }),
 };
 
 const gradientColors = {
-  primary: [tokens.colorGreen500, tokens.colorGreen600],
-  featured: [tokens.colorPink500, tokens.colorPink600],
-  destructive: [tokens.colorWhite, tokens.colorWhite],
-  secondary: [tokens.colorWhite, tokens.colorWhite],
-  disabled: [tokens.colorGray100, tokens.colorGray100],
+  primary: [colorGreen500, colorGreen600],
+  featured: [colorPink500, colorPink600],
+  destructive: [colorWhite, colorWhite],
+  secondary: [colorWhite, colorWhite],
+  disabled: [colorGray100, colorGray100],
 };
 
 const themeMappings = {

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-test.android.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-test.android.js
@@ -29,7 +29,14 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('./../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 jest.mock('./layout/BpkButtonContainer', () => require.requireActual('./layout/BpkButtonContainer.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-test.ios.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-test.ios.js
@@ -18,23 +18,8 @@
 
 import commonTests from './BpkButton-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-  return reactNative;
-});
+jest.mock('react-native-linear-gradient', () => 'View');
 
-jest.mock('react-native-linear-gradient', () => (props) => {
-  const React = require.requireActual('react');
-  const { View } = require.requireActual('react-native');
-
-  return <View {...props} />;
-});
-
-jest.mock('./layout/BpkButtonContainer', () => require.requireActual('./layout/BpkButtonContainer.ios.js'));
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-button/src/utils.js
+++ b/native/packages/react-native-bpk-component-button/src/utils.js
@@ -16,14 +16,11 @@
  * limitations under the License.
  */
 
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import difference from 'lodash/difference';
-import styles from './BpkButton-styles';
+import { colorWhite } from 'bpk-tokens/tokens/base.react.native';
 
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
+import styles from './BpkButton-styles';
 
 const REQUIRED_THEME_ATTRIBUTES = {
   primary: [
@@ -139,7 +136,7 @@ export const getAndroidBackgroundColour = (theme, props) => {
    * for iOS, can be made explicit in the style file if needed
    */
   const [mainColour] = getGradientColors(theme, props);
-  if (mainColour.toString() === tokens.colorWhite) {
+  if (mainColour.toString() === colorWhite) {
     return StyleSheet.create({ style }).style;
   }
   style.backgroundColor = mainColour;

--- a/native/packages/react-native-bpk-component-button/stories.js
+++ b/native/packages/react-native-bpk-component-button/stories.js
@@ -16,28 +16,22 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import {
   Text,
-  StyleSheet,
   View,
-  ScrollView,
   Platform,
+  ScrollView,
+  StyleSheet,
 } from 'react-native';
-
+import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
-
 import BpkThemeProvider from 'react-native-bpk-theming';
-
-import { StoryHeading, StorySubheading } from '../../storybook/TextStyles';
-import themeAttributes from '../../storybook/themeAttributes';
+import { spacingMd } from 'bpk-tokens/tokens/base.react.native';
 
 import BpkButton, { BUTTON_TYPES } from './src/BpkButton';
-
-const tokens = Platform.OS === 'ios' ?
-  require('bpk-tokens/tokens/ios/base.react.native.common.js') :
-  require('bpk-tokens/tokens/android/base.react.native.common.js');
+import themeAttributes from '../../storybook/themeAttributes';
+import { StoryHeading, StorySubheading } from '../../storybook/TextStyles';
 
 const styles = StyleSheet.create({
   btnContainer: {
@@ -46,8 +40,8 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
   },
   buttonStyles: {
-    marginBottom: tokens.spacingMd,
-    marginRight: tokens.spacingMd,
+    marginBottom: spacingMd,
+    marginRight: spacingMd,
   },
 });
 

--- a/native/packages/react-native-bpk-component-card/readme.md
+++ b/native/packages/react-native-bpk-component-card/readme.md
@@ -15,13 +15,13 @@ import React, { Component } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import BpkCard from 'react-native-bpk-component-card';
 import BpkText from 'react-native-bpk-component-text';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-card/src/BpkCard-test.android.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard-test.android.js
@@ -30,8 +30,11 @@ jest.mock('react-native', () => {
 
 jest.mock('./BpkCard', () => require.requireActual('./BpkCard.android'));
 
+jest.mock('./../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 jest.mock('bpk-tokens/tokens/base.react.native',
-  () => require.requireActual('bpk-tokens/tokens/base.react.native.android'));
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
 
 jest.mock('TouchableNativeFeedback', () => ({ children, ...rest }) => {
   const { cloneElement } = require.requireActual('react');

--- a/native/packages/react-native-bpk-component-card/src/BpkCard-test.ios.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard-test.ios.js
@@ -18,18 +18,6 @@
 
 import commonTests from './BpkCard-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
-jest.mock('./BpkCard', () => require.requireActual('./BpkCard.ios.js'));
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-horizontal-nav/readme.md
+++ b/native/packages/react-native-bpk-component-horizontal-nav/readme.md
@@ -13,14 +13,14 @@ npm install react-native-bpk-component-horizontal-nav --save-dev
 ```js
 import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
-import BpkHorizontalNav, { BpkHorizontalNavItem } from './index';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
+import BpkHorizontalNav, { BpkHorizontalNavItem } from 'react-native-bpk-component-horizontal-nav';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.android.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.android.js
@@ -28,6 +28,12 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('./../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.ios.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkHorizontalNav-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -18,31 +18,24 @@
 
 import {
   ScrollView,
-  Platform,
   StyleSheet,
   View,
   ViewPropTypes,
 } from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { colorGray100, borderSizeSm } from 'bpk-tokens/tokens/base.react.native';
 
 import BpkHorizontalNavSelectedIndicator from './BpkHorizontalNavSelectedIndicator';
 import withAnimatedProps from './withAnimatedProps';
 
 const AnimatedIndicator = withAnimatedProps(BpkHorizontalNavSelectedIndicator, ['xOffset', 'width']);
 
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
 const styles = StyleSheet.create({
   horizontalNav: {
     borderColor: 'transparent',
-    borderBottomColor: tokens.colorGray100,
-    borderWidth: tokens.borderSizeSm,
-  },
-  horizontalNavInner: {
+    borderBottomColor: colorGray100,
+    borderWidth: borderSizeSm,
     flexDirection: 'row',
   },
   spaceAround: {

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -36,6 +36,8 @@ const styles = StyleSheet.create({
     borderColor: 'transparent',
     borderBottomColor: colorGray100,
     borderWidth: borderSizeSm,
+  },
+  horizontalNavInner: {
     flexDirection: 'row',
   },
   spaceAround: {

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.android.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.android.js
@@ -29,6 +29,12 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('./../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.ios.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkHorizontalNavItem-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -17,39 +17,41 @@
  */
 
 import {
-  TouchableNativeFeedback,
-  TouchableHighlight,
+  View,
   Platform,
   StyleSheet,
-  View,
   ViewPropTypes,
+  TouchableHighlight,
+  TouchableNativeFeedback,
 } from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { setOpacity } from 'bpk-tokens';
-import BpkText from 'react-native-bpk-component-text';
+import {
+  colorGray300,
+  colorGray700,
+  colorBlue700,
+  spacingMd,
+  spacingBase,
+  underlayColor,
+  underlayOpacity,
+} from 'bpk-tokens/tokens/base.react.native';
 import { withTheme } from 'react-native-bpk-theming';
+import BpkText from 'react-native-bpk-component-text';
 
 import { THEMING_ATTRIBUTE, themePropType } from './theming';
 
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-const selectedColor = tokens.colorBlue700;
 const styles = StyleSheet.create({
   text: {
-    color: tokens.colorGray700,
-    paddingVertical: tokens.spacingMd,
-    paddingHorizontal: tokens.spacingBase,
+    color: colorGray700,
+    paddingVertical: spacingMd,
+    paddingHorizontal: spacingBase,
   },
   disabledText: {
-    color: tokens.colorGray300,
+    color: colorGray300,
   },
   selectedText: {
-    color: selectedColor,
+    color: colorBlue700,
   },
 });
 
@@ -87,7 +89,7 @@ const BpkHorizontalNavItem = (props) => {
   const formattedTitle = isAndroid ? title.toUpperCase() : title;
   const platformSpecificProps = isAndroid
     ? { background: TouchableNativeFeedback.SelectableBackgroundBorderless() }
-    : { underlayColor: setOpacity(tokens.underlayColor, tokens.underlayOpacity) };
+    : { underlayColor: setOpacity(underlayColor, underlayOpacity) };
 
   return (
     <Touchable
@@ -126,7 +128,5 @@ BpkHorizontalNavItem.defaultProps = {
   theme: null,
 };
 
+export { propTypes };
 export default withTheme(BpkHorizontalNavItem);
-export {
-  propTypes,
-};

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator.js
@@ -19,23 +19,19 @@
 import React from 'react';
 import {
   Animated,
-  Platform,
   StyleSheet,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { withTheme } from 'react-native-bpk-theming';
+import { colorBlue700, borderSizeLg } from 'bpk-tokens/tokens/base.react.native';
 
 import { THEMING_ATTRIBUTE, themePropType } from './theming';
 
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
 
 const styles = StyleSheet.create({
   selectedIndicator: {
-    backgroundColor: tokens.colorBlue700,
-    height: tokens.borderSizeLg,
+    backgroundColor: colorBlue700,
+    height: borderSizeLg,
   },
 });
 

--- a/native/packages/react-native-bpk-component-horizontal-nav/stories.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/stories.js
@@ -19,25 +19,21 @@
 import React from 'react';
 import {
   View,
-  Platform,
   StyleSheet,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import BpkThemeProvider from 'react-native-bpk-theming';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
+
 import BpkHorizontalNav, { BpkHorizontalNavItem } from './index';
 import { StorySubheading } from '../../storybook/TextStyles';
 import themeAttributes from '../../storybook/themeAttributes';
 
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
 const styles = StyleSheet.create({
   bottomMargin: {
-    marginBottom: tokens.spacingBase,
+    marginBottom: spacingBase,
   },
 });
 

--- a/native/packages/react-native-bpk-component-icon/readme.md
+++ b/native/packages/react-native-bpk-component-icon/readme.md
@@ -42,16 +42,16 @@ apply from: "node_modules/react-native-bpk-component-icon/fonts.gradle"
 ## Usage
 
 ```js
-import React, { Component } from 'react';
 import { View } from 'react-native';
+import React, { Component } from 'react';
 import BpkIcon from 'react-native-bpk-component-icon';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import { spacingBase, colorBlue500 } from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   }
 });
 
@@ -61,12 +61,12 @@ export default class App extends Component {
       <View style={styles.container}>
         <BpkIcon
           icon="beer"
-          style={{ color: TOKENS.colorBlue500 }}
+          style={{ color: colorBlue500 }}
           small
         />
         <BpkIcon
           icon="beer"
-          style={{ color: TOKENS.colorBlue500 }}
+          style={{ color: colorBlue500 }}
         />
       </View>
     );

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.android.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.android.js
@@ -28,6 +28,12 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('./../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.ios.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkIcon-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
@@ -18,19 +18,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Text, Platform, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 import iconMappings from 'bpk-svgs/dist/font/iconMapping.json';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-const {
+import {
   spacingBase,
   spacingLg,
   colorGray700,
-} = tokens;
+} from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
   icon: {

--- a/native/packages/react-native-bpk-component-icon/stories.js
+++ b/native/packages/react-native-bpk-component-icon/stories.js
@@ -17,24 +17,19 @@
  */
 
 import React from 'react';
+import { View, StyleSheet } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
-import { Platform, View, StyleSheet } from 'react-native';
-import iconMappings from 'bpk-svgs/dist/font/iconMapping.json';
-import { StorySubheading } from '../../storybook/TextStyles';
-import BpkIcon from './index';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-const {
+import {
   colorBlue500,
   colorGreen500,
   colorYellow500,
   spacingBase,
   spacingSm,
-} = tokens;
+} from 'bpk-tokens/tokens/base.react.native';
+import iconMappings from 'bpk-svgs/dist/font/iconMapping.json';
+
+import BpkIcon from './index';
+import { StorySubheading } from '../../storybook/TextStyles';
 
 const styles = StyleSheet.create({
   container: {

--- a/native/packages/react-native-bpk-component-spinner/readme.md
+++ b/native/packages/react-native-bpk-component-spinner/readme.md
@@ -14,13 +14,13 @@ npm install react-native-bpk-component-spinner --save-dev
 import React, { Component } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import BpkSpinner from 'react-native-bpk-component-spinner';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.android.js
+++ b/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.android.js
@@ -28,6 +28,9 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.ios.js
+++ b/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkSpinner-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-spinner/src/BpkSpinner.js
+++ b/native/packages/react-native-bpk-component-spinner/src/BpkSpinner.js
@@ -16,18 +16,11 @@
  * limitations under the License.
  */
 
-import {
-  ActivityIndicator,
-  Platform,
-} from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { ActivityIndicator } from 'react-native';
 import { withTheme } from 'react-native-bpk-theming';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
+import { colorBlue500, colorWhite, colorGray700 } from 'bpk-tokens/tokens/base.react.native';
 
 const SPINNER_TYPES = ['primary', 'light', 'dark'];
 
@@ -48,9 +41,9 @@ const themePropType = (props, propName, componentName) => {
 
 const getSpinnerColor = (theme, type) => {
   const colorMappings = {
-    primary: tokens.colorBlue500,
-    light: tokens.colorWhite,
-    dark: tokens.colorGray700,
+    primary: colorBlue500,
+    light: colorWhite,
+    dark: colorGray700,
   };
   if (theme && type === 'primary') {
     return theme[THEMING_ATTRIBUTE];

--- a/native/packages/react-native-bpk-component-spinner/stories.js
+++ b/native/packages/react-native-bpk-component-spinner/stories.js
@@ -17,30 +17,22 @@
  */
 
 import React from 'react';
-import {
-  View,
-  Platform,
-  ScrollView,
-  StyleSheet,
-} from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import BpkThemeProvider from 'react-native-bpk-theming';
-import BpkSpinner from './index';
-import { StoryHeading, StorySubheading } from '../../storybook/TextStyles';
-import themeAttributes from '../../storybook/themeAttributes';
+import { View, ScrollView, StyleSheet } from 'react-native';
+import { colorGray900, spacingBase } from 'bpk-tokens/tokens/base.react.native';
 
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
+import BpkSpinner from './index';
+import themeAttributes from '../../storybook/themeAttributes';
+import { StoryHeading, StorySubheading } from '../../storybook/TextStyles';
 
 const styles = StyleSheet.create({
   dark: {
-    backgroundColor: tokens.colorGray900,
-    padding: tokens.spacingBase,
+    backgroundColor: colorGray900,
+    padding: spacingBase,
   },
   bottomMargin: {
-    marginBottom: tokens.spacingBase,
+    marginBottom: spacingBase,
   },
 });
 

--- a/native/packages/react-native-bpk-component-switch/readme.md
+++ b/native/packages/react-native-bpk-component-switch/readme.md
@@ -14,13 +14,13 @@ npm install react-native-bpk-component-switch --save-dev
 import React, { Component } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import BpkSwitch from 'react-native-bpk-component-switch';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.android.js
+++ b/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.android.js
@@ -28,6 +28,9 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.ios.js
+++ b/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkSwitch-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-switch/src/BpkSwitch.js
+++ b/native/packages/react-native-bpk-component-switch/src/BpkSwitch.js
@@ -16,26 +16,19 @@
  * limitations under the License.
  */
 
-import {
-  Platform,
-  Switch,
-} from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Platform, Switch } from 'react-native';
 import { withTheme } from 'react-native-bpk-theming';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
+import { colorBlue500, colorGray100, colorGray50 } from 'bpk-tokens/tokens/base.react.native';
 
 // If theming is ever expanded to support other types, this should be changed
 // to something akin to BpkButton's theming functions.
 const THEMING_ATTRIBUTE = 'switchPrimaryColor';
 
 const getColors = (theme, value) => {
-  const primaryColor = theme ? theme[THEMING_ATTRIBUTE] : tokens.colorBlue500;
-  const secondaryColor = tokens.colorGray100;
+  const primaryColor = theme ? theme[THEMING_ATTRIBUTE] : colorBlue500;
+  const secondaryColor = colorGray100;
 
   // The color props mean different things based on the platform.
   const colors = Platform.select({
@@ -47,7 +40,7 @@ const getColors = (theme, value) => {
     },
     android: {
       tintColor: secondaryColor, // Track when OFF.
-      thumbTintColor: value ? primaryColor : tokens.colorGray50,
+      thumbTintColor: value ? primaryColor : colorGray50,
       onTintColor: secondaryColor, // Track when ON.
     },
   });

--- a/native/packages/react-native-bpk-component-switch/stories.js
+++ b/native/packages/react-native-bpk-component-switch/stories.js
@@ -17,35 +17,26 @@
  */
 
 import React, { Component } from 'react';
-import {
-  Platform,
-  StyleSheet,
-  View,
-} from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import BpkThemeProvider from 'react-native-bpk-theming';
+import { spacingXl, spacingBase } from 'bpk-tokens/tokens/base.react.native';
+
 import BpkSwitch from './index';
 import { StorySubheading } from '../../storybook/TextStyles';
 import themeAttributes from '../../storybook/themeAttributes';
 
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
 const styles = StyleSheet.create({
-
   //  Necessary because on iOS the switches get left aligned, on Android right
   // aligned. This normalises it so that both screenshots are comparable.
   viewWidth: {
-    width: tokens.spacingXl * 1.5,
+    width: spacingXl * 1.5,
   },
   bottomMargin: {
-    marginBottom: tokens.spacingBase,
+    marginBottom: spacingBase,
   },
 });
 
-// Simple state management for allowing toggling.
 class SwitchContainer extends Component {
   constructor(props) {
     super(props);
@@ -59,8 +50,6 @@ class SwitchContainer extends Component {
 }
 
 storiesOf('BpkSwitch', module)
-
-  // State management not required in this story as it's just used for docs screenshots.
   .add('docs:default', () => (
     <View style={styles.viewWidth}>
       <View style={styles.bottomMargin}>

--- a/native/packages/react-native-bpk-component-text-input/readme.md
+++ b/native/packages/react-native-bpk-component-text-input/readme.md
@@ -14,16 +14,16 @@ npm install react-native-bpk-component-text-input --save-dev
 import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
 import BpkTextInput from 'react-native-bpk-component-text-input';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   },
   input: {
-    marginBottom: TOKENS.spacingBase,
+    marginBottom: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.android.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.android.js
@@ -28,6 +28,12 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('./../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.ios.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkTextInput-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
@@ -25,18 +25,9 @@ import {
 } from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const tickSmIcon = require('./icons/sm/tick-circle.png'); // eslint-disable-line import/no-unresolved
-const tickLgIcon = require('./icons/lg/tick-circle.png'); // eslint-disable-line import/no-unresolved
-const exclaimationSmIcon = require('./icons/sm/exclaimation-circle.png'); // eslint-disable-line import/no-unresolved
-const exclaimationLgIcon = require('./icons/lg/exclaimation-circle.png'); // eslint-disable-line import/no-unresolved
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-const {
+import {
+  fontFamily,
+  fontFamilyEmphasize,
   borderRadiusSm,
   borderSizeSm,
   colorGray100,
@@ -55,7 +46,12 @@ const {
   textXsFontSize,
   textXsFontWeight,
   textXsLineHeight,
-} = tokens;
+} from 'bpk-tokens/tokens/base.react.native';
+
+const tickSmIcon = require('./icons/sm/tick-circle.png'); // eslint-disable-line import/no-unresolved
+const tickLgIcon = require('./icons/lg/tick-circle.png'); // eslint-disable-line import/no-unresolved
+const exclaimationSmIcon = require('./icons/sm/exclaimation-circle.png'); // eslint-disable-line import/no-unresolved
+const exclaimationLgIcon = require('./icons/lg/exclaimation-circle.png'); // eslint-disable-line import/no-unresolved
 
 const styles = StyleSheet.create({
   input: {
@@ -75,7 +71,7 @@ const styles = StyleSheet.create({
     fontSize: textLgFontSize,
     color: colorGray700,
     fontWeight: textLgFontWeight,
-    fontFamily: Platform.OS === 'android' ? tokens.fontFamilyEmphasize : tokens.fontFamily,
+    fontFamily: Platform.OS === 'android' ? fontFamilyEmphasize : fontFamily,
     lineHeight: textLgLineHeight,
     height: '100%',
   },
@@ -87,7 +83,7 @@ const styles = StyleSheet.create({
   smallText: {
     fontSize: textXsFontSize,
     fontWeight: textXsFontWeight,
-    fontFamily: tokens.fontFamily,
+    fontFamily,
     lineHeight: textXsLineHeight,
   },
   placeholderText: {

--- a/native/packages/react-native-bpk-component-text-input/stories.js
+++ b/native/packages/react-native-bpk-component-text-input/stories.js
@@ -1,18 +1,10 @@
 import React from 'react';
+import { StyleSheet, View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
-import { StyleSheet, View, Platform } from 'react-native';
-import { StorySubheading } from '../../storybook/TextStyles';
+import { spacingBase, spacingXs } from 'bpk-tokens/tokens/base.react.native';
+
 import BpkTextInput from './index';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-const {
-  spacingBase,
-  spacingXs,
-} = tokens;
+import { StorySubheading } from '../../storybook/TextStyles';
 
 const styles = StyleSheet.create({
   label: {

--- a/native/packages/react-native-bpk-component-text/readme.md
+++ b/native/packages/react-native-bpk-component-text/readme.md
@@ -14,13 +14,13 @@ npm install react-native-bpk-component-text --save-dev
 import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
 import BpkText from 'react-native-bpk-component-text';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-text/src/BpkText-test.android.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText-test.android.js
@@ -28,6 +28,9 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-text/src/BpkText-test.ios.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText-test.ios.js
@@ -19,18 +19,9 @@
 import BpkText from './BpkText';
 import commonTests from './BpkText-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
+
   it('should error on invalid emphasize prop', () => {
     expect(BpkText.propTypes.emphasize({
       textStyle: 'xxl',

--- a/native/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText.js
@@ -19,13 +19,53 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Text, Platform, StyleSheet } from 'react-native';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
+import {
+  colorGray700,
+  fontFamily,
+  fontFamilyEmphasize,
+  textEmphasizedFontWeight,
+  textXsFontSize,
+  textXsFontWeight,
+  textXsLineHeight,
+  textSmFontSize,
+  textSmFontWeight,
+  textSmLineHeight,
+  textBaseFontSize,
+  textBaseFontWeight,
+  textBaseLineHeight,
+  textLgFontSize,
+  textLgFontWeight,
+  textLgLineHeight,
+  textXlFontSize,
+  textXlFontWeight,
+  textXlLineHeight,
+  textXxlFontSize,
+  textXxlFontWeight,
+  textXxlLineHeight,
+} from 'bpk-tokens/tokens/base.react.native';
 
 const TEXT_STYLES = ['xs', 'sm', 'base', 'lg', 'xl', 'xxl'];
+
+const TEXT_TOKENS = {
+  textXsFontSize,
+  textXsFontWeight,
+  textXsLineHeight,
+  textSmFontSize,
+  textSmFontWeight,
+  textSmLineHeight,
+  textBaseFontSize,
+  textBaseFontWeight,
+  textBaseLineHeight,
+  textLgFontSize,
+  textLgFontWeight,
+  textLgLineHeight,
+  textXlFontSize,
+  textXlFontWeight,
+  textXlLineHeight,
+  textXxlFontSize,
+  textXxlFontWeight,
+  textXxlLineHeight,
+};
 
 const emphasizePropType = (props, propName, componentName) => {
   const value = props[propName];
@@ -56,15 +96,19 @@ const stylePropType = (props, propName, componentName) => {
 
 const getStyleByTextStyle = (textStyle) => {
   const camelCasedStyle = textStyle[0].toUpperCase() + textStyle.slice(1);
+
   const {
-    colorGray700: color,
     [`text${camelCasedStyle}FontSize`]: fontSize,
     [`text${camelCasedStyle}LineHeight`]: lineHeight,
-    fontFamily,
     [`text${camelCasedStyle}FontWeight`]: fontWeight,
-  } = tokens;
+  } = TEXT_TOKENS;
+
   return {
-    fontSize, lineHeight, color, fontFamily, fontWeight,
+    color: colorGray700,
+    fontFamily,
+    fontSize,
+    lineHeight,
+    fontWeight,
   };
 };
 
@@ -72,9 +116,9 @@ const getEmphasizeProperties = () => {
   const emphasizeProperties = {
   };
   if (Platform.OS === 'android') {
-    emphasizeProperties.fontFamily = tokens.fontFamilyEmphasize;
+    emphasizeProperties.fontFamily = fontFamilyEmphasize;
   } else {
-    emphasizeProperties.fontWeight = tokens.textEmphasizedFontWeight;
+    emphasizeProperties.fontWeight = textEmphasizedFontWeight;
   }
   return emphasizeProperties;
 };

--- a/native/packages/react-native-bpk-component-text/stories.js
+++ b/native/packages/react-native-bpk-component-text/stories.js
@@ -1,7 +1,13 @@
 import React from 'react';
+import {
+  colorRed500,
+  colorBlue700,
+  colorGray500,
+  colorGreen500,
+  colorYellow500,
+} from 'bpk-tokens/tokens/base.react.native';
 import { View, Platform } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
 
 import BpkText from './index';
 
@@ -28,11 +34,11 @@ storiesOf('BpkText', module)
   ))
   .add('Colours', () => (
     <View>
-      <BpkText textStyle="xxl" style={{ color: TOKENS.colorBlue700 }}>Flights to Edinburgh</BpkText>
-      <BpkText textStyle="xl" style={{ color: TOKENS.colorRed500 }}>Flights to Edinburgh</BpkText>
-      <BpkText textStyle="lg" style={{ color: TOKENS.colorGreen500 }}>Flights to Edinburgh</BpkText>
-      <BpkText textStyle="base" style={{ color: TOKENS.colorYellow500 }}>Flights to Edinburgh</BpkText>
-      <BpkText textStyle="sm" style={{ color: TOKENS.colorBlue700 }}>Flights to Edinburgh</BpkText>
-      <BpkText textStyle="xs" style={{ color: TOKENS.colorGray500 }}>Flights to Edinburgh</BpkText>
+      <BpkText textStyle="xxl" style={{ color: colorBlue700 }}>Flights to Edinburgh</BpkText>
+      <BpkText textStyle="xl" style={{ color: colorRed500 }}>Flights to Edinburgh</BpkText>
+      <BpkText textStyle="lg" style={{ color: colorGreen500 }}>Flights to Edinburgh</BpkText>
+      <BpkText textStyle="base" style={{ color: colorYellow500 }}>Flights to Edinburgh</BpkText>
+      <BpkText textStyle="sm" style={{ color: colorBlue700 }}>Flights to Edinburgh</BpkText>
+      <BpkText textStyle="xs" style={{ color: colorGray500 }}>Flights to Edinburgh</BpkText>
     </View>
   ));

--- a/native/packages/react-native-bpk-component-ticket/readme.md
+++ b/native/packages/react-native-bpk-component-ticket/readme.md
@@ -15,13 +15,13 @@ import React, { Component } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import BpkText from 'react-native-bpk-component-text';
 import BpkTicket from 'react-native-bpk-component-ticket';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-component-ticket/src/BpkTicket-test.android.js
+++ b/native/packages/react-native-bpk-component-ticket/src/BpkTicket-test.android.js
@@ -28,6 +28,13 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+
+jest.mock('./../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-ticket/src/BpkTicket-test.ios.js
+++ b/native/packages/react-native-bpk-component-ticket/src/BpkTicket-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkTicket-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-component-ticket/src/BpkTicket.js
+++ b/native/packages/react-native-bpk-component-ticket/src/BpkTicket.js
@@ -16,24 +16,10 @@
  * limitations under the License.
  */
 
-import {
-  View,
-  Platform,
-  StyleSheet,
-  PixelRatio,
-  ViewPropTypes,
-} from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Dash from 'react-native-dash';
-import BpkTouchableOverlay from 'react-native-bpk-component-touchable-overlay';
-
-const tokens = Platform.select({
-  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
-  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
-})();
-
-const {
+import {
   colorGray100,
   colorWhite,
   elevationXs,
@@ -52,7 +38,9 @@ const {
   shadowXlOffsetHeight,
   shadowXlOpacity,
   shadowXlRadius,
-} = tokens;
+} from 'bpk-tokens/tokens/base.react.native';
+import { View, StyleSheet, PixelRatio, ViewPropTypes } from 'react-native';
+import BpkTouchableOverlay from 'react-native-bpk-component-touchable-overlay';
 
 /**
  * Define styles needed by the component

--- a/native/packages/react-native-bpk-component-touchable-overlay/readme.md
+++ b/native/packages/react-native-bpk-component-touchable-overlay/readme.md
@@ -14,14 +14,14 @@ npm install react-native-bpk-component-touchable-overlay --save-dev
 import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
 import BpkText from 'react-native-bpk-component-text';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 import BpkTouchableOverlay from 'react-native-bpk-component-touchable-overlay';
-import * as TOKENS from 'bpk-tokens/tokens/ios/base.react.native.es6';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    padding: TOKENS.spacingBase,
+    padding: spacingBase,
   }
 });
 

--- a/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.android.js
+++ b/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.android.js
@@ -28,6 +28,9 @@ jest.mock('react-native', () => {
   return reactNative;
 });
 
+jest.mock('bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'));
+
 describe('Android', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.ios.js
+++ b/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.ios.js
@@ -18,16 +18,6 @@
 
 import commonTests from './BpkThemeProvider-test.common';
 
-jest.mock('react-native', () => {
-  const reactNative = require.requireActual('react-native');
-  jest
-    .spyOn(reactNative.Platform, 'select')
-    .mockImplementation(obj => obj.ios || obj.default);
-  reactNative.Platform.OS = 'ios';
-
-  return reactNative;
-});
-
 describe('iOS', () => {
   commonTests();
 });

--- a/native/packages/react-native-bpk-theming/stories.js
+++ b/native/packages/react-native-bpk-theming/stories.js
@@ -17,36 +17,36 @@
  */
 
 import React, { Component } from 'react';
-import {
-  StyleSheet,
-  View,
-  Platform,
-  Picker,
-} from 'react-native';
-
-import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
-
+import { storiesOf } from '@storybook/react-native';
+import { StyleSheet, View, Picker } from 'react-native';
 import BpkButton from 'react-native-bpk-component-button';
+import {
+  spacingMd,
+  colorWhite,
+  colorRed400,
+  colorRed500,
+  colorBlue400,
+  colorBlue500,
+  colorYellow400,
+  colorYellow500,
+} from 'bpk-tokens/tokens/base.react.native';
 
 import BpkThemeProvider from './index';
 
-const tokens = Platform.OS === 'ios' ?
-  require('bpk-tokens/tokens/ios/base.react.native.common.js') :
-  require('bpk-tokens/tokens/android/base.react.native.common.js');
 
 const generateThemeAttributes = (gradientStartColor, gradientEndColor) => ({
-  buttonPrimaryTextColor: tokens.colorWhite,
+  buttonPrimaryTextColor: colorWhite,
   buttonPrimaryGradientStartColor: gradientStartColor,
   buttonPrimaryGradientEndColor: gradientEndColor,
   buttonSecondaryTextColor: gradientEndColor,
-  buttonSecondaryBackgroundColor: tokens.colorWhite,
+  buttonSecondaryBackgroundColor: colorWhite,
   buttonSecondaryBorderColor: gradientEndColor,
 });
 
 const styles = StyleSheet.create({
   bottomMargin: {
-    marginBottom: tokens.spacingMd,
+    marginBottom: spacingMd,
   },
 });
 
@@ -55,9 +55,9 @@ class BpkThemePicker extends Component {
     super();
 
     this.themes = {
-      blue: generateThemeAttributes(tokens.colorBlue400, tokens.colorBlue500),
-      yellow: generateThemeAttributes(tokens.colorYellow400, tokens.colorYellow500),
-      red: generateThemeAttributes(tokens.colorRed400, tokens.colorRed500),
+      blue: generateThemeAttributes(colorBlue400, colorBlue500),
+      yellow: generateThemeAttributes(colorYellow400, colorYellow500),
+      red: generateThemeAttributes(colorRed400, colorRed500),
     };
 
     this.state = {

--- a/native/storybook/TextStyles.js
+++ b/native/storybook/TextStyles.js
@@ -18,29 +18,24 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Platform } from 'react-native';
-import BpkText from '../packages/react-native-bpk-component-text';
 
-const tokens = Platform.select({
-  ios: () => require('../../packages/bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require,max-len
-  android: () => require('../../packages/bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require,max-len
-})();
+import BpkText from './../packages/react-native-bpk-component-text';
+import { spacingSm } from './../../packages/bpk-tokens/tokens/base.react.native';
 
 const StoryHeading = ({ children, ...rest }) => (
   <BpkText textStyle="xxl" {...rest}>{children}</BpkText>
 );
+
 StoryHeading.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
 const StorySubheading = ({ children, ...rest }) => (
-  <BpkText textStyle="sm" style={{ marginBottom: tokens.spacingSm }} {...rest}>{children}</BpkText>
+  <BpkText textStyle="sm" style={{ marginBottom: spacingSm }} {...rest}>{children}</BpkText>
 );
+
 StorySubheading.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export {
-  StoryHeading,
-  StorySubheading,
-};
+export { StoryHeading, StorySubheading };

--- a/native/storybook/storybook.js
+++ b/native/storybook/storybook.js
@@ -17,25 +17,17 @@
  */
 
 import React from 'react';
-import {
-  AppRegistry,
-  StyleSheet,
-  View,
-  Platform,
-} from 'react-native';
+import { AppRegistry, StyleSheet, View } from 'react-native';
 import { getStorybookUI, configure, addDecorator } from '@storybook/react-native';
 
-const tokens = Platform.select({
-  ios: () => require('../../packages/bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require,max-len
-  android: () => require('../../packages/bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require,max-len
-})();
+import { spacingBase } from './../../packages/bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
   centered: {
     flex: 1,
     flexDirection: 'column',
     justifyContent: 'center',
-    padding: tokens.spacingBase,
+    padding: spacingBase,
     width: '100%',
   },
 });


### PR DESCRIPTION
This PR stops doing this:
```
const tokens = Platform.select({
  ios: () => require('bpk-tokens/tokens/ios/base.react.native.common.js'), // eslint-disable-line global-require
  android: () => require('bpk-tokens/tokens/android/base.react.native.common.js'), // eslint-disable-line global-require
})();
```

And start doing this:
```
import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
```