### PR TITLE
Replace padded prop on withScrim with more generic contentClassName

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,13 +2,15 @@
 
 ## UNRELEASED
 
-_Nothing yet_
+**Breaking:**
+- bpk-scrim-utils:
+  - Removed `padded` prop in favour of more generic `contentClassName`
 
 ## 2017-11-17 - New native horizontal nav interface and enhancements to `bpk-animate-height`
 
 **Breaking:**
 - react-native-bpk-component-horizontal-nav: 1.0.1 => 2.0.0
- - `BpkHorizontalNavItem` no longer supports the `selected` prop. Instead, add an `id` prop to `BpkHorizontalNavItem` and a `selectedId` prop to `BpkHorizontalNav`. This allows the selected indicator line to animate when the `selectedId` prop changes. See http://backpack.prod.aws.skyscnr.com/components/native/horizontal-nav for an example.
+  - `BpkHorizontalNavItem` no longer supports the `selected` prop. Instead, add an `id` prop to `BpkHorizontalNavItem` and a `selectedId` prop to `BpkHorizontalNav`. This allows the selected indicator line to animate when the `selectedId` prop changes. See http://backpack.prod.aws.skyscnr.com/components/native/horizontal-nav for an example.
 
 **Added:**
 - react-native-bpk-component-ticket: 1.0.32 => 1.1.0

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 **Breaking:**
 - bpk-scrim-utils:
   - Removed `padded` prop in favour of more generic `contentClassName`
+  - Fixed modal white background on iPhone not showing
 
 ## 2017-11-17 - New native horizontal nav interface and enhancements to `bpk-animate-height`
 

--- a/packages/bpk-component-modal/src/BpkModal.js
+++ b/packages/bpk-component-modal/src/BpkModal.js
@@ -16,13 +16,15 @@
  * limitations under the License.
  */
 
-import { Portal } from 'bpk-react-utils';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { Portal, cssModules } from 'bpk-react-utils';
 import { withScrim } from 'bpk-scrim-utils';
 
 import BpkModalDialog from './BpkModalDialog';
+import STYLES from './bpk-modal.scss';
 
