### PR TITLE
[BPK-1142] On mobile, drawer component is now 100% width

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@
 
 _Nothing yet._
 
+**Fixed:**
+- bpk-component-drawer:
+ - Drawer components are now full-width on mobile screen sizes.
+ - The header now remains fixed to the top of the screen when the drawer content overflows.
+
 ## 2018-01-16 - New native button prop for positioning icons
 
 **Added:**

--- a/packages/bpk-component-drawer/src/bpk-drawer-content.scss
+++ b/packages/bpk-component-drawer/src/bpk-drawer-content.scss
@@ -41,6 +41,11 @@
     transform: translate(-100%);
   }
 
+  @include bpk-breakpoint-mobile {
+    width: 100%;
+    max-width: 100%;
+  }
+
   &--entering,
   &--entered {
     transform: translate(0);
@@ -92,7 +97,9 @@
   }
 
   &__content {
+    height: 100%;
     padding: $bpk-spacing-sm;
     flex: 1 1 100%;
+    overflow-y: auto;
   }
 }


### PR DESCRIPTION
With no visible scrim for users to press on mobile, when content overflows, scrolling will hide the close button. So, I've also made the fixed the header to the top of the drawer so that the close button is visible when scrolling.

![kapture 2018-01-19 at 10 25 13](https://user-images.githubusercontent.com/73652/35146481-0dbb5aca-fd03-11e7-9b6a-eeddbdd49bda.gif)

**Browser Testing**
* Firefox ✅ 
* Chrome (Mac) ✅ 
* IE11 (Windows 10) ✅ 
* IE11 (Windows 8.1) ✅ 
* Edge ✅ 
* Safari (Mac) ✅ 
* Safari (iOS 9) ✅ 
* Safari (iOS 11) ✅ 
* Chrome (Android, Galaxy S8) ✅ 