### PR TITLE
[BPK-1123] Close button hover / active styles now work in firefox.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,9 +3,17 @@
 ## UNRELEASED
 
 **Added:**
-
 - react-native-bpk-component-button:
- - New `iconAlignment` prop allows icons inside buttons to be leading or trailing.
+  - New `iconAlignment` prop allows icons inside buttons to be leading or trailing.
+
+**Fixed:**
+- bpk-component-banner-alert:
+- bpk-component-chip:
+- bpk-component-close-button:
+- bpk-component-drawer:
+- bpk-component-modal:
+- bpk-component-popover:
+  - Close button hover / active styles now work in firefox.
 
 ## 2018-01-10 - Replacing Tether with Popper.js and new API for web banner alerts
 

--- a/packages/bpk-component-close-button/src/bpk-close-button.scss
+++ b/packages/bpk-component-close-button/src/bpk-close-button.scss
@@ -22,18 +22,19 @@
   padding: 0;
   border: 0;
   background-color: transparent;
+  color: $bpk-color-gray-500;
   cursor: pointer;
   appearance: none;
 
+  @include bpk-hover {
+    color: $bpk-color-gray-700;
+  }
+
+  &:active {
+    color: $bpk-color-gray-900;
+  }
+
   &__icon {
-    fill: $bpk-color-gray-500;
-
-    @include bpk-hover {
-      fill: $bpk-color-gray-700;
-    }
-
-    &:active {
-      fill: $bpk-color-gray-900;
-    }
+    fill: currentColor;
   }
 }


### PR DESCRIPTION
Test in FF on windows/osx, edge, IE11 and chrome on windows/osx