### PR TITLE
Add a HOC to BpkBannerAlert to wrap default dismissable/expandable behaviour

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## UNRELEASED
 
-_Nothing yet..._
+**Added:**
+- bpk-component-banner-alert:
+  - `withBannerAlertState` HOC, see https://backpack.github.io/components/web/banner-alerts/#withBannerAlertState
 
 ## 2017-12-14 - React Native text inputs now correctly support placeholders
 

--- a/packages/bpk-component-banner-alert/index.js
+++ b/packages/bpk-component-banner-alert/index.js
@@ -17,6 +17,7 @@
  */
 
 import BpkBannerAlert, { ALERT_TYPES } from './src/BpkBannerAlert';
+import withBannerAlertState from './src/withBannerAlertState';
 
-export { ALERT_TYPES };
+export { ALERT_TYPES, withBannerAlertState };
 export default BpkBannerAlert;

--- a/packages/bpk-component-banner-alert/readme.md
+++ b/packages/bpk-component-banner-alert/readme.md
@@ -70,7 +70,40 @@ export default () => (
 );
 ```
 
+### withBannerAlertState(BpkBannerAlert)
+
+```js
+import React, { Component } from 'react';
+import BpkBannerAlert, { ALERT_TYPES, withBannerAlertState } from 'bpk-component-banner-alert';
+
+const BannerAlertState = withBannerAlertState(BpkBannerAlert);
+
+<BannerAlertState
+  dismissable
+  dismissButtonLabel="Dismiss"
+  message="Successful alert with dismiss option."
+  type={ALERT_TYPES.SUCCESS}
+/>
+
+<BannerAlertState
+  message="Successful alert that will disappear after 5 seconds."
+  hideAfter={5}
+  type={ALERT_TYPES.SUCCESS}
+/>
+
+<BannerAlertState
+  message="Successful alert with expandable option."
+  type={ALERT_TYPES.SUCCESS}
+  toggleButtonLabel="View more"
+>
+  Lorem ipsum dolor sit amet.
+</BannerAlertState>
+```
+
+
 ## Props
+
+### BpkBannerAlert
 
 | Property           | PropType             | Required | Default Value |
 | ------------------ | -------------------- | -------- | ------------- |
@@ -84,5 +117,14 @@ export default () => (
 | dismissButtonLabel | string               | false    | null          |
 | onDismiss          | func                 | false    | null          |
 | show               | bool                 | false    | true          |
+| expanded           | bool                 | false    | false         |
 | toggleButtonLabel  | string               | false    | null          |
+| onExpandToggle     | func                 | false    | null          |
 | className          | string               | false    | null          |
+
+### withBannerAlertState(BpkBannerAlert)
+
+| Property       | PropType | Required | Default Value |
+| -------------- | -------- | -------- | ------------- |
+| hideAfter      | number   | false    | null          |
+| onDismiss      | func     | false    | null          |

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
@@ -85,21 +85,39 @@ describe('BpkBannerAlert', () => {
 
   it('should render correctly with show set false', () => {
     const tree = renderer.create(
-      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} dismissable show={false} />,
+      <BpkBannerAlert
+        type={ALERT_TYPES.WARN}
+        message={message}
+        dismissable
+        dismissButtonLabel="Dismiss"
+        show={false}
+      />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('should render correctly with animateOnEnter', () => {
     const tree = renderer.create(
-      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} dismissable animateOnEnter />,
+      <BpkBannerAlert
+        type={ALERT_TYPES.WARN}
+        message={message}
+        dismissable
+        dismissButtonLabel="Dismiss"
+        animateOnEnter
+      />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('should render correctly with animateOnLeave', () => {
     const tree = renderer.create(
-      <BpkBannerAlert type={ALERT_TYPES.WARN} message={message} dismissable animateOnLeave />,
+      <BpkBannerAlert
+        type={ALERT_TYPES.WARN}
+        message={message}
+        dismissable
+        dismissButtonLabel="Dismiss"
+        animateOnLeave
+      />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
@@ -17,7 +17,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { withButtonAlignment } from 'bpk-component-icon';
 import BpkAnimateHeight from 'bpk-animate-height';
 import BpkCloseButton from 'bpk-component-close-button';
@@ -85,110 +85,98 @@ ToggleButton.propTypes = {
   expanded: PropTypes.bool.isRequired,
 };
 
-class BpkBannerAlert extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      expanded: false,
-    };
-
-    this.onExpand = this.onExpand.bind(this);
-    this.onDismiss = this.onDismiss.bind(this);
-  }
-
-  onExpand() {
-    this.setState(state => ({
-      expanded: !state.expanded,
-    }));
-  }
-
-  onDismiss() {
-    if (this.props.onDismiss) {
-      this.props.onDismiss();
+const BpkBannerAlert = (props) => {
+  const onBannerExpandToggle = () => {
+    if (props.onExpandToggle) {
+      props.onExpandToggle();
     }
+  };
+
+  const onBannerDismiss = () => {
+    if (props.onDismiss) {
+      props.onDismiss();
+    }
+  };
+
+  const {
+    animateOnEnter,
+    animateOnLeave,
+    ariaLive,
+    children,
+    className,
+    dismissable,
+    dismissButtonLabel,
+    message,
+    onDismiss,
+    show,
+    type,
+    toggleButtonLabel,
+    expanded,
+    onExpandToggle,
+    ...rest
+  } = props;
+  const isExpandable = children;
+  const showChildren = isExpandable && expanded;
+  const ariaRoles = ['alert'];
+
+  const headerClassNames = [getClassName('bpk-banner-alert__header')];
+  const sectionClassNames = ['bpk-banner-alert', `bpk-banner-alert--${type}`]
+    .map(sectionClassName => getClassName(sectionClassName));
+
+  if (isExpandable) {
+    headerClassNames.push(getClassName('bpk-banner-alert__header--expandable'));
+    ariaRoles.push('button');
   }
 
-  render() {
-    const {
-      animateOnEnter,
-      animateOnLeave,
-      ariaLive,
-      children,
-      className,
-      dismissable,
-      dismissButtonLabel,
-      message,
-      onDismiss,
-      show,
-      type,
-      toggleButtonLabel,
-      ...rest
-    } = this.props;
-    const isExpanded = this.state.expanded;
-    const isExpandable = children;
-    const showChildren = isExpandable && isExpanded;
-    const ariaRoles = ['alert'];
-
-    const headerClassNames = [getClassName('bpk-banner-alert__header')];
-    const sectionClassNames = ['bpk-banner-alert', `bpk-banner-alert--${type}`]
-      .map(sectionClassName => getClassName(sectionClassName));
-
-    if (isExpandable) {
-      headerClassNames.push(getClassName('bpk-banner-alert__header--expandable'));
-      ariaRoles.push('button');
-    }
-
-    /* eslint-disable
-    jsx-a11y/no-static-element-interactions,
-    jsx-a11y/click-events-have-key-events,
-    jsx-a11y/no-noninteractive-element-interactions
-    */
-    // Disabling 'click-events-have-key-events and interactive-supports-focus' because header element is not focusable.
-    // ToggleButton is focusable and works for this.
-    return (
-      <AnimateAndFade
-        className={className}
-        animateOnEnter={animateOnEnter}
-        animateOnLeave={dismissable || animateOnLeave}
-        show={show}
-      >
-        <section className={sectionClassNames.join(' ')} {...rest}>
-          <header
-            role={ariaRoles.join(' ')}
-            aria-live={ariaLive}
-            className={headerClassNames.join(' ')}
-            onClick={this.onExpand}
-          >
-            <span className={getClassName('bpk-banner-alert__icon')}>{getIconForType(type)}</span>
-          &nbsp;
-            <span className={getClassName('bpk-banner-alert__message')}>{message}</span>
-          &nbsp;
-            {isExpandable && (
-              <span className={getClassName('bpk-banner-alert__toggle')}>
-                <ToggleButton expanded={isExpanded} label={toggleButtonLabel} />
-              </span>
+  /* eslint-disable
+  jsx-a11y/no-static-element-interactions,
+  jsx-a11y/click-events-have-key-events,
+  jsx-a11y/no-noninteractive-element-interactions
+  */
+  // Disabling 'click-events-have-key-events and interactive-supports-focus' because header element is not focusable.
+  // ToggleButton is focusable and works for this.
+  return (
+    <AnimateAndFade
+      className={className}
+      animateOnEnter={animateOnEnter}
+      animateOnLeave={dismissable || animateOnLeave}
+      show={show}
+    >
+      <section className={sectionClassNames.join(' ')} {...rest}>
+        <header
+          role={ariaRoles.join(' ')}
+          aria-live={ariaLive}
+          className={headerClassNames.join(' ')}
+          onClick={onBannerExpandToggle}
+        >
+          <span className={getClassName('bpk-banner-alert__icon')}>{getIconForType(type)}</span>
+        &nbsp;
+          <span className={getClassName('bpk-banner-alert__message')}>{message}</span>
+        &nbsp;
+          {isExpandable && (
+            <span className={getClassName('bpk-banner-alert__toggle')}>
+              <ToggleButton expanded={expanded} label={toggleButtonLabel} />
+            </span>
+        )}
+          {dismissable && (
+            <span className={getClassName('bpk-banner-alert__toggle')}>
+              <BpkCloseButton
+                className={getClassName('bpk-banner-alert__toggle-button')}
+                onClick={onBannerDismiss}
+                aria-label={dismissButtonLabel}
+                label={dismissButtonLabel}
+              />
+            </span>
           )}
-            {dismissable && (
-              <span className={getClassName('bpk-banner-alert__toggle')}>
-                <BpkCloseButton
-                  className={getClassName('bpk-banner-alert__toggle-button')}
-                  onClick={this.onDismiss}
-                  aria-label={dismissButtonLabel}
-                  label={dismissButtonLabel}
-                />
-              </span>
-            )}
-          </header>
-          <BpkAnimateHeight duration={parseInt(durationSm, 10)} height={showChildren ? 'auto' : 0}>
-            <div className={getClassName('bpk-banner-alert__children-container')}>{children}</div>
-          </BpkAnimateHeight>
-        </section>
-      </AnimateAndFade>
-    );
-    /* eslint-enable */
-  }
-}
+        </header>
+        <BpkAnimateHeight duration={parseInt(durationSm, 10)} height={showChildren ? 'auto' : 0}>
+          <div className={getClassName('bpk-banner-alert__children-container')}>{children}</div>
+        </BpkAnimateHeight>
+      </section>
+    </AnimateAndFade>
+  );
+  /* eslint-enable */
+};
 
 BpkBannerAlert.propTypes = {
   type: PropTypes.oneOf([
@@ -206,11 +194,13 @@ BpkBannerAlert.propTypes = {
   animateOnEnter: PropTypes.bool,
   animateOnLeave: PropTypes.bool,
   children: PropTypes.node,
+  expanded: PropTypes.bool,
+  toggleButtonLabel: PropTypes.string,
+  onExpandToggle: PropTypes.func,
   dismissable: PropTypes.bool,
   dismissButtonLabel: PropTypes.string,
   onDismiss: PropTypes.func,
   show: PropTypes.bool,
-  toggleButtonLabel: PropTypes.string,
   className: PropTypes.string,
 };
 
@@ -219,11 +209,13 @@ BpkBannerAlert.defaultProps = {
   animateOnLeave: false,
   ariaLive: ARIA_LIVE.ASSERTIVE,
   children: null,
+  expanded: false,
+  toggleButtonLabel: null,
+  onExpandToggle: null,
   dismissable: false,
   dismissButtonLabel: null,
   onDismiss: null,
   show: true,
-  toggleButtonLabel: null,
   className: null,
 };
 

--- a/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.js.snap
+++ b/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.js.snap
@@ -570,10 +570,10 @@ exports[`BpkBannerAlert should render correctly with animateOnEnter 1`] = `
           className="bpk-banner-alert__toggle"
         >
           <button
