### PR TITLE
[BPK-955] Add web theming package

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -69,5 +69,6 @@ configure(() => {
   require('./../packages/bpk-component-tile/stories');
   require('./../packages/bpk-component-tooltip/stories');
   require('./../packages/bpk-mixins/stories');
+  require('./../packages/bpk-theming/stories');
 }, module);
 /* eslint-enable */

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,9 @@
 **Added:**
 - bpk-component-spinner:
   - New `type` prop. Options are `primary`, `light` or `dark`
-
+- bpk-theming:
+  - New `BpkTheming` utility, see https://backpack.github.io/components/utilities/theming.
+  
 ## 2017-11-21 - React Native cards can now have a dividing line
 
 **Added:**

--- a/packages/bpk-theming/bpk-themeable-text/BpkThemeableText.js
+++ b/packages/bpk-theming/bpk-themeable-text/BpkThemeableText.js
@@ -1,0 +1,39 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { cssModules } from 'bpk-react-utils';
+
+import STYLES from './bpk-themeable-text.scss';
+
+const getClassName = cssModules(STYLES);
+
+const BpkThemeableText = ({ children }) => {
+  const className = getClassName('bpk-themeable-text');
+  return <p className={className}>{ children }</p>;
+};
+
+BpkThemeableText.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+const themeAttributes = ['textColor', 'textBackgroundColor'];
+
+export default BpkThemeableText;
+export { themeAttributes };

--- a/packages/bpk-theming/bpk-themeable-text/bpk-themeable-text.scss
+++ b/packages/bpk-theming/bpk-themeable-text/bpk-themeable-text.scss
@@ -1,0 +1,27 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.bpk-themeable-text {
+  $color: #93a;
+  $background-color: lighten($color, 50%);
+
+  background-color: $background-color;
+  background-color: var(--bpk-text-background-color, $background-color);
+  color: $color;
+  color: var(--bpk-text-color, $color);
+}

--- a/packages/bpk-theming/index.js
+++ b/packages/bpk-theming/index.js
@@ -1,0 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BpkThemeProvider from './src/BpkThemeProvider';
+
+export default BpkThemeProvider;

--- a/packages/bpk-theming/package-lock.json
+++ b/packages/bpk-theming/package-lock.json
@@ -1,0 +1,278 @@
+{
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "bpk-component-select": {
+      "version": "2.1.37",
+      "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.1.37.tgz",
+      "integrity": "sha512-5W42LIKZOByTiF+WYkVWXcTcENUnpujf1OOsTwCtBMg27ll5axEkxb1ArRqs3cSWSg0C63wRajVX2bJl9Q5yuw==",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "17.0.13",
+        "bpk-react-utils": "2.3.7",
+        "prop-types": "15.6.0"
+      }
+    },
+    "bpk-mixins": {
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.0.13.tgz",
+      "integrity": "sha512-NzHSvIq24DzNrh0l07yPMe4WH075R6N7cjMgJjtkMvLdrJy6xAihdkeah66IWHZmzR3K2Zkb9r90OGi7xPc6oQ==",
+      "dev": true,
+      "requires": {
+        "bpk-svgs": "5.11.8",
+        "bpk-tokens": "26.5.1"
+      }
+    },
+    "bpk-react-utils": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.3.7.tgz",
+      "integrity": "sha512-CspBBajQ+GBkaaSOniRGihAGGBC0WwWNUut6FeeKLZTmna/gGtIwJKGyokD45vxiCh8JAAAcOAg5gZ6IMn+1Ew==",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0",
+        "react-transition-group": "1.1.3",
+        "recompose": "0.26.0"
+      }
+    },
+    "bpk-svgs": {
+      "version": "5.11.8",
+      "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-5.11.8.tgz",
+      "integrity": "sha512-1F/qZkEcNJ4IGk0XI70jYb71pbB/2AG66pHzwaIPztWhfK+YMgSfAoJUk5dyUBV0VpFmeNFLQsBLr/LyINXgYQ==",
+      "dev": true
+    },
+    "bpk-tokens": {
+      "version": "26.5.1",
+      "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-26.5.1.tgz",
+      "integrity": "sha512-yUEa4GalhG3QbmMAnzXYm8Q4OTiQCfSPWjAw+IVa+tU9fGB6EwleKwQt6xudCtFcGIXJYQ1ktIUvo5yo3vrB0w==",
+      "dev": true,
+      "requires": {
+        "color": "2.0.1"
+      }
+    },
+    "chain-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w=",
+      "dev": true
+    },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
+      "dev": true
+    },
+    "color": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+      "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1",
+        "color-string": "1.5.2"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "color-string": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3",
+        "simple-swizzle": "0.2.2"
+      }
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "dom-helpers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
+      "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo=",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
+      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "is-arrayish": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
+      "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "react-transition-group": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.1.3.tgz",
+      "integrity": "sha1-XgLPbkSoYzFP88aKDIJsLZ1wsiE=",
+      "dev": true,
+      "requires": {
+        "chain-function": "1.0.0",
+        "dom-helpers": "3.2.1",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
+      }
+    },
+    "recompose": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+      "dev": true,
+      "requires": {
+        "change-emitter": "0.1.6",
+        "fbjs": "0.8.16",
+        "hoist-non-react-statics": "2.3.1",
+        "symbol-observable": "1.0.4"
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.3.1"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    }
+  }
+}