+const getClassName = cssModules(STYLES);
 const ScrimBpkModalDialog = withScrim(BpkModalDialog);
 
 const BpkModal = (props) => {
@@ -34,7 +36,7 @@ const BpkModal = (props) => {
 
   return (
     <Portal isOpen={isOpen} onClose={onClose} target={target}>
-      <ScrimBpkModalDialog onClose={onClose} padded {...rest} />
+      <ScrimBpkModalDialog onClose={onClose} {...rest} contentClassName={getClassName('bpk-modal__container')} />
     </Portal>
   );
 };

--- a/packages/bpk-component-modal/src/bpk-modal.scss
+++ b/packages/bpk-component-modal/src/bpk-modal.scss
@@ -18,31 +18,18 @@
 
 @import '~bpk-mixins/index';
 
-.bpk-scrim {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: $bpk-zindex-scrim;
-  transition: opacity $bpk-duration-xs ease-in-out;
-  background-color: $bpk-scrim-background-color;
-  opacity: $bpk-scrim-opacity;
-  overflow: hidden;
-
+.bpk-modal__container {
   @include bpk-breakpoint-mobile {
-    opacity: $bpk-scrim-mobile-opacity;
+    background-color: $bpk-modal-background-color;
   }
 
-  &--appear {
-    opacity: $bpk-scrim-initial-opacity;
+  @include bpk-breakpoint-above-mobile {
+    display: flex;
+    padding: $bpk-spacing-base;
   }
 
-  &--appear-active {
-    opacity: $bpk-scrim-opacity;
-
-    @include bpk-breakpoint-mobile {
-      opacity: $bpk-scrim-mobile-opacity;
-    }
+  // IE11 and below hack for buggy flexbox support
+  @media screen\0 {
+    display: block;
   }
 }

--- a/packages/bpk-scrim-utils/readme.md
+++ b/packages/bpk-scrim-utils/readme.md
@@ -30,6 +30,9 @@ const BoxWithScrim = withScrim(Box);
 - `onClose` should be set as the `onClick` action on a button or a link
 - `isIphone` can be used to apply iPhone only styles or behaviour, as it has different scrolling behaviour
 
+`contentClassName` can be used to apply styles to the full-screen container into which the enriched component is inserted
+ (eg. `display: flex` or `display: grid`)
+
 ### Props
 
 | Property              | PropType | Required | Default Value |
@@ -37,4 +40,4 @@ const BoxWithScrim = withScrim(Box);
 | onClose               | func     | true     | -             |
 | getApplicationElement | func     | true     | -             |
 | isIphone              | bool     | false    | /iPhone/i.test(typeof window !== 'undefined' ? window.navigator.platform : '')|
-| padded                | bool     | false    | true          |
+| contentClassName      | string   | false    | ''            |

--- a/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
+++ b/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
@@ -6,7 +6,7 @@ exports[`BpkScrim render should render correctly 1`] = `
     className="bpk-scrim"
   />
   <div
-    className="bpk-scrim-content bpk-scrim-content--padded"
+    className="bpk-scrim-content "
     onMouseDown={[Function]}
     onMouseMove={[Function]}
     onMouseUp={[Function]}
@@ -39,7 +39,7 @@ exports[`BpkScrim render should render correctly when is iPhone 1`] = `
     className="bpk-scrim"
   />
   <div
-    className="bpk-scrim-content bpk-scrim-content--padded bpk-scrim-content--iphone-fix"
+    className="bpk-scrim-content bpk-scrim-content--iphone-fix "
     onMouseDown={[Function]}
     onMouseMove={[Function]}
     onMouseUp={[Function]}
@@ -60,6 +60,39 @@ exports[`BpkScrim render should render correctly when is iPhone 1`] = `
       }
       getDialogRef={[Function]}
       isIphone={true}
+      onClose={[Function]}
+    />
+  </div>
+</div>
+`;
+
+exports[`BpkScrim render should render correctly with contentClassName 1`] = `
+<div>
+  <div
+    className="bpk-scrim"
+  />
+  <div
+    className="bpk-scrim-content contentClassName"
+    onMouseDown={[Function]}
+    onMouseMove={[Function]}
+    onMouseUp={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+  >
+    <TestComponent
+      closeEvents={
+        Object {
+          "onMouseDown": [Function],
+          "onMouseMove": [Function],
+          "onMouseUp": [Function],
+          "onTouchEnd": [Function],
+          "onTouchMove": [Function],
+          "onTouchStart": [Function],
+        }
+      }
+      getDialogRef={[Function]}
+      isIphone={false}
       onClose={[Function]}
     />
   </div>

--- a/packages/bpk-scrim-utils/src/bpk-scrim-content.scss
+++ b/packages/bpk-scrim-utils/src/bpk-scrim-content.scss
@@ -25,25 +25,9 @@
   bottom: 0;
   left: 0;
   z-index: $bpk-zindex-scrim;
-  overflow: auto;
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-
-  @include bpk-breakpoint-above-mobile {
-    display: flex;
-  }
-
-  // IE11 and below hack for buggy flexbox support
-  @media screen\0 {
-    display: block;
-  }
-
-  &--padded {
-    @include bpk-breakpoint-above-mobile {
-      padding: $bpk-spacing-base;
-    }
-  }
 
   &--iphone-fix {
     position: absolute;

--- a/packages/bpk-scrim-utils/src/bpk-scrim-content.scss
+++ b/packages/bpk-scrim-utils/src/bpk-scrim-content.scss
@@ -25,6 +25,7 @@
   bottom: 0;
   left: 0;
   z-index: $bpk-zindex-scrim;
+  overflow: auto;
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/packages/bpk-scrim-utils/src/withScrim-test.js
+++ b/packages/bpk-scrim-utils/src/withScrim-test.js
@@ -71,6 +71,17 @@ describe('BpkScrim', () => {
       ).toJSON();
       expect(tree).toMatchSnapshot();
     });
+
+    it('should render correctly with contentClassName', () => {
+      const tree = renderer.create(
+        <Component
+          onClose={jest.fn()}
+          getApplicationElement={jest.fn()}
+          contentClassName="contentClassName"
+        />,
+      ).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
   });
 
   describe('componentDidMount', () => {

--- a/packages/bpk-scrim-utils/src/withScrim.js
+++ b/packages/bpk-scrim-utils/src/withScrim.js
@@ -110,15 +110,15 @@ const withScrim = (WrappedComponent) => {
 
     render() {
       const {
-        padded,
         isIphone,
         getApplicationElement,
+        contentClassName,
         ...rest
       } = this.props;
 
       const classNames = [getClassName('bpk-scrim-content')];
-      if (padded) { classNames.push(getClassName('bpk-scrim-content--padded')); }
       if (isIphone) { classNames.push(getClassName('bpk-scrim-content--iphone-fix')); }
+      classNames.push(contentClassName);
 
       const closeEvents = {
         onTouchStart: this.onContentMouseDown,
@@ -161,12 +161,12 @@ const withScrim = (WrappedComponent) => {
     onClose: PropTypes.func.isRequired,
     getApplicationElement: PropTypes.func.isRequired,
     isIphone: PropTypes.bool,
-    padded: PropTypes.bool,
+    contentClassName: PropTypes.string,
   };
 
   component.defaultProps = {
     isIphone: /iPhone/i.test(typeof window !== 'undefined' ? window.navigator.platform : ''),
-    padded: true,
+    contentClassName: '',
   };
 
   return component;


### PR DESCRIPTION
This allows the extraction of some modal specific code and makes the component more versatile.
Only the modal needs display: flex and padding on the container, it now injects the styles it requires.