### PR TITLE
[BPK-1078] Expose `icons` constant from native icons and consume it

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## UNRELEASED
 
-_Nothing yet..._
+**Added:**
+- react-native-bpk-component-icon:
+ - `icons` object is now exposed, allowing users to refer to icon names using a constant. 
 
 ## 2017-12-21 - Fix web button warnings
 

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.android.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.android.js
@@ -43,7 +43,7 @@ import {
 } from 'bpk-tokens/tokens/base.react.native';
 
 import BpkAnimateHeight from 'react-native-bpk-component-animate-height';
-import BpkIcon from 'react-native-bpk-component-icon';
+import BpkIcon, { icons } from 'react-native-bpk-component-icon';
 import BpkText from 'react-native-bpk-component-text';
 
 import AnimateAndFade from './AnimateAndFade';
@@ -101,25 +101,25 @@ const styles = StyleSheet.create({
 
 const ALERT_TYPE_STYLES = {
   [ALERT_TYPES.SUCCESS]: {
-    iconSource: 'tick-circle',
+    iconSource: icons['tick-circle'],
     iconStyle: {
       color: colorGreen500,
     },
   },
   [ALERT_TYPES.WARN]: {
-    iconSource: 'information-circle',
+    iconSource: icons['information-circle'],
     iconStyle: {
       color: colorYellow500,
     },
   },
   [ALERT_TYPES.ERROR]: {
-    iconSource: 'information-circle',
+    iconSource: icons['information-circle'],
     iconStyle: {
       color: colorRed500,
     },
   },
   [ALERT_TYPES.NEUTRAL]: {
-    iconSource: 'information-circle',
+    iconSource: icons['information-circle'],
     iconStyle: {
       color: colorGray500,
     },
@@ -153,7 +153,7 @@ const ExpandableIcon = ({ expanded }) => (
   <View style={styles.dismissableContainer}>
     <BpkIcon
       style={styles.icon}
-      icon={expanded ? 'chevron-up' : 'chevron-down'}
+      icon={expanded ? icons['chevron-up'] : icons['chevron-down']}
       small
     />
   </View>

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.ios.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert.ios.js
@@ -38,7 +38,7 @@ import {
 } from 'bpk-tokens/tokens/base.react.native';
 
 import BpkAnimateHeight from 'react-native-bpk-component-animate-height';
-import BpkIcon from 'react-native-bpk-component-icon';
+import BpkIcon, { icons } from 'react-native-bpk-component-icon';
 import BpkText from 'react-native-bpk-component-text';
 import BpkTouchableOverlay from 'react-native-bpk-component-touchable-overlay';
 
@@ -142,22 +142,22 @@ const styles = StyleSheet.create({
 
 const ALERT_TYPE_STYLES = {
   [ALERT_TYPES.SUCCESS]: {
-    iconSource: 'tick-circle',
+    iconSource: icons['tick-circle'],
     outerStyle: styles.outerContainerSuccess,
     iconStyle: styles.iconSuccess,
   },
   [ALERT_TYPES.WARN]: {
-    iconSource: 'information-circle',
+    iconSource: icons['information-circle'],
     outerStyle: styles.outerContainerWarn,
     iconStyle: styles.iconWarn,
   },
   [ALERT_TYPES.ERROR]: {
-    iconSource: 'information-circle',
+    iconSource: icons['information-circle'],
     outerStyle: styles.outerContainerError,
     iconStyle: styles.iconError,
   },
   [ALERT_TYPES.NEUTRAL]: {
-    iconSource: 'information-circle',
+    iconSource: icons['information-circle'],
     outerStyle: styles.outerContainerNeutral,
     iconStyle: styles.iconNeutral,
   },
@@ -202,7 +202,7 @@ const BpkBannerAlert = props => {
       {expandable && (
         <BpkIcon
           style={[styles.button, styles.buttonExpand]}
-          icon={expanded ? 'chevron-up' : 'chevron-down'}
+          icon={expanded ? icons['chevron-up'] : icons['chevron-down']}
           small
         />
       )}

--- a/native/packages/react-native-bpk-component-button/stories.js
+++ b/native/packages/react-native-bpk-component-button/stories.js
@@ -21,6 +21,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import BpkThemeProvider from 'react-native-bpk-theming';
+import { icons } from 'react-native-bpk-component-icon';
 import { spacingMd } from 'bpk-tokens/tokens/base.react.native';
 
 import BpkButton, { BUTTON_TYPES } from './src/BpkButton';
@@ -40,7 +41,7 @@ const styles = StyleSheet.create({
 });
 
 const getIconType = type =>
-  type === 'destructive' ? 'trash' : 'long-arrow-right';
+  type === 'destructive' ? icons.trash : icons['long-arrow-right'];
 
 const generateButtonStoryForType = type => {
   function getLargeVersion() {

--- a/native/packages/react-native-bpk-component-icon/index.js
+++ b/native/packages/react-native-bpk-component-icon/index.js
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
-import BpkIcon from './src/BpkIcon';
+import BpkIcon, { icons } from './src/BpkIcon';
 
 export default BpkIcon;
+export { icons };

--- a/native/packages/react-native-bpk-component-icon/readme.md
+++ b/native/packages/react-native-bpk-component-icon/readme.md
@@ -44,7 +44,7 @@ apply from: "node_modules/react-native-bpk-component-icon/fonts.gradle"
 ```js
 import { View } from 'react-native';
 import React, { Component } from 'react';
-import BpkIcon from 'react-native-bpk-component-icon';
+import BpkIcon, { icons } from 'react-native-bpk-component-icon';
 import { spacingBase, colorBlue500 } from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
@@ -60,12 +60,12 @@ export default class App extends Component {
     return (
       <View style={styles.container}>
         <BpkIcon
-          icon="beer"
+          icon={icons.beer}
           style={{ color: colorBlue500 }}
           small
         />
         <BpkIcon
-          icon="beer"
+          icon={icons.beer}
           style={{ color: colorBlue500 }}
         />
       </View>
@@ -78,5 +78,5 @@ export default class App extends Component {
 
 | Property  | PropType  | Required | Default Value |
 | --------- | --------- | -------- | ------------- |
-| icon      | string    | yes      | -             |
-| small     | bool      | no       | false         |
+| icon      | string    | true     | -             |
+| small     | bool      | false    | false         |

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.common.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon-test.common.js
@@ -18,23 +18,25 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
-import BpkIcon from './BpkIcon';
+import BpkIcon, { icons } from './BpkIcon';
 
 const commonTests = () => {
   describe('BpkIcon', () => {
     it('should render correctly', () => {
-      const tree = renderer.create(<BpkIcon icon="beer" />).toJSON();
+      const tree = renderer.create(<BpkIcon icon={icons.beer} />).toJSON();
       expect(tree).toMatchSnapshot();
     });
 
     it('should render small icon correctly', () => {
-      const tree = renderer.create(<BpkIcon icon="beer" small />).toJSON();
+      const tree = renderer
+        .create(<BpkIcon icon={icons.beer} small />)
+        .toJSON();
       expect(tree).toMatchSnapshot();
     });
 
     it('should apply user props', () => {
       const tree = renderer
-        .create(<BpkIcon icon="beer" style={{ color: 'blue' }} />)
+        .create(<BpkIcon icon={icons.beer} style={{ color: 'blue' }} />)
         .toJSON();
       expect(tree).toMatchSnapshot();
     });

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
@@ -75,4 +75,14 @@ BpkIcon.defaultProps = {
   style: null,
 };
 
+/*
+Expose icon mapping keys as both key and value
+so they can be used by consumers.
+*/
+const icons = {};
+Object.keys(iconMappings).forEach(name => {
+  icons[name] = name;
+});
+
 export default BpkIcon;
+export { icons };

--- a/native/packages/react-native-bpk-component-icon/stories.js
+++ b/native/packages/react-native-bpk-component-icon/stories.js
@@ -26,9 +26,8 @@ import {
   spacingBase,
   spacingSm,
 } from 'bpk-tokens/tokens/base.react.native';
-import iconMappings from 'bpk-svgs/dist/font/iconMapping.json';
 
-import BpkIcon from './index';
+import BpkIcon, { icons } from './index';
 import { StorySubheading } from '../../storybook/TextStyles';
 
 const styles = StyleSheet.create({
@@ -60,9 +59,9 @@ const getSmallIcons = () => (
   <View style={styles.column}>
     <StorySubheading>Small</StorySubheading>
     <View style={[styles.singleRow, styles.group]}>
-      <BpkIcon style={styles.singleIcon} icon="flight" small />
-      <BpkIcon style={styles.singleIcon} icon="cars" small />
-      <BpkIcon style={styles.singleIcon} icon="hotels" small />
+      <BpkIcon style={styles.singleIcon} icon={icons.flight} small />
+      <BpkIcon style={styles.singleIcon} icon={icons.cars} small />
+      <BpkIcon style={styles.singleIcon} icon={icons.hotels} small />
     </View>
   </View>
 );
@@ -71,9 +70,9 @@ const getLargeIcons = () => (
   <View style={styles.column}>
     <StorySubheading>Large</StorySubheading>
     <View style={[styles.singleRow, styles.group]}>
-      <BpkIcon style={styles.singleIcon} icon="flight" />
-      <BpkIcon style={styles.singleIcon} icon="cars" />
-      <BpkIcon style={styles.singleIcon} icon="hotels" />
+      <BpkIcon style={styles.singleIcon} icon={icons.flight} />
+      <BpkIcon style={styles.singleIcon} icon={icons.cars} />
+      <BpkIcon style={styles.singleIcon} icon={icons.hotels} />
     </View>
   </View>
 );
@@ -84,15 +83,15 @@ const getColouredIcons = () => (
     <View style={[styles.singleRow, styles.group]}>
       <BpkIcon
         style={[styles.singleIcon, { color: colorBlue500 }]}
-        icon="flight"
+        icon={icons.flight}
       />
       <BpkIcon
         style={[styles.singleIcon, { color: colorGreen500 }]}
-        icon="cars"
+        icon={icons.cars}
       />
       <BpkIcon
         style={[styles.singleIcon, { color: colorYellow500 }]}
-        icon="hotels"
+        icon={icons.hotels}
       />
     </View>
   </View>
@@ -109,7 +108,7 @@ storiesOf('BpkIcon', module)
   .add('docs:all-icons', () => (
     <View style={styles.container}>
       <View style={styles.group}>
-        {Object.keys(iconMappings).map(name => (
+        {Object.keys(icons).map(name => (
           <BpkIcon key={name} icon={name} style={styles.icon} />
         ))}
       </View>

--- a/native/packages/react-native-bpk-component-star-rating/src/BpkStar.js
+++ b/native/packages/react-native-bpk-component-star-rating/src/BpkStar.js
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { I18nManager, StyleSheet, View } from 'react-native';
-import BpkIcon from 'react-native-bpk-component-icon';
+import BpkIcon, { icons } from 'react-native-bpk-component-icon';
 import {
   spacingMd,
   spacingSm,
@@ -58,7 +58,7 @@ const styles = StyleSheet.create({
 
 const BpkStar = props => {
   const { type, ...rest } = props;
-  const iconType = type === STAR_TYPES.FULL ? 'star' : 'star-half';
+  const iconType = type === STAR_TYPES.FULL ? icons.star : icons['star-half'];
 
   const commonStarStyles = [styles.star];
 
@@ -74,12 +74,12 @@ const BpkStar = props => {
 
   /*
    * Here we render two stars that are absolutely positioned inside a View.
-   * We always render a gray star(background) and then conditionally render
+   * We always render a gray star (background) and then conditionally render
    * a yellow half star or star ontop of it.
    */
   return (
     <View style={styles.container} {...rest} accessible={false}>
-      <BpkIcon icon="star" style={commonStarStyles} />
+      <BpkIcon icon={icons.star} style={commonStarStyles} />
       {type !== STAR_TYPES.EMPTY && (
         <BpkIcon icon={iconType} style={foregroundStarStyles} />
       )}

--- a/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons.js
+++ b/native/packages/react-native-bpk-component-text-input/src/BpkTextInputIcons.js
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { StyleSheet, I18nManager } from 'react-native';
-import BpkIcon from 'react-native-bpk-component-icon';
+import BpkIcon, { icons } from 'react-native-bpk-component-icon';
 import {
   colorRed500,
   colorGreen500,
@@ -43,12 +43,12 @@ const styles = StyleSheet.create({
 });
 
 const ValidIcon = () => (
-  <BpkIcon icon="tick" small style={[styles.icon, styles.valid]} />
+  <BpkIcon icon={icons.tick} small style={[styles.icon, styles.valid]} />
 );
 
 const InvalidIcon = () => (
   <BpkIcon
-    icon="exclamation-circle"
+    icon={icons['exclamation-circle']}
     small
     style={[styles.icon, styles.invalid]}
   />


### PR DESCRIPTION
Right now I've done this in the simplest way possible. We can change it, but I thought it best to keep it simple and then we can discuss it.

We expose the mappings in an object that looks like this:

```
{
  beer: 'beer',
  'alert--remove': 'alert--remove',
  ..etc
}
```

Which means it's used like this:

```
import BpkIcon, { icons } from 'react-native-bpk-component-icon';

<BpkIcon icon={icons.beer} />
<BpkIcon icon={icons['alert--remove']} />
```

Having to use the array syntax for icon names that include hyphens is a little inelegant, so I'm wondering whether we should transform them so that it's more like this:

```
{
  BEER: 'beer',
  ALERT__REMOVE: 'alert--remove',
  ..etc
}

<BpkIcon icon={icons.BEER} />
<BpkIcon icon={icons.ALERT__REMOVE} />
```

The downside of this approach is that we'd need to add something to the [icons docs](https://backpack.github.io/components/web/icons/) to explain the syntax for native consumers.