### PR TITLE
[BPK-748] Drag scrolling for desktop

### DIFF
--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -55,7 +55,7 @@ const BpkHorizontalNavItem = props => {
     <button
       type="button"
       className={innerClassNames.join(' ')}
-      disabled={selected}
+      aria-disabled={selected}
       {...rest}
     >
       {children}

--- a/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav-item.scss
+++ b/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav-item.scss
@@ -57,6 +57,7 @@
       @include bpk-themeable-property(color, --bpk-horizontal-nav-link-selected-color, $bpk-horizontal-nav-link-selected-color);
 
       @include bpk-hover {
+        @include bpk-themeable-property(color, --bpk-horizontal-nav-link-selected-color, $bpk-horizontal-nav-link-selected-color);
         @include bpk-border-bottom-xl($bpk-horizontal-nav-bar-selected-color);
         @include bpk-border-bottom-xl(var(--bpk-horizontal-nav-bar-selected-color, $bpk-horizontal-nav-bar-selected-color));
       }

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
@@ -28,7 +28,7 @@ import STYLES from './bpk-mobile-scroll-container.scss';
 const getClassName = cssModules(STYLES);
 
 const computeScrollBarAwareHeight = (
-  scrollerEl: ?HTMLElement,
+  scrollerEl: HTMLElement,
   innerEl: ?HTMLElement,
 ): ?string => {
   if (!(scrollerEl && innerEl)) {
@@ -65,7 +65,7 @@ type Props = {
   children: Node,
   innerContainerTagName: string,
   className: ?string,
-  style: ?Object,
+  style: ?Object | Array<Object>,
 };
 
 type State = {
@@ -74,8 +74,10 @@ type State = {
 };
 
 class BpkMobileScrollContainer extends Component<Props, State> {
+  curDown: ?boolean;
+  curXPos: ?Number;
   innerEl: ?HTMLElement;
-  scrollerEl: ?HTMLElement;
+  scrollerEl: HTMLElement;
 
   static propTypes = {
     children: PropTypes.node.isRequired,
@@ -102,12 +104,36 @@ class BpkMobileScrollContainer extends Component<Props, State> {
   componentDidMount() {
     this.setScrollBarAwareHeight();
     this.setScrollIndicatorClassName();
-    window.addEventListener('resize', this.onWindowResize);
+    this.scrollerEl.addEventListener('resize', this.onWindowResize);
+    this.scrollerEl.addEventListener('mousemove', this.onMouseMove);
+    this.scrollerEl.addEventListener('mousedown', this.onMouseDown);
+    this.scrollerEl.addEventListener('mouseup', this.onMouseUp);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.onWindowResize);
+    this.scrollerEl.removeEventListener('resize', this.onWindowResize);
+    this.scrollerEl.removeEventListener('mousemove', this.onMouseMove);
+    this.scrollerEl.removeEventListener('mousedown', this.onMouseDown);
+    this.scrollerEl.removeEventListener('mouseup', this.onMouseUp);
   }
+
+  onMouseMove = (e: Object) => {
+    if (this.curDown) {
+      this.scrollerEl.scrollLeft =
+        this.scrollerEl.scrollLeft + (+this.curXPos - e.offsetX);
+    }
+  };
+
+  onMouseUp = () => {
+    this.curDown = false;
+    this.scrollerEl.style.cursor = '';
+  };
+
+  onMouseDown = (e: Object) => {
+    this.curXPos = e.offsetX;
+    this.curDown = true;
+    this.scrollerEl.style.cursor = '-webkit-grabbing';
+  };
 
   onWindowResize = debounce(() => {
     this.setScrollBarAwareHeight();

--- a/packages/bpk-component-mobile-scroll-container/src/bpk-mobile-scroll-container.scss
+++ b/packages/bpk-component-mobile-scroll-container/src/bpk-mobile-scroll-container.scss
@@ -64,6 +64,10 @@
     &::-webkit-scrollbar {
       display: none;
     }
+
+    &--dragging {
+      cursor: grabbing;
+    }
   }
 
   &__inner {

--- a/packages/bpk-component-mobile-scroll-container/stories.js
+++ b/packages/bpk-component-mobile-scroll-container/stories.js
@@ -72,6 +72,6 @@ storiesOf('bpk-component-mobile-scroll-container', module)
   ))
   .add('Bar chart', () => (
     <BpkButton onClick={linkTo('bpk-component-barchart', 'Default')}>
-      See horizontal nav example
+      See bar chart example
     </BpkButton>
   ));


### PR DESCRIPTION
![](https://media1.tenor.com/images/545cc9fa561b3384b90ea21c92d8747e/tenor.gif)

Tbh I'm not actually convinced we should actually be doing this, because:

* It's quite janky for me (reviewers, please try to replicate this. It happens particularly on the bar chart storybook).
* Any children that have the `disabled` attribute can't be clicked and dragged.
* We're sort-of subverting standard OS scrolling behaviour, it's not quite as bad as scroll jacking but it's in that arena IMO. 
  