### PR TITLE
[NoJira] update copyright to 2018

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/.storybook/themeableAttributes.js
+++ b/.storybook/themeableAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contributing.md
+++ b/contributing.md
@@ -33,7 +33,7 @@ If you are adding a new file it should have a header comment like this:
 ```
 Backpack - Skyscanner's Design System
 
-Copyright 2017 Skyscanner Ltd
+Copyright 2018 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -2,7 +2,7 @@
  *
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/index.android.js
+++ b/native/index.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/index.ios.js
+++ b/native/index.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-animate-height/index.js
+++ b/native/packages/react-native-bpk-component-animate-height/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.android.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.common.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.ios.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-animate-height/stories.js
+++ b/native/packages/react-native-bpk-component-animate-height/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/index.js
+++ b/native/packages/react-native-bpk-component-banner-alert/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade-test.android.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade-test.common.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade-test.common.js
@@ -1,7 +1,7 @@
 /*
 * Backpack - Skyscanner's Design System
 *
-* Copyright 2017 Skyscanner Ltd
+* Copyright 2018 Skyscanner Ltd
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade-test.ios.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.android.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
@@ -1,7 +1,7 @@
 /*
 * Backpack - Skyscanner's Design System
 *
-* Copyright 2017 Skyscanner Ltd
+* Copyright 2018 Skyscanner Ltd
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.ios.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.android.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.ios.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/customPropTypes-test.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/customPropTypes-test.js
@@ -1,7 +1,7 @@
 /*
 * Backpack - Skyscanner's Design System
 *
-* Copyright 2017 Skyscanner Ltd
+* Copyright 2018 Skyscanner Ltd
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/src/customPropTypes.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/customPropTypes.js
@@ -3,7 +3,7 @@ import { isString } from 'util';
 /*
 * Backpack - Skyscanner's Design System
 *
-* Copyright 2017 Skyscanner Ltd
+* Copyright 2018 Skyscanner Ltd
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-banner-alert/stories.js
+++ b/native/packages/react-native-bpk-component-banner-alert/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/index.js
+++ b/native/packages/react-native-bpk-component-button/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-styles.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-test.android.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-test.ios.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/src/BpkButton.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/src/layout/BpkButtonContainer.android.js
+++ b/native/packages/react-native-bpk-component-button/src/layout/BpkButtonContainer.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/src/layout/BpkButtonContainer.ios.js
+++ b/native/packages/react-native-bpk-component-button/src/layout/BpkButtonContainer.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/src/utils.js
+++ b/native/packages/react-native-bpk-component-button/src/utils.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-button/stories.js
+++ b/native/packages/react-native-bpk-component-button/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/index.js
+++ b/native/packages/react-native-bpk-component-card/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/src/BpkCard-test.android.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/src/BpkCard-test.common.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/src/BpkCard-test.ios.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/src/BpkCard.android.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/src/BpkCard.ios.js
+++ b/native/packages/react-native-bpk-component-card/src/BpkCard.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/src/withDivider-test.android.js
+++ b/native/packages/react-native-bpk-component-card/src/withDivider-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/src/withDivider-test.common.js
+++ b/native/packages/react-native-bpk-component-card/src/withDivider-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/src/withDivider-test.ios.js
+++ b/native/packages/react-native-bpk-component-card/src/withDivider-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/src/withDivider.js
+++ b/native/packages/react-native-bpk-component-card/src/withDivider.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-card/stories.js
+++ b/native/packages/react-native-bpk-component-card/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/index.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.android.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.common.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.ios.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.android.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.common.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.ios.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.android.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.common.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.ios.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/theming.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/theming.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/withAnimatedProps.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/withAnimatedProps.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-horizontal-nav/stories.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-icon/index.js
+++ b/native/packages/react-native-bpk-component-icon/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.android.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.common.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.ios.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-icon/stories.js
+++ b/native/packages/react-native-bpk-component-icon/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-spinner/index.js
+++ b/native/packages/react-native-bpk-component-spinner/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.android.js
+++ b/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.common.js
+++ b/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.ios.js
+++ b/native/packages/react-native-bpk-component-spinner/src/BpkSpinner-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-spinner/src/BpkSpinner.js
+++ b/native/packages/react-native-bpk-component-spinner/src/BpkSpinner.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-spinner/stories.js
+++ b/native/packages/react-native-bpk-component-spinner/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/index.js
+++ b/native/packages/react-native-bpk-component-star-rating/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStar-test.android.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStar-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStar-test.common.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStar-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStar-test.ios.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStar-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStar.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStar.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating-RTL-test.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating-RTL-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating-test.android.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating-test.common.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating-test.ios.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStarRating.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/star-types-test.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/star-types-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/src/star-types.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/star-types.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-star-rating/stories.js
+++ b/native/packages/react-native-bpk-component-star-rating/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-switch/index.js
+++ b/native/packages/react-native-bpk-component-switch/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.android.js
+++ b/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.common.js
+++ b/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.ios.js
+++ b/native/packages/react-native-bpk-component-switch/src/BpkSwitch-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-switch/src/BpkSwitch.js
+++ b/native/packages/react-native-bpk-component-switch/src/BpkSwitch.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-switch/stories.js
+++ b/native/packages/react-native-bpk-component-switch/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/index.js
+++ b/native/packages/react-native-bpk-component-text-input/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-RTL-test.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-RTL-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.android.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.common.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.ios.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons-RTL-test.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons-RTL-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons-test.android.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons-test.common.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons-test.ios.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text-input/src/styles.js
+++ b/native/packages/react-native-bpk-component-text-input/src/styles.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text/index.js
+++ b/native/packages/react-native-bpk-component-text/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text/src/BpkText-test.android.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text/src/BpkText-test.common.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text/src/BpkText-test.ios.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-text/src/customPropTypes.js
+++ b/native/packages/react-native-bpk-component-text/src/customPropTypes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-touchable-overlay/index.js
+++ b/native/packages/react-native-bpk-component-touchable-overlay/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-touchable-overlay/src/BpkTouchableOverlay-test.js
+++ b/native/packages/react-native-bpk-component-touchable-overlay/src/BpkTouchableOverlay-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-touchable-overlay/src/BpkTouchableOverlay.js
+++ b/native/packages/react-native-bpk-component-touchable-overlay/src/BpkTouchableOverlay.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-component-touchable-overlay/stories.js
+++ b/native/packages/react-native-bpk-component-touchable-overlay/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-styles/index.js
+++ b/native/packages/react-native-bpk-styles/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-styles/src/shadows.js
+++ b/native/packages/react-native-bpk-styles/src/shadows.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-theming/index.js
+++ b/native/packages/react-native-bpk-theming/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.android.js
+++ b/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.common.js
+++ b/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.common.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.ios.js
+++ b/native/packages/react-native-bpk-theming/src/BpkThemeProvider-test.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-theming/src/BpkThemeProvider.js
+++ b/native/packages/react-native-bpk-theming/src/BpkThemeProvider.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-theming/src/create-theme-listener.js
+++ b/native/packages/react-native-bpk-theming/src/create-theme-listener.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-theming/src/create-with-theme.js
+++ b/native/packages/react-native-bpk-theming/src/create-with-theme.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/packages/react-native-bpk-theming/stories.js
+++ b/native/packages/react-native-bpk-theming/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/react-version-test.js
+++ b/native/react-version-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/storybook/TextStyles.js
+++ b/native/storybook/TextStyles.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/storybook/addons.js
+++ b/native/storybook/addons.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/storybook/index.android.js
+++ b/native/storybook/index.android.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/storybook/index.ios.js
+++ b/native/storybook/index.ios.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/storybook/storybook.js
+++ b/native/storybook/storybook.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/storybook/themeAttributes.js
+++ b/native/storybook/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-animate-height/index.js
+++ b/packages/bpk-animate-height/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-animate-height/src/AnimateHeight-test.js
+++ b/packages/bpk-animate-height/src/AnimateHeight-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-animate-height/src/AnimateHeight.js
+++ b/packages/bpk-animate-height/src/AnimateHeight.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-animate-height/stories.js
+++ b/packages/bpk-animate-height/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/index.js
+++ b/packages/bpk-component-accordion/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/BpkAccordion-test.js
+++ b/packages/bpk-component-accordion/src/BpkAccordion-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/BpkAccordion.js
+++ b/packages/bpk-component-accordion/src/BpkAccordion.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/bpk-accordion-item.scss
+++ b/packages/bpk-component-accordion/src/bpk-accordion-item.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/bpk-accordion.scss
+++ b/packages/bpk-component-accordion/src/bpk-accordion.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/themeAttributes-test.js
+++ b/packages/bpk-component-accordion/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/themeAttributes.js
+++ b/packages/bpk-component-accordion/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/withAccordionItemState-test.js
+++ b/packages/bpk-component-accordion/src/withAccordionItemState-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/withAccordionItemState.js
+++ b/packages/bpk-component-accordion/src/withAccordionItemState.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/withSingleItemAccordionState-test.js
+++ b/packages/bpk-component-accordion/src/withSingleItemAccordionState-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/src/withSingleItemAccordionState.js
+++ b/packages/bpk-component-accordion/src/withSingleItemAccordionState.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-accordion/stories.js
+++ b/packages/bpk-component-accordion/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-autosuggest/index.js
+++ b/packages/bpk-component-autosuggest/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggest-test.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggest-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggest.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggest.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion-test.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-autosuggest/src/bpk-autosuggest.scss
+++ b/packages/bpk-component-autosuggest/src/bpk-autosuggest.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-autosuggest/stories.js
+++ b/packages/bpk-component-autosuggest/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-badge/index.js
+++ b/packages/bpk-component-badge/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-badge/src/BpkBadge-test.js
+++ b/packages/bpk-component-badge/src/BpkBadge-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-badge/src/BpkBadge.js
+++ b/packages/bpk-component-badge/src/BpkBadge.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-badge/src/bpk-badge.scss
+++ b/packages/bpk-component-badge/src/bpk-badge.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-badge/stories.js
+++ b/packages/bpk-component-badge/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/index.js
+++ b/packages/bpk-component-banner-alert/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/src/AnimateAndFade-test.js
+++ b/packages/bpk-component-banner-alert/src/AnimateAndFade-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/src/AnimateAndFade.js
+++ b/packages/bpk-component-banner-alert/src/AnimateAndFade.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/src/animate-and-fade.scss
+++ b/packages/bpk-component-banner-alert/src/animate-and-fade.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/src/bpk-banner-alert.scss
+++ b/packages/bpk-component-banner-alert/src/bpk-banner-alert.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState-test.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-banner-alert/stories.js
+++ b/packages/bpk-component-banner-alert/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/hocs.js
+++ b/packages/bpk-component-barchart/hocs.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/index.js
+++ b/packages/bpk-component-barchart/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkBarchart-test.js
+++ b/packages/bpk-component-barchart/src/BpkBarchart-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkBarchart.js
+++ b/packages/bpk-component-barchart/src/BpkBarchart.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkBarchartBar-test.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartBar-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkBarchartBar.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartBar.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkBarchartBars-test.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartBars-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkBarchartBars.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartBars.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkBarchartDefs-test.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartDefs-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkBarchartDefs.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartDefs.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkChartAxis-test.js
+++ b/packages/bpk-component-barchart/src/BpkChartAxis-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkChartAxis.js
+++ b/packages/bpk-component-barchart/src/BpkChartAxis.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkChartDataTable-test.js
+++ b/packages/bpk-component-barchart/src/BpkChartDataTable-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkChartDataTable.js
+++ b/packages/bpk-component-barchart/src/BpkChartDataTable.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkChartGridLines-test.js
+++ b/packages/bpk-component-barchart/src/BpkChartGridLines-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkChartGridLines.js
+++ b/packages/bpk-component-barchart/src/BpkChartGridLines.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkChartMargin-test.js
+++ b/packages/bpk-component-barchart/src/BpkChartMargin-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/BpkChartMargin.js
+++ b/packages/bpk-component-barchart/src/BpkChartMargin.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/RTLtransforms.js
+++ b/packages/bpk-component-barchart/src/RTLtransforms.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/bpk-barchart-bar.scss
+++ b/packages/bpk-component-barchart/src/bpk-barchart-bar.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/bpk-barchart.scss
+++ b/packages/bpk-component-barchart/src/bpk-barchart.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/bpk-chart-axis.scss
+++ b/packages/bpk-component-barchart/src/bpk-chart-axis.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/bpk-chart-data-table.scss
+++ b/packages/bpk-component-barchart/src/bpk-chart-data-table.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/bpk-chart-grid-lines.scss
+++ b/packages/bpk-component-barchart/src/bpk-chart-grid-lines.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/customPropTypes-test.js
+++ b/packages/bpk-component-barchart/src/customPropTypes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/customPropTypes.js
+++ b/packages/bpk-component-barchart/src/customPropTypes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/orientation.js
+++ b/packages/bpk-component-barchart/src/orientation.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/themeAttributes-test.js
+++ b/packages/bpk-component-barchart/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/themeAttributes.js
+++ b/packages/bpk-component-barchart/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/utils-test.js
+++ b/packages/bpk-component-barchart/src/utils-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/src/utils.js
+++ b/packages/bpk-component-barchart/src/utils.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-barchart/stories.js
+++ b/packages/bpk-component-barchart/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-blockquote/index.js
+++ b/packages/bpk-component-blockquote/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-blockquote/src/BpkBlockquote-test.js
+++ b/packages/bpk-component-blockquote/src/BpkBlockquote-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-blockquote/src/BpkBlockquote.js
+++ b/packages/bpk-component-blockquote/src/BpkBlockquote.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-blockquote/src/bpk-blockquote.scss
+++ b/packages/bpk-component-blockquote/src/bpk-blockquote.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-blockquote/src/themeAttributes-test.js
+++ b/packages/bpk-component-blockquote/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-blockquote/src/themeAttributes.js
+++ b/packages/bpk-component-blockquote/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-blockquote/stories.js
+++ b/packages/bpk-component-blockquote/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-breakpoint/index.js
+++ b/packages/bpk-component-breakpoint/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-breakpoint/src/BpkBreakpoint-test.js
+++ b/packages/bpk-component-breakpoint/src/BpkBreakpoint-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-breakpoint/src/BpkBreakpoint.js
+++ b/packages/bpk-component-breakpoint/src/BpkBreakpoint.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-breakpoint/stories.js
+++ b/packages/bpk-component-breakpoint/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-button/index.js
+++ b/packages/bpk-component-button/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-button/src/BpkButton-test.js
+++ b/packages/bpk-component-button/src/BpkButton-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-button/src/BpkButton.js
+++ b/packages/bpk-component-button/src/BpkButton.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-button/src/bpk-button.scss
+++ b/packages/bpk-component-button/src/bpk-button.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-button/src/themeAttributes-test.js
+++ b/packages/bpk-component-button/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-button/src/themeAttributes.js
+++ b/packages/bpk-component-button/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-button/stories.js
+++ b/packages/bpk-component-button/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/index.js
+++ b/packages/bpk-component-calendar/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/readme.md
+++ b/packages/bpk-component-calendar/readme.md
@@ -283,7 +283,7 @@ If set to false, the calendar is of fluid width and will take up the space of it
 
 #### formatDateFull
 
-A function to format a full, human-readable date, for example: "Friday, 13th January 2017":
+A function to format a full, human-readable date, for example: "Monday, 8th January 2018":
 
 ```js
 import format from 'date-fns/format';
