### PR TITLE
Make BpkBannerAlert dismissable option self-contained

### DIFF
--- a/packages/bpk-component-banner-alert/readme.md
+++ b/packages/bpk-component-banner-alert/readme.md
@@ -34,53 +34,26 @@ export default () => (
 import React, { Component } from 'react';
 import BpkBannerAlert, { ALERT_TYPES } from 'bpk-component-banner-alert';
 
-class DismissableBpkBannerAlert extends Component {
-  constructor() {
-    super();
-
-    this.setDismissed = this.setDismissed.bind(this);
-
-    this.state = {
-      show: true,
-    };
-  }
-
-  setDismissed() {
-    this.setState({
-      show: false,
-    });
-  }
-
-  render() {
-    return (
-      <BpkBannerAlert
-        message="Successful alert with more information."
-        type={ALERT_TYPES.SUCCESS}
-        dismissable
-        onDismiss={this.setDismissed}
-        show={this.state.show}
-        dismissButtonLabel="Dismiss"
-      />
-    );
-  }
-}
-
 export default () => (
-  <DismissableBpkBannerAlert />
+  <BpkBannerAlert
+    message="Successful alert with dismiss option."
+    type={ALERT_TYPES.SUCCESS}
+    dismissable
+    dismissButtonLabel="Dismiss"
+  />
 );
 ```
 
 ## Props
 
-| Property          | PropType             | Required | Default Value |
-| ----------------- | -------------------- | -------- | ------------- |
-| type              | ALERT_TYPES (one of) | true     | -             |
-| message           | node                 | true     | -             |
-| ariaLive          | ARIA_LIVE (one of)   | false    | 'assertive'   |
-| children          | node                 | false    | null          |
-| dismissable       | bool                 | false    | false         |
-| dismissLabel      | string               | false    | null          |
-| onDismiss         | func                 | false    | null          |
-| show              | bool                 | false    | true          |
-| toggleButtonLabel | string               | false    | null          |
-| className         | string               | false    | null          |
+| Property           | PropType             | Required | Default Value |
+| ------------------ | -------------------- | -------- | ------------- |
+| type               | ALERT_TYPES (one of) | true     | -             |
+| message            | node                 | true     | -             |
+| ariaLive           | ARIA_LIVE (one of)   | false    | 'assertive'   |
+| children           | node                 | false    | null          |
+| dismissable        | bool                 | false    | false         |
+| dismissButtonLabel | string               | false    | null          |
+| onDismiss          | func                 | false    | null          |
+| toggleButtonLabel  | string               | false    | null          |
+| className          | string               | false    | null          |

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
@@ -18,6 +18,8 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
 import BpkBannerAlert, { ALERT_TYPES } from './BpkBannerAlert';
 
 const message = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.';
@@ -78,15 +80,30 @@ describe('BpkBannerAlert', () => {
 
   it('should render correctly with dismissable option', () => {
     const tree = renderer.create(
-      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} dismissable />,
+      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} dismissable dismissButtonLabel="Dismiss" />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('should render correctly with show set false', () => {
-    const tree = renderer.create(
-      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} dismissable show={false} />,
-    ).toJSON();
-    expect(tree).toMatchSnapshot();
+  it('should render correctly when dismissed', () => {
+    const banner = shallow(
+      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} dismissable dismissButtonLabel="Dismiss" />,
+    );
+    banner.find('DismissButton').at(0).simulate('click');
+
+    expect(shallowToJson(banner)).toMatchSnapshot();
+  });
+
+  it('should call "onDismiss" when dismissed', () => {
+    const onDismissMock = jest.fn();
+    const banner = shallow(
+      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} dismissable onDismiss={onDismissMock} />,
+    );
+
+    expect(onDismissMock.mock.calls.length).toBe(0);
+
+    banner.find('DismissButton').at(0).simulate('click');
+
+    expect(onDismissMock.mock.calls.length).toBe(1);
   });
 });

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
@@ -107,6 +107,7 @@ class BpkBannerAlert extends Component {
 
     this.state = {
       expanded: false,
+      dismissed: false,
     };
 
     this.onExpand = this.onExpand.bind(this);
@@ -120,6 +121,7 @@ class BpkBannerAlert extends Component {
   }
 
   onDismiss() {
+    this.setState({ dismissed: true });
     if (this.props.onDismiss) {
       this.props.onDismiss();
     }
@@ -134,12 +136,11 @@ class BpkBannerAlert extends Component {
       dismissButtonLabel,
       message,
       onDismiss,
-      show,
       type,
       toggleButtonLabel,
       ...rest
     } = this.props;
-    const isExpanded = this.state.expanded;
+    const { expanded: isExpanded, dismissed } = this.state;
     const isExpandable = children;
     const showChildren = isExpandable && isExpanded;
     const ariaRoles = ['alert'];
@@ -161,7 +162,7 @@ class BpkBannerAlert extends Component {
     */
     // Disabling 'click-events-have-key-events and interactive-supports-focus' because header element is not focusable.
     // ToggleButton is focusable and works for this.
-    return !show ? null : (
+    return dismissed ? null : (
       <section className={sectionClassNames.join(' ')} {...rest}>
         <header
           role={ariaRoles.join(' ')}
@@ -208,7 +209,6 @@ BpkBannerAlert.propTypes = {
   dismissable: PropTypes.bool,
   dismissButtonLabel: PropTypes.string,
   onDismiss: PropTypes.func,
-  show: PropTypes.bool,
   toggleButtonLabel: PropTypes.string,
   className: PropTypes.string,
 };
@@ -219,7 +219,6 @@ BpkBannerAlert.defaultProps = {
   dismissable: false,
   dismissButtonLabel: null,
   onDismiss: null,
-  show: true,
   toggleButtonLabel: null,
   className: null,
 };

--- a/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.js.snap
+++ b/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BpkBannerAlert should render correctly when dismissed 1`] = `""`;
+
 exports[`BpkBannerAlert should render correctly with "type" attribute equal to "error" 1`] = `
 <section
   className="bpk-banner-alert bpk-banner-alert--error"
@@ -650,10 +652,10 @@ exports[`BpkBannerAlert should render correctly with dismissable option 1`] = `
     </span>
      
     <button
