### PR TITLE
Revert "[BPK-1069] Change popover max-width on mobile"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,6 @@
 
 ## UNRELEASED
 
-**Changed:**
-- bpk-component-popover:
- - On mobile screen sizes, popovers now have a margin to prevent them from filling the entire width of their container.
-
 **Fixed:**
 - bpk-component-banner-alert:
   - Fixed issue where banner was shown if `show` was initially set `false`.

--- a/packages/bpk-component-popover/src/bpk-popover.scss
+++ b/packages/bpk-component-popover/src/bpk-popover.scss
@@ -29,11 +29,6 @@
   outline: 0;
   opacity: 1;
 
-  @include bpk-breakpoint-mobile {
-    margin-right: $bpk-spacing-sm;
-    margin-left: $bpk-spacing-sm;
-  }
-
   @include bpk-breakpoint-above-mobile {
     max-width: $bpk-breakpoint-mobile;
     transition: opacity $bpk-duration-xs ease-in-out;


### PR DESCRIPTION
Reverts Skyscanner/backpack#426

Agreed with @matthewdavidson to temporarily revert this before release to avoid making two breaking changes in quick succession.