--- a/packages/bpk-theming/package.json
+++ b/packages/bpk-theming/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bpk-theming",
+  "version": "0.0.0",
+  "main": "index.js",
+  "description": "Backpack theming utlities.",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  },
+  "devDependencies": {
+    "bpk-component-select": "^2.1.37",
+    "bpk-react-utils": "^2.3.7",
+    "bpk-tokens": "^26.5.1"
+  }
+}

--- a/packages/bpk-theming/readme.md
+++ b/packages/bpk-theming/readme.md
@@ -1,0 +1,45 @@
+# bpk-theming
+
+> Backpack theming utilities.
+
+## Installation
+
+```sh
+npm install bpk-theming --save-dev
+```
+
+## Usage
+
+```js
+import BpkThemeProvider from 'bpk-theming';
+
+import BpkButton, {themeAttributes as buttonThemeAttributes} from 'bpk-component-button';
+
+const theme = {
+  buttonPrimaryGradientStartColor: '#fce134',
+  buttonPrimaryGradientEndColor: '#f8c42d',
+  buttonPrimaryTextColor: '#2d244c',
+  buttonSecondaryBackgroundColor: '#fff',
+  buttonSecondaryTextColor: '#2d244c',
+  buttonSecondaryBorderColor: '#2d244c',
+};
+
+export default class App extends Component {
+  render() {
+    return (
+      <BpkThemeProvider theme={theme} themeAttributes={[...buttonThemeAttributes]}>
+        <BpkButton type="primary" onClick={() => {}}>Primary</BpkButton>
+        <BpkButton type="secondary" onClick={() => {}}>Secondary</BpkButton>
+      </BpkThemeProvider>
+    );
+  }
+}
+```
+
+## Props
+
+| Property            | PropType        | Required | Default Value |
+| -----------         | --------------- | -------- | ------------- |
+| children            | node            | true     | -             |
+| theme               | object          | true     | -             |
+| themeAttributes     | arrayOf(string) | true     | -             |