-      aria-label={null}
+      aria-label="Dismiss"
       className="bpk-close-button bpk-banner-alert__toggle-button"
       onClick={[Function]}
-      title={null}
+      title="Dismiss"
       type="button"
     >
       <span
@@ -708,5 +710,3 @@ exports[`BpkBannerAlert should render correctly with dismissable option 1`] = `
   </div>
 </section>
 `;
-
-exports[`BpkBannerAlert should render correctly with show set false 1`] = `null`;

--- a/packages/bpk-docs/src/pages/BannerAlertsPage/BannerAlertsPage.js
+++ b/packages/bpk-docs/src/pages/BannerAlertsPage/BannerAlertsPage.js
@@ -16,10 +16,9 @@
  * limitations under the License.
  */
 
-import React, { Component } from 'react';
+import React from 'react';
 import { fontWeightBold } from 'bpk-tokens/tokens/base.es6';
-import PropTypes from 'prop-types';
-import { cssModules } from 'bpk-react-utils';
+import { cssModules, withDefaultProps } from 'bpk-react-utils';
 import BpkBannerAlert, { ALERT_TYPES } from 'bpk-component-banner-alert';
 import bannerAlertReadme from 'bpk-component-banner-alert/readme.md';
 import DocsPageBuilder from './../../components/DocsPageBuilder';