-            aria-label={null}
+            aria-label="Dismiss"
             className="bpk-close-button bpk-banner-alert__toggle-button"
             onClick={[Function]}
-            title={null}
+            title="Dismiss"
             type="button"
           >
             <span
@@ -701,10 +701,10 @@ exports[`BpkBannerAlert should render correctly with animateOnLeave 1`] = `
           className="bpk-banner-alert__toggle"
         >
           <button
-            aria-label={null}
+            aria-label="Dismiss"
             className="bpk-close-button bpk-banner-alert__toggle-button"
             onClick={[Function]}
-            title={null}
+            title="Dismiss"
             type="button"
           >
             <span
@@ -1188,10 +1188,10 @@ exports[`BpkBannerAlert should render correctly with show set false 1`] = `
           className="bpk-banner-alert__toggle"
         >
           <button
-            aria-label={null}
+            aria-label="Dismiss"
             className="bpk-close-button bpk-banner-alert__toggle-button"
             onClick={[Function]}
-            title={null}
+            title="Dismiss"
             type="button"
           >
             <span

--- a/packages/bpk-component-banner-alert/src/__snapshots__/withBannerAlertState-test.js.snap
+++ b/packages/bpk-component-banner-alert/src/__snapshots__/withBannerAlertState-test.js.snap
@@ -1,0 +1,523 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withBannerAlertState(BpkBannerAlert) should render correctly 1`] = `
+<div
+  className=""
+  onTransitionEnd={[Function]}
+  style={
+    Object {
+      "MozTransition": "height 200ms ease ",
+      "OTransition": "height 200ms ease ",
+      "WebkitTransition": "height 200ms ease ",
+      "height": "auto",
+      "msTransition": "height 200ms ease ",
+      "overflow": "visible",
+      "transition": "height 200ms ease ",
+    }
+  }
+>
+  <div>
+    <section
+      className="bpk-banner-alert bpk-banner-alert--success"
+    >
+      <header
+        aria-live="assertive"
+        className="bpk-banner-alert__header"
+        onClick={[Function]}
+        role="alert"
+      >
+        <span
+          className="bpk-banner-alert__icon"
+        >
+          <span
+            style={
+              Object {
+                "display": "inline-block",
+                "lineHeight": "1.125rem",
+                "marginTop": "0.1875rem",
+                "verticalAlign": "top",
+              }
+            }
+          >
+            <svg
+              className="bpk-banner-alert__success-icon"
+              height="18"
+              style={
+                Object {
+                  "height": "1.125rem",
+                  "width": "1.125rem",
+                }
+              }
+              viewBox="0 0 24 24"
+              width="18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm5.9 7l-6.5 7.4c-.4.5-1.2.6-1.7.1l-3.5-3.1c-.3-.2-.3-.6-.1-.8l.8-.9c.2-.3.6-.3.8-.1l2.4 2.1c.1.1.3.1.3 0L16 7.4c.2-.2.6-.3.8-.1l.9.8c.3.3.4.6.2.9z"
+              />
+            </svg>
+          </span>
+        </span>
+         
+        <span
+          className="bpk-banner-alert__message"
+        >
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </span>
+         
+      </header>
+      <div
+        onTransitionEnd={[Function]}
+        style={
+          Object {
+            "MozTransition": "height 200ms ease ",
+            "OTransition": "height 200ms ease ",
+            "WebkitTransition": "height 200ms ease ",
+            "height": 0,
+            "msTransition": "height 200ms ease ",
+            "overflow": "hidden",
+            "transition": "height 200ms ease ",
+          }
+        }
+      >
+        <div>
+          <div
+            className="bpk-banner-alert__children-container"
+          />
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`withBannerAlertState(BpkBannerAlert) should render correctly and hide after some seconds 1`] = `
+<div
+  className=""
+  onTransitionEnd={[Function]}
+  style={
+    Object {
+      "MozTransition": "height 200ms ease ",
+      "OTransition": "height 200ms ease ",
+      "WebkitTransition": "height 200ms ease ",
+      "height": "auto",
+      "msTransition": "height 200ms ease ",
+      "overflow": "visible",
+      "transition": "height 200ms ease ",
+    }
+  }
+>
+  <div>
+    <section
+      className="bpk-banner-alert bpk-banner-alert--success"
+    >
+      <header
+        aria-live="assertive"
+        className="bpk-banner-alert__header bpk-banner-alert__header--expandable"
+        onClick={[Function]}
+        role="alert button"
+      >
+        <span
+          className="bpk-banner-alert__icon"
+        >
+          <span
+            style={
+              Object {
+                "display": "inline-block",
+                "lineHeight": "1.125rem",
+                "marginTop": "0.1875rem",
+                "verticalAlign": "top",
+              }
+            }
+          >
+            <svg
+              className="bpk-banner-alert__success-icon"
+              height="18"
+              style={
+                Object {
+                  "height": "1.125rem",
+                  "width": "1.125rem",
+                }
+              }
+              viewBox="0 0 24 24"
+              width="18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm5.9 7l-6.5 7.4c-.4.5-1.2.6-1.7.1l-3.5-3.1c-.3-.2-.3-.6-.1-.8l.8-.9c.2-.3.6-.3.8-.1l2.4 2.1c.1.1.3.1.3 0L16 7.4c.2-.2.6-.3.8-.1l.9.8c.3.3.4.6.2.9z"
+              />
+            </svg>
+          </span>
+        </span>
+         
+        <span
+          className="bpk-banner-alert__message"
+        >
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </span>
+         
+        <span
+          className="bpk-banner-alert__toggle"
+        >
+          <button
+            aria-expanded={false}
+            aria-label="View more"
+            className="bpk-banner-alert__toggle-button"
+            title="View more"
+          >
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "lineHeight": "1.125rem",
+                  "marginTop": "0.1875rem",
+                  "verticalAlign": "top",
+                }
+              }
+            >
+              <svg
+                className="bpk-banner-alert__expand-icon"
+                height="18"
+                style={
+                  Object {
+                    "height": "1.125rem",
+                    "width": "1.125rem",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 17.5l-7.2-6.4c-.6-.5-.7-1.5-.1-2.1.5-.6 1.5-.7 2.1-.1l5.2 4.6 5.2-4.6c.6-.6 1.6-.5 2.1.1s.5 1.6-.1 2.1L12 17.5z"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </header>
+      <div
+        onTransitionEnd={[Function]}
+        style={
+          Object {
+            "MozTransition": "height 200ms ease ",
+            "OTransition": "height 200ms ease ",
+            "WebkitTransition": "height 200ms ease ",
+            "height": 0,
+            "msTransition": "height 200ms ease ",
+            "overflow": "hidden",
+            "transition": "height 200ms ease ",
+          }
+        }
+      >
+        <div>
+          <div
+            className="bpk-banner-alert__children-container"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id
+blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis
+nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at. Mauris
+porta varius ullamcorper. Sed laoreet libero mauris, non pretium lectus accumsan et. Suspendisse vehicula ullamcorper
+sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rhoncus. Fusce id enim porttitor, mattis
+ante in, vestibulum nulla.
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`withBannerAlertState(BpkBannerAlert) should render correctly and hide after some seconds 2`] = `
+<div
+  className=""
+  onTransitionEnd={[Function]}
+  style={
+    Object {
+      "MozTransition": "height 200ms ease ",
+      "OTransition": "height 200ms ease ",
+      "WebkitTransition": "height 200ms ease ",
+      "height": "auto",
+      "msTransition": "height 200ms ease ",
+      "overflow": "visible",
+      "transition": "height 200ms ease ",
+    }
+  }
+>
+  <div />
+</div>
+`;
+
+exports[`withBannerAlertState(BpkBannerAlert) should render correctly collapsed 1`] = `
+<div
+  className=""
+  onTransitionEnd={[Function]}
+  style={
+    Object {
+      "MozTransition": "height 200ms ease ",
+      "OTransition": "height 200ms ease ",
+      "WebkitTransition": "height 200ms ease ",
+      "height": "auto",
+      "msTransition": "height 200ms ease ",
+      "overflow": "visible",
+      "transition": "height 200ms ease ",
+    }
+  }
+>
+  <div>
+    <section
+      className="bpk-banner-alert bpk-banner-alert--success"
+    >
+      <header
+        aria-live="assertive"
+        className="bpk-banner-alert__header bpk-banner-alert__header--expandable"
+        onClick={[Function]}
+        role="alert button"
+      >
+        <span
+          className="bpk-banner-alert__icon"
+        >
+          <span
+            style={
+              Object {
+                "display": "inline-block",
+                "lineHeight": "1.125rem",
+                "marginTop": "0.1875rem",
+                "verticalAlign": "top",
+              }
+            }
+          >
+            <svg
+              className="bpk-banner-alert__success-icon"
+              height="18"
+              style={
+                Object {
+                  "height": "1.125rem",
+                  "width": "1.125rem",
+                }
+              }
+              viewBox="0 0 24 24"
+              width="18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm5.9 7l-6.5 7.4c-.4.5-1.2.6-1.7.1l-3.5-3.1c-.3-.2-.3-.6-.1-.8l.8-.9c.2-.3.6-.3.8-.1l2.4 2.1c.1.1.3.1.3 0L16 7.4c.2-.2.6-.3.8-.1l.9.8c.3.3.4.6.2.9z"
+              />
+            </svg>
+          </span>
+        </span>
+         
+        <span
+          className="bpk-banner-alert__message"
+        >
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </span>
+         
+        <span
+          className="bpk-banner-alert__toggle"
+        >
+          <button
+            aria-expanded={false}
+            aria-label="View more"
+            className="bpk-banner-alert__toggle-button"
+            title="View more"
+          >
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "lineHeight": "1.125rem",
+                  "marginTop": "0.1875rem",
+                  "verticalAlign": "top",
+                }
+              }
+            >
+              <svg
+                className="bpk-banner-alert__expand-icon"
+                height="18"
+                style={
+                  Object {
+                    "height": "1.125rem",
+                    "width": "1.125rem",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 17.5l-7.2-6.4c-.6-.5-.7-1.5-.1-2.1.5-.6 1.5-.7 2.1-.1l5.2 4.6 5.2-4.6c.6-.6 1.6-.5 2.1.1s.5 1.6-.1 2.1L12 17.5z"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </header>
+      <div
+        onTransitionEnd={[Function]}
+        style={
+          Object {
+            "MozTransition": "height 200ms ease ",
+            "OTransition": "height 200ms ease ",
+            "WebkitTransition": "height 200ms ease ",
+            "height": 0,
+            "msTransition": "height 200ms ease ",
+            "overflow": "hidden",
+            "transition": "height 200ms ease ",
+          }
+        }
+      >
+        <div>
+          <div
+            className="bpk-banner-alert__children-container"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id
+blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis
+nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at. Mauris
+porta varius ullamcorper. Sed laoreet libero mauris, non pretium lectus accumsan et. Suspendisse vehicula ullamcorper
+sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rhoncus. Fusce id enim porttitor, mattis
+ante in, vestibulum nulla.
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`withBannerAlertState(BpkBannerAlert) should render correctly expanded 1`] = `
+<div
+  className=""
+  onTransitionEnd={[Function]}
+  style={
+    Object {
+      "MozTransition": "height 200ms ease ",
+      "OTransition": "height 200ms ease ",
+      "WebkitTransition": "height 200ms ease ",
+      "height": "auto",
+      "msTransition": "height 200ms ease ",
+      "overflow": "visible",
+      "transition": "height 200ms ease ",
+    }
+  }
+>
+  <div>
+    <section
+      className="bpk-banner-alert bpk-banner-alert--success"
+    >
+      <header
+        aria-live="assertive"
+        className="bpk-banner-alert__header bpk-banner-alert__header--expandable"
+        onClick={[Function]}
+        role="alert button"
+      >
+        <span
+          className="bpk-banner-alert__icon"
+        >
+          <span
+            style={
+              Object {
+                "display": "inline-block",
+                "lineHeight": "1.125rem",
+                "marginTop": "0.1875rem",
+                "verticalAlign": "top",
+              }
+            }
+          >
+            <svg
+              className="bpk-banner-alert__success-icon"
+              height="18"
+              style={
+                Object {
+                  "height": "1.125rem",
+                  "width": "1.125rem",
+                }
+              }
+              viewBox="0 0 24 24"
+              width="18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm5.9 7l-6.5 7.4c-.4.5-1.2.6-1.7.1l-3.5-3.1c-.3-.2-.3-.6-.1-.8l.8-.9c.2-.3.6-.3.8-.1l2.4 2.1c.1.1.3.1.3 0L16 7.4c.2-.2.6-.3.8-.1l.9.8c.3.3.4.6.2.9z"
+              />
+            </svg>
+          </span>
+        </span>
+         
+        <span
+          className="bpk-banner-alert__message"
+        >
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </span>
+         
+        <span
+          className="bpk-banner-alert__toggle"
+        >
+          <button
+            aria-expanded={true}
+            aria-label="View more"
+            className="bpk-banner-alert__toggle-button"
+            title="View more"
+          >
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "lineHeight": "1.125rem",
+                  "marginTop": "0.1875rem",
+                  "verticalAlign": "top",
+                }
+              }
+            >
+              <svg
+                className="bpk-banner-alert__expand-icon bpk-banner-alert__expand-icon--flipped"
+                height="18"
+                style={
+                  Object {
+                    "height": "1.125rem",
+                    "width": "1.125rem",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 17.5l-7.2-6.4c-.6-.5-.7-1.5-.1-2.1.5-.6 1.5-.7 2.1-.1l5.2 4.6 5.2-4.6c.6-.6 1.6-.5 2.1.1s.5 1.6-.1 2.1L12 17.5z"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </header>
+      <div
+        onTransitionEnd={[Function]}
+        style={
+          Object {
+            "MozTransition": "height 200ms ease ",
+            "OTransition": "height 200ms ease ",
+            "WebkitTransition": "height 200ms ease ",
+            "height": "auto",
+            "msTransition": "height 200ms ease ",
+            "overflow": "visible",
+            "transition": "height 200ms ease ",
+          }
+        }
+      >
+        <div>
+          <div
+            className="bpk-banner-alert__children-container"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id
+blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis
+nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at. Mauris
+porta varius ullamcorper. Sed laoreet libero mauris, non pretium lectus accumsan et. Suspendisse vehicula ullamcorper
+sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rhoncus. Fusce id enim porttitor, mattis
+ante in, vestibulum nulla.
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+`;

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState-test.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState-test.js
@@ -1,0 +1,124 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import renderer from 'react-test-renderer';
+
+import { withDefaultProps } from 'bpk-react-utils';
+import BpkCloseButton from 'bpk-component-close-button';
+
+import BpkBannerAlert, { ALERT_TYPES } from './BpkBannerAlert';
+import withBannerAlertState from './withBannerAlertState';
+
+
+const message = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.';
+const longMessage = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id
+blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis
+nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at. Mauris
+porta varius ullamcorper. Sed laoreet libero mauris, non pretium lectus accumsan et. Suspendisse vehicula ullamcorper
+sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rhoncus. Fusce id enim porttitor, mattis
+ante in, vestibulum nulla.`;
+
+const BannerAlert = withDefaultProps(BpkBannerAlert, {
+  message,
+  type: ALERT_TYPES.SUCCESS,
+  toggleButtonLabel: 'View more',
+  dismissButtonLabel: 'Dismiss',
+});
+const EnhancedComponent = withBannerAlertState(BannerAlert);
+
+describe('withBannerAlertState(BpkBannerAlert)', () => {
+  it('should render correctly', () => {
+    const tree = renderer.create(
+      <EnhancedComponent />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly collapsed', () => {
+    const tree = renderer.create(
+      <EnhancedComponent expanded={false}>
+        {longMessage}
+      </EnhancedComponent>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly expanded', () => {
+    const tree = renderer.create(
+      <EnhancedComponent expanded>
+        {longMessage}
+      </EnhancedComponent>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly and hide after some seconds', () => {
+    jest.useFakeTimers();
+
+    const tree = renderer.create(
+      <EnhancedComponent hideAfter={3}>
+        {longMessage}
+      </EnhancedComponent>,
+    );
+
+    expect(tree.toJSON()).toMatchSnapshot();
+
+    jest.runAllTimers();
+
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  it('should call provided "onDismiss"', () => {
+    const onDismissMock = jest.fn();
+
+    const wrapper = mount(
+      <EnhancedComponent dismissable onDismiss={onDismissMock} />,
+    );
+
+    wrapper.find(BpkCloseButton).first().simulate('click');
+    expect(onDismissMock).toBeCalled();
+  });
+
+  it('should call provided "onDismiss" when hidding automatically', () => {
+    jest.useFakeTimers();
+    const onDismissMock = jest.fn();
+
+    mount(
+      <EnhancedComponent dismissable hideAfter={3} onDismiss={onDismissMock} />,
+    );
+
+    jest.runAllTimers();
+
+    expect(onDismissMock).toBeCalled();
+  });
+
+  it('should call provided "onExpandToggle"', () => {
+    const onExpandMock = jest.fn();
+
+    const wrapper = mount(
+      <EnhancedComponent onExpandToggle={onExpandMock}>
+        {longMessage}
+      </EnhancedComponent>,
+    );
+
+    wrapper.find('button').first().simulate('click');
+    expect(onExpandMock).toBeCalled();
+  });
+});

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState.js
@@ -1,0 +1,116 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { wrapDisplayName } from 'bpk-react-utils';
+
+const withBannerAlertState = (WrappedComponent) => {
+  class component extends Component {
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        expanded: props.expanded,
+        show: true,
+      };
+
+      this.onExpandToggle = this.onExpandToggle.bind(this);
+      this.onDismiss = this.onDismiss.bind(this);
+    }
+
+    componentWillMount() {
+      const { hideAfter } = this.props;
+
+      if (hideAfter && hideAfter > 0) {
+        this.hideIntervalId = setTimeout(() => {
+          this.onDismiss();
+        }, hideAfter * 1000);
+      }
+    }
+
+    componentWillUnmount() {
+      if (this.hideIntervalId) {
+        clearTimeout(this.hideIntervalId);
+      }
+    }
+
+    onExpandToggle() {
+      const expanded = !this.state.expanded;
+      this.setState({ expanded });
+
+      if (this.props.onExpandToggle) {
+        this.props.onExpandToggle(expanded);
+      }
+    }
+
+    onDismiss() {
+      this.setState({ show: false });
+
+      if (this.props.onDismiss) {
+        this.props.onDismiss();
+      }
+    }
+
+    render() {
+      const {
+        onDismiss, onExpandToggle, expanded, show, hideAfter, animateOnLeave, children, ...rest
+      } = this.props;
+
+      return (
+        <WrappedComponent
+          expanded={this.state.expanded}
+          onExpandToggle={this.onExpandToggle}
+          onDismiss={this.onDismiss}
+          show={this.state.show}
+          animateOnLeave={(hideAfter && hideAfter > 0) || animateOnLeave}
+          {...rest}
+        >
+          {children}
+        </WrappedComponent>
+      );
+    }
+  }
+
+  component.displayName = wrapDisplayName(WrappedComponent, 'withBannerAlertState');
+
+  component.propTypes = {
+    onDismiss: PropTypes.func,
+    onExpandToggle: PropTypes.func,
+    expanded: PropTypes.bool,
+    show: PropTypes.bool,
+    hideAfter: PropTypes.number,
+    animateOnLeave: PropTypes.bool,
+    children: PropTypes.node,
+  };
+
+  component.defaultProps = {
+    onDismiss: null,
+    onExpandToggle: null,
+    expanded: false,
+    show: true,
+    hideAfter: null,
+    animateOnLeave: false,
+    children: null,
+  };
+
+  return component;
+};
+
+export default withBannerAlertState;
+

--- a/packages/bpk-component-banner-alert/stories.js
+++ b/packages/bpk-component-banner-alert/stories.js
@@ -21,7 +21,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { fontWeightBold } from 'bpk-tokens/tokens/base.es6';
 
-import BpkBannerAlert, { ALERT_TYPES } from './index';
+import BpkBannerAlert, { ALERT_TYPES, withBannerAlertState } from './index';
 
 const message = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.';
 const longMessage = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id
@@ -30,6 +30,8 @@ nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fr
 porta varius ullamcorper. Sed laoreet libero mauris, non pretium lectus accumsan et. Suspendisse vehicula ullamcorper
 sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rhoncus. Fusce id enim porttitor, mattis
 ante in, vestibulum nulla.`;
+
+const BannerAlertState = withBannerAlertState(BpkBannerAlert);
 
 storiesOf('bpk-component-banner-alert', module)
   .add('Neutral', () => (
@@ -42,7 +44,13 @@ storiesOf('bpk-component-banner-alert', module)
     <BpkBannerAlert message={longMessage} type={ALERT_TYPES.SUCCESS} />
   ))
   .add('Success (dismissable)', () => (
-    <BpkBannerAlert dismissable message={message} type={ALERT_TYPES.SUCCESS} onDismiss={action('dismissed')} />
+    <BpkBannerAlert
+      dismissable
+      dismissButtonLabel="Dismiss"
+      message={message}
+      type={ALERT_TYPES.SUCCESS}
+      onDismiss={action('dismissed')}
+    />
   ))
   .add('Success (animate on enter)', () => (
     <BpkBannerAlert animateOnEnter message={message} type={ALERT_TYPES.SUCCESS} onDismiss={action('dismissed')} />
@@ -68,4 +76,17 @@ storiesOf('bpk-component-banner-alert', module)
   ))
   .add('Error', () => (
     <BpkBannerAlert message={message} type={ALERT_TYPES.ERROR} />
+  ))
+  .add('Success (dismissable behaviour)', () => (
+    <BannerAlertState dismissable dismissButtonLabel="Dismiss" message={message} type={ALERT_TYPES.SUCCESS} />
+  ))
+  .add('Success (expandable behaviour)', () => (
+    <BannerAlertState message={message} type={ALERT_TYPES.SUCCESS} toggleButtonLabel="View more">
+      {longMessage}
+    </BannerAlertState>
+  ))
+  .add('Success (automatically dismissed after 5 seconds)', () => (
+    <BannerAlertState hideAfter={5} message={message} type={ALERT_TYPES.SUCCESS} toggleButtonLabel="View more">
+      {longMessage}
+    </BannerAlertState>
   ));

--- a/packages/bpk-docs/src/pages/BannerAlertsPage/BannerAlertsPage.js
+++ b/packages/bpk-docs/src/pages/BannerAlertsPage/BannerAlertsPage.js
@@ -258,6 +258,19 @@ const components = [
       />,
     ],
   },
