### PR TITLE
[NOJIRA] Lerna ignore bpk-tether

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,14 @@
   "packages": [
     "packages/*",
     "native/packages/*"
-  ]
+  ],
+  "commands": {
+    "bootstrap": {
+      "ignore": "bpk-tether"
+    },
+    "publish": {
+      "ignore": "bpk-tether",
+      "allowBranch": "master"
+    }
+  }
 }

--- a/packages/bpk-tether/.eslintrc
+++ b/packages/bpk-tether/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "import/no-unresolved": 0, 
+    "import/extensions": 0
+  }
+}


### PR DESCRIPTION
Since [`bpk-tether`](https://github.com/Skyscanner/backpack/tree/master/packages/bpk-tether) isn't used by any other bpk package, we don't need to include it in any lerna operations anymore.
I wanna keep the source in the repo though for any bug fixes that may arise.
```
npm run bootstrap

> backpack@0.0.1 bootstrap /Users/matthewdavidson/projects/backpack
> lerna bootstrap

lerna info version 2.6.0
lerna info versioning independent
lerna info ignore bpk-tether
lerna WARN ECYCLE Encountered a cycle in the dependency graph.This may cause instability! Packages in cycle are: "bpk-docs", "react-native-bpk-component-animate-height", "react-native-bpk-component-banner-alert", "react-native-bpk-component-button", "react-native-bpk-component-horizontal-nav", "react-native-bpk-component-spinner", "react-native-bpk-component-switch", "react-native-bpk-theming"
lerna info Bootstrapping 78 packages
lerna info lifecycle preinstall
lerna info Installing external dependencies
lerna info Symlinking packages and binaries
lerna info lifecycle postinstall
lerna info lifecycle prepublish
lerna info lifecycle prepare
lerna success Bootstrapped 78 packages


npm run lerna publish

> backpack@0.0.1 lerna /Users/matthewdavidson/projects/backpack
> lerna "publish"

lerna info version 2.6.0
lerna info versioning independent
lerna info ignore bpk-tether
lerna info Checking for updated packages...
lerna info Comparing with bpk-component-image@2.0.11.
lerna info Checking for prereleased packages...
```