### PR TITLE
[BPK-1153] Downgrade @storybook/react-native to fix issue

### DIFF
--- a/native/package-lock.json
+++ b/native/package-lock.json
@@ -10,6 +10,62 @@
       "integrity": "sha1-6pn2EhtKjwZbTHH4VZXbJxRJiAc=",
       "dev": true
     },
+    "@storybook/addon-actions": {
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.17.tgz",
+      "integrity": "sha512-B4++4+p6zWTeTBzqe9lgzT8J0onaMfSZsBRJpa5URoDo3d4kTq+DTDs2qHhhTKJb2Drtu24/JlEgJG7lv0Fb0w==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "3.2.17",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "prop-types": "15.6.0",
+        "react-inspector": "2.2.1",
+        "uuid": "3.1.0"
+      }
+    },
+    "@storybook/addon-links": {
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.17.tgz",
+      "integrity": "sha512-AdCH9DsbOfiMDv42/l0Zfk2yhiBrlWuzHk7ubhSwqF3/61sXr+BWFv+SlOx2oFfSWAT7zfg2sC7Wr+us8gs7GQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "3.2.17"
+      }
+    },
+    "@storybook/addons": {
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.17.tgz",
+      "integrity": "sha512-1/Ux++3hMfYqAgBwgWbGtGAM0CfSdAchf//wDLBUmX09+E5CjiQvW3YwVplNYzfRuAsSrE1GOYJRAsz639oTYQ==",
+      "dev": true
+    },
+    "@storybook/channel-websocket": {
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-3.2.17.tgz",
+      "integrity": "sha512-0oDJq7xZfxZZ8zBju8VlimVXL7MqeX3i0vHwWKYM/6j0IxEHZmFNNx5/x6cmpzB0UqjDK3SOUowWvIbkzyWJlQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/channels": "3.2.17",
+        "global": "4.3.2"
+      }
+    },
+    "@storybook/channels": {
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.17.tgz",
+      "integrity": "sha512-HIdRmFTFVLcbrwYFf6+LyAlgcd57ki+6DDTmcvXQTHCWrOOCJKwfKjHgn6tbnHlGHiWByA8lAdO1bFcYhHxl4Q==",
+      "dev": true
+    },
+    "@storybook/components": {
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.17.tgz",
+      "integrity": "sha512-pXwNKLavYCu18B2EynFu9EKXlKi0LDo0B/KctbJvidxR5ubzqkZu9h2ti3hPPVomR2DQiRx61Vzqd7cbcyy14w==",
+      "dev": true,
+      "requires": {
+        "glamor": "2.20.40",
+        "glamorous": "4.11.0",
+        "prop-types": "15.6.0"
+      }
+    },
     "@storybook/mantra-core": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@storybook/mantra-core/-/mantra-core-1.7.2.tgz",
@@ -17,7 +73,7 @@
       "dev": true,
       "requires": {
         "@storybook/react-komposer": "2.0.3",
-        "@storybook/react-simple-di": "1.2.1",
+        "@storybook/react-simple-di": "1.3.0",
         "babel-runtime": "6.26.0"
       }
     },
