### PR TITLE
[BPK-434] use bpk-component-icon for sort direction icons

### DIFF
--- a/packages/bpk-component-datatable/package.json
+++ b/packages/bpk-component-datatable/package.json
@@ -13,6 +13,7 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "bpk-component-icon": "^3.14.14",
     "bpk-mixins": "^17.2.0",
     "bpk-react-utils": "^2.4.0",
     "lodash": "^4.17.4",

--- a/packages/bpk-component-datatable/readme.md
+++ b/packages/bpk-component-datatable/readme.md
@@ -46,14 +46,14 @@ Supports all properties defined in [`Table`](https://github.com/bvaughn/react-vi
 in addition to the following:
 
 
-| Property     | PropType                | Required | Default Value        |
-| ------------ | ----------------------- | -------- | -------------------- |
-| rows         | arrayOf(Object)         | yes      | -                    |
-| children     | node                    | yes      | -                    |
-| height       | number                  | yes      | -                    |
-| width        | number                  | no       | full width of parent |
-| headerHeight | number                  | no       | 60                   |
-| rowHeight    | number                  | no       | 60                   |
+| Property     | PropType                    | Required | Default Value        |
+| ------------ | --------------------------- | -------- | -------------------- |
+| rows         | arrayOf(Object)             | true     | -                    |
+| children     | arrayOf(BpkDataTableColumn) | true     | -                    |
+| height       | number                      | true     | -                    |
+| width        | number                      | false    | full width of parent |
+| headerHeight | number                      | false    | 60                   |
+| rowHeight    | number                      | false    | 60                   |
 
 
 

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -25,6 +25,7 @@ import _omit from 'lodash/omit';
 
 import STYLES from './bpk-data-table.scss';
 import BpkDataTableColumn from './BpkDataTableColumn';
+import hasChildrenOfType from './hasChildrenOfType';
 
 const getClassName = cssModules(STYLES);
 const omittedTableProps = [
@@ -153,7 +154,7 @@ class BpkDataTable extends Component {
 BpkDataTable.propTypes = {
   ..._omit(Table.propTypes, omittedTableProps),
   rows: PropTypes.arrayOf(Object).isRequired,
-  children: PropTypes.arrayOf(Object).isRequired,
+  children: hasChildrenOfType(BpkDataTableColumn),
   width: PropTypes.number,
   headerHeight: PropTypes.number,
   className: PropTypes.string,

--- a/packages/bpk-component-datatable/src/BpkDataTableColumn-test.js
+++ b/packages/bpk-component-datatable/src/BpkDataTableColumn-test.js
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { Column } from 'react-virtualized';
-import BpkDataTableColumn from './BpkDataTableColumn';
+import BpkDataTableColumn, { bpkHeaderRenderer } from './BpkDataTableColumn';
 
 const defaultProps = { label: 'Name', dataKey: 'name', width: 100 };
 
@@ -26,8 +26,11 @@ describe('BpkDataTableColumn', () => {
   it('has the same propTypes as react-virtualized Column', () => {
     expect(BpkDataTableColumn.propTypes).toEqual(Column.propTypes);
   });
-  it('has the same defaultProps as react-virtualized Column', () => {
-    expect(BpkDataTableColumn.defaultProps).toEqual(Column.defaultProps);
+  it('has the same defaultProps as react-virtualized Column, with the exception of headerRenderer', () => {
+    expect(BpkDataTableColumn.defaultProps).toEqual({
+      ...Column.defaultProps,
+      headerRenderer: bpkHeaderRenderer,
+    });
   });
   describe('toColumn', () => {
     const toColumn = (props = {}) =>

--- a/packages/bpk-component-datatable/src/BpkDataTableColumn.js
+++ b/packages/bpk-component-datatable/src/BpkDataTableColumn.js
@@ -17,12 +17,47 @@
  */
 
 import React from 'react';
-import { Column } from 'react-virtualized';
+import { Column, SortDirection } from 'react-virtualized';
 import { cssModules } from 'bpk-react-utils';
+import BpkSmallArrowDownIcon from 'bpk-component-icon/sm/arrow-down';
+import BpkSmallArrowUpIcon from 'bpk-component-icon/sm/arrow-up';
+import { withRtlSupport } from 'bpk-component-icon';
 
 import STYLES from './bpk-data-table-column.scss';
 
 const getClassName = cssModules(STYLES);
+const DownIcon = withRtlSupport(BpkSmallArrowDownIcon);
+const UpIcon = withRtlSupport(BpkSmallArrowUpIcon);
+
+export const bpkHeaderRenderer = ({
+  dataKey,
+  label,
+  sortBy,
+  sortDirection,
+}) => {
+  const showSortIndicator = sortBy === dataKey;
+  const children = [
+    <span
+      className={getClassName('bpk-data-table-column__header')}
+      key="label"
+      title={label}
+    >
+      {label}
+    </span>,
+  ];
+
+  if (showSortIndicator) {
+    const Icon = sortDirection === SortDirection.ASC ? DownIcon : UpIcon;
+    children.push(
+      <Icon
+        className={getClassName('bpk-data-table-column__sort-icon')}
+        key="sortIcon"
+      />,
+    );
+  }
+
+  return children;
+};
 
 // BpkDataTableColumn is just a props wrapper since Table only accepts Column children
 // BpkDataTable uses BpkDataTableColumn.toColumn to convert BpkDataTableColumn to Columns
@@ -40,6 +75,9 @@ BpkDataTableColumn.toColumn = (bpkDataTableColumn, key) => {
 };
 
 BpkDataTableColumn.propTypes = { ...Column.propTypes };
-BpkDataTableColumn.defaultProps = { ...Column.defaultProps };
+BpkDataTableColumn.defaultProps = {
+  ...Column.defaultProps,
+  headerRenderer: bpkHeaderRenderer,
+};
 
 export default BpkDataTableColumn;

--- a/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
+++ b/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
@@ -44,23 +44,26 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
         tabIndex={0}
       >
         <span
-          className="ReactVirtualized__Table__headerTruncatedText"
+          className="bpk-data-table-column__header"
           title="Name"
         >
           Name
         </span>
         <svg
-          className="ReactVirtualized__Table__sortableHeaderIcon ReactVirtualized__Table__sortableHeaderIcon--ASC"
-          height={18}
+          className="bpk-data-table-column__sort-icon bpk-icon--rtl-support"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
           viewBox="0 0 24 24"
-          width={18}
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M7 14l5-5 5 5z"
-          />
-          <path
-            d="M0 0h24v24H0z"
-            fill="none"
+            d="M19.7 10.3L12 17.4l-7.7-7.1c-.6-.6-.2-1.7.7-1.7h14c.9 0 1.3 1.1.7 1.7z"
           />
         </svg>
       </div>
@@ -80,7 +83,7 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
         tabIndex={0}
       >
         <span
-          className="ReactVirtualized__Table__headerTruncatedText"
+          className="bpk-data-table-column__header"
           title="Description"
         >
           Description
@@ -102,7 +105,7 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
         tabIndex={0}
       >
         <span
-          className="ReactVirtualized__Table__headerTruncatedText"
+          className="bpk-data-table-column__header"
           title="Bla"
         >
           Bla
@@ -171,23 +174,26 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
       tabIndex={0}
     >
       <span
-        className="ReactVirtualized__Table__headerTruncatedText"
+        className="bpk-data-table-column__header"
         title="Name"
       >
         Name
       </span>
       <svg
-        className="ReactVirtualized__Table__sortableHeaderIcon ReactVirtualized__Table__sortableHeaderIcon--ASC"
-        height={18}
+        className="bpk-data-table-column__sort-icon bpk-icon--rtl-support"
+        height="18"
+        style={
+          Object {
+            "height": "1.125rem",
+            "width": "1.125rem",
+          }
+        }
         viewBox="0 0 24 24"
-        width={18}
+        width="18"
+        xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M7 14l5-5 5 5z"
-        />
-        <path
-          d="M0 0h24v24H0z"
-          fill="none"
+          d="M19.7 10.3L12 17.4l-7.7-7.1c-.6-.6-.2-1.7.7-1.7h14c.9 0 1.3 1.1.7 1.7z"
         />
       </svg>
     </div>
@@ -207,7 +213,7 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
       tabIndex={0}
     >
       <span
-        className="ReactVirtualized__Table__headerTruncatedText"
+        className="bpk-data-table-column__header"
         title="Description"
       >
         Description
@@ -229,7 +235,7 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
       tabIndex={0}
     >
       <span
-        className="ReactVirtualized__Table__headerTruncatedText"
+        className="bpk-data-table-column__header"
         title="Bla"
       >
         Bla
@@ -450,23 +456,26 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
         tabIndex={0}
       >
         <span
-          className="ReactVirtualized__Table__headerTruncatedText"
+          className="bpk-data-table-column__header"
           title="Name"
         >
           Name
         </span>
         <svg
-          className="ReactVirtualized__Table__sortableHeaderIcon ReactVirtualized__Table__sortableHeaderIcon--ASC"
-          height={18}
+          className="bpk-data-table-column__sort-icon bpk-icon--rtl-support"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
           viewBox="0 0 24 24"
-          width={18}
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M7 14l5-5 5 5z"
-          />
-          <path
-            d="M0 0h24v24H0z"
-            fill="none"
+            d="M19.7 10.3L12 17.4l-7.7-7.1c-.6-.6-.2-1.7.7-1.7h14c.9 0 1.3 1.1.7 1.7z"
           />
         </svg>
       </div>
@@ -486,7 +495,7 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
         tabIndex={0}
       >
         <span
-          className="ReactVirtualized__Table__headerTruncatedText"
+          className="bpk-data-table-column__header"
           title="Description"
         >
           Description
@@ -508,7 +517,7 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
         tabIndex={0}
       >
         <span
-          className="ReactVirtualized__Table__headerTruncatedText"
+          className="bpk-data-table-column__header"
           title="Bla"
         >
           Bla
@@ -585,23 +594,26 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
         tabIndex={0}
       >
         <span
-          className="ReactVirtualized__Table__headerTruncatedText"
+          className="bpk-data-table-column__header"
           title="Name"
         >
           Name
         </span>
         <svg
-          className="ReactVirtualized__Table__sortableHeaderIcon ReactVirtualized__Table__sortableHeaderIcon--ASC"
-          height={18}
+          className="bpk-data-table-column__sort-icon bpk-icon--rtl-support"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
           viewBox="0 0 24 24"
-          width={18}
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M7 14l5-5 5 5z"
-          />
-          <path
-            d="M0 0h24v24H0z"
-            fill="none"
+            d="M19.7 10.3L12 17.4l-7.7-7.1c-.6-.6-.2-1.7.7-1.7h14c.9 0 1.3 1.1.7 1.7z"
           />
         </svg>
       </div>
@@ -621,7 +633,7 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
         tabIndex={0}
       >
         <span
-          className="ReactVirtualized__Table__headerTruncatedText"
+          className="bpk-data-table-column__header"
           title="Description"
         >
           Description
@@ -643,7 +655,7 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
         tabIndex={0}
       >
         <span
-          className="ReactVirtualized__Table__headerTruncatedText"
+          className="bpk-data-table-column__header"
           title="Bla"
         >
           Bla

--- a/packages/bpk-component-datatable/src/bpk-data-table-column.scss
+++ b/packages/bpk-component-datatable/src/bpk-data-table-column.scss
@@ -24,3 +24,20 @@
   white-space: nowrap;
   overflow: hidden;
 }
+
+.bpk-data-table-column__header {
+  display: inline-block;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.bpk-data-table-column__sort-icon {
+  margin: 0 0 0 $bpk-spacing-xs;
+  fill: $bpk-color-gray-700;
+
+  @include bpk-rtl {
+    margin: 0 $bpk-spacing-xs 0 0;
+  }
+}

--- a/packages/bpk-component-datatable/src/hasChildrenOfType-test.js
+++ b/packages/bpk-component-datatable/src/hasChildrenOfType-test.js
@@ -1,0 +1,85 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import hasChildrenOfType, { getDisplayName } from './hasChildrenOfType';
+
+const Component = () => <div>Component</div>;
+const Child = () => <span>Child</span>;
+
+const runPropTypeValidatorWith = (component, atLeast = 1, type = Child) => {
+  const propTypeValidator = hasChildrenOfType(type, atLeast);
+  return propTypeValidator(
+    component.props,
+    'children',
+    getDisplayName(component.type),
+  );
+};
+
+describe('hasChildrenOfType', () => {
+  it('should not return an error if conditions are satisfied', () => {
+    const error = runPropTypeValidatorWith(
+      <Component>
+        <Child />
+      </Component>,
+    );
+    expect(error).toBeUndefined();
+  });
+
+  it('should return an error if it has less children than it should (0 < 1)', () => {
+    const error = runPropTypeValidatorWith(<Component />);
+    expect(error).toEqual(
+      Error("Component requires at least 1 'Child' child."),
+    );
+  });
+
+  it('should return an error if it has less children than it should (1 < 2)', () => {
+    const error = runPropTypeValidatorWith(
+      <Component>
+        <Child />
+      </Component>,
+      2,
+    );
+    expect(error).toEqual(
+      Error("Component requires at least 2 'Child' children."),
+    );
+  });
+
+  it('should return an error if it has single non matching child ', () => {
+    const error = runPropTypeValidatorWith(
+      <Component>
+        <div />
+      </Component>,
+    );
+    expect(error).toEqual(
+      Error("Component only allows 'Child' as children. Found 'div'."),
+    );
+  });
+
+  it('should return an error if it has a mix of matching and non matching children ', () => {
+    const error = runPropTypeValidatorWith(
+      <Component>
+        <Child />
+        <div />
+      </Component>,
+    );
+    expect(error).toEqual(
+      Error("Component only allows 'Child' as children. Found 'div'."),
+    );
+  });
+});

--- a/packages/bpk-component-datatable/src/hasChildrenOfType.js
+++ b/packages/bpk-component-datatable/src/hasChildrenOfType.js
@@ -1,0 +1,59 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2017 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Children } from 'react';
+
+export function getDisplayName(Component) {
+  return (
+    Component.displayName ||
+    Component.name ||
+    (typeof Component === 'string' && Component.length > 0
+      ? Component
+      : 'Unknown')
+  );
+}
+
+const hasChildrenOfType = (type, atLeast = 1) => (
+  props,
+  propType,
+  componentName,
+) => {
+  if (Children.count(props[propType]) < atLeast) {
+    const inflectedNoun = atLeast === 1 ? 'child' : 'children';
+    return Error(
+      `${componentName} requires at least ${atLeast} '${getDisplayName(
+        type,
+      )}' ${inflectedNoun}.`,
+    );
+  }
+
+  const children = Children.toArray(props[propType]);
+  for (let i = 0; i < children.length; i += 1) {
+    const child = children[i];
+    if (child.type !== type && !(child.type.prototype instanceof type)) {
+      return Error(
+        `${componentName} only allows '${getDisplayName(type)}' as children. ` +
+          `Found '${getDisplayName(child.type)}'.`,
+      );
+    }
+  }
+
+  return undefined;
+};
+
+export default hasChildrenOfType;


### PR DESCRIPTION
- https://github.com/Skyscanner/backpack/commit/bf00596c8a0c941e8e6af80c90b24357f3f1aadf: add `hasChildrenOfType` util (probably a good candidate for `bpk-react-utils`) to ensure children of `BpkDataTable` are `BpkDataTableColumn`s.
- https://github.com/Skyscanner/backpack/commit/6f019c38fb25d9d9034416daa8965d54ac9b5d35: use `bpk-component-icon` for sort direction icons