### PR TITLE
[BPK-991] Theme support for bpk-component-blockquote

### DIFF
--- a/packages/bpk-component-blockquote/readme.md
+++ b/packages/bpk-component-blockquote/readme.md
@@ -29,3 +29,7 @@ export default () => (
 | ----------- | -------- | -------- | ------------- |
 | children    | -        | true     | -             |
 | extraSpace  | bool     | false    | false         |
+
+## Theme Props
+
+* `blockquoteBarColor`

--- a/packages/bpk-component-blockquote/src/BpkBlockquote-test.js
+++ b/packages/bpk-component-blockquote/src/BpkBlockquote-test.js
@@ -40,4 +40,3 @@ describe('BpkBlockquote', () => {
     expect(tree).toMatchSnapshot();
   });
 });
-

--- a/packages/bpk-component-blockquote/src/themeAttributes-test.js
+++ b/packages/bpk-component-blockquote/src/themeAttributes-test.js
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 
-import BpkBlockquote from './src/BpkBlockquote';
-import themeAttributes from './src/themeAttributes';
+import themeAttributes from './themeAttributes';
 
-export default BpkBlockquote;
-export { themeAttributes };
+describe('themeAttributes', () => {
+  it('exports the expected themeAttributes', () => {
+    expect(themeAttributes).toEqual(['blockquoteBarColor']);
+  });
+});

--- a/packages/bpk-component-blockquote/src/themeAttributes.js
+++ b/packages/bpk-component-blockquote/src/themeAttributes.js
@@ -16,8 +16,4 @@
  * limitations under the License.
  */
 
-import BpkBlockquote from './src/BpkBlockquote';
-import themeAttributes from './src/themeAttributes';
-
-export default BpkBlockquote;
-export { themeAttributes };
+export default ['blockquoteBarColor'];

--- a/packages/bpk-mixins/src/mixins/_typography.scss
+++ b/packages/bpk-mixins/src/mixins/_typography.scss
@@ -671,12 +671,14 @@
   color: $bpk-color-gray-500;
 
   @include bpk-border-left-lg($bpk-color-blue-500);
+  @include bpk-border-left-lg(var(--bpk-blockquote-bar-color, $bpk-color-blue-500));
 
   @include bpk-rtl {
     padding: $bpk-spacing-xs $bpk-spacing-md $bpk-spacing-xs $bpk-spacing-xs;
     border-left: 0;
 
     @include bpk-border-right-lg($bpk-color-blue-500);
+    @include bpk-border-right-lg(var(--bpk-blockquote-bar-color, $bpk-color-blue-500));
   }
 
   > *:last-child {


### PR DESCRIPTION
I haven't added a changelog entry because I noticed the other PRs for theming didn't include one and assumed it's a deliberate convention.