### PR TITLE
[BPK-1140] pagination theming

### DIFF
--- a/.storybook/themeableAttributes.js
+++ b/.storybook/themeableAttributes.js
@@ -28,6 +28,7 @@ import { themeAttributes as horizontalNavThemeAttributes } from './../packages/b
 import { themeAttributes as linkThemeAttributes } from './../packages/bpk-component-link';
 import { themeAttributes as modalThemeAttributes } from './../packages/bpk-component-modal';
 import { themeAttributes as nudgerThemeAttributes } from './../packages/bpk-component-nudger';
+import { themeAttributes as paginationThemeAttributes } from './../packages/bpk-component-pagination';
 import { themeAttributes as popoverThemeAttributes } from './../packages/bpk-component-popover';
 import { themeAttributes as progressThemeAttributes } from './../packages/bpk-component-progress';
 import { themeAttributes as radioThemeAttributes } from './../packages/bpk-component-radio';
@@ -48,6 +49,7 @@ export default [
   ...linkThemeAttributes,
   ...modalThemeAttributes,
   ...nudgerThemeAttributes,
+  ...paginationThemeAttributes,
   ...popoverThemeAttributes,
   ...progressThemeAttributes,
   ...radioThemeAttributes,

--- a/packages/bpk-component-pagination/index.js
+++ b/packages/bpk-component-pagination/index.js
@@ -17,5 +17,7 @@
  */
 
 import BpkPagination from './src/BpkPagination';
+import themeAttributes from './src/themeAttributes';
 
 export default BpkPagination;
+export { themeAttributes };

--- a/packages/bpk-component-pagination/readme.md
+++ b/packages/bpk-component-pagination/readme.md
@@ -18,7 +18,7 @@ const Pagination = () => (
   <BpkPagination
     pageCount={20}
     selectedPageIndex={0}
-    onPageChange={(pageIndex) => alert(`page ${pageIndex + 1}`)}}
+    onPageChange={pageIndex => alert(`page ${pageIndex + 1}`)}
     previousLabel="previous"
     nextLabel="next"
     visibleRange={3}
@@ -38,3 +38,19 @@ const Pagination = () => (
 | onPageChange      | func                 | false    | null          |
 | visibleRange      | number               | false    | 3             |
 | className         | string               | false    | null          |
+
+## Theme Props
+
+* `buttonSecondaryTextColor`
+* `buttonSecondaryHoverTextColor`
+* `buttonSecondaryActiveTextColor`
+* `buttonSecondaryBorderColor`
+* `buttonSecondaryHoverBorderColor`
+* `buttonSecondaryActiveBorderColor`
+* `buttonSecondaryBackgroundColor`
+* `buttonSecondaryHoverBackgroundColor`
+* `buttonSecondaryActiveBackgroundColor`
+* `paginationNudgerActiveColor`
+* `paginationNudgerColor`
+* `paginationNudgerHoverColor`
+* `paginationSelectedBackgroundColor`

--- a/packages/bpk-component-pagination/src/BpkPaginationPage.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationPage.js
@@ -26,19 +26,20 @@ import STYLES from './bpk-pagination-page.scss';
 const getClassName = cssModules(STYLES);
 
 const BpkPaginationPage = (props) => {
+  const classNames = [getClassName('bpk-pagination-page')];
   const {
     label, onSelect, isSelected,
   } = props;
 
+  if (isSelected) { classNames.push(getClassName('bpk-pagination-page--selected')); }
+
   return (
     <BpkButton
-      iconOnly
       secondary
-      selected={isSelected}
       onClick={onSelect}
-      className={getClassName('bpk-pagination-page')}
+      className={classNames.join(' ')}
     >
-      <span>{ label }</span>
+      <span>{label}</span>
     </BpkButton>
   );
 };

--- a/packages/bpk-component-pagination/src/bpk-pagination-nudger.scss
+++ b/packages/bpk-component-pagination/src/bpk-pagination-nudger.scss
@@ -27,17 +27,18 @@
     padding: 0 $bpk-spacing-xs;
     border: none;
     background: none;
-    color: $bpk-color-blue-500;
     line-height: 100%; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
     cursor: pointer;
     appearance: none;
 
+    @include bpk-themeable-property(color, --bpk-pagination-nudger-color, $bpk-color-blue-500);
+
     @include bpk-hover {
-      color: $bpk-color-blue-700;
+      @include bpk-themeable-property(color, --bpk-pagination-nudger-hover-color, $bpk-color-blue-700);
     }
 
     &:active {
-      color: $bpk-color-blue-600;
+      @include bpk-themeable-property(color, --bpk-pagination-nudger-active-color, $bpk-color-blue-600);
     }
 
     &:disabled {

--- a/packages/bpk-component-pagination/src/bpk-pagination-page.scss
+++ b/packages/bpk-component-pagination/src/bpk-pagination-page.scss
@@ -23,3 +23,38 @@
   height: $bpk-spacing-xl;
   padding: 0;
 }
+
+.bpk-pagination-page--selected {
+  background-image: $bpk-button-secondary-background-image;
+  color: $bpk-button-selected-color;
+  box-shadow: $bpk-button-selected-box-shadow;
+  cursor: auto;
+
+  @include bpk-themeable-property(background-color, --bpk-pagination-selected-background-color, $bpk-color-blue-700);
+  @include bpk-border-lg($bpk-color-blue-700);
+  @include bpk-border-lg(var(--bpk-pagination-selected-background-color, $bpk-color-blue-700));
+
+  @include bpk-hover {
+    background-image: $bpk-button-selected-hover-background-image;
+    color: $bpk-button-selected-hover-color;
+    box-shadow: $bpk-button-selected-hover-box-shadow;
+
+    @include bpk-themeable-property(background-color, --bpk-pagination-selected-background-color, $bpk-color-blue-700);
+    @include bpk-border-lg($bpk-color-blue-700);
+    @include bpk-border-lg(var(--bpk-pagination-selected-background-color, $bpk-color-blue-700));
+  }
+
+  &:active {
+    background-image: $bpk-button-selected-active-background-image;
+    color: $bpk-button-selected-active-color;
+    box-shadow: $bpk-button-selected-active-box-shadow;
+
+    @include bpk-themeable-property(background-color, --bpk-pagination-selected-background-color, $bpk-color-blue-700);
+    @include bpk-border-lg($bpk-color-blue-700);
+    @include bpk-border-lg(var(--bpk-pagination-selected-background-color, $bpk-color-blue-700));
+  }
+
+  &:disabled {
+    box-shadow: $bpk-button-selected-disabled-box-shadow;
+  }
+}

--- a/packages/bpk-component-pagination/src/themeAttributes-test.js
+++ b/packages/bpk-component-pagination/src/themeAttributes-test.js
@@ -1,0 +1,39 @@
+/*
+  * Backpack - Skyscanner's Design System
+  *
+  * Copyright 2017 Skyscanner Ltd
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+import themeAttributes from './themeAttributes';
+
+describe('themeAttributes', () => {
+  it('should export the correct theme attributes', () => {
+    expect(themeAttributes).toEqual([
+      'buttonSecondaryTextColor',
+      'buttonSecondaryHoverTextColor',
+      'buttonSecondaryActiveTextColor',
+      'buttonSecondaryBorderColor',
+      'buttonSecondaryHoverBorderColor',
+      'buttonSecondaryActiveBorderColor',
+      'buttonSecondaryBackgroundColor',
+      'buttonSecondaryHoverBackgroundColor',
+      'buttonSecondaryActiveBackgroundColor',
+      'paginationNudgerActiveColor',
+      'paginationNudgerColor',
+      'paginationNudgerHoverColor',
+      'paginationSelectedBackgroundColor',
+    ]);
+  });
+});

--- a/packages/bpk-component-pagination/src/themeAttributes.js
+++ b/packages/bpk-component-pagination/src/themeAttributes.js
@@ -1,0 +1,29 @@
+/*
+  * Backpack - Skyscanner's Design System
+  *
+  * Copyright 2017 Skyscanner Ltd
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+import {
+  secondaryThemeAttributes,
+} from 'bpk-component-button';
+
+export default [
+  ...secondaryThemeAttributes,
+  'paginationNudgerActiveColor',
+  'paginationNudgerColor',
+  'paginationNudgerHoverColor',
+  'paginationSelectedBackgroundColor',
+];
+

--- a/packages/bpk-component-theme-toggle/src/theming.js
+++ b/packages/bpk-component-theme-toggle/src/theming.js
@@ -21,6 +21,7 @@ import {
   horizontalNavLinkActiveColor,
   calendarDayHoverColor,
   calendarDayActiveColor,
+  colorGray100,
 } from 'bpk-tokens/tokens/base.es6';
 
 const theme = {
@@ -59,7 +60,7 @@ const bpkCustomTheme = {
   buttonSecondaryTextColor: theme.primaryColor500,
   buttonSecondaryHoverTextColor: theme.primaryColor600,
   buttonSecondaryActiveTextColor: theme.primaryColor700,
-  buttonSecondaryBorderColor: theme.primaryColor500,
+  buttonSecondaryBorderColor: colorGray100,
   buttonSecondaryHoverBorderColor: theme.primaryColor600,
   buttonSecondaryActiveBorderColor: theme.primaryColor700,
   buttonSecondaryBackgroundColor: theme.white,
@@ -80,6 +81,11 @@ const bpkCustomTheme = {
   spinnerPrimaryColor: theme.primaryColor500,
 
   sliderBarColor: theme.primaryColor500,
+
+  paginationNudgerActiveColor: theme.primaryColor500,
+  paginationNudgerColor: theme.primaryColor500,
+  paginationNudgerHoverColor: theme.primaryColor700,
+  paginationSelectedBackgroundColor: theme.primaryColor700,
 
   progressBarFillColor: theme.primaryColor500,
 

--- a/packages/bpk-docs/src/themeableAttributes.js
+++ b/packages/bpk-docs/src/themeableAttributes.js
@@ -28,6 +28,7 @@ import { themeAttributes as horizontalNavThemeAttributes } from 'bpk-component-h
 import { themeAttributes as linkThemeAttributes } from 'bpk-component-link';
 import { themeAttributes as modalThemeAttributes } from 'bpk-component-modal';
 import { themeAttributes as nudgerThemeAttributes } from 'bpk-component-nudger';
+import { themeAttributes as paginationThemeAttributes } from 'bpk-component-pagination';
 import { themeAttributes as popoverThemeAttributes } from 'bpk-component-popover';
 import { themeAttributes as progressThemeAttributes } from 'bpk-component-progress';
 import { themeAttributes as radioThemeAttributes } from 'bpk-component-radio';
@@ -48,6 +49,7 @@ export default [
   ...linkThemeAttributes,
   ...modalThemeAttributes,
   ...nudgerThemeAttributes,
+  ...paginationThemeAttributes,
   ...popoverThemeAttributes,
   ...progressThemeAttributes,
   ...radioThemeAttributes,


### PR DESCRIPTION
This makes the pagination themable, two main changes:
`paginationBackgroundColorSelected` get applied to the background and border of a selected button and the cursor `pointer` has been removed

in the storybook the secondary button had a different behaviour than the docs site, now the default border is `Gray100`

both changes discussed with @jamesf3rguson 

Screenshots time!

<img width="874" alt="screen shot 2017-12-06 at 3 04 16 pm" src="https://user-images.githubusercontent.com/3579758/33668297-426255aa-da97-11e7-86b6-bd6158189af1.png">
<img width="874" alt="screen shot 2017-12-06 at 3 04 23 pm" src="https://user-images.githubusercontent.com/3579758/33668298-427d427a-da97-11e7-96ad-ee168d05d06a.png">
<img width="870" alt="screen shot 2017-12-06 at 3 04 44 pm" src="https://user-images.githubusercontent.com/3579758/33668299-4290b7ce-da97-11e7-95b2-69f9a90481cf.png">