@@ -47,9 +103,9 @@
       }
     },
     "@storybook/react-native": {
-      "version": "3.2.17",
-      "resolved": "https://registry.npmjs.org/@storybook/react-native/-/react-native-3.2.17.tgz",
-      "integrity": "sha512-PDbAP1IKgAUyCfmlLm5262oR9iHC85mdmvVcxb2K1XBhicn1ZJxhi988c3svMQ5EJlmoG2taR1r0qDol9DKIxQ==",
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/react-native/-/react-native-3.2.16.tgz",
+      "integrity": "sha512-piwvOFk5heAnvqe5HJ26u3lsFjMOLfDq+QGF95iOZ3tH/TI8qLKFXOfrvPqwQ3VyhjrPYKyFyX6xZIGN7Q826g==",
       "dev": true,
       "requires": {
         "@storybook/addon-actions": "3.2.17",
@@ -57,7 +113,7 @@
         "@storybook/addons": "3.2.17",
         "@storybook/channel-websocket": "3.2.17",
         "@storybook/ui": "3.2.17",
-        "autoprefixer": "7.1.6",
+        "autoprefixer": "7.2.1",
         "babel-core": "6.26.0",
         "babel-loader": "7.1.2",
         "babel-plugin-syntax-async-functions": "6.13.0",
@@ -74,7 +130,7 @@
         "babel-preset-stage-0": "6.24.1",
         "babel-runtime": "6.26.0",
         "case-sensitive-paths-webpack-plugin": "2.1.1",
-        "commander": "2.12.2",
+        "commander": "2.11.0",
         "css-loader": "0.28.7",
         "events": "1.1.1",
         "express": "4.16.2",
@@ -93,115 +149,22 @@
         "url-parse": "1.2.0",
         "util-deprecate": "1.0.2",
         "uuid": "3.1.0",
-        "webpack": "3.8.1",
+        "webpack": "3.10.0",
         "webpack-dev-middleware": "1.12.2",
         "webpack-hot-middleware": "2.21.0",
         "ws": "3.3.2"
-      },
-      "dependencies": {
-        "@storybook/addon-actions": {
-          "version": "3.2.17",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.17.tgz",
-          "integrity": "sha512-B4++4+p6zWTeTBzqe9lgzT8J0onaMfSZsBRJpa5URoDo3d4kTq+DTDs2qHhhTKJb2Drtu24/JlEgJG7lv0Fb0w==",
-          "dev": true,
-          "requires": {
-            "@storybook/addons": "3.2.17",
-            "deep-equal": "1.0.1",
-            "json-stringify-safe": "5.0.1",
-            "prop-types": "15.6.0",
-            "react-inspector": "2.2.1",
-            "uuid": "3.1.0"
-          }
-        },
-        "@storybook/addon-links": {
-          "version": "3.2.17",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.17.tgz",
-          "integrity": "sha512-AdCH9DsbOfiMDv42/l0Zfk2yhiBrlWuzHk7ubhSwqF3/61sXr+BWFv+SlOx2oFfSWAT7zfg2sC7Wr+us8gs7GQ==",
-          "dev": true,
-          "requires": {
-            "@storybook/addons": "3.2.17"
-          }
-        },
-        "@storybook/addons": {
-          "version": "3.2.17",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.17.tgz",
-          "integrity": "sha512-1/Ux++3hMfYqAgBwgWbGtGAM0CfSdAchf//wDLBUmX09+E5CjiQvW3YwVplNYzfRuAsSrE1GOYJRAsz639oTYQ==",
-          "dev": true
-        },
-        "@storybook/channel-websocket": {
-          "version": "3.2.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-3.2.17.tgz",
-          "integrity": "sha512-0oDJq7xZfxZZ8zBju8VlimVXL7MqeX3i0vHwWKYM/6j0IxEHZmFNNx5/x6cmpzB0UqjDK3SOUowWvIbkzyWJlQ==",
-          "dev": true,
-          "requires": {
-            "@storybook/channels": "3.2.17",
-            "global": "4.3.2"
-          }
-        },
-        "@storybook/channels": {
-          "version": "3.2.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.17.tgz",
-          "integrity": "sha512-HIdRmFTFVLcbrwYFf6+LyAlgcd57ki+6DDTmcvXQTHCWrOOCJKwfKjHgn6tbnHlGHiWByA8lAdO1bFcYhHxl4Q==",
-          "dev": true
-        },
-        "@storybook/components": {
-          "version": "3.2.17",
-          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.17.tgz",
-          "integrity": "sha512-pXwNKLavYCu18B2EynFu9EKXlKi0LDo0B/KctbJvidxR5ubzqkZu9h2ti3hPPVomR2DQiRx61Vzqd7cbcyy14w==",
-          "dev": true,
-          "requires": {
-            "glamor": "2.20.40",
-            "glamorous": "4.11.0",
-            "prop-types": "15.6.0"
-          }
-        },
-        "@storybook/ui": {
-          "version": "3.2.17",
-          "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.17.tgz",
-          "integrity": "sha512-At0oWWTALJrJhtdnP+0AMANBC5omIBnEg3Pin3M0+yzUy6Poelcvt8+81dQEKLBP6LiyFOVpiDjfqpiHR5l0ow==",
-          "dev": true,
-          "requires": {
-            "@hypnosphi/fuse.js": "3.0.9",
-            "@storybook/components": "3.2.17",
-            "@storybook/mantra-core": "1.7.2",
-            "@storybook/react-fuzzy": "0.4.3",
-            "@storybook/react-komposer": "2.0.3",
-            "babel-runtime": "6.26.0",
-            "deep-equal": "1.0.1",
-            "events": "1.1.1",
-            "global": "4.3.2",
-            "json-stringify-safe": "5.0.1",
-            "keycode": "2.1.9",
-            "lodash.debounce": "4.0.8",
-            "lodash.pick": "4.4.0",
-            "lodash.sortby": "4.7.0",
-            "podda": "1.2.2",
-            "prop-types": "15.6.0",
-            "qs": "6.5.1",
-            "react-icons": "2.2.7",
-            "react-inspector": "2.2.1",
-            "react-modal": "3.1.5",
-            "react-split-pane": "0.1.71",
-            "react-treebeard": "2.1.0",
-            "redux": "3.7.2"
-          }
-        },
-        "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
-          "dev": true
-        }
       }
     },
     "@storybook/react-simple-di": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.2.1.tgz",
