### PR TITLE
[BPK-1180] React Native support for Flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/node_modules/jsonlint/.*
+.*/native/node_modules/.*
 
 [include]
 
@@ -10,6 +11,13 @@
 [options]
 module.name_mapper.extension='scss' -> '<PROJECT_ROOT>/scripts/stubs/styleStub.js'
 module.name_mapper.extension='md' -> '<PROJECT_ROOT>/scripts/stubs/fileStub.js'
+module.name_mapper='\(react-native\)' -> '<PROJECT_ROOT>/scripts/stubs/jsModuleStub.js'
+module.name_mapper='\(@storybook/react-native\)' -> '<PROJECT_ROOT>/scripts/stubs/jsModuleStub.js'
 emoji=true
+
+module.file_ext=.js
+module.file_ext=.json
+module.file_ext=.ios.js
+module.file_ext=.android.js
 
 [strict]

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Text, StyleSheet } from 'react-native';
@@ -42,7 +44,13 @@ const styles = StyleSheet.create({
 const mapCharacterCode = characterCode =>
   String.fromCharCode(parseInt(characterCode, 16));
 
-const BpkIcon = props => {
+type Props = {
+  icon: string,
+  small?: boolean,
+  style?: {} | Array<{}>,
+};
+
+const BpkIcon = (props: Props) => {
   const { icon, small, style, ...rest } = props;
 
   const characterCode = iconMappings[icon];
@@ -79,7 +87,7 @@ BpkIcon.defaultProps = {
 Expose icon mapping keys as both key and value
 so they can be used by consumers.
 */
-const icons = {};
+const icons: Object = {};
 Object.keys(iconMappings).forEach(name => {
   icons[name] = name;
 });

--- a/native/packages/react-native-bpk-component-icon/stories.js
+++ b/native/packages/react-native-bpk-component-icon/stories.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow */
+
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { storiesOf } from '@storybook/react-native';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6545,9 +6545,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.61.0.tgz",
-      "integrity": "sha512-w6SGi5CDfKLNGzYssRhW6N37qKclDXijsxDQ5M8c3WbivRYta0Horv22bwakegfKBVDnyeS0lRW3OqBC74eq2g==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.62.0.tgz",
+      "integrity": "sha1-FLymaabj+VwLwMLR61XsTpjLHYM=",
       "dev": true
     },
     "flow-typed": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "eslint_d": "^5.2.1",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.5",
-    "flow-bin": "^0.61.0",
+    "flow-bin": "^0.62.0",
     "flow-typed": "^2.2.3",
     "gulp": "^3.9.1",
     "gulp-chmod": "^2.0.0",

--- a/scripts/stubs/jsModuleStub.js
+++ b/scripts/stubs/jsModuleStub.js
@@ -16,9 +16,4 @@
  * limitations under the License.
  */
 
-/* @flow */
-
-import BpkIcon, { icons } from './src/BpkIcon';
-
-export default BpkIcon;
-export { icons };
+export default {};


### PR DESCRIPTION
@matteo-hertel and I tried a number of ways to get this to work correctly, but we couldn't manage it.

So, we're ignoring all native node_modules, and are using a stub to mock any third party deps that are used in the code.

This isn't particularly great, as it means we won't get code completion for third party deps, but it does mean that we can still benefit from adding types to the public APIs.

We think that this solution is good enough as a unit of work to merge now, and then we* can look at not ignoring all node_modules down the line.

We've also added types to the native icon component.

I'll add comments inline where necessary, too.

*_by 'we' I mean 'not me'_ 🤣 