### PR TITLE
[no-jira] Danger now only thanks external contributors

### DIFF
--- a/NPM_OWNERS
+++ b/NPM_OWNERS
@@ -1,6 +1,0 @@
-georgegillams
-jamesferguson
-k0nserv
-mattface
-mhdev
-shaundon

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -28,12 +28,27 @@ import {
   propKeys as iosPropKeys,
 } from './packages/bpk-tokens/tokens/base.raw.ios.json';
 
+const BACKPACK_SQUAD_MEMBERS = [
+  'georgegillams',
+  'jamesf3rguson',
+  'k0nserv',
+  'matteo-hertel',
+  'matthewdavidson',
+  'shaundon',
+  // TODO Will needs a GitHub account.
+  // TODO Use the API for this. It requires auth though so this is ok for now.
+];
+const author = danger.github.pr.user.login;
+const isPrExternal = !BACKPACK_SQUAD_MEMBERS.includes(author);
+
 const createdFiles = danger.git.created_files;
 const modifiedFiles = danger.git.modified_files;
 const fileChanges = [...modifiedFiles, ...createdFiles];
 
-// Always be nice.
-message('Thanks for the PR 🎉.');
+// Be nice to our neighbours.
+if (isPrExternal) {
+  message('Thanks for the PR 🎉.');
+}
 
 // Ensure new web components are extensible by consumers.
 const webComponentIntroduced = createdFiles.some(filePath =>

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -28,16 +28,11 @@ import {
   propKeys as iosPropKeys,
 } from './packages/bpk-tokens/tokens/base.raw.ios.json';
 
-const BACKPACK_SQUAD_MEMBERS = [
-  'georgegillams',
-  'jamesf3rguson',
-  'k0nserv',
-  'matteo-hertel',
-  'matthewdavidson',
-  'shaundon',
-  // TODO Will needs a GitHub account.
-  // TODO Use the API for this. It requires auth though so this is ok for now.
-];
+import * as meta from './meta.json';
+
+const BACKPACK_SQUAD_MEMBERS = meta.maintainers.map(
+  maintainer => maintainer.github,
+);
 const author = danger.github.pr.user.login;
 const isPrExternal = !BACKPACK_SQUAD_MEMBERS.includes(author);
 

--- a/meta.json
+++ b/meta.json
@@ -1,0 +1,28 @@
+{
+  "maintainers": [
+    {
+      "npm": "georgegillams",
+      "github": "georgegillams"
+    },
+    {
+      "npm": "jamesferguson",
+      "github": "jamesf3rguson"
+    },
+    {
+      "npm": "k0nserv",
+      "github": "k0nserv"
+    },
+    {
+      "npm": "mhdev",
+      "github": "matteo-hertel"
+    },
+    {
+      "npm": "mattface",
+      "github": "matthewdavidson"
+    },
+    {
+      "npm": "shaundon",
+      "github": "shaundon"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:native": "(cd ./native && npm test)",
     "ios": "(cd ./native && npm run ios)",
     "android": "(cd ./native && npm run android)",
-    "check-owners": "npm whoami && grep -E $(npm whoami) NPM_OWNERS && node scripts/npm/check-owners.js",
+    "check-owners": "npm whoami && ( node scripts/npm/get-owners.js | grep -E $(npm whoami) ) && node scripts/npm/check-owners.js",
     "publish": "npm run check-owners && npm run build && git pull --rebase && npm run test && lerna publish",
     "danger": "danger",
     "prettier": "prettier --config .prettierrc --write \"**/*.js\""

--- a/scripts/npm/check-owners.js
+++ b/scripts/npm/check-owners.js
@@ -26,13 +26,11 @@ const http = require('http');
 
 const readdir = util.promisify(fs.readdir);
 
+const meta = require('../../meta.json');
+
 let failures = false;
 
-const owners = fs
-  .readFileSync('NPM_OWNERS', { encoding: 'utf-8' })
-  .split('\n')
-  .filter(s => s.trim() !== '')
-  .sort();
+const owners = meta.maintainers.map(maintainer => maintainer.npm).sort();
 
 const getPackageMaintainers = pkg =>
   new Promise((resolve, reject) => {

--- a/scripts/npm/get-owners.js
+++ b/scripts/npm/get-owners.js
@@ -1,0 +1,30 @@
+/*
+ *
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ Simple script to return npm maintainers of Backpack in
+ a form easily digestible by a bash script.
+ */
+
+const meta = require('../../meta.json');
+
+meta.maintainers.forEach(maintainer => {
+  process.stdout.write(`${maintainer.npm}\n`);
+});

--- a/scripts/npm/remove-owner.sh
+++ b/scripts/npm/remove-owner.sh
@@ -22,7 +22,7 @@ read -p "Username: " username
 read -p "Are you sure you want to remove $username from all packages (y/n)? " confirm
 
 if [ "$confirm" != "y" ]; then
-  echo "Ok bye."
+  echo "Ok bye. 💁"
   exit 0
 fi
 
@@ -34,6 +34,4 @@ for f in packages/*; do
   fi
 done
 
-sed -i '' "/$username/d" NPM_OWNERS
-
-echo "Success."
+echo "Removed '${username}' from all packages. Remember to remove them from meta.json.";

--- a/scripts/npm/update-owners.sh
+++ b/scripts/npm/update-owners.sh
@@ -18,11 +18,13 @@
 #
 set -e
 
-cat NPM_OWNERS
+NPM_OWNERS="$( node scripts/npm/get-owners.js )"
+
+echo "$NPM_OWNERS"
 read -p "Do you want to add the above owners to all packages (y/n)? " confirm
 
 if [ "$confirm" != "y" ]; then
-  echo "Ok bye."
+  echo "Ok bye. 💁"
   exit 0
 fi
 
@@ -36,6 +38,6 @@ do
       npm owner add $username $package
     fi
   done
-done < NPM_OWNERS
+done <<< "$NPM_OWNERS"
 
-echo "Success."
+echo "Success. 🎉"


### PR DESCRIPTION
After discussing it on Slack, I threw together a quick check for external contributors.

We could probably make it use the GitHub API to determine team members, but then Danger would need to be authenticated as a member of the Skyscanner organisation, which seemed like a lot to get into for a quick check. 

I figured the squad doesn't change much so it's quite low-impact to have hard-coded team members, but feel free to disagree!

I also think we're reaching the point where Danger should be split across a few different files, probably in `scripts/danger/`, but in the interest of keeping this small I thought that can be handled in another PR. 