### PR TITLE
Fix stray character in the readme for bpk-component-slider

### DIFF
--- a/packages/bpk-component-slider/readme.md
+++ b/packages/bpk-component-slider/readme.md
@@ -34,4 +34,4 @@ const Slider = () => (
 | Property                 | PropType                      | Required | Default Value |
 | ------------------------ | ----------------------------- | -------- | ------------- |
 | className                | string                        | false    | null          |
-| large                    | bool                          | false    | false         |u
+| large                    | bool                          | false    | false         |


### PR DESCRIPTION
you can see the stray 'u' here: https://backpack.github.io/components/web/sliders#props