### PR TITLE
[no jira] Add logoFillColor to theme attributes

### DIFF
--- a/packages/bpk-component-theme-toggle/src/theming.js
+++ b/packages/bpk-component-theme-toggle/src/theming.js
@@ -69,6 +69,8 @@ const generateTheme = ({
   linkActiveColor: primaryColor600,
   linkVisitedColor: primaryColor700,
 
+  logoFillColor: primaryColor500,
+
   horizontalNavBarSelectedColor: primaryColor500,
   horizontalNavLinkSelectedColor: primaryColor500,
   horizontalNavLinkColor,


### PR DESCRIPTION
This means that `bpk-logos` will be able to use `bpk-component-theme-toggle` in their test harness (same as we currently use in storybook and docs site) instead of having to duplicate the logic.