### PR TITLE
[no jira] Add duration type to token formatter and consume it

### DIFF
--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight.js
@@ -118,7 +118,7 @@ BpkAnimateHeight.propTypes = {
 };
 
 BpkAnimateHeight.defaultProps = {
-  animationDuration: parseInt(animationDurationSm, 10),
+  animationDuration: animationDurationSm,
   style: null,
 };
 

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/withAnimatedProps.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/withAnimatedProps.js
@@ -32,8 +32,8 @@
 
 import React from 'react';
 import { Animated } from 'react-native';
+import { animationDurationSm } from 'bpk-tokens/tokens/base.react.native';
 
-const ANIMATION_DURATION = 200; // milliseconds.
 
 const withAnimatedProps = (Component, propsToMonitor) => class extends React.Component {
   constructor(props) {
@@ -47,7 +47,7 @@ const withAnimatedProps = (Component, propsToMonitor) => class extends React.Com
     const animations = propsToMonitor.map(prop => (
       Animated.timing(this.state[prop], {
         toValue: nextProps[prop],
-        duration: ANIMATION_DURATION,
+        duration: animationDurationSm,
       })
     ));
     Animated.parallel(animations).start();

--- a/packages/bpk-tokens/formatters/react-native-value-template.js
+++ b/packages/bpk-tokens/formatters/react-native-value-template.js
@@ -9,6 +9,11 @@ export default function (value, type) {
       formattedValue = `"${formattedColor.toRgbString()}"`;
       break;
     }
+    case 'duration': {
+      const parsedDuration = Number.parseInt(value, 10);
+      formattedValue = Number.isNaN(parsedDuration) ? value : parsedDuration;
+      break;
+    }
     case 'string':
       formattedValue = `"${value.replace(/"/g, '\\"')}"`;
       break;

--- a/packages/bpk-tokens/src/android/base/animations.json
+++ b/packages/bpk-tokens/src/android/base/animations.json
@@ -1,6 +1,6 @@
 {
   "global": {
-    "type": "string"
+    "type": "duration"
   },
   "props": {
     "ANIMATION_DURATION_XS": {

--- a/packages/bpk-tokens/src/ios/base/animations.json
+++ b/packages/bpk-tokens/src/ios/base/animations.json
@@ -1,6 +1,6 @@
 {
   "global": {
-    "type": "string"
+    "type": "duration"
   },
   "props": {
     "ANIMATION_DURATION_XS": {

--- a/packages/bpk-tokens/tokens/android/base.react.native.common.js
+++ b/packages/bpk-tokens/tokens/android/base.react.native.common.js
@@ -19,9 +19,9 @@
  */
 
 module.exports = {
-  animationDurationXs: "50ms",
-  animationDurationSm: "200ms",
-  animationDurationBase: "400ms",
+  animationDurationXs: 50,
+  animationDurationSm: 200,
+  animationDurationBase: 400,
   borderSizeSm: 1,
   borderSizeLg: 2,
   borderSizeXl: 3,

--- a/packages/bpk-tokens/tokens/android/base.react.native.es6.js
+++ b/packages/bpk-tokens/tokens/android/base.react.native.es6.js
@@ -17,9 +17,9 @@
  * limitations under the License.
  * 
  */
-export const animationDurationXs = "50ms";
-export const animationDurationSm = "200ms";
-export const animationDurationBase = "400ms";
+export const animationDurationXs = 50;
+export const animationDurationSm = 200;
+export const animationDurationBase = 400;
 export const borderSizeSm = 1;
 export const borderSizeLg = 2;
 export const borderSizeXl = 3;

--- a/packages/bpk-tokens/tokens/base.ios.json
+++ b/packages/bpk-tokens/tokens/base.ios.json
@@ -1,7 +1,7 @@
 {
   "properties": [
     {
-      "type": "string",
+      "type": "duration",
       "value": "50ms",
       "category": "animations",
       ".alias": {
@@ -10,7 +10,7 @@
       "name": "animationDurationXs"
     },
     {
-      "type": "string",
+      "type": "duration",
       "value": "200ms",
       "category": "animations",
       ".alias": {
@@ -19,7 +19,7 @@
       "name": "animationDurationSm"
     },
     {
-      "type": "string",
+      "type": "duration",
       "value": "400ms",
       "category": "animations",
       ".alias": {

--- a/packages/bpk-tokens/tokens/base.raw.android.json
+++ b/packages/bpk-tokens/tokens/base.raw.android.json
@@ -297,7 +297,7 @@
   },
   "props": {
     "ANIMATION_DURATION_XS": {
-      "type": "string",
+      "type": "duration",
       "value": "50ms",
       "category": "animations",
       ".alias": {
@@ -306,7 +306,7 @@
       "name": "ANIMATION_DURATION_XS"
     },
     "ANIMATION_DURATION_SM": {
-      "type": "string",
+      "type": "duration",
       "value": "200ms",
       "category": "animations",
       ".alias": {
@@ -315,7 +315,7 @@
       "name": "ANIMATION_DURATION_SM"
     },
     "ANIMATION_DURATION_BASE": {
-      "type": "string",
+      "type": "duration",
       "value": "400ms",
       "category": "animations",
       ".alias": {

--- a/packages/bpk-tokens/tokens/base.raw.ios.json
+++ b/packages/bpk-tokens/tokens/base.raw.ios.json
@@ -279,7 +279,7 @@
   },
   "props": {
     "ANIMATION_DURATION_XS": {
-      "type": "string",
+      "type": "duration",
       "value": "50ms",
       "category": "animations",
       ".alias": {
@@ -288,7 +288,7 @@
       "name": "ANIMATION_DURATION_XS"
     },
     "ANIMATION_DURATION_SM": {
-      "type": "string",
+      "type": "duration",
       "value": "200ms",
       "category": "animations",
       ".alias": {
@@ -297,7 +297,7 @@
       "name": "ANIMATION_DURATION_SM"
     },
     "ANIMATION_DURATION_BASE": {
-      "type": "string",
+      "type": "duration",
       "value": "400ms",
       "category": "animations",
       ".alias": {

--- a/packages/bpk-tokens/tokens/base.react.native.android.js
+++ b/packages/bpk-tokens/tokens/base.react.native.android.js
@@ -17,9 +17,9 @@
  * limitations under the License.
  * 
  */
-export const animationDurationXs = "50ms";
-export const animationDurationSm = "200ms";
-export const animationDurationBase = "400ms";
+export const animationDurationXs = 50;
+export const animationDurationSm = 200;
+export const animationDurationBase = 400;
 export const borderSizeSm = 1;
 export const borderSizeLg = 2;
 export const borderSizeXl = 3;

--- a/packages/bpk-tokens/tokens/base.react.native.ios.js
+++ b/packages/bpk-tokens/tokens/base.react.native.ios.js
@@ -17,9 +17,9 @@
  * limitations under the License.
  * 
  */
-export const animationDurationXs = "50ms";
-export const animationDurationSm = "200ms";
-export const animationDurationBase = "400ms";
+export const animationDurationXs = 50;
+export const animationDurationSm = 200;
+export const animationDurationBase = 400;
 export const borderSizeSm = 1;
 export const borderSizeLg = 2;
 export const borderSizeXl = 3;

--- a/packages/bpk-tokens/tokens/ios/base.react.native.common.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.common.js
@@ -19,9 +19,9 @@
  */
 
 module.exports = {
-  animationDurationXs: "50ms",
-  animationDurationSm: "200ms",
-  animationDurationBase: "400ms",
+  animationDurationXs: 50,
+  animationDurationSm: 200,
+  animationDurationBase: 400,
   borderSizeSm: 1,
   borderSizeLg: 2,
   borderSizeXl: 3,

--- a/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
@@ -17,9 +17,9 @@
  * limitations under the License.
  * 
  */
-export const animationDurationXs = "50ms";
-export const animationDurationSm = "200ms";
-export const animationDurationBase = "400ms";
+export const animationDurationXs = 50;
+export const animationDurationSm = 200;
+export const animationDurationBase = 400;
 export const borderSizeSm = 1;
 export const borderSizeLg = 2;
 export const borderSizeXl = 3;


### PR DESCRIPTION
React Native animations take an integer in milliseconds as their arguments, so the previous values we were using, such as `"200ms"` do not work.

This PR adds a formatter so that `duration` tokens are converted, and then consumes it in the horizontal nav.