### PR TITLE
[BPK-975] Make accordions themeable

### DIFF
--- a/.storybook/themeableAttributes.js
+++ b/.storybook/themeableAttributes.js
@@ -20,9 +20,10 @@ import { primaryThemeAttributes, secondaryThemeAttributes } from './../packages/
 
 /* eslint-disable global-require */
 export default {
-  'bpk-component-button': [...primaryThemeAttributes, ...secondaryThemeAttributes],
+  'bpk-component-accordion': require('./../packages/bpk-component-accordion').themeAttributes,
+  'bpk-component-barchart': require('./../packages/bpk-component-barchart').themeAttributes,
   'bpk-component-blockquote': require('./../packages/bpk-component-blockquote').themeAttributes,
+  'bpk-component-button': [...primaryThemeAttributes, ...secondaryThemeAttributes],
   'bpk-component-horizontal-nav': require('./../packages/bpk-component-horizontal-nav').themeAttributes,
   'bpk-component-spinner': require('./../packages/bpk-component-spinner').themeAttributes,
-  'bpk-component-barchart': require('./../packages/bpk-component-barchart').themeAttributes,
 };

--- a/packages/bpk-component-accordion/readme.md
+++ b/packages/bpk-component-accordion/readme.md
@@ -90,3 +90,9 @@ export default () => (
 | Property                       | PropType | Required | Default Value |
 | ------------------------------ | -------- | -------- | ------------- |
 | ~~expanded~~ initiallyExpanded | bool     | false    | false         |
+
+## Theme Props
+
+* `accordionColor`,
+* `accordionHoverColor`,
+* `accordionActiveColor`,

--- a/packages/bpk-component-accordion/src/bpk-accordion-item.scss
+++ b/packages/bpk-component-accordion/src/bpk-accordion-item.scss
@@ -28,21 +28,22 @@
     padding: $bpk-spacing-xs 0;
     border: 0;
     background-color: transparent;
-    color: $bpk-link-color;
     text-align: left;
     cursor: pointer;
     appearance: none;
+
+    @include bpk-themeable-property(color, --bpk-accordion-color, $bpk-link-color);
 
     @include bpk-rtl {
       text-align: right;
     }
 
     @include bpk-hover {
-      color: $bpk-link-hover-color;
+      @include bpk-themeable-property(color, --bpk-accordion-hover-color, $bpk-link-hover-color);
     }
 
     &:active {
-      color: $bpk-link-active-color;
+      @include bpk-themeable-property(color, --bpk-accordion-active-color, $bpk-link-active-color);
     }
   }
 
@@ -62,14 +63,14 @@
   }
 
   &__item-expand-icon {
-    fill: $bpk-link-color;
+    @include bpk-themeable-property(fill, --bpk-accordion-color, $bpk-link-color);
 
     @include bpk-hover {
-      fill: $bpk-link-hover-color;
+      @include bpk-themeable-property(fill, --bpk-accordion-hover-color, $bpk-link-hover-color);
     }
 
     &:active {
-      fill: $bpk-link-active-color;
+      @include bpk-themeable-property(fill, --bpk-accordion-active-color, $bpk-link-active-color);
     }
 
     &--flipped {

--- a/packages/bpk-component-accordion/src/themeAttributes-test.js
+++ b/packages/bpk-component-accordion/src/themeAttributes-test.js
@@ -16,10 +16,14 @@
  * limitations under the License.
  */
 
-import BpkAccordion from './src/BpkAccordion';
-import BpkAccordionItem from './src/BpkAccordionItem';
-import withSingleItemAccordionState from './src/withSingleItemAccordionState';
-import withAccordionItemState from './src/withAccordionItemState';
-import themeAttributes from './src/themeAttributes';
+import themeAttributes from './themeAttributes';
 
-export { BpkAccordion, BpkAccordionItem, withSingleItemAccordionState, withAccordionItemState, themeAttributes };
+describe('themeAttributes', () => {
+  it('should export the expected themeAttributes', () => {
+    expect(themeAttributes).toEqual([
+      'accordionColor',
+      'accordionHoverColor',
+      'accordionActiveColor',
+    ]);
+  });
+});

--- a/packages/bpk-component-accordion/src/themeAttributes.js
+++ b/packages/bpk-component-accordion/src/themeAttributes.js
@@ -16,10 +16,8 @@
  * limitations under the License.
  */
 
-import BpkAccordion from './src/BpkAccordion';
-import BpkAccordionItem from './src/BpkAccordionItem';
-import withSingleItemAccordionState from './src/withSingleItemAccordionState';
-import withAccordionItemState from './src/withAccordionItemState';
-import themeAttributes from './src/themeAttributes';
-
-export { BpkAccordion, BpkAccordionItem, withSingleItemAccordionState, withAccordionItemState, themeAttributes };
+export default [
+  'accordionColor',
+  'accordionHoverColor',
+  'accordionActiveColor',
+];

--- a/packages/bpk-component-theme-toggle/src/theming.js
+++ b/packages/bpk-component-theme-toggle/src/theming.js
@@ -20,6 +20,10 @@ import {
 } from 'bpk-tokens/tokens/base.es6';
 
 const bpkCustomTheme = {
+  accordionActiveColor: '#1a1331',
+  accordionColor: '#461963',
+  accordionHoverColor: '#2d244c',
+
   barchartBarBackgroundColorNormal: '#865f9e',
   barchartBarBackgroundColorHover: '#461962',
   barchartBarBackgroundColorActive: '#2d244c',

--- a/packages/bpk-docs/src/themeableAttributes.js
+++ b/packages/bpk-docs/src/themeableAttributes.js
@@ -20,6 +20,7 @@ import { primaryThemeAttributes, secondaryThemeAttributes } from 'bpk-component-
 
 /* eslint-disable global-require */
 export default [
+  require('bpk-component-accordion').themeAttributes,
   require('bpk-component-barchart').themeAttributes,
   require('bpk-component-blockquote').themeAttributes,
   [...primaryThemeAttributes, ...secondaryThemeAttributes],


### PR DESCRIPTION
I changed the variables from what we initially had in mind. The same variable apply to both the title and icon in normal, active, and hover states.

Theming on the docs

<img width="865" alt="screen shot 2017-11-24 at 2 15 37 pm" src="https://user-images.githubusercontent.com/3579758/33214015-068408b8-d122-11e7-9cbe-086859e9753e.png">

cc @jamesf3rguson 
