### PR TITLE
[No JIRA] Rename pageLabelFormatter to pageLabel

### DIFF
--- a/packages/bpk-component-pagination/readme.md
+++ b/packages/bpk-component-pagination/readme.md
@@ -22,7 +22,7 @@ const Pagination = () => (
     previousLabel="previous"
     nextLabel="next"
     visibleRange={3}
-    pageLabelFormatter={(page, isSelected) => `page ${page}`}
+    pageLabel={(page, isSelected) => `page ${page}`}
   />
 );
 
@@ -37,7 +37,7 @@ const Pagination = () => (
 | previousLabel     | string               | true     | -             |
 | nextLabel         | string               | true     | -             |
 | paginationLabel   | string               | true     | -             |
-| pageLabelFormatter| func                 | true     | -             |
+| pageLabel         | func                 | true     | -             |
 | onPageChange      | func                 | false    | null          |
 | visibleRange      | number               | false    | 3             |
 | className         | string               | false    | null          |

--- a/packages/bpk-component-pagination/src/BpkPagination-test.js
+++ b/packages/bpk-component-pagination/src/BpkPagination-test.js
@@ -28,7 +28,7 @@ describe('BpkPagination', () => {
       previousLabel="previous"
       nextLabel="next"
       paginationLabel="Pagination Navigation"
-      pageLabelFormatter={(page, isSelected) =>
+      pageLabel={(page, isSelected) =>
         `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
       }
     />);
@@ -44,7 +44,7 @@ describe('BpkPagination', () => {
       previousLabel="previous"
       nextLabel="next"
       paginationLabel="Pagination Navigation"
-      pageLabelFormatter={(page, isSelected) =>
+      pageLabel={(page, isSelected) =>
         `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
       }
     />);
@@ -60,7 +60,7 @@ describe('BpkPagination', () => {
       previousLabel="previous"
       nextLabel="next"
       paginationLabel="Pagination Navigation"
-      pageLabelFormatter={(page, isSelected) =>
+      pageLabel={(page, isSelected) =>
         `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
       }
     />);
@@ -78,7 +78,7 @@ describe('BpkPagination', () => {
       nextLabel="next"
       onPageChange={onPageChange}
       paginationLabel="Pagination Navigation"
-      pageLabelFormatter={(page, isSelected) =>
+      pageLabel={(page, isSelected) =>
         `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
       }
     />);
@@ -101,7 +101,7 @@ describe('BpkPagination', () => {
       nextLabel="next"
       onPageChange={onPageChange}
       paginationLabel="Pagination Navigation"
-      pageLabelFormatter={(page, isSelected) =>
+      pageLabel={(page, isSelected) =>
         `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
       }
     />);

--- a/packages/bpk-component-pagination/src/BpkPagination.js
+++ b/packages/bpk-component-pagination/src/BpkPagination.js
@@ -44,7 +44,7 @@ const BpkPagination = (props) => {
     visibleRange,
     className,
     paginationLabel,
-    pageLabelFormatter,
+    pageLabel,
     ...rest
   } = props;
 
@@ -71,7 +71,7 @@ const BpkPagination = (props) => {
         pageCount={pageCount}
         onPageChange={pageChanged}
         visibleRange={visibleRange}
-        pageLabelFormatter={pageLabelFormatter}
+        pageLabel={pageLabel}
       />
       <BpkPaginationNudger
         label={nextLabel}
@@ -90,7 +90,7 @@ BpkPagination.propTypes = {
   previousLabel: PropTypes.string.isRequired,
   nextLabel: PropTypes.string.isRequired,
   paginationLabel: PropTypes.string.isRequired,
-  pageLabelFormatter: PropTypes.func.isRequired,
+  pageLabel: PropTypes.func.isRequired,
   visibleRange: PropTypes.number,
   className: PropTypes.string,
 };

--- a/packages/bpk-component-pagination/src/BpkPaginationList-test.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationList-test.js
@@ -28,7 +28,7 @@ describe('BpkPaginationList', () => {
       selectedPageIndex={0}
       visibleRange={3}
       onPageChange={() => null}
-      pageLabelFormatter={(page, isSelected) =>
+      pageLabel={(page, isSelected) =>
         `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
       }
     />);
@@ -46,7 +46,7 @@ describe('BpkPaginationList', () => {
       selectedPageIndex={5}
       visibleRange={3}
       onPageChange={() => null}
-      pageLabelFormatter={(page, isSelected) =>
+      pageLabel={(page, isSelected) =>
         `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
       }
     />);
@@ -66,7 +66,7 @@ describe('BpkPaginationList', () => {
       selectedPageIndex={0}
       visibleRange={3}
       onPageChange={() => null}
-      pageLabelFormatter={(page, isSelected) =>
+      pageLabel={(page, isSelected) =>
         `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
       }
     />);

--- a/packages/bpk-component-pagination/src/BpkPaginationList.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationList.js
@@ -27,7 +27,7 @@ const getClassName = cssModules(STYLES);
 
 const BpkPaginationList = (props) => {
   const {
-    selectedPageIndex, pageCount, onPageChange, visibleRange, pageLabelFormatter,
+    selectedPageIndex, pageCount, onPageChange, visibleRange, pageLabel,
   } = props;
 
   const shoulderRange = Math.ceil(visibleRange / 2);
@@ -51,7 +51,7 @@ const BpkPaginationList = (props) => {
           page={i + 1}
           onSelect={() => onPageChange(i)}
           isSelected={selectedPageIndex === i}
-          pageLabelFormatter={pageLabelFormatter}
+          pageLabel={pageLabel}
         />
       );
     }
@@ -81,7 +81,7 @@ BpkPaginationList.propTypes = {
   pageCount: PropTypes.number.isRequired,
   visibleRange: PropTypes.number.isRequired,
   onPageChange: PropTypes.func.isRequired,
-  pageLabelFormatter: PropTypes.func.isRequired,
+  pageLabel: PropTypes.func.isRequired,
 };
 
 export default BpkPaginationList;

--- a/packages/bpk-component-pagination/src/BpkPaginationPage.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationPage.js
@@ -28,7 +28,7 @@ const getClassName = cssModules(STYLES);
 const BpkPaginationPage = (props) => {
   const classNames = [getClassName('bpk-pagination-page')];
   const {
-    page, onSelect, isSelected, pageLabelFormatter,
+    page, onSelect, isSelected, pageLabel,
   } = props;
 
   if (isSelected) { classNames.push(getClassName('bpk-pagination-page--selected')); }
@@ -38,7 +38,7 @@ const BpkPaginationPage = (props) => {
       secondary
       onClick={onSelect}
       className={classNames.join(' ')}
-      aria-label={pageLabelFormatter(page, isSelected)}
+      aria-label={pageLabel(page, isSelected)}
       aria-current={isSelected}
     >
       <span>{ page }</span>
@@ -49,7 +49,7 @@ const BpkPaginationPage = (props) => {
 BpkPaginationPage.propTypes = {
   page: PropTypes.number.isRequired,
   onSelect: PropTypes.func.isRequired,
-  pageLabelFormatter: PropTypes.func.isRequired,
+  pageLabel: PropTypes.func.isRequired,
   isSelected: PropTypes.bool,
 };
 

--- a/packages/bpk-component-pagination/stories.js
+++ b/packages/bpk-component-pagination/stories.js
@@ -47,7 +47,7 @@ class PaginationContainer extends Component {
           nextLabel="next"
           visibleRange={visibleRange}
           paginationLabel="Pagination Navigation"
-          pageLabelFormatter={(page, isSelected) =>
+          pageLabel={(page, isSelected) =>
             `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
           }
         />

--- a/packages/bpk-docs/src/pages/PaginationPage/PaginationPage.js
+++ b/packages/bpk-docs/src/pages/PaginationPage/PaginationPage.js
@@ -50,7 +50,7 @@ class PaginationContainer extends Component {
           nextLabel="next"
           visibleRange={visibleRange}
           paginationLabel="Pagination Navigation"
-          pageLabelFormatter={(page, isSelected) =>
+          pageLabel={(page, isSelected) =>
             `Go to page ${page}${isSelected ? ', this is the current page' : ''}.`
           }
         />


### PR DESCRIPTION
The word `formatter` in `pageLabelFormatter` is redundant as this
is capture by the prop type being `func`.