@@ -38,47 +37,18 @@ sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rho
 ante in, vestibulum nulla.`;
 const richMessage = <span style={{ fontWeight: fontWeightBold }}>Successful alert with custom rendered message</span>;
 
-class BpkBannerDismissable extends Component {
-  constructor() {
-    super();
-
-    this.setDismissed = this.setDismissed.bind(this);
-
-    this.state = {
-      show: true,
-    };
-  }
-
-  setDismissed() {
-    this.setState({
-      show: false,
-    });
-  }
-
-  render() {
-    return (
-      <BpkBannerAlert
-        className={componentClassName}
-        message={this.props.message}
-        type={this.props.type}
-        dismissable
-        onDismiss={this.setDismissed}
-        show={this.state.show}
-        dismissButtonLabel="Dismiss"
-      />
-    );
-  }
-}
-
-BpkBannerDismissable.propTypes = {
-  message: PropTypes.string,
-  type: PropTypes.string,
-};
-
-BpkBannerDismissable.defaultProps = {
-  message: null,
-  type: null,
-};
+const BannerAlert = withDefaultProps(BpkBannerAlert, {
+  className: componentClassName,
+});
+const BannerAlertExpandable = withDefaultProps(BpkBannerAlert, {
+  className: componentClassName,
+  toggleButtonLabel: 'See more',
+});
+const BannerAlertDismissable = withDefaultProps(BpkBannerAlert, {
+  className: componentClassName,
+  dismissable: true,
+  dismissButtonLabel: 'Dismiss',
+});
 
 const components = [
   {
@@ -90,28 +60,23 @@ const components = [
       </Paragraph>,
     ],
     examples: [
-      <BpkBannerAlert
-        className={componentClassName}
+      <BannerAlert
         message="Neutral alert."
         type={ALERT_TYPES.NEUTRAL}
       />,
-      <BpkBannerAlert
-        className={componentClassName}
+      <BannerAlert
         message="Successful alert."
         type={ALERT_TYPES.SUCCESS}
       />,
-      <BpkBannerAlert
-        className={componentClassName}
+      <BannerAlert
         message={richMessage}
         type={ALERT_TYPES.SUCCESS}
       />,
-      <BpkBannerAlert
-        className={componentClassName}
+      <BannerAlert
         message="Warn alert."
         type={ALERT_TYPES.WARN}
       />,
-      <BpkBannerAlert
-        className={componentClassName}
+      <BannerAlert
         message="Error alert."
         type={ALERT_TYPES.ERROR}
       />,
@@ -127,38 +92,30 @@ const components = [
       </Paragraph>,
     ],
     examples: [
-      <BpkBannerAlert
-        className={componentClassName}
+      <BannerAlertExpandable
         message="Neutral alert with more information."
         type={ALERT_TYPES.NEUTRAL}
-        toggleButtonLabel="See more"
       >
         {longMessage}
-      </BpkBannerAlert>,
-      <BpkBannerAlert
-        className={componentClassName}
+      </BannerAlertExpandable>,
+      <BannerAlertExpandable
         message="Successful alert with more information."
         type={ALERT_TYPES.SUCCESS}
-        toggleButtonLabel="See more"
       >
         {longMessage}
-      </BpkBannerAlert>,
-      <BpkBannerAlert
-        className={componentClassName}
+      </BannerAlertExpandable>,
+      <BannerAlertExpandable
         message="Warn alert with more information."
         type={ALERT_TYPES.WARN}
-        toggleButtonLabel="See more"
       >
         {longMessage}
-      </BpkBannerAlert>,
-      <BpkBannerAlert
-        className={componentClassName}
+      </BannerAlertExpandable>,
+      <BannerAlertExpandable
         message="Error alert with more information."
         type={ALERT_TYPES.ERROR}
-        toggleButtonLabel="See more"
       >
         {longMessage}
-      </BpkBannerAlert>,
+      </BannerAlertExpandable>,
     ],
   },
   {
@@ -170,33 +127,21 @@ const components = [
       </Paragraph>,
     ],
     examples: [
-      <BpkBannerDismissable
-        className={componentClassName}
+      <BannerAlertDismissable
         message="Neutral alert with dismiss option."
         type={ALERT_TYPES.NEUTRAL}
-        dismissable
-        dismissButtonLabel="Dismiss"
       />,
-      <BpkBannerDismissable
-        className={componentClassName}
+      <BannerAlertDismissable
         message="Successful alert with dismiss option."
         type={ALERT_TYPES.SUCCESS}
-        dismissable
-        dismissButtonLabel="Dismiss"
       />,
-      <BpkBannerDismissable
-        className={componentClassName}
+      <BannerAlertDismissable
         message="Warn alert with dismiss option."
         type={ALERT_TYPES.WARN}
-        dismissable
-        dismissButtonLabel="Dismiss"
       />,
-      <BpkBannerDismissable
-        className={componentClassName}
+      <BannerAlertDismissable
         message="Error alert with dismiss option."
         type={ALERT_TYPES.ERROR}
-        dismissable
-        dismissButtonLabel="Dismiss"
       />,
     ],
   },


### PR DESCRIPTION
Hi,
I've noticed that when using the "dismissable" feature from `BpkBannerAlert`, the state must be handled by the parent, providing the `show` prop with the right value. Is there a reason for that? Wouldn't this feature be easier to use if it was self-contained?

This PR includes the changes in the component to avoid having to handle the "dismissed" state from the parent.