### PR TITLE
[no jira] Changed the way Danger reports new components

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -37,8 +37,7 @@ const webComponentIntroduced = createdFiles.some(filePath => (
 ));
 
 if (webComponentIntroduced) {
-  message('It looks like you are introducing a web component.');
-  warn('Ensure the component style is extensible via `className`.');
+  warn('It looks like you are introducing a web component. Ensure the component style is extensible via `className`.');
 }
 
 // Ensure new native components are extensible by consumers.
@@ -47,8 +46,7 @@ const nativeComponentIntroduced = createdFiles.some(filePath => (
 ));
 
 if (nativeComponentIntroduced) {
-  message('It looks like you are introducing a native component.');
-  warn('Ensure the component style is extensible via `style`.');
+  warn('It looks like you are introducing a native component. Ensure the component style is extensible via `style`.');
 }
 
 // If any of the packages have changed, the changelog should have been updated.


### PR DESCRIPTION
Danger uses this code to advise people introducing new components:

```
if (nativeComponentIntroduced) {
  message('It looks like you are introducing a native component.');
  warn('Ensure the component style is extensible via `style`.');
}
```

However, when this is posted to GitHub, they're placed away from each other, which removes a lot of the context:

<img width="776" alt="screen shot 2017-11-17 at 12 01 18" src="https://user-images.githubusercontent.com/73652/32946560-f321b848-cb8f-11e7-94eb-b032d5af3446.png">

This PR changes the code to use `warn` for all of the message, which will make more sense:

```
if (nativeComponentIntroduced) {
  warn('It looks like you are introducing a native component. Ensure the component style is extensible via `style`.');
}
```

