### PR TITLE
[BPK-979] Add theming for calendar

### DIFF
--- a/.storybook/themeableAttributes.js
+++ b/.storybook/themeableAttributes.js
@@ -24,6 +24,7 @@ export default {
   'bpk-component-barchart': require('./../packages/bpk-component-barchart').themeAttributes,
   'bpk-component-blockquote': require('./../packages/bpk-component-blockquote').themeAttributes,
   'bpk-component-button': [...primaryThemeAttributes, ...secondaryThemeAttributes],
+  'bpk-component-calendar': require('./../packages/bpk-component-calendar').themeAttributes,
   'bpk-component-link': require('./../packages/bpk-component-link').themeAttributes,
   'bpk-component-horizontal-nav': require('./../packages/bpk-component-horizontal-nav').themeAttributes,
   'bpk-component-nudger': require('./../packages/bpk-component-nudger').themeAttributes,

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@
   - Adds `$bpk-zindex-drawer`
 - bpk-tokens:
   - Adds value for drawer z-index.
+- bpk-component-calendar:
+  - Calendar now supports theming.
 
 ## 2017-11-28 - Add support for refs in react-native-bpk-component-input
 

--- a/packages/bpk-component-calendar/index.js
+++ b/packages/bpk-component-calendar/index.js
@@ -24,6 +24,7 @@ import BpkCalendarDate from './src/BpkCalendarDate';
 import composeCalendar from './src/composeCalendar';
 import CustomPropTypes from './src/custom-proptypes';
 import * as DateUtils from './src/date-utils';
+import themeAttributes from './src/themeAttributes';
 
 export default BpkCalendarContainer;
 
@@ -36,4 +37,5 @@ export {
   DateUtils,
   composeCalendar,
   withCalendarState,
+  themeAttributes,
 };

--- a/packages/bpk-component-calendar/readme.md
+++ b/packages/bpk-component-calendar/readme.md
@@ -322,4 +322,16 @@ const onMonthChange = (event, {
 
 Sets the date that is focused initially, this prop has no effect if `selectedDate` or the deprecated `date` prop are specified in which case the date specified in those props is focused. If no selected date is set and `initiallyFocusedDate` is not set the focused date is the `minDate`(defaults to today if it has not been explicitly set).
 
+## Theme Props
+
+* `calendarDateTextColor`
+* `calendarDateTextHoverColor`
+* `calendarDateTextActiveColor`
+* `calendarDateTextFocusColor`
+* `calendarDateTextSelectedColor`
+* `calendarDateSelectedBackgroundColor`
+* `calendarDateFocusedBorderColor`
+* `calendarNudgerIconColor`
+* `calendarNudgerIconHoverColor`
+* `calendarNudgerIconActiveColor`
 

--- a/packages/bpk-component-calendar/src/bpk-calendar-date.scss
+++ b/packages/bpk-component-calendar/src/bpk-calendar-date.scss
@@ -25,23 +25,26 @@
   border: none;
   border-radius: $bpk-border-radius-pill;
   background-color: $bpk-calendar-day-background-color;
-  color: $bpk-calendar-day-color;
   font-size: $bpk-font-size-base;
   text-align: center;
   cursor: pointer;
   appearance: none;
   box-sizing: border-box;
 
+  @include bpk-themeable-property(color, --bpk-calendar-date-text-color, $bpk-calendar-day-color);
+
   @include bpk-hover {
     &:not(.bpk-calendar-date--selected) {
       background-color: $bpk-calendar-day-hover-background-color;
-      color: $bpk-calendar-day-hover-color;
+
+      @include bpk-themeable-property(color, --bpk-calendar-date-text-hover-color, $bpk-calendar-day-hover-color);
     }
   }
 
   &:not(.bpk-calendar-date--selected):active {
     background-color: $bpk-calendar-day-active-background-color;
-    color: $bpk-calendar-day-active-color;
+
+    @include bpk-themeable-property(color, --bpk-calendar-date-text-active-color, $bpk-calendar-day-active-color);
   }
 
   &--outside {
@@ -54,15 +57,18 @@
   }
 
   &--selected {
-    background-color: $bpk-state-selected-background-color;
-    color: $bpk-calendar-day-selected-color;
     font-weight: bold;
     cursor: default;
+
+    @include bpk-themeable-property(background-color, --bpk-calendar-date-selected-background-color, $bpk-state-selected-background-color);
+    @include bpk-themeable-property(color, --bpk-calendar-date-text-selected-color, $bpk-calendar-day-selected-color);
   }
 
   &--focused:not(:disabled):not(.bpk-calendar-date--selected) {
-    color: $bpk-state-selected-background-color;
     box-shadow: 0 0 0 2px $bpk-state-selected-background-color inset;
+    box-shadow: 0 0 0 2px var(--bpk-calendar-date-focused-border-color, $bpk-state-selected-background-color) inset;
+
+    @include bpk-themeable-property(color, --bpk-calendar-date-text-focus-color, $bpk-state-selected-background-color);
   }
 
   &:disabled {

--- a/packages/bpk-component-calendar/src/bpk-calendar-nav.scss
+++ b/packages/bpk-component-calendar/src/bpk-calendar-nav.scss
@@ -47,20 +47,20 @@
     cursor: pointer;
     appearance: none;
 
+    @include bpk-themeable-property(color, --bpk-calendar-nudger-icon-color, $bpk-calendar-nav-icon-fill);
+
     @include bpk-hover {
-      .bpk-calendar-nav__icon {
-        fill: $bpk-calendar-nav-icon-hover-fill;
-      }
+      @include bpk-themeable-property(color, --bpk-calendar-nudger-icon-hover-color, $bpk-calendar-nav-icon-hover-fill);
+    }
+
+    &:active {
+      @include bpk-themeable-property(color, --bpk-calendar-nudger-icon-active-color, $bpk-calendar-nav-icon-active-fill);
     }
 
     .bpk-calendar-nav__icon {
-      fill: $bpk-calendar-nav-icon-fill;
+      fill: currentColor;
 
       @include bpk-icon--rtl-support;
-    }
-
-    &:active .bpk-calendar-nav__icon {
-      fill: $bpk-calendar-nav-icon-active-fill;
     }
 
     &:disabled {

--- a/packages/bpk-component-calendar/src/themeAttributes-test.js
+++ b/packages/bpk-component-calendar/src/themeAttributes-test.js
@@ -1,0 +1,36 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import themeAttributes from './themeAttributes';
+
+describe('themeAttributes', () => {
+  it('should export the expected themeAttributes', () => {
+    expect(themeAttributes).toEqual([
+      'calendarDateTextColor',
+      'calendarDateTextHoverColor',
+      'calendarDateTextActiveColor',
+      'calendarDateTextFocusColor',
+      'calendarDateTextSelectedColor',
+      'calendarDateSelectedBackgroundColor',
+      'calendarDateFocusedBorderColor',
+      'calendarNudgerIconColor',
+      'calendarNudgerIconHoverColor',
+      'calendarNudgerIconActiveColor',
+    ]);
+  });
+});

--- a/packages/bpk-component-calendar/src/themeAttributes.js
+++ b/packages/bpk-component-calendar/src/themeAttributes.js
@@ -1,0 +1,30 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default [
+  'calendarDateTextColor',
+  'calendarDateTextHoverColor',
+  'calendarDateTextActiveColor',
+  'calendarDateTextFocusColor',
+  'calendarDateTextSelectedColor',
+  'calendarDateSelectedBackgroundColor',
+  'calendarDateFocusedBorderColor',
+  'calendarNudgerIconColor',
+  'calendarNudgerIconHoverColor',
+  'calendarNudgerIconActiveColor',
+];

--- a/packages/bpk-component-theme-toggle/src/theming.js
+++ b/packages/bpk-component-theme-toggle/src/theming.js
@@ -19,6 +19,8 @@ import {
   horizontalNavLinkColor,
   horizontalNavLinkHoverColor,
   horizontalNavLinkActiveColor,
+  calendarDayHoverColor,
+  calendarDayActiveColor,
 } from 'bpk-tokens/tokens/base.es6';
 
 const theme = {
@@ -78,6 +80,17 @@ const bpkCustomTheme = {
   spinnerPrimaryColor: theme.primaryColor500,
 
   progressBarFillColor: theme.primaryColor500,
+
+  calendarDateTextColor: theme.primaryColor500,
+  calendarDateTextHoverColor: calendarDayHoverColor,
+  calendarDateTextActiveColor: calendarDayActiveColor,
+  calendarDateTextFocusColor: theme.primaryColor500,
+  calendarDateTextSelectedColor: theme.white,
+  calendarDateSelectedBackgroundColor: theme.primaryColor700,
+  calendarDateFocusedBorderColor: theme.primaryColor500,
+  calendarNudgerIconColor: theme.primaryColor500,
+  calendarNudgerIconHoverColor: theme.primaryColor600,
+  calendarNudgerIconActiveColor: theme.primaryColor700,
 };
 
 export default bpkCustomTheme;

--- a/packages/bpk-docs/src/pages/ThemingPage/ThemingPage.js
+++ b/packages/bpk-docs/src/pages/ThemingPage/ThemingPage.js
@@ -29,6 +29,7 @@ import {
   ACCORDIONS,
   BARCHARTS,
   BUTTONS,
+  CALENDAR,
   HORIZONTAL_NAV,
   PROGRESS,
   NATIVE_BUTTON,
@@ -83,6 +84,9 @@ const components = [
         </BpkListItem>
         <BpkListItem>
           <BpkLink href={BUTTONS}>Buttons</BpkLink>
+        </BpkListItem>
+        <BpkListItem>
+          <BpkLink href={CALENDAR}>Calendars</BpkLink>
         </BpkListItem>
         <BpkListItem>
           <BpkLink href={HORIZONTAL_NAV}>Horizontal navigation</BpkLink>

--- a/packages/bpk-docs/src/themeableAttributes.js
+++ b/packages/bpk-docs/src/themeableAttributes.js
@@ -24,6 +24,7 @@ export default [
   require('bpk-component-barchart').themeAttributes,
   require('bpk-component-blockquote').themeAttributes,
   [...primaryThemeAttributes, ...secondaryThemeAttributes],
+  require('bpk-component-calendar').themeAttributes,
   require('bpk-component-link').themeAttributes,
   require('bpk-component-horizontal-nav').themeAttributes,
   require('bpk-component-nudger').themeAttributes,


### PR DESCRIPTION
This adds support for theming the calendar. On top of the specified themeable attributes I had to add `calendarDateTextFocusColor` and `calendarDateFocusedBorderColor` which were not accounted for.

![](https://media.giphy.com/media/l2Rnla2UTBZk95GzS/giphy.gif)

**Note:** The Datepicker suffers from the same issues as all components that use the portal, namely it doesn't work.

cc @jamesf3rguson, @matthewdavidson 