### PR TITLE
[nojira] Remove import * as React

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,11 @@
 
 ## UNRELEASED
 
-_Nothing Yet_
+**Fixed:**
+- bpk-component-button:
+  - Fixed react warnings about `PropTypes` and `createClass`.
 
-## 2017-12-21 - Android Support for React Native Banner Alert 
+## 2017-12-21 - Android Support for React Native Banner Alert
 
 **Added:**
 - react-native-bpk-component-banner-alert:

--- a/packages/bpk-component-button/src/BpkButton.js
+++ b/packages/bpk-component-button/src/BpkButton.js
@@ -18,7 +18,7 @@
 
 /* @flow */
 
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 
 import STYLES from './bpk-button.scss';
@@ -33,7 +33,7 @@ const cssModules = (styles = {}) => className =>
 const getClassName = cssModules(STYLES);
 
 type Props = {
-  children: React.Node,
+  children: Node,
   href: ?string,
   className: ?string,
   disabled: boolean,

--- a/packages/bpk-docs/src/pages/ButtonsPage/ButtonsPage.js
+++ b/packages/bpk-docs/src/pages/ButtonsPage/ButtonsPage.js
@@ -18,7 +18,7 @@
 
 /* @flow */
 
-import * as React from 'react';
+import React, { Component } from 'react';
 import BpkButton from 'bpk-component-button';
 import { colors, buttons } from 'bpk-tokens/tokens/base.es6';
 import { alignToButton, alignToLargeButton } from 'bpk-component-icon';
@@ -51,7 +51,7 @@ const AlignedBpkLargeHelpIcon = alignToLargeButton(TestBpkLargeHelpIcon);
 const AlignedBpkSmallSearchIcon = alignToButton(TestBpkSmallSearchIcon);
 const AlignedBpkLargeSearchIcon = alignToLargeButton(TestBpkLargeSearchIcon);
 
-class LoadingButtonContainer extends React.Component<{}, { loading: boolean }> {
+class LoadingButtonContainer extends Component<{}, { loading: boolean }> {
   constructor() {
     super();
 


### PR DESCRIPTION
This fixes the following warnings caused by `import * as React from 'react';` change:

```
  console.warn node_modules/react/lib/lowPriorityWarning.js:38
    Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs

  console.warn node_modules/react/lib/lowPriorityWarning.js:38
    Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class
```