-      "integrity": "sha512-Sj3JU1KpnTIyBWBp+uAZT3PlZ2IVYrxvOOXgpT92Injcmg2KV2ry1GkZen6XuVZqUfU0vz/sK08aP45boErFnw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.3.0.tgz",
+      "integrity": "sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
-        "hoist-non-react-statics": "1.2.0"
+        "create-react-class": "15.6.2",
+        "hoist-non-react-statics": "1.2.0",
+        "prop-types": "15.6.0"
       }
     },
     "@storybook/react-stubber": {
@@ -213,6 +176,37 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "@storybook/ui": {
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.17.tgz",
+      "integrity": "sha512-At0oWWTALJrJhtdnP+0AMANBC5omIBnEg3Pin3M0+yzUy6Poelcvt8+81dQEKLBP6LiyFOVpiDjfqpiHR5l0ow==",
+      "dev": true,
+      "requires": {
+        "@hypnosphi/fuse.js": "3.0.9",
+        "@storybook/components": "3.2.17",
+        "@storybook/mantra-core": "1.7.2",
+        "@storybook/react-fuzzy": "0.4.3",
+        "@storybook/react-komposer": "2.0.3",
+        "babel-runtime": "6.26.0",
+        "deep-equal": "1.0.1",
+        "events": "1.1.1",
+        "global": "4.3.2",
+        "json-stringify-safe": "5.0.1",
+        "keycode": "2.1.9",
+        "lodash.debounce": "4.0.8",
+        "lodash.pick": "4.4.0",
+        "lodash.sortby": "4.7.0",
+        "podda": "1.2.2",
+        "prop-types": "15.6.0",
+        "qs": "6.5.1",
+        "react-icons": "2.2.7",
+        "react-inspector": "2.2.1",
+        "react-modal": "3.1.7",
+        "react-split-pane": "0.1.71",
+        "react-treebeard": "2.1.0",
+        "redux": "3.7.2"
+      }
+    },
     "@types/inline-style-prefixer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz",
@@ -220,9 +214,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.25.tgz",
-      "integrity": "sha512-K79zMwWRzQ2db+nPoKpi3gA/KmLo6ZQgT4iO2QPEUdBO7as0PcgrmU9KHYzIO3V6lbD7gRjOM0/nUch6xBfOvQ==",
+      "version": "16.0.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.27.tgz",
+      "integrity": "sha512-7lGRcNEI0Iit54ferTJvsNQdY7m97fQmmhFT/3lxpC31b/qshkDoIKTXcVMLteVEza4F+ReEyZIZqSuk4LRb4A==",
       "dev": true
     },
     "absolute-path": {
@@ -504,13 +498,13 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.6.tgz",
-      "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.1.tgz",
+      "integrity": "sha512-lTbsa2X03maxG45xCNh30sJaRKDn8JPnanOeQOW3wvD9yPGmIsf041LHqlrZ1lXPF/1M3yTZKXqqYfmxU69xuQ==",
       "dev": true,
       "requires": {
-        "browserslist": "2.9.1",
-        "caniuse-lite": "1.0.30000775",
+        "browserslist": "2.10.0",
+        "caniuse-lite": "1.0.30000780",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.14",
@@ -1696,7 +1690,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.9.1",
+        "browserslist": "2.10.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -2261,13 +2255,13 @@
       }
     },
     "browserslist": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.1.tgz",