@@ -293,7 +293,7 @@ const formatDateFull = date => format(date, 'dddd, Do MMMM YYYY');
 
 #### formatMonth
 
-A function to format a human-readable month, for example: "January 2017":
+A function to format a human-readable month, for example: "January 2018":
 
 If you just need to quickly prototype, use the following from [date-fns](https://date-fns.org/docs/format#usage):
 

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarDate-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarDate.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarGridHeader.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridHeader.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarGridTransition-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridTransition-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarGridTransition.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridTransition.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarNav-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarNav-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/BpkCalendarNav.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarNav.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/Week.js
+++ b/packages/bpk-component-calendar/src/Week.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/_variables.scss
+++ b/packages/bpk-component-calendar/src/_variables.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/bpk-calendar-date.scss
+++ b/packages/bpk-component-calendar/src/bpk-calendar-date.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/bpk-calendar-grid-header.scss
+++ b/packages/bpk-component-calendar/src/bpk-calendar-grid-header.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/bpk-calendar-grid-transition.scss
+++ b/packages/bpk-component-calendar/src/bpk-calendar-grid-transition.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/bpk-calendar-grid.scss
+++ b/packages/bpk-component-calendar/src/bpk-calendar-grid.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/bpk-calendar-nav.scss
+++ b/packages/bpk-component-calendar/src/bpk-calendar-nav.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/bpk-calendar.scss
+++ b/packages/bpk-component-calendar/src/bpk-calendar.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/composeCalendar-test.js
+++ b/packages/bpk-component-calendar/src/composeCalendar-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/composeCalendar.js
+++ b/packages/bpk-component-calendar/src/composeCalendar.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/custom-proptypes.js
+++ b/packages/bpk-component-calendar/src/custom-proptypes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/date-utils.js
+++ b/packages/bpk-component-calendar/src/date-utils.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/themeAttributes-test.js
+++ b/packages/bpk-component-calendar/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/themeAttributes.js
+++ b/packages/bpk-component-calendar/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/src/utils.js
+++ b/packages/bpk-component-calendar/src/utils.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/stories-components.js
+++ b/packages/bpk-component-calendar/stories-components.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/stories.js
+++ b/packages/bpk-component-calendar/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-calendar/test-utils.js
+++ b/packages/bpk-component-calendar/test-utils.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-card/index.js
+++ b/packages/bpk-component-card/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-card/src/BpkCard-test.js
+++ b/packages/bpk-component-card/src/BpkCard-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-card/src/BpkCard.js
+++ b/packages/bpk-component-card/src/BpkCard.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-card/src/bpk-card.scss
+++ b/packages/bpk-component-card/src/bpk-card.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-card/stories.js
+++ b/packages/bpk-component-card/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-checkbox/index.js
+++ b/packages/bpk-component-checkbox/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-checkbox/src/BpkCheckbox-test.js
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-checkbox/src/BpkCheckbox.js
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-checkbox/src/BpkCheckbox.scss
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-checkbox/src/themeAttributes-test.js
+++ b/packages/bpk-component-checkbox/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-checkbox/src/themeAttributes.js
+++ b/packages/bpk-component-checkbox/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-checkbox/stories.js
+++ b/packages/bpk-component-checkbox/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-chip/index.js
+++ b/packages/bpk-component-chip/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-chip/src/BpkChip-test.js
+++ b/packages/bpk-component-chip/src/BpkChip-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-chip/src/BpkChip.js
+++ b/packages/bpk-component-chip/src/BpkChip.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-chip/src/bpk-chip.scss
+++ b/packages/bpk-component-chip/src/bpk-chip.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-chip/stories.js
+++ b/packages/bpk-component-chip/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-close-button/index.js
+++ b/packages/bpk-component-close-button/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-close-button/src/BpkCloseButton-test.js
+++ b/packages/bpk-component-close-button/src/BpkCloseButton-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-close-button/src/BpkCloseButton.js
+++ b/packages/bpk-component-close-button/src/BpkCloseButton.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-close-button/src/bpk-close-button.scss
+++ b/packages/bpk-component-close-button/src/bpk-close-button.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-close-button/stories.js
+++ b/packages/bpk-component-close-button/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-code/index.js
+++ b/packages/bpk-component-code/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-code/src/BpkCode-test.js
+++ b/packages/bpk-component-code/src/BpkCode-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-code/src/BpkCode.js
+++ b/packages/bpk-component-code/src/BpkCode.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-code/src/BpkCodeBlock-test.js
+++ b/packages/bpk-component-code/src/BpkCodeBlock-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-code/src/BpkCodeBlock.js
+++ b/packages/bpk-component-code/src/BpkCodeBlock.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-code/src/bpk-code-block.scss
+++ b/packages/bpk-component-code/src/bpk-code-block.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-code/src/bpk-code.scss
+++ b/packages/bpk-component-code/src/bpk-code.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-code/stories.js
+++ b/packages/bpk-component-code/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-content-container/index.js
+++ b/packages/bpk-component-content-container/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-content-container/src/BpkContentContainer-test.js
+++ b/packages/bpk-component-content-container/src/BpkContentContainer-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-content-container/src/BpkContentContainer.js
+++ b/packages/bpk-component-content-container/src/BpkContentContainer.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-content-container/src/bpk-content-container.scss
+++ b/packages/bpk-component-content-container/src/bpk-content-container.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-content-container/stories.js
+++ b/packages/bpk-component-content-container/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/index.js
+++ b/packages/bpk-component-datatable/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/src/BpkDataTable-test.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/src/BpkDataTableColumn-test.js
+++ b/packages/bpk-component-datatable/src/BpkDataTableColumn-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/src/BpkDataTableColumn.js
+++ b/packages/bpk-component-datatable/src/BpkDataTableColumn.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/src/bpk-data-table-column.scss
+++ b/packages/bpk-component-datatable/src/bpk-data-table-column.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/src/bpk-data-table.scss
+++ b/packages/bpk-component-datatable/src/bpk-data-table.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/src/hasChildrenOfType-test.js
+++ b/packages/bpk-component-datatable/src/hasChildrenOfType-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/src/hasChildrenOfType.js
+++ b/packages/bpk-component-datatable/src/hasChildrenOfType.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datatable/stories.js
+++ b/packages/bpk-component-datatable/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datepicker/index.js
+++ b/packages/bpk-component-datepicker/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datepicker/src/bpk-datepicker.scss
+++ b/packages/bpk-component-datepicker/src/bpk-datepicker.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datepicker/src/themeAttibutes-test.js
+++ b/packages/bpk-component-datepicker/src/themeAttibutes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datepicker/src/themeAttributes.js
+++ b/packages/bpk-component-datepicker/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-datepicker/stories.js
+++ b/packages/bpk-component-datepicker/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/index.js
+++ b/packages/bpk-component-description-list/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/src/BpkDescriptionDetails-test.js
+++ b/packages/bpk-component-description-list/src/BpkDescriptionDetails-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/src/BpkDescriptionDetails.js
+++ b/packages/bpk-component-description-list/src/BpkDescriptionDetails.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/src/BpkDescriptionList-test.js
+++ b/packages/bpk-component-description-list/src/BpkDescriptionList-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/src/BpkDescriptionList.js
+++ b/packages/bpk-component-description-list/src/BpkDescriptionList.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/src/BpkDescriptionList.scss
+++ b/packages/bpk-component-description-list/src/BpkDescriptionList.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/src/BpkDescriptionTerm-test.js
+++ b/packages/bpk-component-description-list/src/BpkDescriptionTerm-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/src/BpkDescriptionTerm.js
+++ b/packages/bpk-component-description-list/src/BpkDescriptionTerm.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/src/ComponentFactory.js
+++ b/packages/bpk-component-description-list/src/ComponentFactory.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-description-list/stories.js
+++ b/packages/bpk-component-description-list/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/index.js
+++ b/packages/bpk-component-drawer/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/src/BpkDrawer-test.js
+++ b/packages/bpk-component-drawer/src/BpkDrawer-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/src/BpkDrawer.js
+++ b/packages/bpk-component-drawer/src/BpkDrawer.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/src/BpkDrawerContent-test.js
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.js
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/src/bpk-drawer-content.scss
+++ b/packages/bpk-component-drawer/src/bpk-drawer-content.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/src/bpk-drawer.scss
+++ b/packages/bpk-component-drawer/src/bpk-drawer.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/src/themeAttributes-test.js
+++ b/packages/bpk-component-drawer/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/src/themeAttributes.js
+++ b/packages/bpk-component-drawer/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/stories.js
+++ b/packages/bpk-component-drawer/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-drawer/stories.scss
+++ b/packages/bpk-component-drawer/stories.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-fieldset/index.js
+++ b/packages/bpk-component-fieldset/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-fieldset/src/BpkFieldset-test.js
+++ b/packages/bpk-component-fieldset/src/BpkFieldset-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-fieldset/src/BpkFieldset.js
+++ b/packages/bpk-component-fieldset/src/BpkFieldset.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-fieldset/src/bpk-fieldset.scss
+++ b/packages/bpk-component-fieldset/src/bpk-fieldset.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-fieldset/stories.js
+++ b/packages/bpk-component-fieldset/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-form-validation/index.js
+++ b/packages/bpk-component-form-validation/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-form-validation/src/BpkFormValidation-test.js
+++ b/packages/bpk-component-form-validation/src/BpkFormValidation-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-form-validation/src/BpkFormValidation.js
+++ b/packages/bpk-component-form-validation/src/BpkFormValidation.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-form-validation/src/bpk-form-validation.scss
+++ b/packages/bpk-component-form-validation/src/bpk-form-validation.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-form-validation/stories.js
+++ b/packages/bpk-component-form-validation/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid-toggle/index.js
+++ b/packages/bpk-component-grid-toggle/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid-toggle/src/BpkGridToggle-test.js
+++ b/packages/bpk-component-grid-toggle/src/BpkGridToggle-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
+++ b/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid-toggle/src/bpk-grid-toggle.scss
+++ b/packages/bpk-component-grid-toggle/src/bpk-grid-toggle.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid-toggle/stories.js
+++ b/packages/bpk-component-grid-toggle/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/index.js
+++ b/packages/bpk-component-grid/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/src/BpkGridColumn-test.js
+++ b/packages/bpk-component-grid/src/BpkGridColumn-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/src/BpkGridColumn.js
+++ b/packages/bpk-component-grid/src/BpkGridColumn.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/src/BpkGridContainer-test.js
+++ b/packages/bpk-component-grid/src/BpkGridContainer-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/src/BpkGridContainer.js
+++ b/packages/bpk-component-grid/src/BpkGridContainer.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/src/BpkGridRow-test.js
+++ b/packages/bpk-component-grid/src/BpkGridRow-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/src/BpkGridRow.js
+++ b/packages/bpk-component-grid/src/BpkGridRow.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/src/bpk-grid-column.scss
+++ b/packages/bpk-component-grid/src/bpk-grid-column.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/src/bpk-grid-container.scss
+++ b/packages/bpk-component-grid/src/bpk-grid-container.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/src/bpk-grid-row.scss
+++ b/packages/bpk-component-grid/src/bpk-grid-row.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-grid/stories.js
+++ b/packages/bpk-component-grid/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-heading/index.js
+++ b/packages/bpk-component-heading/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-heading/src/BpkHeading-test.js
+++ b/packages/bpk-component-heading/src/BpkHeading-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-heading/src/BpkHeading.js
+++ b/packages/bpk-component-heading/src/BpkHeading.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-heading/src/bpk-heading.scss
+++ b/packages/bpk-component-heading/src/bpk-heading.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-heading/stories.js
+++ b/packages/bpk-component-heading/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-horizontal-nav/index.js
+++ b/packages/bpk-component-horizontal-nav/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav-test.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav-item.scss
+++ b/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav-item.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav.scss
+++ b/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-horizontal-nav/stories.js
+++ b/packages/bpk-component-horizontal-nav/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/all.js
+++ b/packages/bpk-component-icon/all.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/gulpfile.babel.js
+++ b/packages/bpk-component-icon/gulpfile.babel.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/index.js
+++ b/packages/bpk-component-icon/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/src/bpk-icon.scss
+++ b/packages/bpk-component-icon/src/bpk-icon.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/src/classNameModifierHOCFactory-test.js
+++ b/packages/bpk-component-icon/src/classNameModifierHOCFactory-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/src/classNameModifierHOCFactory.js
+++ b/packages/bpk-component-icon/src/classNameModifierHOCFactory.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/src/withAlignment-test.js
+++ b/packages/bpk-component-icon/src/withAlignment-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/src/withAlignment.js
+++ b/packages/bpk-component-icon/src/withAlignment.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/src/withRtlSupport.js
+++ b/packages/bpk-component-icon/src/withRtlSupport.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-icon/stories.js
+++ b/packages/bpk-component-icon/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/index.js
+++ b/packages/bpk-component-image/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/src/BpkBackgroundImage-test.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/src/BpkBackgroundImage.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/src/BpkImage-test.js
+++ b/packages/bpk-component-image/src/BpkImage-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/src/bpk-background-image.scss
+++ b/packages/bpk-component-image/src/bpk-background-image.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/src/bpk-image.scss
+++ b/packages/bpk-component-image/src/bpk-image.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/src/withLazyLoading-test.js
+++ b/packages/bpk-component-image/src/withLazyLoading-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/src/withLazyLoading.js
+++ b/packages/bpk-component-image/src/withLazyLoading.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/src/withLoadingBehavior.js
+++ b/packages/bpk-component-image/src/withLoadingBehavior.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-image/stories.js
+++ b/packages/bpk-component-image/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-input/index.js
+++ b/packages/bpk-component-input/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-input/src/BpkInput-test.js
+++ b/packages/bpk-component-input/src/BpkInput-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-input/src/BpkInput.js
+++ b/packages/bpk-component-input/src/BpkInput.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-input/src/bpk-input.scss
+++ b/packages/bpk-component-input/src/bpk-input.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-input/src/withOpenEvents-test.js
+++ b/packages/bpk-component-input/src/withOpenEvents-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-input/src/withOpenEvents.js
+++ b/packages/bpk-component-input/src/withOpenEvents.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-input/stories.js
+++ b/packages/bpk-component-input/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-label/index.js
+++ b/packages/bpk-component-label/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-label/src/BpkLabel-test.js
+++ b/packages/bpk-component-label/src/BpkLabel-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-label/src/BpkLabel.js
+++ b/packages/bpk-component-label/src/BpkLabel.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-label/src/bpk-label.scss
+++ b/packages/bpk-component-label/src/bpk-label.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-label/stories.js
+++ b/packages/bpk-component-label/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-link/index.js
+++ b/packages/bpk-component-link/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-link/src/BpkButtonLink-test.js
+++ b/packages/bpk-component-link/src/BpkButtonLink-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-link/src/BpkButtonLink.js
+++ b/packages/bpk-component-link/src/BpkButtonLink.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-link/src/BpkLink-test.js
+++ b/packages/bpk-component-link/src/BpkLink-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-link/src/BpkLink.js
+++ b/packages/bpk-component-link/src/BpkLink.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-link/src/bpk-link.scss
+++ b/packages/bpk-component-link/src/bpk-link.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-link/src/themeAttributes.js
+++ b/packages/bpk-component-link/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-link/stories.js
+++ b/packages/bpk-component-link/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-list/index.js
+++ b/packages/bpk-component-list/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-list/src/BpkList-test.js
+++ b/packages/bpk-component-list/src/BpkList-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-list/src/BpkList.js
+++ b/packages/bpk-component-list/src/BpkList.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-list/src/BpkListItem-test.js
+++ b/packages/bpk-component-list/src/BpkListItem-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-list/src/BpkListItem.js
+++ b/packages/bpk-component-list/src/BpkListItem.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-list/src/bpk-list.scss
+++ b/packages/bpk-component-list/src/bpk-list.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-list/stories.js
+++ b/packages/bpk-component-list/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-loading-button/index.js
+++ b/packages/bpk-component-loading-button/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-loading-button/src/BpkLoadingButton-test.js
+++ b/packages/bpk-component-loading-button/src/BpkLoadingButton-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-loading-button/src/BpkLoadingButton.js
+++ b/packages/bpk-component-loading-button/src/BpkLoadingButton.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-loading-button/stories.js
+++ b/packages/bpk-component-loading-button/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-mobile-scroll-container/index.js
+++ b/packages/bpk-component-mobile-scroll-container/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer-test.js
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-mobile-scroll-container/src/bpk-mobile-scroll-container.scss
+++ b/packages/bpk-component-mobile-scroll-container/src/bpk-mobile-scroll-container.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-mobile-scroll-container/stories.js
+++ b/packages/bpk-component-mobile-scroll-container/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/index.js
+++ b/packages/bpk-component-modal/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/src/BpkModal-test.js
+++ b/packages/bpk-component-modal/src/BpkModal-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/src/BpkModal.js
+++ b/packages/bpk-component-modal/src/BpkModal.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/src/BpkModalDialog-test.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/src/BpkModalDialog.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/src/bpk-modal-dialog.scss
+++ b/packages/bpk-component-modal/src/bpk-modal-dialog.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/src/bpk-modal.scss
+++ b/packages/bpk-component-modal/src/bpk-modal.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/src/themeAttributes-test.js
+++ b/packages/bpk-component-modal/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/src/themeAttributes.js
+++ b/packages/bpk-component-modal/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/stories.js
+++ b/packages/bpk-component-modal/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-modal/stories.scss
+++ b/packages/bpk-component-modal/stories.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-nudger/index.js
+++ b/packages/bpk-component-nudger/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-nudger/src/BpkNudger-test.js
+++ b/packages/bpk-component-nudger/src/BpkNudger-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-nudger/src/BpkNudger.js
+++ b/packages/bpk-component-nudger/src/BpkNudger.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-nudger/src/bpk-nudger.scss
+++ b/packages/bpk-component-nudger/src/bpk-nudger.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-nudger/src/themeAttributes-test.js
+++ b/packages/bpk-component-nudger/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-nudger/src/themeAttributes.js
+++ b/packages/bpk-component-nudger/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-nudger/stories.js
+++ b/packages/bpk-component-nudger/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/index.js
+++ b/packages/bpk-component-pagination/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/BpkPagination-test.js
+++ b/packages/bpk-component-pagination/src/BpkPagination-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/BpkPagination.js
+++ b/packages/bpk-component-pagination/src/BpkPagination.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/BpkPaginationBreak-test.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationBreak-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/BpkPaginationBreak.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationBreak.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/BpkPaginationList-test.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationList-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/BpkPaginationList.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationList.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/BpkPaginationNudger-test.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationNudger-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/BpkPaginationNudger.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationNudger.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/BpkPaginationPage.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/bpk-pagination-list.scss
+++ b/packages/bpk-component-pagination/src/bpk-pagination-list.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/bpk-pagination-nudger.scss
+++ b/packages/bpk-component-pagination/src/bpk-pagination-nudger.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/bpk-pagination-page.scss
+++ b/packages/bpk-component-pagination/src/bpk-pagination-page.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/bpk-pagination.scss
+++ b/packages/bpk-component-pagination/src/bpk-pagination.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/themeAttributes-test.js
+++ b/packages/bpk-component-pagination/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/src/themeAttributes.js
+++ b/packages/bpk-component-pagination/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-pagination/stories.js
+++ b/packages/bpk-component-pagination/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-panel/index.js
+++ b/packages/bpk-component-panel/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-panel/src/BpkPanel-test.js
+++ b/packages/bpk-component-panel/src/BpkPanel-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-panel/src/BpkPanel.js
+++ b/packages/bpk-component-panel/src/BpkPanel.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-panel/src/bpk-panel.scss
+++ b/packages/bpk-component-panel/src/bpk-panel.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-panel/stories.js
+++ b/packages/bpk-component-panel/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-paragraph/index.js
+++ b/packages/bpk-component-paragraph/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-paragraph/src/BpkParagraph-test.js
+++ b/packages/bpk-component-paragraph/src/BpkParagraph-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-paragraph/src/BpkParagraph.js
+++ b/packages/bpk-component-paragraph/src/BpkParagraph.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-paragraph/src/bpk-paragraph.scss
+++ b/packages/bpk-component-paragraph/src/bpk-paragraph.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-paragraph/stories.js
+++ b/packages/bpk-component-paragraph/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/index.js
+++ b/packages/bpk-component-popover/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/src/BpkPopover-test.js
+++ b/packages/bpk-component-popover/src/BpkPopover-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/src/BpkPopover.js
+++ b/packages/bpk-component-popover/src/BpkPopover.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/src/BpkPopoverPortal-test.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/src/bpk-popover.scss
+++ b/packages/bpk-component-popover/src/bpk-popover.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/src/constants.js
+++ b/packages/bpk-component-popover/src/constants.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/src/themeAttributes-test.js
+++ b/packages/bpk-component-popover/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/src/themeAttributes.js
+++ b/packages/bpk-component-popover/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
   * Backpack - Skyscanner's Design System
   *
-  * Copyright 2017 Skyscanner Ltd
+  * Copyright 2018 Skyscanner Ltd
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-popover/stories.js
+++ b/packages/bpk-component-popover/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-progress/index.js
+++ b/packages/bpk-component-progress/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-progress/src/BpkProgress-test.js
+++ b/packages/bpk-component-progress/src/BpkProgress-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-progress/src/BpkProgress.js
+++ b/packages/bpk-component-progress/src/BpkProgress.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-progress/src/bpk-progress.scss
+++ b/packages/bpk-component-progress/src/bpk-progress.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-progress/src/themeAttributes-test.js
+++ b/packages/bpk-component-progress/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-progress/src/themeAttributes.js
+++ b/packages/bpk-component-progress/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-progress/stories.js
+++ b/packages/bpk-component-progress/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-radio/index.js
+++ b/packages/bpk-component-radio/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-radio/src/BpkRadio-test.js
+++ b/packages/bpk-component-radio/src/BpkRadio-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-radio/src/BpkRadio.js
+++ b/packages/bpk-component-radio/src/BpkRadio.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-radio/src/BpkRadio.scss
+++ b/packages/bpk-component-radio/src/BpkRadio.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-radio/src/themeAttributes-test.js
+++ b/packages/bpk-component-radio/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-radio/src/themeAttributes.js
+++ b/packages/bpk-component-radio/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-radio/stories.js
+++ b/packages/bpk-component-radio/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-router-link/index.js
+++ b/packages/bpk-component-router-link/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-router-link/src/BpkRouterLink-test.js
+++ b/packages/bpk-component-router-link/src/BpkRouterLink-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-router-link/src/BpkRouterLink.js
+++ b/packages/bpk-component-router-link/src/BpkRouterLink.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-router-link/src/bpk-router-link.scss
+++ b/packages/bpk-component-router-link/src/bpk-router-link.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-router-link/stories.js
+++ b/packages/bpk-component-router-link/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-rtl-toggle/index.js
+++ b/packages/bpk-component-rtl-toggle/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-rtl-toggle/src/BpkRtlToggle-test.js
+++ b/packages/bpk-component-rtl-toggle/src/BpkRtlToggle-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-rtl-toggle/src/BpkRtlToggle.js
+++ b/packages/bpk-component-rtl-toggle/src/BpkRtlToggle.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange-test.js
+++ b/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange.js
+++ b/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-rtl-toggle/src/utils.js
+++ b/packages/bpk-component-rtl-toggle/src/utils.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-rtl-toggle/stories.js
+++ b/packages/bpk-component-rtl-toggle/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-select/index.js
+++ b/packages/bpk-component-select/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-select/src/BpkSelect-test.js
+++ b/packages/bpk-component-select/src/BpkSelect-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-select/src/BpkSelect.js
+++ b/packages/bpk-component-select/src/BpkSelect.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-select/src/bpk-select.scss
+++ b/packages/bpk-component-select/src/bpk-select.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-select/stories.js
+++ b/packages/bpk-component-select/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-slider/index.js
+++ b/packages/bpk-component-slider/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-slider/src/BpkSlider-test.js
+++ b/packages/bpk-component-slider/src/BpkSlider-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-slider/src/BpkSlider.js
+++ b/packages/bpk-component-slider/src/BpkSlider.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-slider/src/bpk-slider.scss
+++ b/packages/bpk-component-slider/src/bpk-slider.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-slider/src/themeAttributes-test.js
+++ b/packages/bpk-component-slider/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-slider/src/themeAttributes.js
+++ b/packages/bpk-component-slider/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-slider/stories.js
+++ b/packages/bpk-component-slider/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/SpinnerLayout.js
+++ b/packages/bpk-component-spinner/SpinnerLayout.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/SpinnerLayout.scss
+++ b/packages/bpk-component-spinner/SpinnerLayout.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/index.js
+++ b/packages/bpk-component-spinner/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/BpkExtraLargeSpinner-test.js
+++ b/packages/bpk-component-spinner/src/BpkExtraLargeSpinner-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/BpkExtraLargeSpinner.js
+++ b/packages/bpk-component-spinner/src/BpkExtraLargeSpinner.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/BpkLargeSpinner-test.js
+++ b/packages/bpk-component-spinner/src/BpkLargeSpinner-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/BpkLargeSpinner.js
+++ b/packages/bpk-component-spinner/src/BpkLargeSpinner.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/BpkSpinner-test.js
+++ b/packages/bpk-component-spinner/src/BpkSpinner-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/BpkSpinner.js
+++ b/packages/bpk-component-spinner/src/BpkSpinner.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/bpk-spinner.scss
+++ b/packages/bpk-component-spinner/src/bpk-spinner.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/spinnerTypes.js
+++ b/packages/bpk-component-spinner/src/spinnerTypes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/themeAttributes-test.js
+++ b/packages/bpk-component-spinner/src/themeAttributes-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/src/themeAttributes.js
+++ b/packages/bpk-component-spinner/src/themeAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-spinner/stories.js
+++ b/packages/bpk-component-spinner/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/index.js
+++ b/packages/bpk-component-star-rating/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStar-test.js
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStar-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStar.js
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStar.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStar.scss
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStar.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStarRating-test.js
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStarRating-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.js
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkStar-test.js
+++ b/packages/bpk-component-star-rating/src/BpkStar-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkStar.js
+++ b/packages/bpk-component-star-rating/src/BpkStar.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkStar.scss
+++ b/packages/bpk-component-star-rating/src/BpkStar.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkStarRating-test.js
+++ b/packages/bpk-component-star-rating/src/BpkStarRating-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkStarRating.js
+++ b/packages/bpk-component-star-rating/src/BpkStarRating.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/BpkStarRating.scss
+++ b/packages/bpk-component-star-rating/src/BpkStarRating.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/withInteractiveStarRatingState-test.js
+++ b/packages/bpk-component-star-rating/src/withInteractiveStarRatingState-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/src/withInteractiveStarRatingState.js
+++ b/packages/bpk-component-star-rating/src/withInteractiveStarRatingState.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-star-rating/stories.js
+++ b/packages/bpk-component-star-rating/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/index.js
+++ b/packages/bpk-component-table/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTable-test.js
+++ b/packages/bpk-component-table/src/BpkTable-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTable.js
+++ b/packages/bpk-component-table/src/BpkTable.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableBody-test.js
+++ b/packages/bpk-component-table/src/BpkTableBody-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableBody.js
+++ b/packages/bpk-component-table/src/BpkTableBody.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableCell-test.js
+++ b/packages/bpk-component-table/src/BpkTableCell-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableCell.js
+++ b/packages/bpk-component-table/src/BpkTableCell.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableHead-test.js
+++ b/packages/bpk-component-table/src/BpkTableHead-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableHead.js
+++ b/packages/bpk-component-table/src/BpkTableHead.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableHeadCell-test.js
+++ b/packages/bpk-component-table/src/BpkTableHeadCell-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableHeadCell.js
+++ b/packages/bpk-component-table/src/BpkTableHeadCell.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableRow-test.js
+++ b/packages/bpk-component-table/src/BpkTableRow-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/BpkTableRow.js
+++ b/packages/bpk-component-table/src/BpkTableRow.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/src/bpk-table.scss
+++ b/packages/bpk-component-table/src/bpk-table.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-table/stories.js
+++ b/packages/bpk-component-table/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-text/index.js
+++ b/packages/bpk-component-text/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-text/src/BpkText-test.js
+++ b/packages/bpk-component-text/src/BpkText-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-text/src/BpkText.js
+++ b/packages/bpk-component-text/src/BpkText.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-text/stories.js
+++ b/packages/bpk-component-text/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-textarea/index.js
+++ b/packages/bpk-component-textarea/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-textarea/src/BpkTextarea-test.js
+++ b/packages/bpk-component-textarea/src/BpkTextarea-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-textarea/src/BpkTextarea.js
+++ b/packages/bpk-component-textarea/src/BpkTextarea.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-textarea/src/bpk-textarea.scss
+++ b/packages/bpk-component-textarea/src/bpk-textarea.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-textarea/stories.js
+++ b/packages/bpk-component-textarea/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-theme-toggle/index.js
+++ b/packages/bpk-component-theme-toggle/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-theme-toggle/src/BpkThemeToggle-test.js
+++ b/packages/bpk-component-theme-toggle/src/BpkThemeToggle-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-theme-toggle/src/BpkThemeToggle.js
+++ b/packages/bpk-component-theme-toggle/src/BpkThemeToggle.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-theme-toggle/src/theming.js
+++ b/packages/bpk-component-theme-toggle/src/theming.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-theme-toggle/src/updateOnThemeChange-test.js
+++ b/packages/bpk-component-theme-toggle/src/updateOnThemeChange-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-theme-toggle/src/updateOnThemeChange.js
+++ b/packages/bpk-component-theme-toggle/src/updateOnThemeChange.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-theme-toggle/src/utils.js
+++ b/packages/bpk-component-theme-toggle/src/utils.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-theme-toggle/stories.js
+++ b/packages/bpk-component-theme-toggle/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-ticket/index.js
+++ b/packages/bpk-component-ticket/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-ticket/src/BpkTicket-test.js
+++ b/packages/bpk-component-ticket/src/BpkTicket-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-ticket/src/BpkTicket.js
+++ b/packages/bpk-component-ticket/src/BpkTicket.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-ticket/src/bpk-ticket.scss
+++ b/packages/bpk-component-ticket/src/bpk-ticket.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-ticket/stories.js
+++ b/packages/bpk-component-ticket/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-ticket/stories.scss
+++ b/packages/bpk-component-ticket/stories.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tile/index.js
+++ b/packages/bpk-component-tile/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tile/src/BpkTile.js
+++ b/packages/bpk-component-tile/src/BpkTile.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tile/src/bpk-tile.scss
+++ b/packages/bpk-component-tile/src/bpk-tile.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tile/stories.js
+++ b/packages/bpk-component-tile/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tooltip/index.js
+++ b/packages/bpk-component-tooltip/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tooltip/src/BpkTooltip-test.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltip-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tooltip/src/BpkTooltip.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltip.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal-test.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.scss
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tooltip/src/bpk-tooltip.scss
+++ b/packages/bpk-component-tooltip/src/bpk-tooltip.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tooltip/src/constants.js
+++ b/packages/bpk-component-tooltip/src/constants.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-component-tooltip/stories.js
+++ b/packages/bpk-component-tooltip/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/index.js
+++ b/packages/bpk-docs/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/secrets.template.yml
+++ b/packages/bpk-docs/secrets.template.yml
@@ -1,7 +1,7 @@
 #
 # Backpack - Skyscanner's Design System
 #
-# Copyright 2017 Skyscanner Ltd
+# Copyright 2018 Skyscanner Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/bag-check-bookmarklet/index.js
+++ b/packages/bpk-docs/src/bag-check-bookmarklet/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/ColorSwatch/ColorSwatch.js
+++ b/packages/bpk-docs/src/components/ColorSwatch/ColorSwatch.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/ColorSwatch/color-swatch.scss
+++ b/packages/bpk-docs/src/components/ColorSwatch/color-swatch.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/ColorSwatch/index.js
+++ b/packages/bpk-docs/src/components/ColorSwatch/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/DocsPageBuilder/ComponentScreenshots.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/ComponentScreenshots.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/DocsPageBuilder/ComponentScreenshots.scss
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/ComponentScreenshots.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/DocsPageBuilder/DocsPageBuilder.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/DocsPageBuilder.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/DocsPageBuilder/TokenSwitcher.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/TokenSwitcher.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/DocsPageBuilder/index.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Header/HamburgerButton.js
+++ b/packages/bpk-docs/src/components/Header/HamburgerButton.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Header/HamburgerButton.scss
+++ b/packages/bpk-docs/src/components/Header/HamburgerButton.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Header/Header.js
+++ b/packages/bpk-docs/src/components/Header/Header.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Header/Header.scss
+++ b/packages/bpk-docs/src/components/Header/Header.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Header/index.js
+++ b/packages/bpk-docs/src/components/Header/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Heading/Heading.js
+++ b/packages/bpk-docs/src/components/Heading/Heading.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Heading/Heading.scss
+++ b/packages/bpk-docs/src/components/Heading/Heading.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Heading/index.js
+++ b/packages/bpk-docs/src/components/Heading/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/IconSearchApp/IconSearchApp.js
+++ b/packages/bpk-docs/src/components/IconSearchApp/IconSearchApp.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/IconSearchApp/IconSearchForm.js
+++ b/packages/bpk-docs/src/components/IconSearchApp/IconSearchForm.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/IconSearchApp/IconSearchForm.scss
+++ b/packages/bpk-docs/src/components/IconSearchApp/IconSearchForm.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/IconSearchApp/IconSearchResult.js
+++ b/packages/bpk-docs/src/components/IconSearchApp/IconSearchResult.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/IconSearchApp/IconSearchResult.scss
+++ b/packages/bpk-docs/src/components/IconSearchApp/IconSearchResult.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/IconSearchApp/IconSearchResults.js
+++ b/packages/bpk-docs/src/components/IconSearchApp/IconSearchResults.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/IconSearchApp/IconSearchResults.scss
+++ b/packages/bpk-docs/src/components/IconSearchApp/IconSearchResults.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/IconSearchApp/index.js
+++ b/packages/bpk-docs/src/components/IconSearchApp/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/IconSearchApp/propTypes.js
+++ b/packages/bpk-docs/src/components/IconSearchApp/propTypes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Paragraph/Paragraph.js
+++ b/packages/bpk-docs/src/components/Paragraph/Paragraph.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Paragraph/Paragraph.scss
+++ b/packages/bpk-docs/src/components/Paragraph/Paragraph.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/Paragraph/index.js
+++ b/packages/bpk-docs/src/components/Paragraph/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/PresentationBlock/PresentationBlock.js
+++ b/packages/bpk-docs/src/components/PresentationBlock/PresentationBlock.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/PresentationBlock/index.js
+++ b/packages/bpk-docs/src/components/PresentationBlock/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/PresentationBlock/presentation-block.scss
+++ b/packages/bpk-docs/src/components/PresentationBlock/presentation-block.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/SassdocLink/SassdocLink.js
+++ b/packages/bpk-docs/src/components/SassdocLink/SassdocLink.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/SassdocLink/index.js
+++ b/packages/bpk-docs/src/components/SassdocLink/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/SassdocLink/sassdoc-link.scss
+++ b/packages/bpk-docs/src/components/SassdocLink/sassdoc-link.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/UsageTable/UsageTable.js
+++ b/packages/bpk-docs/src/components/UsageTable/UsageTable.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/UsageTable/UsageTable.scss
+++ b/packages/bpk-docs/src/components/UsageTable/UsageTable.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/components/UsageTable/index.js
+++ b/packages/bpk-docs/src/components/UsageTable/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/constants/redirect-routes.js
+++ b/packages/bpk-docs/src/constants/redirect-routes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/constants/routes.js
+++ b/packages/bpk-docs/src/constants/routes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/helpers/tokens-helper.js
+++ b/packages/bpk-docs/src/helpers/tokens-helper.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/helpers/tokens.helper-test.js
+++ b/packages/bpk-docs/src/helpers/tokens.helper-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/index.js
+++ b/packages/bpk-docs/src/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/DefaultLayout/DefaultLayout.js
+++ b/packages/bpk-docs/src/layouts/DefaultLayout/DefaultLayout.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/DefaultLayout/default-layout.scss
+++ b/packages/bpk-docs/src/layouts/DefaultLayout/default-layout.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/DefaultLayout/index.js
+++ b/packages/bpk-docs/src/layouts/DefaultLayout/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
+++ b/packages/bpk-docs/src/layouts/DocsLayout/DocsLayout.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/DocsLayout/index.js
+++ b/packages/bpk-docs/src/layouts/DocsLayout/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/SideNavLayout/NavList.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/NavList.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/SideNavLayout/NavSelect.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/NavSelect.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/SideNavLayout/SideNavLayout.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/SideNavLayout.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/SideNavLayout/index.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/SideNavLayout/links-sorter-test.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/links-sorter-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/SideNavLayout/links-sorter.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/links-sorter.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/SideNavLayout/nav-list.scss
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/nav-list.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/SideNavLayout/side-nav-layout.scss
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/side-nav-layout.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/SideNavLayout/sideNavPropTypes.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/sideNavPropTypes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/TokensLayout/TokensLayout.js
+++ b/packages/bpk-docs/src/layouts/TokensLayout/TokensLayout.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/TokensLayout/index.js
+++ b/packages/bpk-docs/src/layouts/TokensLayout/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/UsingLayout/UsingLayout.js
+++ b/packages/bpk-docs/src/layouts/UsingLayout/UsingLayout.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/layouts/UsingLayout/index.js
+++ b/packages/bpk-docs/src/layouts/UsingLayout/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/AccordionsPage/AccordionsPage.js
+++ b/packages/bpk-docs/src/pages/AccordionsPage/AccordionsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/AccordionsPage/index.js
+++ b/packages/bpk-docs/src/pages/AccordionsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/AlignmentPage/AlignmentPage.js
+++ b/packages/bpk-docs/src/pages/AlignmentPage/AlignmentPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/AlignmentPage/index.js
+++ b/packages/bpk-docs/src/pages/AlignmentPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/AnimationPage/AnimationPage.js
+++ b/packages/bpk-docs/src/pages/AnimationPage/AnimationPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/AnimationPage/index.js
+++ b/packages/bpk-docs/src/pages/AnimationPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/AutosuggestPage/AutosuggestPage.js
+++ b/packages/bpk-docs/src/pages/AutosuggestPage/AutosuggestPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/AutosuggestPage/index.js
+++ b/packages/bpk-docs/src/pages/AutosuggestPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BackpackReactScriptsPage/BackpackReactScriptsPage.js
+++ b/packages/bpk-docs/src/pages/BackpackReactScriptsPage/BackpackReactScriptsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BackpackReactScriptsPage/index.js
+++ b/packages/bpk-docs/src/pages/BackpackReactScriptsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BadgePage/BadgePage.js
+++ b/packages/bpk-docs/src/pages/BadgePage/BadgePage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BadgePage/badge-page.scss
+++ b/packages/bpk-docs/src/pages/BadgePage/badge-page.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BadgePage/index.js
+++ b/packages/bpk-docs/src/pages/BadgePage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BannerAlertsPage/BannerAlertsPage.js
+++ b/packages/bpk-docs/src/pages/BannerAlertsPage/BannerAlertsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BannerAlertsPage/bpk-banner-alerts-page.scss
+++ b/packages/bpk-docs/src/pages/BannerAlertsPage/bpk-banner-alerts-page.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BannerAlertsPage/index.js
+++ b/packages/bpk-docs/src/pages/BannerAlertsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BarchartsPage/BarchartsPage.js
+++ b/packages/bpk-docs/src/pages/BarchartsPage/BarchartsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BarchartsPage/index.js
+++ b/packages/bpk-docs/src/pages/BarchartsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BaseStylesheetPage/BaseStylesheetPage.js
+++ b/packages/bpk-docs/src/pages/BaseStylesheetPage/BaseStylesheetPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BaseStylesheetPage/index.js
+++ b/packages/bpk-docs/src/pages/BaseStylesheetPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BordersPage/BordersPage.js
+++ b/packages/bpk-docs/src/pages/BordersPage/BordersPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BordersPage/index.js
+++ b/packages/bpk-docs/src/pages/BordersPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BreakpointsPage/BreakpointsPage.js
+++ b/packages/bpk-docs/src/pages/BreakpointsPage/BreakpointsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BreakpointsPage/breakpoints-page.scss
+++ b/packages/bpk-docs/src/pages/BreakpointsPage/breakpoints-page.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/BreakpointsPage/index.js
+++ b/packages/bpk-docs/src/pages/BreakpointsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ButtonsPage/ButtonsPage.js
+++ b/packages/bpk-docs/src/pages/ButtonsPage/ButtonsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ButtonsPage/index.js
+++ b/packages/bpk-docs/src/pages/ButtonsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/CalendarPage/CalendarPage.js
+++ b/packages/bpk-docs/src/pages/CalendarPage/CalendarPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/CalendarPage/index.js
+++ b/packages/bpk-docs/src/pages/CalendarPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/CardsPage/CardsPage.js
+++ b/packages/bpk-docs/src/pages/CardsPage/CardsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/CardsPage/index.js
+++ b/packages/bpk-docs/src/pages/CardsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ChipsPage/ChipsPage.js
+++ b/packages/bpk-docs/src/pages/ChipsPage/ChipsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ChipsPage/index.js
+++ b/packages/bpk-docs/src/pages/ChipsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ColorsPage/ColorsPage.js
+++ b/packages/bpk-docs/src/pages/ColorsPage/ColorsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ColorsPage/colors-page.scss
+++ b/packages/bpk-docs/src/pages/ColorsPage/colors-page.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ColorsPage/index.js
+++ b/packages/bpk-docs/src/pages/ColorsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/DatepickerPage/DatepickerPage.js
+++ b/packages/bpk-docs/src/pages/DatepickerPage/DatepickerPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/DatepickerPage/index.js
+++ b/packages/bpk-docs/src/pages/DatepickerPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/DrawerPage/DrawerPage.js
+++ b/packages/bpk-docs/src/pages/DrawerPage/DrawerPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/DrawerPage/index.js
+++ b/packages/bpk-docs/src/pages/DrawerPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/FieldsetsPage/FieldsetsPage.js
+++ b/packages/bpk-docs/src/pages/FieldsetsPage/FieldsetsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/FieldsetsPage/fieldsets-page.scss
+++ b/packages/bpk-docs/src/pages/FieldsetsPage/fieldsets-page.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/FieldsetsPage/index.js
+++ b/packages/bpk-docs/src/pages/FieldsetsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/FormsPage/FormsPage.js
+++ b/packages/bpk-docs/src/pages/FormsPage/FormsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/FormsPage/InputContainer.js
+++ b/packages/bpk-docs/src/pages/FormsPage/InputContainer.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/FormsPage/RadioContainer.js
+++ b/packages/bpk-docs/src/pages/FormsPage/RadioContainer.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/FormsPage/forms-page.scss
+++ b/packages/bpk-docs/src/pages/FormsPage/forms-page.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/FormsPage/index.js
+++ b/packages/bpk-docs/src/pages/FormsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/GettingStartedPage/GettingStartedPage.js
+++ b/packages/bpk-docs/src/pages/GettingStartedPage/GettingStartedPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/GettingStartedPage/index.js
+++ b/packages/bpk-docs/src/pages/GettingStartedPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/GridDemoPages/GridColumnDemoPage.js
+++ b/packages/bpk-docs/src/pages/GridDemoPages/GridColumnDemoPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/GridDemoPages/GridOffsetDemoPage.js
+++ b/packages/bpk-docs/src/pages/GridDemoPages/GridOffsetDemoPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/GridDemoPages/Lozenge.js
+++ b/packages/bpk-docs/src/pages/GridDemoPages/Lozenge.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/GridDemoPages/grid-demo-pages.scss
+++ b/packages/bpk-docs/src/pages/GridDemoPages/grid-demo-pages.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/GridDemoPages/index.js
+++ b/packages/bpk-docs/src/pages/GridDemoPages/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/HomePage/HomePage.js
+++ b/packages/bpk-docs/src/pages/HomePage/HomePage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/HomePage/home-page.scss
+++ b/packages/bpk-docs/src/pages/HomePage/home-page.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/HomePage/index.js
+++ b/packages/bpk-docs/src/pages/HomePage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/HorizontalGridPage/HorizontalGridPage.js
+++ b/packages/bpk-docs/src/pages/HorizontalGridPage/HorizontalGridPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/HorizontalGridPage/index.js
+++ b/packages/bpk-docs/src/pages/HorizontalGridPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/HorizontalNavPage/HorizontalNavPage.js
+++ b/packages/bpk-docs/src/pages/HorizontalNavPage/HorizontalNavPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/HorizontalNavPage/index.js
+++ b/packages/bpk-docs/src/pages/HorizontalNavPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/IconsPage/IconsPage.js
+++ b/packages/bpk-docs/src/pages/IconsPage/IconsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/IconsPage/index.js
+++ b/packages/bpk-docs/src/pages/IconsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ImagesPage/ImagesPage.js
+++ b/packages/bpk-docs/src/pages/ImagesPage/ImagesPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design Systrem
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ImagesPage/index.js
+++ b/packages/bpk-docs/src/pages/ImagesPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ModalsPage/LoginFormExample.js
+++ b/packages/bpk-docs/src/pages/ModalsPage/LoginFormExample.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ModalsPage/ModalsPage.js
+++ b/packages/bpk-docs/src/pages/ModalsPage/ModalsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ModalsPage/index.js
+++ b/packages/bpk-docs/src/pages/ModalsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeBannerAlertPage/NativeBannerAlertPage.js
+++ b/packages/bpk-docs/src/pages/NativeBannerAlertPage/NativeBannerAlertPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeBannerAlertPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeBannerAlertPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeButtonPage/NativeButtonPage.js
+++ b/packages/bpk-docs/src/pages/NativeButtonPage/NativeButtonPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeButtonPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeButtonPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeCardsPage/NativeCardsPage.js
+++ b/packages/bpk-docs/src/pages/NativeCardsPage/NativeCardsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeCardsPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeCardsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeHorizontalNavPage/NativeHorizontalNavPage.js
+++ b/packages/bpk-docs/src/pages/NativeHorizontalNavPage/NativeHorizontalNavPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeHorizontalNavPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeHorizontalNavPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeIconsPage/NativeIconsPage.js
+++ b/packages/bpk-docs/src/pages/NativeIconsPage/NativeIconsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeIconsPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeIconsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeSpinnerPage/NativeSpinnerPage.js
+++ b/packages/bpk-docs/src/pages/NativeSpinnerPage/NativeSpinnerPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeSpinnerPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeSpinnerPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeStarRatingPage/NativeStarRatingPage.js
+++ b/packages/bpk-docs/src/pages/NativeStarRatingPage/NativeStarRatingPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeStarRatingPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeStarRatingPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeSwitchPage/NativeSwitchPage.js
+++ b/packages/bpk-docs/src/pages/NativeSwitchPage/NativeSwitchPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeSwitchPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeSwitchPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeTextInputPage/NativeTextInputPage.js
+++ b/packages/bpk-docs/src/pages/NativeTextInputPage/NativeTextInputPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeTextInputPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeTextInputPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeTextPage/NativeTextPage.js
+++ b/packages/bpk-docs/src/pages/NativeTextPage/NativeTextPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NativeTextPage/index.js
+++ b/packages/bpk-docs/src/pages/NativeTextPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NudgersPage/NudgersPage.js
+++ b/packages/bpk-docs/src/pages/NudgersPage/NudgersPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/NudgersPage/index.js
+++ b/packages/bpk-docs/src/pages/NudgersPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/PaginationPage/PaginationPage.js
+++ b/packages/bpk-docs/src/pages/PaginationPage/PaginationPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/PaginationPage/index.js
+++ b/packages/bpk-docs/src/pages/PaginationPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/PanelsPage/PanelsPage.js
+++ b/packages/bpk-docs/src/pages/PanelsPage/PanelsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/PanelsPage/index.js
+++ b/packages/bpk-docs/src/pages/PanelsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/PopoversPage/PopoversPage.js
+++ b/packages/bpk-docs/src/pages/PopoversPage/PopoversPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/PopoversPage/index.js
+++ b/packages/bpk-docs/src/pages/PopoversPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ProgressPage/ProgressContainer.js
+++ b/packages/bpk-docs/src/pages/ProgressPage/ProgressContainer.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ProgressPage/ProgressPage.js
+++ b/packages/bpk-docs/src/pages/ProgressPage/ProgressPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ProgressPage/SteppedProgressContainer.js
+++ b/packages/bpk-docs/src/pages/ProgressPage/SteppedProgressContainer.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ProgressPage/index.js
+++ b/packages/bpk-docs/src/pages/ProgressPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ProgressPage/progress-container.scss
+++ b/packages/bpk-docs/src/pages/ProgressPage/progress-container.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/RadiiPage/RadiiPage.js
+++ b/packages/bpk-docs/src/pages/RadiiPage/RadiiPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/RadiiPage/index.js
+++ b/packages/bpk-docs/src/pages/RadiiPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ResourcesPage/ResourcesPage.js
+++ b/packages/bpk-docs/src/pages/ResourcesPage/ResourcesPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ResourcesPage/index.js
+++ b/packages/bpk-docs/src/pages/ResourcesPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ShadowsPage/ShadowsPage.js
+++ b/packages/bpk-docs/src/pages/ShadowsPage/ShadowsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ShadowsPage/index.js
+++ b/packages/bpk-docs/src/pages/ShadowsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/SlidersPage/SlidersPage.js
+++ b/packages/bpk-docs/src/pages/SlidersPage/SlidersPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/SlidersPage/index.js
+++ b/packages/bpk-docs/src/pages/SlidersPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/SpacingsPage/SpacingsPage.js
+++ b/packages/bpk-docs/src/pages/SpacingsPage/SpacingsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/SpacingsPage/index.js
+++ b/packages/bpk-docs/src/pages/SpacingsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/SpinnersPage/SpinnersPage.js
+++ b/packages/bpk-docs/src/pages/SpinnersPage/SpinnersPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/SpinnersPage/index.js
+++ b/packages/bpk-docs/src/pages/SpinnersPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/StarRatingPage/StarRatingPage.js
+++ b/packages/bpk-docs/src/pages/StarRatingPage/StarRatingPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/StarRatingPage/index.js
+++ b/packages/bpk-docs/src/pages/StarRatingPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/StylePage/StylePage.js
+++ b/packages/bpk-docs/src/pages/StylePage/StylePage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/StylePage/StylePage.scss
+++ b/packages/bpk-docs/src/pages/StylePage/StylePage.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/StylePage/index.js
+++ b/packages/bpk-docs/src/pages/StylePage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ThemingPage/ThemingPage.js
+++ b/packages/bpk-docs/src/pages/ThemingPage/ThemingPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ThemingPage/index.js
+++ b/packages/bpk-docs/src/pages/ThemingPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/TicketsPage/TicketsPage.js
+++ b/packages/bpk-docs/src/pages/TicketsPage/TicketsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/TicketsPage/index.js
+++ b/packages/bpk-docs/src/pages/TicketsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/TooltipsPage/TooltipsPage.js
+++ b/packages/bpk-docs/src/pages/TooltipsPage/TooltipsPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/TooltipsPage/index.js
+++ b/packages/bpk-docs/src/pages/TooltipsPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/TooltipsPage/tooltips-page.scss
+++ b/packages/bpk-docs/src/pages/TooltipsPage/tooltips-page.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/TypesettingPage/TypesettingPage.js
+++ b/packages/bpk-docs/src/pages/TypesettingPage/TypesettingPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/TypesettingPage/index.js
+++ b/packages/bpk-docs/src/pages/TypesettingPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/TypographyPage/TypographyPage.js
+++ b/packages/bpk-docs/src/pages/TypographyPage/TypographyPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/TypographyPage/index.js
+++ b/packages/bpk-docs/src/pages/TypographyPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ZIndexesPage/ZIndexesPage.js
+++ b/packages/bpk-docs/src/pages/ZIndexesPage/ZIndexesPage.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/pages/ZIndexesPage/index.js
+++ b/packages/bpk-docs/src/pages/ZIndexesPage/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/routes/index.js
+++ b/packages/bpk-docs/src/routes/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/template.js
+++ b/packages/bpk-docs/src/template.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/themeableAttributes.js
+++ b/packages/bpk-docs/src/themeableAttributes.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-docs/src/webpackStats.js
+++ b/packages/bpk-docs/src/webpackStats.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/_index.scss
+++ b/packages/bpk-mixins/_index.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/sass-functions.js
+++ b/packages/bpk-mixins/sass-functions.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/_bonds.scss
+++ b/packages/bpk-mixins/src/_bonds.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_badges.scss
+++ b/packages/bpk-mixins/src/mixins/_badges.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_borders.scss
+++ b/packages/bpk-mixins/src/mixins/_borders.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_breakpoints.scss
+++ b/packages/bpk-mixins/src/mixins/_breakpoints.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_buttons.scss
+++ b/packages/bpk-mixins/src/mixins/_buttons.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_cards.scss
+++ b/packages/bpk-mixins/src/mixins/_cards.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_chips.scss
+++ b/packages/bpk-mixins/src/mixins/_chips.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_forms.scss
+++ b/packages/bpk-mixins/src/mixins/_forms.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_grids.scss
+++ b/packages/bpk-mixins/src/mixins/_grids.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_layers.scss
+++ b/packages/bpk-mixins/src/mixins/_layers.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_panels.scss
+++ b/packages/bpk-mixins/src/mixins/_panels.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_radii.scss
+++ b/packages/bpk-mixins/src/mixins/_radii.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_shadows.scss
+++ b/packages/bpk-mixins/src/mixins/_shadows.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_svgs.scss
+++ b/packages/bpk-mixins/src/mixins/_svgs.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_typography.scss
+++ b/packages/bpk-mixins/src/mixins/_typography.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/src/mixins/_utils.scss
+++ b/packages/bpk-mixins/src/mixins/_utils.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/stories.js
+++ b/packages/bpk-mixins/stories.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-mixins/stories.scss
+++ b/packages/bpk-mixins/stories.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-react-utils/index.js
+++ b/packages/bpk-react-utils/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-react-utils/src/Portal-test.js
+++ b/packages/bpk-react-utils/src/Portal-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-react-utils/src/Portal.js
+++ b/packages/bpk-react-utils/src/Portal.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-react-utils/src/TransitionInitialMount-test.js
+++ b/packages/bpk-react-utils/src/TransitionInitialMount-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-react-utils/src/TransitionInitialMount.js
+++ b/packages/bpk-react-utils/src/TransitionInitialMount.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-react-utils/src/cssModules-test.js
+++ b/packages/bpk-react-utils/src/cssModules-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-react-utils/src/cssModules.js
+++ b/packages/bpk-react-utils/src/cssModules.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-react-utils/src/withDefaultProps-test.js
+++ b/packages/bpk-react-utils/src/withDefaultProps-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-react-utils/src/withDefaultProps.js
+++ b/packages/bpk-react-utils/src/withDefaultProps.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-scrim-utils/index.js
+++ b/packages/bpk-scrim-utils/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-scrim-utils/src/BpkScrim-test.js
+++ b/packages/bpk-scrim-utils/src/BpkScrim-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-scrim-utils/src/BpkScrim.js
+++ b/packages/bpk-scrim-utils/src/BpkScrim.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-scrim-utils/src/bpk-scrim-content.scss
+++ b/packages/bpk-scrim-utils/src/bpk-scrim-content.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-scrim-utils/src/bpk-scrim.scss
+++ b/packages/bpk-scrim-utils/src/bpk-scrim.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-scrim-utils/src/scroll-utils.js
+++ b/packages/bpk-scrim-utils/src/scroll-utils.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-scrim-utils/src/withScrim-test.js
+++ b/packages/bpk-scrim-utils/src/withScrim-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-scrim-utils/src/withScrim.js
+++ b/packages/bpk-scrim-utils/src/withScrim.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-stylesheets/base.css
+++ b/packages/bpk-stylesheets/base.css
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-stylesheets/base.js
+++ b/packages/bpk-stylesheets/base.js
@@ -91,7 +91,7 @@ __webpack_require__(1);
 })(); /*
        * Backpack - Skyscanner's Design System
        *
-       * Copyright 2017 Skyscanner Ltd
+       * Copyright 2018 Skyscanner Ltd
        *
        * Licensed under the Apache License, Version 2.0 (the "License");
        * you may not use this file except in compliance with the License.

--- a/packages/bpk-stylesheets/index.js
+++ b/packages/bpk-stylesheets/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-stylesheets/index.scss
+++ b/packages/bpk-stylesheets/index.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-stylesheets/webpack.config.babel.js
+++ b/packages/bpk-stylesheets/webpack.config.babel.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-svgs/_index.scss
+++ b/packages/bpk-svgs/_index.scss
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-svgs/gulpfile.babel.js
+++ b/packages/bpk-svgs/gulpfile.babel.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-svgs/tasks/svg2datauri.js
+++ b/packages/bpk-svgs/tasks/svg2datauri.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-svgs/tasks/svg2react.js
+++ b/packages/bpk-svgs/tasks/svg2react.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tether/index.js
+++ b/packages/bpk-tether/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tether/src/TetherWrapper.js
+++ b/packages/bpk-tether/src/TetherWrapper.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tether/src/applyRTLTransforms-test.js
+++ b/packages/bpk-tether/src/applyRTLTransforms-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tether/src/applyRTLTransforms.js
+++ b/packages/bpk-tether/src/applyRTLTransforms.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tether/src/getArrowPositionCallback.js
+++ b/packages/bpk-tether/src/getArrowPositionCallback.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tether/src/getScriptDirection.js
+++ b/packages/bpk-tether/src/getScriptDirection.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-theming/index.js
+++ b/packages/bpk-theming/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-theming/src/BpkThemeProvider-test.js
+++ b/packages/bpk-theming/src/BpkThemeProvider-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-theming/src/BpkThemeProvider.js
+++ b/packages/bpk-theming/src/BpkThemeProvider.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/formatters/bpk.android.xml.js
+++ b/packages/bpk-tokens/formatters/bpk.android.xml.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/formatters/bpk.common.js.js
+++ b/packages/bpk-tokens/formatters/bpk.common.js.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/formatters/bpk.default.scss.js
+++ b/packages/bpk-tokens/formatters/bpk.default.scss.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/formatters/bpk.es6.js.js
+++ b/packages/bpk-tokens/formatters/bpk.es6.js.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/formatters/bpk.react.native.common.js.js
+++ b/packages/bpk-tokens/formatters/bpk.react.native.common.js.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/formatters/bpk.react.native.es6.js.js
+++ b/packages/bpk-tokens/formatters/bpk.react.native.es6.js.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/formatters/bpk.scss.js
+++ b/packages/bpk-tokens/formatters/bpk.scss.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/formatters/license-header.js
+++ b/packages/bpk-tokens/formatters/license-header.js
@@ -1,7 +1,7 @@
 const TEXT = `
 Backpack - Skyscanner's Design System
 
-Copyright 2017 Skyscanner Ltd
+Copyright 2018 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/gulpfile.babel.js
+++ b/packages/bpk-tokens/gulpfile.babel.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/index.js
+++ b/packages/bpk-tokens/index.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/src/react-native-output-test.js
+++ b/packages/bpk-tokens/src/react-native-output-test.js
@@ -2,7 +2,7 @@
  *
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/src/setOpacity-test.js
+++ b/packages/bpk-tokens/src/setOpacity-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/src/setOpacity.js
+++ b/packages/bpk-tokens/src/setOpacity.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/android/base.react.native.common.js
+++ b/packages/bpk-tokens/tokens/android/base.react.native.common.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/android/base.react.native.es6.js
+++ b/packages/bpk-tokens/tokens/android/base.react.native.es6.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/b2b-widgets.common.js
+++ b/packages/bpk-tokens/tokens/b2b-widgets.common.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/b2b-widgets.default.scss
+++ b/packages/bpk-tokens/tokens/b2b-widgets.default.scss
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/b2b-widgets.es6.js
+++ b/packages/bpk-tokens/tokens/b2b-widgets.es6.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/b2b-widgets.scss
+++ b/packages/bpk-tokens/tokens/b2b-widgets.scss
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/base.android.xml
+++ b/packages/bpk-tokens/tokens/base.android.xml
@@ -4,7 +4,7 @@
   
   Backpack - Skyscanner's Design System
   
-  Copyright 2017 Skyscanner Ltd
+  Copyright 2018 Skyscanner Ltd
   
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/base.common.js
+++ b/packages/bpk-tokens/tokens/base.common.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/base.default.scss
+++ b/packages/bpk-tokens/tokens/base.default.scss
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/base.es6.js
+++ b/packages/bpk-tokens/tokens/base.es6.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/base.react.native.android.js
+++ b/packages/bpk-tokens/tokens/base.react.native.android.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/base.react.native.ios.js
+++ b/packages/bpk-tokens/tokens/base.react.native.ios.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/base.scss
+++ b/packages/bpk-tokens/tokens/base.scss
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/breakpoints.common.js
+++ b/packages/bpk-tokens/tokens/breakpoints.common.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/breakpoints.default.scss
+++ b/packages/bpk-tokens/tokens/breakpoints.default.scss
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/breakpoints.es6.js
+++ b/packages/bpk-tokens/tokens/breakpoints.es6.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/breakpoints.scss
+++ b/packages/bpk-tokens/tokens/breakpoints.scss
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/ios/base.react.native.common.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.common.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/travelpro.common.js
+++ b/packages/bpk-tokens/tokens/travelpro.common.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/travelpro.default.scss
+++ b/packages/bpk-tokens/tokens/travelpro.default.scss
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/travelpro.es6.js
+++ b/packages/bpk-tokens/tokens/travelpro.es6.js
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/bpk-tokens/tokens/travelpro.scss
+++ b/packages/bpk-tokens/tokens/travelpro.scss
@@ -2,7 +2,7 @@
  * 
  * Backpack - Skyscanner's Design System
  * 
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/react-version-test.js
+++ b/packages/react-version-test.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/jest/setup.js
+++ b/scripts/jest/setup.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/npm/check-bpk-dependencies.js
+++ b/scripts/npm/check-bpk-dependencies.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/npm/check-owners.js
+++ b/scripts/npm/check-owners.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/npm/remove-owner.sh
+++ b/scripts/npm/remove-owner.sh
@@ -2,7 +2,7 @@
 #
 # Backpack - Skyscanner's Design System
 #
-# Copyright 2017 Skyscanner Ltd
+# Copyright 2018 Skyscanner Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/npm/update-owners.sh
+++ b/scripts/npm/update-owners.sh
@@ -2,7 +2,7 @@
 #
 # Backpack - Skyscanner's Design System
 #
-# Copyright 2017 Skyscanner Ltd
+# Copyright 2018 Skyscanner Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/stubs/cssTransitionStub.js
+++ b/scripts/stubs/cssTransitionStub.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/stubs/fileStub.js
+++ b/scripts/stubs/fileStub.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/stubs/styleStub.js
+++ b/scripts/stubs/styleStub.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/webpack/postCssPlugins.js
+++ b/scripts/webpack/postCssPlugins.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2017 Skyscanner Ltd
+ * Copyright 2018 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This updated the copyright to 2018

all the docs page diff are not displayed automatically, if you want to check them run

```
for (let i of document.getElementsByClassName("load-diff-button")){i.click()}
```

in the console to open all the diff in one go (sorry github's API 🙇 )