--- a/packages/bpk-theming/src/BpkThemeProvider-test.js
+++ b/packages/bpk-theming/src/BpkThemeProvider-test.js
@@ -1,0 +1,99 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import BpkThemeProvider from './BpkThemeProvider';
+
+describe('BpkThemeProvider', () => {
+  it('should render correctly', () => {
+    const tree = renderer.create(
+      <BpkThemeProvider
+        theme={{ color: 'white' }}
+        themeAttributes={['color']}
+      >
+        <p>Lorem Ipsum</p>
+      </BpkThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should correctly flatten the themeAttribute prop', () => {
+    const tree = renderer.create(
+      <BpkThemeProvider
+        theme={{ color: 'white', background: 'black' }}
+        themeAttributes={[['color'], ['background']]}
+      >
+        <p>Lorem Ipsum</p>
+      </BpkThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render without theming when theme is missing attributes', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+    const tree = renderer.create(
+      <BpkThemeProvider
+        theme={{}}
+        themeAttributes={['color']}
+      >
+        <p>Lorem Ipsum</p>
+      </BpkThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should strip out extraneous theme attributes', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+    const tree = renderer.create(
+      <BpkThemeProvider
+        theme={{ a: 'a', color: 'white' }}
+        themeAttributes={['color']}
+      >
+        <p>Lorem Ipsum</p>
+      </BpkThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should reject themeAttribute prop when it is not present', () => {
+    expect(BpkThemeProvider.propTypes.themeAttributes({
+    }, 'themeAttributes', 'BpkThemeProvider').toString()).toEqual('Error: BpkThemeProvider: `themeAttributes` is required.'); // eslint-disable-line max-len
+  });
+
+  it('should reject themeAttribute prop when it is not an array', () => {
+    expect(BpkThemeProvider.propTypes.themeAttributes({
+      themeAttributes: 'foo',
+    }, 'themeAttributes', 'BpkThemeProvider').toString()).toEqual('Error: BpkThemeProvider: `themeAttributes` must be an array.'); // eslint-disable-line max-len
+  });
+
+  it('should warn about missing theme attributes', () => {
+    expect(BpkThemeProvider.propTypes.themeAttributes({
+      theme: {},
+      themeAttributes: ['one'],
+    }, 'themeAttributes', 'BpkThemeProvider').toString()).toEqual('Error: BpkThemeProvider: To apply theming, the theme prop must include `one` (missing `one`)'); // eslint-disable-line max-len
+  });
+
+  it('should warn about extraneous theme attributes', () => {
+    expect(BpkThemeProvider.propTypes.themeAttributes({
+      theme: { one: 'a', two: 'a' },
+      themeAttributes: ['one'],
+    }, 'themeAttributes', 'BpkThemeProvider').toString()).toEqual('Error: BpkThemeProvider: Extraneous theme attributes supplied: `two`.'); // eslint-disable-line max-len
+  });
+});

--- a/packages/bpk-theming/src/BpkThemeProvider.js
+++ b/packages/bpk-theming/src/BpkThemeProvider.js
@@ -1,0 +1,107 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const uniq = (arr) => {
+  const seen = {};
+  return arr.filter(((item) => {
+    if (seen.hasOwnProperty[item]) {
+      return false;
+    }
+    seen[item] = true;
+    return true;
+  }));
+};
+
+const createStyle = (theme, themeAttributes) => {
+  const flattenedThemeAttributes = [].concat(...themeAttributes);
+  let style = {};
+  const missingThemeAttributes = [];
+  flattenedThemeAttributes.forEach((attribute) => {
+    if (theme[attribute]) {
+      const cssName = attribute.replace(/([A-Z])/g, variable => `-${variable.toLowerCase()}`);
+      const value = theme[attribute];
+      style[`--bpk-${cssName}`] = value;
+    } else {
+      missingThemeAttributes.push(attribute);
+    }
+  });
+
+  if (missingThemeAttributes.length > 0) {
+    style = {};
+  }
+
+  return style;
+};
+
+const BpkThemeProvider = (props) => {
+  const { children, theme, themeAttributes } = props;
+  const dedupedThemeAttributes = uniq(themeAttributes);
+  const style = createStyle(theme, dedupedThemeAttributes);
+  return (
+    <div style={style}>
+      {children}
+    </div>
+  );
+};
+
+const themeAttributesPropType = (props, propName, componentName) => {
+  const { theme } = props;
+  let { themeAttributes } = props;
+
+  // Validate types.
+  if (!themeAttributes) {
+    return new Error(`${componentName}: \`themeAttributes\` is required.`);
+  }
+  if (!Array.isArray(themeAttributes)) {
+    return new Error(`${componentName}: \`themeAttributes\` must be an array.`);
+  }
+
+  themeAttributes = [].concat(...themeAttributes);
+  const extraneousThemeAttributes = Object.assign({}, theme);
+  const missingThemeAttributes = [];
+  themeAttributes.forEach((attribute) => {
+    if (theme[attribute]) {
+      delete extraneousThemeAttributes[attribute];
+    } else {
+      missingThemeAttributes.push(attribute);
+    }
+  });
+  const errors = [];
+  if (missingThemeAttributes.length > 0) {
+    errors.push(`${componentName}: To apply theming, the theme prop must include \`${themeAttributes.join(', ')}\` (missing \`${missingThemeAttributes.join(', ')}\`)`); // eslint-disable-line max-len
+  }
+  if (Object.keys(extraneousThemeAttributes).length > 0) {
+    errors.push(`${componentName}: Extraneous theme attributes supplied: \`${Object.keys(extraneousThemeAttributes).join(', ')}\`.`); // eslint-disable-line max-len
+  }
+  if (errors.length > 0) {
+    return new Error(errors.join('\n'));
+  }
+  return false;
+};
+
+BpkThemeProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  themeAttributes: themeAttributesPropType, // eslint-disable-line react/require-default-props
+  // (disabled because isRequired is inside the custom validator)
+};
+
+export default BpkThemeProvider;

--- a/packages/bpk-theming/src/__snapshots__/BpkThemeProvider-test.js.snap
+++ b/packages/bpk-theming/src/__snapshots__/BpkThemeProvider-test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkThemeProvider should correctly flatten the themeAttribute prop 1`] = `
+<div
+  style={
+    Object {
+      "--bpk-background": "black",
+      "--bpk-color": "white",
+    }
+  }
+>
+  <p>
+    Lorem Ipsum
+  </p>
+</div>
+`;
+
+exports[`BpkThemeProvider should render correctly 1`] = `
+<div
+  style={
+    Object {
+      "--bpk-color": "white",
+    }
+  }
+>
+  <p>
+    Lorem Ipsum
+  </p>
+</div>
+`;
+
+exports[`BpkThemeProvider should render without theming when theme is missing attributes 1`] = `
+<div
+  style={Object {}}
+>
+  <p>
+    Lorem Ipsum
+  </p>
+</div>
+`;
+
+exports[`BpkThemeProvider should strip out extraneous theme attributes 1`] = `
+<div
+  style={
+    Object {
+      "--bpk-color": "white",
+    }
+  }
+>
+  <p>
+    Lorem Ipsum
+  </p>
+</div>
+`;

--- a/packages/bpk-theming/stories.js
+++ b/packages/bpk-theming/stories.js
@@ -1,0 +1,91 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import BpkSelect from 'bpk-component-select';
+
+import {
+  colorBlue100,
+  colorBlue500,
+  colorRed100,
+  colorRed500,
+  colorYellow100,
+  colorYellow500,
+} from 'bpk-tokens/tokens/base.es6';
+
+import BpkThemeProvider from './index';
+import BpkThemeableText, {
+  themeAttributes as buttonThemeAttributes,
+} from './bpk-themeable-text/BpkThemeableText';
+
+const generateThemeAttributes = (textColor, textBackgroundColor) => ({
+  textColor,
+  textBackgroundColor,
+});
+
+
+class BpkThemePicker extends Component {
+  constructor(props) {
+    super(props);
+    this.themes = {
+      blue: generateThemeAttributes(colorBlue500, colorBlue100),
+      yellow: generateThemeAttributes(colorYellow500, colorYellow100),
+      red: generateThemeAttributes(colorRed500, colorRed100),
+    };
+    this.state = {
+      themeId: 'blue',
+      theme: this.themes.blue,
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(event) {
+    const { value } = event.target;
+    this.setState({
+      themeId: value,
+      theme: this.themes[value],
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <BpkSelect
+          id="themes"
+          name="themes"
+          value={this.state.themeId}
+          onChange={this.handleChange}
+        >
+          <option value="blue">Blue</option>
+          <option value="yellow">Yellow</option>
+          <option value="red">Red</option>
+        </BpkSelect>
+        <BpkThemeProvider theme={this.state.theme} themeAttributes={[...buttonThemeAttributes]}>
+          <BpkThemeableText>Hello world</BpkThemeableText>
+        </BpkThemeProvider>
+      </div>
+    );
+  }
+}
+
+storiesOf('bpk-theming', module)
+  .add('Default', () => (
+    <BpkThemePicker />
+  ));


### PR DESCRIPTION
- Uses CSS variables to apply theming to `BpkThemeProvider`.
- Components need updating to support theming, for now I've made one called `BpkThemeableText` which is for the storybook. When we have a themeable component, we can delete this.
- If a theme doesn't supply all of the necessary attributes for a specific component to be themed, the theme will not be applied to that component at all (same as native). You can test this by going to `stories.js` and commenting out one of the theme attributes for a theme.