+  {
+    id: 'withBannerAlertState',
+    title: 'withBannerAlertState',
+    blurb: [
+      <Paragraph>
+        Most common use of &quot;expandable&quot; and &quot;dismissable&quot; can be easily achieved
+        using the &quot;withBannerAlertState&quot; HOC.
+      </Paragraph>,
+      <Paragraph>
+        It also adds the option to automatically dismiss a banner after a certain period of time has elapsed.
+      </Paragraph>,
+    ],
+  },
 ];
 
 const BannerAlertsPage = () => (<DocsPageBuilder


### PR DESCRIPTION
Hi, as a follow up of https://github.com/Skyscanner/backpack/pull/292 I've created this initial version of the HoC to wrap the default behaviour for `dismissable` and `expandable` (I think it makes more sense and it is easier to use just one HoC wrapping both features instead of two different HoC's, one per feature).

* Remove the `expanded` state from BpkBannerAlert (it was mentioned that this was planned, to be consistent with `dismissable`)
* Create HoC with default behaviour for `dismissable` and `expandable`
* Added the prop `hideAfter` to the HoC, so it can also automatically hide the alert after a period of seconds

What to you think about this approach? If you're fine with this, I'll update the tests, create new tests for the HoC, move BpkBannerAlert into a dumb component (now that it doesn't have state) and update the documentation.