### PR TITLE
Extend drawer content className

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # Backpack changelog
 
 ## UNRELEASED
+**Breaking:**
+-bpk-scrim-utils:
+  - Renamed prop: `contentClassName` to `containerClassName` to better reflect usage
+  - Renamed prop it passes to wrapped component: `getDialogRef` to `dialogRef` to align with convention
+
 **Added:**
 - bpk-mixins:
   - Adds `$bpk-zindex-drawer`

--- a/packages/bpk-component-drawer/readme.md
+++ b/packages/bpk-component-drawer/readme.md
@@ -72,6 +72,7 @@ class App extends Component {
 | --------------------- | -------------------- | -------- | ------------- |
 | id                    | string               | true     | -             |
 | className             | string               | true     | -             |
+| contentClassName      | string               | true     | -             |
 | children              | node                 | true     | -             |
 | isOpen                | bool                 | true     | -             |
 | onClose               | func                 | true     | -             |

--- a/packages/bpk-component-drawer/src/BpkDrawerContent-test.js
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent-test.js
@@ -46,7 +46,7 @@ describe('BpkDrawerContent', () => {
         onCloseAnimationComplete={jest.fn()}
         closeLabel="Close"
         closeEvents={closeEvents}
-        getDialogRef={jest.fn()}
+        dialogRef={jest.fn()}
         isIphone={false}
       >
         Drawer content
@@ -65,7 +65,7 @@ describe('BpkDrawerContent', () => {
         onCloseAnimationComplete={jest.fn()}
         closeLabel="Close"
         closeEvents={closeEvents}
-        getDialogRef={jest.fn()}
+        dialogRef={jest.fn()}
         isIphone={false}
       >
         Drawer content
@@ -84,7 +84,7 @@ describe('BpkDrawerContent', () => {
         onCloseAnimationComplete={jest.fn()}
         closeLabel="Close"
         closeEvents={closeEvents}
-        getDialogRef={jest.fn()}
+        dialogRef={jest.fn()}
         isIphone={false}
       >
         Drawer content
@@ -102,7 +102,7 @@ describe('BpkDrawerContent', () => {
         onCloseAnimationComplete={jest.fn()}
         closeLabel="Close"
         closeEvents={closeEvents}
-        getDialogRef={jest.fn()}
+        dialogRef={jest.fn()}
         hideTitle
       >
         Drawer content

--- a/packages/bpk-component-drawer/src/BpkDrawerContent-test.js
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent-test.js
@@ -74,6 +74,25 @@ describe('BpkDrawerContent', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should render correctly when it has a contentClassName', () => {
+    const tree = renderer.create(
+      <BpkDrawerContent
+        id="my-drawer"
+        contentClassName="my-classname"
+        title="Drawer title"
+        onClose={jest.fn()}
+        onCloseAnimationComplete={jest.fn()}
+        closeLabel="Close"
+        closeEvents={closeEvents}
+        getDialogRef={jest.fn()}
+        isIphone={false}
+      >
+        Drawer content
+      </BpkDrawerContent>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should render correctly with hideTitle', () => {
     const tree = renderer.create(
       <BpkDrawerContent

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.js
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.js
@@ -67,7 +67,7 @@ const BpkDrawerContent = (props) => {
           key="dialog"
           aria-labelledby={headingId}
           className={[drawerClassNames.join(' '), getClassName(`bpk-drawer--${status}`)].join(' ')}
-          ref={props.getDialogRef}
+          ref={props.dialogRef}
           {...props.closeEvents}
         >
           <header className={getClassName('bpk-drawer__header')}>
@@ -94,7 +94,7 @@ const BpkDrawerContent = (props) => {
 };
 
 BpkDrawerContent.propTypes = {
-  getDialogRef: PropTypes.func.isRequired,
+  dialogRef: PropTypes.func.isRequired,
   closeEvents: PropTypes.shape({
     onTouchStart: PropTypes.func,
     onTouchMove: PropTypes.func,

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.js
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.js
@@ -29,15 +29,20 @@ import STYLES from './bpk-drawer-content.scss';
 const getClassName = cssModules(STYLES);
 
 const BpkDrawerContent = (props) => {
-  const contentClassNames = [getClassName('bpk-drawer')];
+  const drawerClassNames = [getClassName('bpk-drawer')];
   const headerClassNames = [getClassName('bpk-drawer__heading')];
+  const contentClassNames = [getClassName('bpk-drawer__content')];
 
   if (props.className) {
-    contentClassNames.push(props.className);
+    drawerClassNames.push(props.className);
   }
 
   if (props.hideTitle) {
     headerClassNames.push(getClassName('bpk-drawer__heading--visually-hidden'));
+  }
+
+  if (props.contentClassName) {
+    contentClassNames.push(props.contentClassName);
   }
 
   const headingId = `bpk-drawer-heading-${props.id}`;
@@ -61,7 +66,7 @@ const BpkDrawerContent = (props) => {
           role="dialog"
           key="dialog"
           aria-labelledby={headingId}
-          className={[contentClassNames.join(' '), getClassName(`bpk-drawer--${status}`)].join(' ')}
+          className={[drawerClassNames.join(' '), getClassName(`bpk-drawer--${status}`)].join(' ')}
           ref={props.getDialogRef}
           {...props.closeEvents}
         >
@@ -79,7 +84,7 @@ const BpkDrawerContent = (props) => {
               />
             }
           </header>
-          <div className={getClassName('bpk-drawer__content')}>
+          <div className={contentClassNames.join(' ')}>
             {props.children}
           </div>
         </section>
@@ -103,6 +108,7 @@ BpkDrawerContent.propTypes = {
   onClose: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
   className: PropTypes.string,
+  contentClassName: PropTypes.string,
   title: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   closeLabel: PropTypes.string,
@@ -112,6 +118,7 @@ BpkDrawerContent.propTypes = {
 
 BpkDrawerContent.defaultProps = {
   className: null,
+  contentClassName: null,
   closeLabel: null,
   closeText: null,
   isDrawerShown: true,

--- a/packages/bpk-component-drawer/src/__snapshots__/BpkDrawerContent-test.js.snap
+++ b/packages/bpk-component-drawer/src/__snapshots__/BpkDrawerContent-test.js.snap
@@ -138,6 +138,75 @@ exports[`BpkDrawerContent should render correctly when it has a className 1`] = 
 </section>
 `;
 
+exports[`BpkDrawerContent should render correctly when it has a contentClassName 1`] = `
+<section
+  aria-labelledby="bpk-drawer-heading-my-drawer"
+  className="bpk-drawer bpk-drawer--entered"
+  id="my-drawer"
+  onMouseDown={[Function]}
+  onMouseMove={[Function]}
+  onMouseUp={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  role="dialog"
+  tabIndex="-1"
+>
+  <header
+    className="bpk-drawer__header"
+  >
+    <h2
+      className="bpk-drawer__heading"
+      id="bpk-drawer-heading-my-drawer"
+    >
+      Drawer title
+    </h2>
+     
+    <button
+      aria-label="Close"
+      className="bpk-close-button bpk-drawer__close-button"
+      onClick={[Function]}
+      title="Close"
+      type="button"
+    >
+      <span
+        style={
+          Object {
+            "display": "inline-block",
+            "lineHeight": "1.125rem",
+            "marginTop": "0.1875rem",
+            "verticalAlign": "top",
+          }
+        }
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.8 12l4.9-4.9c.4-.4.4-1 0-1.4l-1.4-1.4c-.4-.4-1-.4-1.4 0L12 9.2l-4.9-5c-.4-.4-1-.4-1.4 0L4.2 5.6c-.4.4-.4 1 0 1.4l5 5-4.9 4.9c-.4.4-.4 1 0 1.4l1.4 1.4c.4.4 1 .4 1.4 0l4.9-4.9 4.9 4.9c.4.4 1 .4 1.4 0l1.4-1.4c.4-.4.4-1 0-1.4L14.8 12z"
+          />
+        </svg>
+      </span>
+    </button>
+  </header>
+  <div
+    className="bpk-drawer__content my-classname"
+  >
+    Drawer content
+  </div>
+</section>
+`;
+
 exports[`BpkDrawerContent should render correctly with hideTitle 1`] = `
 <section
   aria-labelledby="bpk-drawer-heading-my-drawer"

--- a/packages/bpk-component-drawer/src/bpk-drawer-content.scss
+++ b/packages/bpk-component-drawer/src/bpk-drawer-content.scss
@@ -21,10 +21,12 @@
 .bpk-drawer {
   position: fixed;
   right: 0;
+  display: flex;
   z-index: $bpk-zindex-drawer;
   width: 90%;
   max-width: 67 * $bpk-spacing-xs;
   height: 100%;
+  flex-direction: column;
   transform: translate(100%);
   transition: transform $bpk-duration-sm ease;
   outline: 0;
@@ -66,6 +68,7 @@
     min-height: #{2 * $bpk-spacing-sm + $bpk-text-base-line-height}; // keep height the same if visually hidden title
     padding: $bpk-spacing-sm;
     justify-content: space-between;
+    flex: 0 0;
 
     @include bpk-border-bottom-sm($bpk-color-gray-100);
   }
@@ -90,5 +93,6 @@
 
   &__content {
     padding: $bpk-spacing-sm;
+    flex: 1 1 100%;
   }
 }

--- a/packages/bpk-component-drawer/stories.js
+++ b/packages/bpk-component-drawer/stories.js
@@ -249,4 +249,18 @@ storiesOf('bpk-component-drawer', module)
     >
       This is a default drawer. You can put anything you want in here.
     </DrawerContainer>
+  ))
+  .add('With full height content', () => (
+    <DrawerContainer
+      title="Drawer title"
+      closeLabel="Close drawer"
+      buttonText="Open drawer"
+      getApplicationElement={() => document.getElementById('application-container')}
+      contentClassName={getClassName('bpk-drawer-content-container')}
+    >
+      This is a flex drawer. You can put anything you want in here.
+      <BpkButton secondary className={getClassName('bpk-drawer-button')}>
+        I don&apos;t do anything.
+      </BpkButton>
+    </DrawerContainer>
   ));

--- a/packages/bpk-component-drawer/stories.scss
+++ b/packages/bpk-component-drawer/stories.scss
@@ -21,3 +21,12 @@
 .bpk-drawer-paragraph {
   margin-bottom: $bpk-spacing-xs;
 }
+
+.bpk-drawer-content-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.bpk-drawer-button {
+  margin: auto auto 0;
+}

--- a/packages/bpk-component-modal/src/BpkModal.js
+++ b/packages/bpk-component-modal/src/BpkModal.js
@@ -36,7 +36,7 @@ const BpkModal = (props) => {
 
   return (
     <Portal isOpen={isOpen} onClose={onClose} target={target}>
-      <ScrimBpkModalDialog onClose={onClose} {...rest} contentClassName={getClassName('bpk-modal__container')} />
+      <ScrimBpkModalDialog onClose={onClose} {...rest} containerClassName={getClassName('bpk-modal__container')} />
     </Portal>
   );
 };

--- a/packages/bpk-component-modal/src/BpkModalDialog-test.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog-test.js
@@ -43,7 +43,7 @@ describe('BpkModalDialog', () => {
         onClose={jest.fn()}
         closeLabel="Close"
         closeEvents={closeEvents}
-        getDialogRef={jest.fn()}
+        dialogRef={jest.fn()}
         isIphone={false}
       >
         Modal content
@@ -61,7 +61,7 @@ describe('BpkModalDialog', () => {
         onClose={jest.fn()}
         closeLabel="Close"
         closeEvents={closeEvents}
-        getDialogRef={jest.fn()}
+        dialogRef={jest.fn()}
         isIphone={false}
       >
         Modal content
@@ -78,7 +78,7 @@ describe('BpkModalDialog', () => {
         onClose={jest.fn()}
         closeLabel="Close"
         closeEvents={closeEvents}
-        getDialogRef={jest.fn()}
+        dialogRef={jest.fn()}
         isIphone
       >
         Modal content

--- a/packages/bpk-component-modal/src/BpkModalDialog.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog.js
@@ -48,7 +48,7 @@ const BpkModalDialog = (props) => {
         role="dialog"
         aria-labelledby={headingId}
         className={classNames.join(' ')}
-        ref={props.getDialogRef}
+        ref={props.dialogRef}
         {...props.closeEvents}
       >
         <header className={getClassName('bpk-modal__header')}>
@@ -84,7 +84,7 @@ BpkModalDialog.propTypes = {
   closeText: PropTypes.string,
   wide: PropTypes.bool,
   isIphone: PropTypes.bool.isRequired,
-  getDialogRef: PropTypes.func.isRequired,
+  dialogRef: PropTypes.func.isRequired,
   closeEvents: PropTypes.shape({
     onTouchStart: PropTypes.func,
     onTouchMove: PropTypes.func,

--- a/packages/bpk-scrim-utils/readme.md
+++ b/packages/bpk-scrim-utils/readme.md
@@ -13,7 +13,7 @@ import { withScrim } from 'bpk-scrim-utils';
 
 const Box = props => (
   <div 
-    ref={props.getDialogRef}
+    ref={props.dialogRef}
     {...props.closeEvents}
   >
     <BpkButton onClick={props.onClose}>Close</BpkButton>
@@ -25,7 +25,7 @@ const BoxWithScrim = withScrim(Box);
 ```
 
 `withScrim` sends all props it receives down to the component, except `getApplicationElement` and `padded`. It also adds some props that are used for a11y and closing the modal:
-- `getDialogRef` should be set as the ref on the visible container on top of the scrim; it is used to set focus
+- `dialogRef` should be set as the ref on the visible container on top of the scrim; it is used to set focus
 - `closeEvents` should be spread on the visible container on top of the scrim; they are used to close handle clicking, tapping, or dragging between component and scrim
 - `onClose` should be set as the `onClick` action on a button or a link
 - `isIphone` can be used to apply iPhone only styles or behaviour, as it has different scrolling behaviour

--- a/packages/bpk-scrim-utils/readme.md
+++ b/packages/bpk-scrim-utils/readme.md
@@ -30,7 +30,7 @@ const BoxWithScrim = withScrim(Box);
 - `onClose` should be set as the `onClick` action on a button or a link
 - `isIphone` can be used to apply iPhone only styles or behaviour, as it has different scrolling behaviour
 
-`contentClassName` can be used to apply styles to the full-screen container into which the enriched component is inserted
+`containerClassName` can be used to apply styles to the full-screen container into which the enriched component is inserted
  (eg. `display: flex` or `display: grid`)
 
 ### Props
@@ -40,4 +40,4 @@ const BoxWithScrim = withScrim(Box);
 | onClose               | func     | true     | -             |
 | getApplicationElement | func     | true     | -             |
 | isIphone              | bool     | false    | /iPhone/i.test(typeof window !== 'undefined' ? window.navigator.platform : '')|
-| contentClassName      | string   | false    | ''            |
+| containerClassName    | string   | false    | ''            |

--- a/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
+++ b/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
@@ -66,13 +66,13 @@ exports[`BpkScrim render should render correctly when is iPhone 1`] = `
 </div>
 `;
 
-exports[`BpkScrim render should render correctly with contentClassName 1`] = `
+exports[`BpkScrim render should render correctly with containerClassName 1`] = `
 <div>
   <div
     className="bpk-scrim"
   />
   <div
-    className="bpk-scrim-content contentClassName"
+    className="bpk-scrim-content containerClassName"
     onMouseDown={[Function]}
     onMouseMove={[Function]}
     onMouseUp={[Function]}

--- a/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
+++ b/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
@@ -25,7 +25,7 @@ exports[`BpkScrim render should render correctly 1`] = `
           "onTouchStart": [Function],
         }
       }
-      getDialogRef={[Function]}
+      dialogRef={[Function]}
       isIphone={false}
       onClose={[Function]}
     />
@@ -58,7 +58,7 @@ exports[`BpkScrim render should render correctly when is iPhone 1`] = `
           "onTouchStart": [Function],
         }
       }
-      getDialogRef={[Function]}
+      dialogRef={[Function]}
       isIphone={true}
       onClose={[Function]}
     />
@@ -91,7 +91,7 @@ exports[`BpkScrim render should render correctly with containerClassName 1`] = `
           "onTouchStart": [Function],
         }
       }
-      getDialogRef={[Function]}
+      dialogRef={[Function]}
       isIphone={false}
       onClose={[Function]}
     />

--- a/packages/bpk-scrim-utils/src/withScrim-test.js
+++ b/packages/bpk-scrim-utils/src/withScrim-test.js
@@ -72,12 +72,12 @@ describe('BpkScrim', () => {
       expect(tree).toMatchSnapshot();
     });
 
-    it('should render correctly with contentClassName', () => {
+    it('should render correctly with containerClassName', () => {
       const tree = renderer.create(
         <Component
           onClose={jest.fn()}
           getApplicationElement={jest.fn()}
-          contentClassName="contentClassName"
+          containerClassName="containerClassName"
         />,
       ).toJSON();
       expect(tree).toMatchSnapshot();

--- a/packages/bpk-scrim-utils/src/withScrim.js
+++ b/packages/bpk-scrim-utils/src/withScrim.js
@@ -38,7 +38,7 @@ const withScrim = (WrappedComponent) => {
       this.onDocumentMove = this.onDocumentMove.bind(this);
       this.onOverlayMouseDown = this.onOverlayMouseDown.bind(this);
       this.onOverlayMouseUp = this.onOverlayMouseUp.bind(this);
-      this.getDialogRef = this.getDialogRef.bind(this);
+      this.dialogRef = this.dialogRef.bind(this);
 
       this.shouldClose = false;
     }
@@ -104,7 +104,7 @@ const withScrim = (WrappedComponent) => {
       this.shouldClose = false;
     }
 
-    getDialogRef(ref) {
+    dialogRef(ref) {
       this.dialogElement = ref;
     }
 
@@ -145,7 +145,7 @@ const withScrim = (WrappedComponent) => {
             <WrappedComponent
               {...rest}
               isIphone={isIphone}
-              getDialogRef={this.getDialogRef}
+              dialogRef={this.dialogRef}
               closeEvents={closeEvents}
             />
           </div>

--- a/packages/bpk-scrim-utils/src/withScrim.js
+++ b/packages/bpk-scrim-utils/src/withScrim.js
@@ -112,13 +112,13 @@ const withScrim = (WrappedComponent) => {
       const {
         isIphone,
         getApplicationElement,
-        contentClassName,
+        containerClassName,
         ...rest
       } = this.props;
 
       const classNames = [getClassName('bpk-scrim-content')];
       if (isIphone) { classNames.push(getClassName('bpk-scrim-content--iphone-fix')); }
-      classNames.push(contentClassName);
+      classNames.push(containerClassName);
 
       const closeEvents = {
         onTouchStart: this.onContentMouseDown,
@@ -161,12 +161,12 @@ const withScrim = (WrappedComponent) => {
     onClose: PropTypes.func.isRequired,
     getApplicationElement: PropTypes.func.isRequired,
     isIphone: PropTypes.bool,
-    contentClassName: PropTypes.string,
+    containerClassName: PropTypes.string,
   };
 
   component.defaultProps = {
     isIphone: /iPhone/i.test(typeof window !== 'undefined' ? window.navigator.platform : ''),
-    contentClassName: '',
+    containerClassName: '',
   };
 
   return component;


### PR DESCRIPTION
For the implementation of the menu in the header, we need to inject styles into the container element of the drawer (ie. make it display: flex). This enables that and refactors bpk-scrim-utils to enable this.

It also fixes the name of the getDialogRef prop.

