### PR TITLE
[no jira] Hide 'style' from header

### DIFF
--- a/packages/bpk-docs/src/components/Header/Header.js
+++ b/packages/bpk-docs/src/components/Header/Header.js
@@ -34,7 +34,6 @@ const getClassName = cssModules(STYLES);
 
 const headerLinks = [
   { to: ROUTES.USING_BACKPACK, children: 'Using Backpack' },
-  { to: ROUTES.STYLE, children: 'Style' },
   { to: ROUTES.TOKENS, children: 'Tokens' },
   { to: ROUTES.COMPONENTS, children: 'Components' },
   { to: ROUTES.RESOURCES, children: 'Resources' },


### PR DESCRIPTION
There are some things on the _Style_ page that shouldn't be there.

As discussed with @jamesf3rguson, for now we'll just remove the link as the section is outdated anyway.

Obviously this won't prevent people accessing the links directly!