### PR TITLE
Add react-transition-group as an explicit dependency

### DIFF
--- a/packages/bpk-component-banner-alert/package-lock.json
+++ b/packages/bpk-component-banner-alert/package-lock.json
@@ -7,10 +7,25 @@
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
+		"chain-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+			"integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+		},
+		"classnames": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+			"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+		},
 		"core-js": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"dom-helpers": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
+			"integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -98,6 +113,19 @@
 				"object-assign": "4.1.1"
 			}
 		},
+		"react-transition-group": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
+			"integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
+			"requires": {
+				"chain-function": "1.0.0",
+				"classnames": "2.2.5",
+				"dom-helpers": "3.2.1",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.0",
+				"warning": "3.0.0"
+			}
+		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -107,6 +135,14 @@
 			"version": "0.7.14",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
 			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+		},
+		"warning": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+			"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
 		},
 		"whatwg-fetch": {
 			"version": "2.0.3",

--- a/packages/bpk-component-banner-alert/package.json
+++ b/packages/bpk-component-banner-alert/package.json
@@ -19,6 +19,7 @@
     "bpk-mixins": "^17.2.0",
     "bpk-react-utils": "^2.4.0",
     "bpk-tokens": "^26.7.0",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "react-transition-group": "^2.2.1"
   }
 }


### PR DESCRIPTION
`bpk-component-banner-alert` uses `react-transition-group` but does not include it as a dependency