-      "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
+      "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000775",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-lite": "1.0.30000780",
+        "electron-to-chromium": "1.3.28"
       }
     },
     "bser": {
@@ -2327,7 +2321,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000775",
+        "caniuse-db": "1.0.30000780",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -2338,22 +2332,22 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000775",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "1.0.30000780",
+            "electron-to-chromium": "1.3.28"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000775",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000775.tgz",
-      "integrity": "sha1-BLzN0CFO3yW5f2GglmCfetaQQzM=",
+      "version": "1.0.30000780",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000780.tgz",
+      "integrity": "sha1-jRl3Vh0A/w8O0ra2YUAyirRQTAo=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000775",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000775.tgz",
-      "integrity": "sha1-dNJ/7dxH88hM+8sTDDCSo168LeI=",
+      "version": "1.0.30000780",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000780.tgz",
+      "integrity": "sha1-H5CV8u/UlA4LpsWZKreptkzDW6Q=",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -3255,7 +3249,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -3360,7 +3354,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000775",
+            "caniuse-db": "1.0.30000780",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -3373,8 +3367,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000775",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "1.0.30000780",
+            "electron-to-chromium": "1.3.28"
           }
         },
         "chalk": {
@@ -3411,7 +3405,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -3668,9 +3662,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
+      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
     "elliptic": {
@@ -6057,9 +6051,9 @@
       }
     },
     "js-base64": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
       "dev": true
     },
     "js-tokens": {
@@ -7532,7 +7526,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -7605,7 +7599,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -7677,7 +7671,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -7748,7 +7742,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -7819,7 +7813,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -7890,7 +7884,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -7961,7 +7955,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8033,7 +8027,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8105,7 +8099,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8222,7 +8216,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8293,7 +8287,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8340,8 +8334,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000775",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "1.0.30000780",
+            "electron-to-chromium": "1.3.28"
           }
         },
         "chalk": {
@@ -8378,7 +8372,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8457,7 +8451,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8529,7 +8523,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8603,7 +8597,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8677,7 +8671,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8787,7 +8781,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8861,7 +8855,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -8933,7 +8927,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9005,7 +8999,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9076,7 +9070,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9149,7 +9143,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9234,7 +9228,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9307,7 +9301,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9386,7 +9380,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9752,13 +9746,14 @@
       }
     },
     "react-modal": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.5.tgz",
-      "integrity": "sha512-EjM32L9JPVibJJgu22QySo9d+tl0POaRTmuM7LmsVkx0U+G9tl4LGLrs2DLNOQp0Oko/5nEF/Rwp/h2noucMAw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.7.tgz",
+      "integrity": "sha512-pIVKqhPZxXqnewkQnjN0VJT0hn1XGJV2pwDJmKwAxPbfXZ1cAX79uO/Z3kYkpnb+2gAAusooK/AvnBjWuKQrRA==",
       "dev": true,
       "requires": {
         "exenv": "1.2.2",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
       }
     },
     "react-native": {
@@ -10099,7 +10094,7 @@
       "dev": true,
       "requires": {
         "@types/inline-style-prefixer": "3.0.1",
-        "@types/react": "16.0.25",
+        "@types/react": "16.0.27",
         "inline-style-prefixer": "3.0.8",
         "prop-types": "15.6.0",
         "react-style-proptype": "3.1.0"
@@ -11572,9 +11567,9 @@
       }
     },
     "webpack": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
-      "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",

--- a/native/package.json
+++ b/native/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "devDependencies": {
-    "@storybook/react-native": "^3.2.17",
+    "@storybook/react-native": "3.2.16",
     "babel-preset-react-native": "^4.0.0",
     "react": "16.0.0-beta.5",
     "react-dom": "16.0.0-beta.5",


### PR DESCRIPTION
**The issue**
When using storybook actions (or indeed any addons), we're getting an issue where triggering the action causes an error to appear.

The error message itself links to [this page](https://storybook.js.org/basics/faq/#why-is-there-no-addons-channel), which in turn links to [this issue](https://github.com/storybooks/storybook/issues/1192).

**The solution**
I tried all sorts of different changes to the code but I couldn't get it to work. In the end, through trial and error I figured out that downgrading `@storybook/react-native` by one patch version (`3.2.17` :arrow_right: `3.2.16`) sorts it out.

It's not an ideal long term solution, but it does fix things for now.

`3.3.0` of Storybook is currently in alpha, I intend to next find out if that fixes the issue, and also find out what exactly changed from `3.2.16` to `3.2.17` to break things.