### PR TITLE
[BPK-898] Add 'clearable' and 'onClear' props to BpkInput

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-_Nothing yet!_
+**Added:**
+- bpk-component-input
+  - Added `clearable`, `onClear` and `clearButtonLabel` props. These allow inputs to have an optional clear button that appears when the input is focused.
 
 ## 2018-01-25 - New link styles
 

--- a/packages/bpk-component-input/package-lock.json
+++ b/packages/bpk-component-input/package-lock.json
@@ -1,16 +1,125 @@
 {
-	"requires": true,
+	"name": "bpk-component-input",
+	"version": "3.2.50",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
+		"bpk-component-icon": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.15.0.tgz",
+			"integrity": "sha512-WiKOI9w8PU6mP/08PWf/28RWlFWuT4Laycd6Cf2shAONsw/hgCkhKP3ADVKjKvvQAIYy9Z7qMVOwvkB6t1T+/Q==",
+			"requires": {
+				"bpk-mixins": "17.3.0",
+				"bpk-react-utils": "2.5.0",
+				"bpk-svgs": "5.12.0",
+				"bpk-tokens": "26.7.2",
+				"prop-types": "15.6.0"
+			},
+			"dependencies": {
+				"bpk-svgs": {
+					"version": "5.12.0",
+					"resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-5.12.0.tgz",
+					"integrity": "sha512-kkKouyd+WhIMEGnk0KmaWvol3XVIsGkqXwKVfFH4k5EIAEfy8DMmLGXC79nK/tT36CCE8d+o+Q8PyK/I6r7GMQ=="
+				}
+			}
+		},
+		"bpk-mixins": {
+			"version": "17.3.0",
+			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.3.0.tgz",
+			"integrity": "sha512-XCQ1N6iUX5tPc4U7dEwybJr4TeuXFCLFLcbHkOaQ5wGaqLHUtx7Rc2kcu2DTpC3JAt7Pzug62qETsT0JWf7GWA==",
+			"requires": {
+				"bpk-svgs": "5.12.0",
+				"bpk-tokens": "26.7.2"
+			},
+			"dependencies": {
+				"bpk-svgs": {
+					"version": "5.12.0",
+					"resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-5.12.0.tgz",
+					"integrity": "sha512-kkKouyd+WhIMEGnk0KmaWvol3XVIsGkqXwKVfFH4k5EIAEfy8DMmLGXC79nK/tT36CCE8d+o+Q8PyK/I6r7GMQ=="
+				}
+			}
+		},
+		"bpk-react-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.5.0.tgz",
+			"integrity": "sha512-3T1/H1TeY99/Sz8+MhFknJHZ4CxMdsWv2ESSPlgaPZ1y0h45YmDMS6GCtmSc4Lf+YIKvB+sLHOLNQCiyAEXCVw==",
+			"requires": {
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.0",
+				"react-transition-group": "2.2.1",
+				"recompose": "0.26.0"
+			}
+		},
+		"bpk-tokens": {
+			"version": "26.7.2",
+			"resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-26.7.2.tgz",
+			"integrity": "sha512-QBHyqgARUt57zxoyVNwYHNvpDFlPcs+n9Is162EkdCaf7ZTtVm3dTVVFtmr0RRYgkBWPhIDYRsdOUfj9id6njw==",
+			"requires": {
+				"color": "2.0.1"
+			},
+			"dependencies": {
+				"color": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+					"integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+					"requires": {
+						"color-convert": "1.9.1",
+						"color-string": "1.5.2"
+					}
+				}
+			}
+		},
+		"chain-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+			"integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+		},
+		"change-emitter": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+		},
+		"classnames": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+			"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"color-string": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+			"integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+			"requires": {
+				"color-name": "1.1.3",
+				"simple-swizzle": "0.2.2"
+			}
+		},
 		"core-js": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"dom-helpers": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -34,10 +143,20 @@
 				"ua-parser-js": "0.7.14"
 			}
 		},
+		"hoist-non-react-statics": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
+			"integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+		},
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
 			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"is-arrayish": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
+			"integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -98,15 +217,60 @@
 				"object-assign": "4.1.1"
 			}
 		},
+		"react-transition-group": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
+			"integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
+			"requires": {
+				"chain-function": "1.0.0",
+				"classnames": "2.2.5",
+				"dom-helpers": "3.3.1",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.0",
+				"warning": "3.0.0"
+			}
+		},
+		"recompose": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+			"integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+			"requires": {
+				"change-emitter": "0.1.6",
+				"fbjs": "0.8.16",
+				"hoist-non-react-statics": "2.3.1",
+				"symbol-observable": "1.1.0"
+			}
+		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"requires": {
+				"is-arrayish": "0.3.1"
+			}
+		},
+		"symbol-observable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+			"integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
+		},
 		"ua-parser-js": {
 			"version": "0.7.14",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
 			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+		},
+		"warning": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+			"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
 		},
 		"whatwg-fetch": {
 			"version": "2.0.3",

--- a/packages/bpk-component-input/package.json
+++ b/packages/bpk-component-input/package.json
@@ -13,6 +13,7 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "bpk-component-icon": "^3.15.1",
     "bpk-mixins": "^17.3.1",
     "bpk-react-utils": "^2.5.0",
     "prop-types": "^15.5.8"

--- a/packages/bpk-component-input/readme.md
+++ b/packages/bpk-component-input/readme.md
@@ -28,19 +28,21 @@ export default () => (
 
 ## Props
 
-| Property     | PropType             | Required  | Default Value    |
-| ------------ | -------------------- | --------- | ---------------- |
-| id           | string               | true      | -                |
-| name         | string               | true      | -                |
-| value        | string               | true      | -                |
-| type         | INPUT_TYPES (one of) | false     | INPUT_TYPES.TEXT |
-| valid        | bool                 | false     | null             |
-| large        | bool                 | false     | false            |
-| docked       | bool                 | false     | false            |
-| dockedFirst  | bool                 | false     | false            |
-| dockedMiddle | bool                 | false     | false            |
-| dockedLast   | bool                 | false     | false            |
-| inputRef     | func                 | false     | null             |
+| Property         | PropType             | Required            | Default Value    |
+| ---------------- | -------------------- | ------------------- | ---------------- |
+| id               | string               | true                | -                |
+| name             | string               | true                | -                |
+| type             | INPUT_TYPES (one of) | false               | INPUT_TYPES.TEXT |
+| value            | string               | true                | -                |
+| clearable        | bool                 | false               | false            |
+| clearButtonLabel | string               | if clearable={true} | null             |
+| dockedFirst      | bool                 | false               | false            |
+| dockedLast       | bool                 | false               | false            |
+| dockedMiddle     | bool                 | false               | false            |
+| inputRef         | func                 | false               | null             |
+| large            | bool                 | false               | false            |
+| onClear          | func                 | if clearable={true} | null             |
+| valid            | bool                 | false               | null             |
 
 Additionally, all native `<input />` attributes such as `placeholder` and `onChange` are supported.
 

--- a/packages/bpk-component-input/src/BpkClearButton-test.js
+++ b/packages/bpk-component-input/src/BpkClearButton-test.js
@@ -1,0 +1,44 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import BpkClearButton from './BpkClearButton';
+
+describe('BpkClearButton', () => {
+  it('should render correctly', () => {
+    const tree = renderer
+      .create(<BpkClearButton label="Clear" onClick={() => null} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with a custom class', () => {
+    const tree = renderer
+      .create(
+        <BpkClearButton
+          label="Clear"
+          onClick={() => null}
+          className="foo-class"
+        />,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/bpk-component-input/src/BpkClearButton.js
+++ b/packages/bpk-component-input/src/BpkClearButton.js
@@ -1,0 +1,63 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import ClearIcon from 'bpk-component-icon/sm/close-circle';
+import { withButtonAlignment } from 'bpk-component-icon';
+import { cssModules } from 'bpk-react-utils';
+
+import STYLES from './bpk-clear-button.scss';
+
+const getClassName = cssModules(STYLES);
+
+const ClearButtonIcon = withButtonAlignment(ClearIcon);
+
+const BpkClearButton = props => {
+  const classNames = [getClassName('bpk-clear-button')];
+  const { label, onClick, className, ...rest } = props;
+
+  if (className) {
+    classNames.push(className);
+  }
+
+  return (
+    <button
+      type="button"
+      title={label}
+      onClick={onClick}
+      aria-label={label}
+      className={classNames.join(' ')}
+      {...rest}
+    >
+      <ClearButtonIcon className={getClassName('bpk-clear-button__icon')} />
+    </button>
+  );
+};
+
+BpkClearButton.propTypes = {
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  className: PropTypes.string,
+};
+
+BpkClearButton.defaultProps = {
+  className: null,
+};
+
+export default BpkClearButton;

--- a/packages/bpk-component-input/src/BpkInput-test.js
+++ b/packages/bpk-component-input/src/BpkInput-test.js
@@ -65,6 +65,48 @@ describe('BpkInput', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should render correctly with "clearable" attribute', () => {
+    // Will report a proptypes error because 'onClear' and 'clearButtonLabel'
+    // are missing. Swallow that as it's tested in customPropTypes-test.js.
+    jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+    const tree = renderer
+      .create(<BpkInput id="test" name="test" value="" clearable />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with "onClear" attribute', () => {
+    const tree = renderer
+      .create(<BpkInput id="test" name="test" value="" onClear={() => {}} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with "clearButtonLabel" attribute', () => {
+    const tree = renderer
+      .create(
+        <BpkInput id="test" name="test" value="" clearButtonLabel="test" />,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with "clearable", "onClear" and "clearButtonLabel" attributes', () => {
+    const tree = renderer
+      .create(
+        <BpkInput
+          id="test"
+          name="test"
+          value=""
+          clearable
+          onClear={() => {}}
+          clearButtonLabel="test"
+        />,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should render correctly with type attribute', () => {
     const tree = renderer
       .create(

--- a/packages/bpk-component-input/src/BpkInput.js
+++ b/packages/bpk-component-input/src/BpkInput.js
@@ -20,6 +20,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { cssModules } from 'bpk-react-utils';
 
+import BpkClearButton from './BpkClearButton';
+
+import clearablePropType from './customPropTypes';
 import STYLES from './bpk-input.scss';
 
 const getClassName = cssModules(STYLES);
@@ -34,17 +37,28 @@ export const INPUT_TYPES = {
 
 const BpkInput = props => {
   const classNames = [getClassName('bpk-input')];
+  const containerClassNames = [getClassName('bpk-input--clearable__container')];
+  const clearButtonClassNames = [
+    getClassName('bpk-input--clearable__clear-button'),
+  ];
   const {
-    valid,
-    large,
+    className,
+    clearable,
+    clearButtonLabel,
     docked,
     dockedFirst,
-    dockedMiddle,
     dockedLast,
-    className,
+    dockedMiddle,
     inputRef,
+    large,
+    onClear,
+    valid,
+    value,
     ...rest
   } = props;
+
+  // Used as a ref for focussing the input when cleared.
+  let ref = null;
 
   // Explicit check for false primitive value as undefined is
   // treated as neither valid nor invalid
@@ -58,6 +72,12 @@ const BpkInput = props => {
 
   if (large) {
     classNames.push(getClassName('bpk-input--large'));
+    clearButtonClassNames.push(
+      getClassName('bpk-input--clearable__clear-button--large'),
+    );
+  }
+  if (clearable) {
+    classNames.push(getClassName('bpk-input--clearable'));
   }
   if (docked) {
     classNames.push(getClassName('bpk-input--docked'));
@@ -72,16 +92,47 @@ const BpkInput = props => {
     classNames.push(getClassName('bpk-input--docked-last'));
   }
   if (className) {
-    classNames.push(className);
+    if (clearable) {
+      containerClassNames.push(className);
+    } else {
+      classNames.push(className);
+    }
   }
 
-  return (
+  const renderedInput = (
     <input
       className={classNames.join(' ')}
-      ref={inputRef}
+      ref={input => {
+        ref = input;
+        if (inputRef) {
+          inputRef(input);
+        }
+      }}
       aria-invalid={isInvalid}
+      value={value}
       {...rest}
     />
+  );
+
+  return clearable ? (
+    <div className={containerClassNames.join(' ')}>
+      {renderedInput}
+      {value.length > 0 && (
+        <BpkClearButton
+          tabIndex="-1"
+          label={clearButtonLabel}
+          onClick={e => {
+            ref.focus();
+            if (onClear) {
+              onClear(e);
+            }
+          }}
+          className={clearButtonClassNames.join(' ')}
+        />
+      )}
+    </div>
+  ) : (
+    renderedInput
   );
 };
 
@@ -104,6 +155,9 @@ BpkInput.propTypes = {
   dockedMiddle: PropTypes.bool,
   dockedLast: PropTypes.bool,
   inputRef: PropTypes.func,
+  clearable: PropTypes.bool,
+  clearButtonLabel: clearablePropType,
+  onClear: clearablePropType,
 };
 
 BpkInput.defaultProps = {
@@ -116,6 +170,9 @@ BpkInput.defaultProps = {
   dockedMiddle: false,
   dockedLast: false,
   inputRef: null,
+  clearable: false,
+  clearButtonLabel: null,
+  onClear: null,
 };
 
 export default BpkInput;

--- a/packages/bpk-component-input/src/__snapshots__/BpkClearButton-test.js.snap
+++ b/packages/bpk-component-input/src/__snapshots__/BpkClearButton-test.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkClearButton should render correctly 1`] = `
+<button
+  aria-label="Clear"
+  className="bpk-clear-button"
+  onClick={[Function]}
+  title="Clear"
+  type="button"
+>
+  <span
+    style={
+      Object {
+        "display": "inline-block",
+        "lineHeight": "1.125rem",
+        "marginTop": "0.1875rem",
+        "verticalAlign": "top",
+      }
+    }
+  >
+    <svg
+      className="bpk-clear-button__icon"
+      height="18"
+      style={
+        Object {
+          "height": "1.125rem",
+          "width": "1.125rem",
+        }
+      }
+      viewBox="0 0 24 24"
+      width="18"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm4.8 12.9c.3.3.3.7 0 .9l-.9.9c-.3.3-.7.3-.9 0l-3-2.8-2.9 2.9c-.3.3-.7.3-.9 0l-.9-.9c-.3-.3-.3-.7 0-.9l2.9-2.9-3-3c-.3-.3-.3-.7 0-.9l.9-.9c.3-.3.7-.3.9 0l2.9 2.9 2.9-2.9c.3-.3.7-.3.9 0l.9.9c.3.3.3.7 0 .9L13.9 12l2.9 2.9z"
+      />
+    </svg>
+  </span>
+</button>
+`;
+
+exports[`BpkClearButton should render correctly with a custom class 1`] = `
+<button
+  aria-label="Clear"
+  className="bpk-clear-button foo-class"
+  onClick={[Function]}
+  title="Clear"
+  type="button"
+>
+  <span
+    style={
+      Object {
+        "display": "inline-block",
+        "lineHeight": "1.125rem",
+        "marginTop": "0.1875rem",
+        "verticalAlign": "top",
+      }
+    }
+  >
+    <svg
+      className="bpk-clear-button__icon"
+      height="18"
+      style={
+        Object {
+          "height": "1.125rem",
+          "width": "1.125rem",
+        }
+      }
+      viewBox="0 0 24 24"
+      width="18"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm4.8 12.9c.3.3.3.7 0 .9l-.9.9c-.3.3-.7.3-.9 0l-3-2.8-2.9 2.9c-.3.3-.7.3-.9 0l-.9-.9c-.3-.3-.3-.7 0-.9l2.9-2.9-3-3c-.3-.3-.3-.7 0-.9l.9-.9c.3-.3.7-.3.9 0l2.9 2.9 2.9-2.9c.3-.3.7-.3.9 0l.9.9c.3.3.3.7 0 .9L13.9 12l2.9 2.9z"
+      />
+    </svg>
+  </span>
+</button>
+`;

--- a/packages/bpk-component-input/src/__snapshots__/BpkInput-test.js.snap
+++ b/packages/bpk-component-input/src/__snapshots__/BpkInput-test.js.snap
@@ -11,6 +11,47 @@ exports[`BpkInput should render correctly 1`] = `
 />
 `;
 
+exports[`BpkInput should render correctly with "clearButtonLabel" attribute 1`] = `
+<input
+  aria-invalid={false}
+  className="bpk-input"
+  id="test"
+  name="test"
+  type="text"
+  value=""
+/>
+`;
+
+exports[`BpkInput should render correctly with "clearable" attribute 1`] = `
+<div
+  className="bpk-input--clearable__container"
+>
+  <input
+    aria-invalid={false}
+    className="bpk-input bpk-input--clearable"
+    id="test"
+    name="test"
+    type="text"
+    value=""
+  />
+</div>
+`;
+
+exports[`BpkInput should render correctly with "clearable", "onClear" and "clearButtonLabel" attributes 1`] = `
+<div
+  className="bpk-input--clearable__container"
+>
+  <input
+    aria-invalid={false}
+    className="bpk-input bpk-input--clearable"
+    id="test"
+    name="test"
+    type="text"
+    value=""
+  />
+</div>
+`;
+
 exports[`BpkInput should render correctly with "docked" attribute 1`] = `
 <input
   aria-invalid={false}
@@ -59,6 +100,17 @@ exports[`BpkInput should render correctly with "large" attribute 1`] = `
 <input
   aria-invalid={false}
   className="bpk-input bpk-input--large"
+  id="test"
+  name="test"
+  type="text"
+  value=""
+/>
+`;
+
+exports[`BpkInput should render correctly with "onClear" attribute 1`] = `
+<input
+  aria-invalid={false}
+  className="bpk-input"
   id="test"
   name="test"
   type="text"

--- a/packages/bpk-component-input/src/bpk-clear-button.scss
+++ b/packages/bpk-component-input/src/bpk-clear-button.scss
@@ -1,0 +1,40 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins';
+
+.bpk-clear-button {
+  padding: 0;
+  border: 0;
+  background-color: transparent;
+  color: $bpk-color-gray-500;
+  cursor: pointer;
+  appearance: none;
+
+  @include bpk-hover {
+    color: $bpk-color-gray-700;
+  }
+
+  &:active {
+    color: $bpk-color-gray-900;
+  }
+
+  &__icon {
+    fill: currentColor;
+  }
+}

--- a/packages/bpk-component-input/src/bpk-input.scss
+++ b/packages/bpk-component-input/src/bpk-input.scss
@@ -33,6 +33,25 @@
     @include bpk-input--large;
   }
 
+  &--clearable {
+    @include bpk-input--clearable;
+
+    &__container {
+      @include bpk-input__container;
+    }
+
+    &__clear-button {
+      opacity: 0;
+
+      @include bpk-input__clear-button;
+    }
+
+    // Display the clear button when a clearable input is focused.
+    &:focus + &__clear-button {
+      opacity: 1;
+    }
+  }
+
   &--docked {
     @include bpk-input--docked;
 

--- a/packages/bpk-component-input/src/customPropTypes-test.js
+++ b/packages/bpk-component-input/src/customPropTypes-test.js
@@ -1,0 +1,136 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import clearablePropType from './customPropTypes';
+
+describe('clearablePropType', () => {
+  const COMPONENT_NAME = 'ExampleComponent';
+
+  describe('"onClear"', () => {
+    const PROP_NAME = 'onClear';
+
+    it('should not produce an error when "clearable" is not provided', () => {
+      const props = {};
+      expect(clearablePropType(props, PROP_NAME, COMPONENT_NAME)).toBeFalsy();
+    });
+
+    it('should not produce an error when "clearable={false}"', () => {
+      const props = {
+        clearable: false,
+      };
+      expect(clearablePropType(props, PROP_NAME, COMPONENT_NAME)).toBeFalsy();
+    });
+
+    it('should produce an error when "clearable={true}" and "onClear" is not provided', () => {
+      const props = {
+        clearable: true,
+      };
+      expect(
+        clearablePropType(props, PROP_NAME, COMPONENT_NAME).toString(),
+      ).toEqual(
+        'Error: Invalid prop `onClear` supplied to `ExampleComponent`. When `clearable={true}`, `onClear` must be supplied.',
+      );
+    });
+
+    it('should produce an error when "clearable={true}" and "onClear" is null', () => {
+      const props = {
+        clearable: true,
+        onClear: null,
+      };
+      expect(
+        clearablePropType(props, PROP_NAME, COMPONENT_NAME).toString(),
+      ).toEqual(
+        'Error: Invalid prop `onClear` supplied to `ExampleComponent`. When `clearable={true}`, `onClear` must be supplied.',
+      );
+    });
+
+    it('should produce an error when "clearable={true}" and "onClear" is not a function', () => {
+      const props = {
+        clearable: true,
+        onClear: 'Hello world',
+      };
+      expect(
+        clearablePropType(props, PROP_NAME, COMPONENT_NAME).toString(),
+      ).toEqual(
+        'Error: Invalid prop `onClear` supplied to `ExampleComponent`. `onClear` must be a function.',
+      );
+    });
+  });
+
+  describe('"clearButtonLabel"', () => {
+    const PROP_NAME = 'clearButtonLabel';
+
+    it('should not produce an error when "clearable" is not provided', () => {
+      const props = {};
+      expect(clearablePropType(props, PROP_NAME, COMPONENT_NAME)).toBeFalsy();
+    });
+
+    it('should not produce an error when "clearable={false}"', () => {
+      const props = {
+        clearable: false,
+      };
+      expect(clearablePropType(props, PROP_NAME, COMPONENT_NAME)).toBeFalsy();
+    });
+
+    it('should produce an error when "clearable={true}" and "clearButtonLabel" is not provided', () => {
+      const props = {
+        clearable: true,
+      };
+      expect(
+        clearablePropType(props, PROP_NAME, COMPONENT_NAME).toString(),
+      ).toEqual(
+        'Error: Invalid prop `clearButtonLabel` supplied to `ExampleComponent`. When `clearable={true}`, `clearButtonLabel` must be supplied.',
+      );
+    });
+
+    it('should produce an error when "clearable={true}" and "clearButtonLabel" is null', () => {
+      const props = {
+        clearable: true,
+        clearButtonLabel: null,
+      };
+      expect(
+        clearablePropType(props, PROP_NAME, COMPONENT_NAME).toString(),
+      ).toEqual(
+        'Error: Invalid prop `clearButtonLabel` supplied to `ExampleComponent`. When `clearable={true}`, `clearButtonLabel` must be supplied.',
+      );
+    });
+
+    it('should produce an error when "clearable={true}" and "clearButtonLabel" is not a string', () => {
+      const props = {
+        clearable: true,
+        clearButtonLabel: 42,
+      };
+      expect(
+        clearablePropType(props, PROP_NAME, COMPONENT_NAME).toString(),
+      ).toEqual(
+        'Error: Invalid prop `clearButtonLabel` supplied to `ExampleComponent`. `clearButtonLabel` must be a string.',
+      );
+    });
+  });
+
+  describe('neither', () => {
+    const PROP_NAME = 'foo';
+    it('should produce no error when "clearable={true}" but the prop name is neither clearButtonLabel or onClear', () => {
+      const props = {
+        clearable: true,
+        foo: 'bar',
+      };
+      expect(clearablePropType(props, PROP_NAME, COMPONENT_NAME)).toBeFalsy();
+    });
+  });
+});

--- a/packages/bpk-component-input/src/customPropTypes.js
+++ b/packages/bpk-component-input/src/customPropTypes.js
@@ -1,0 +1,50 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const clearablePropType = (props, propName, componentName) => {
+  const createError = message =>
+    new Error(
+      `Invalid prop \`${propName}\` supplied to \`${componentName}\`. ${message}.`,
+    );
+
+  const propBeingChecked = props[propName];
+  if (props.clearable) {
+    // Prop is required if clearable=true.
+    if (!propBeingChecked) {
+      return createError(
+        `When \`clearable={true}\`, \`${propName}\` must be supplied`,
+      );
+    }
+
+    switch (propName) {
+      case 'clearButtonLabel':
+        return typeof propBeingChecked === 'string'
+          ? null
+          : createError(`\`clearButtonLabel\` must be a string`);
+      case 'onClear':
+        return typeof propBeingChecked === 'function'
+          ? null
+          : createError(`\`onClear\` must be a function`);
+      default:
+        return null;
+    }
+  }
+  return null;
+};
+
+export default clearablePropType;

--- a/packages/bpk-component-input/stories.js
+++ b/packages/bpk-component-input/stories.js
@@ -71,6 +71,43 @@ storiesOf('bpk-component-input', module)
       disabled
     />
   ))
+  .add('Clearable', () => (
+    <div>
+      <BpkInput
+        id="clearable"
+        name="clearable"
+        value="Edinburgh"
+        onChange={action('input changed')}
+        placeholder="Enter a country, city or airport"
+        clearable
+        clearButtonLabel="Clear field"
+        onClear={action('input cleared')}
+      />
+      <BpkInput
+        id="clearable"
+        name="clearable"
+        value="Edinburgh"
+        onChange={action('input changed')}
+        placeholder="Enter a country, city or airport"
+        valid
+        clearable
+        clearButtonLabel="Clear field"
+        onClear={action('input cleared')}
+      />
+      <BpkInput
+        id="clearable"
+        name="clearable"
+        value="Edinburgh"
+        onChange={action('input changed')}
+        placeholder="Enter a country, city or airport"
+        large
+        valid
+        clearable
+        clearButtonLabel="Clear field"
+        onClear={action('input cleared')}
+      />
+    </div>
+  ))
   .add('Email', () => (
     <BpkInput
       type={INPUT_TYPES.EMAIL}

--- a/packages/bpk-component-select/readme.md
+++ b/packages/bpk-component-select/readme.md
@@ -38,7 +38,6 @@ export default () => (
 | onChange     | func     | true     | -             |
 | valid        | bool     | false    | null          |
 | large        | bool     | false    | false         |
-| docked       | bool     | false    | false         |
 | dockedFirst  | bool     | false    | false         |
 | dockedMiddle | bool     | false    | false         |
 | dockedLast   | bool     | false    | false         |

--- a/packages/bpk-docs/src/pages/FormsPage/FormsPage.js
+++ b/packages/bpk-docs/src/pages/FormsPage/FormsPage.js
@@ -128,6 +128,20 @@ const components = [
         />
       </form>,
       <form className={formClassName}>
+        <BpkLabel htmlFor="input_clearable">Clearable input</BpkLabel>
+        <InputContainer
+          FormComponent={BpkInput}
+          id="input_clearable"
+          name="input_clearable"
+          value="Edinburgh"
+          placeholder="Country, city or airport"
+          onChange={() => null}
+          clearable
+          onClear={() => null}
+          clearButtonLabel="Clear field"
+        />
+      </form>,
+      <form className={formClassName}>
         <BpkLabel htmlFor="input_disabled" disabled>
           Disabled input
         </BpkLabel>
@@ -293,7 +307,7 @@ const components = [
             placeholder="Country, city or airport"
             onChange={() => null}
             className={placeClassName}
-            docked
+            dockedFirst
             large
           />
           <InputContainer
@@ -304,7 +318,7 @@ const components = [
             placeholder="Country, city or airport"
             onChange={() => null}
             className={placeClassName}
-            docked
+            dockedMiddle
             large
           />
           <InputContainer
@@ -312,10 +326,10 @@ const components = [
             id="input_outbound"
             name="input_outbound"
             value={new Date().toLocaleDateString()}
-            placeholder="Country, city or airport"
+            placeholder="Depature date"
             onChange={() => null}
             className={dateClassName}
-            docked
+            dockedMiddle
             large
           />
           <InputContainer
@@ -325,10 +339,10 @@ const components = [
             value={new Date(
               new Date().getTime() + 24 * 60 * 60 * 1000,
             ).toLocaleDateString()}
-            placeholder="Country, city or airport"
+            placeholder="Return date"
             onChange={() => null}
             className={dateClassName}
-            docked
+            dockedLast
             large
           />
         </div>
@@ -363,7 +377,7 @@ const components = [
             placeholder="Destination or hotel name"
             onChange={() => null}
             className={destinationClassName}
-            docked
+            dockedFirst
             large
           />
           <InputContainer
@@ -374,7 +388,7 @@ const components = [
             placeholder=""
             onChange={() => null}
             className={dateClassName}
-            docked
+            dockedMiddle
             large
           />
           <InputContainer
@@ -387,7 +401,7 @@ const components = [
             placeholder=""
             onChange={() => null}
             className={dateClassName}
-            docked
+            dockedMiddle
             large
           />
           <InputContainer
@@ -397,7 +411,7 @@ const components = [
             value="2"
             onChange={() => null}
             className={numberClassName}
-            docked
+            dockedMiddle
             large
           >
             <option value={0}>0</option>
@@ -412,7 +426,7 @@ const components = [
             value="1"
             onChange={() => null}
             className={numberClassName}
-            docked
+            dockedLast
             large
           >
             <option value={0}>0</option>
@@ -449,7 +463,7 @@ const components = [
             placeholder="City or airport"
             onChange={() => null}
             className={pickupClassName}
-            docked
+            dockedFirst
             large
           />
           <InputContainer
@@ -460,7 +474,7 @@ const components = [
             placeholder=""
             onChange={() => null}
             className={dateClassName}
-            docked
+            dockedMiddle
             large
           />
           <InputContainer
@@ -471,7 +485,7 @@ const components = [
             placeholder=""
             onChange={() => null}
             className={timeClassName}
-            docked
+            dockedMiddle
             large
           >
             <option value="10:00">10:00</option>
@@ -489,7 +503,7 @@ const components = [
             placeholder=""
             onChange={() => null}
             className={dateClassName}
-            docked
+            dockedMiddle
             large
           />
           <InputContainer
@@ -499,7 +513,7 @@ const components = [
             value="10:00"
             onChange={() => null}
             className={timeClassName}
-            docked
+            dockedLast
             large
           >
             <option value="10:00">10:00</option>

--- a/packages/bpk-docs/src/pages/FormsPage/InputContainer.js
+++ b/packages/bpk-docs/src/pages/FormsPage/InputContainer.js
@@ -45,6 +45,7 @@ class InputContainer extends Component {
       overrideProps = {
         value: this.state.value,
         onChange: e => this.setState({ value: e.target.value }),
+        onClear: () => this.setState({ value: '' }),
       };
     }
     return <FormComponent {...rest} {...overrideProps} />;

--- a/packages/bpk-mixins/src/mixins/_forms.scss
+++ b/packages/bpk-mixins/src/mixins/_forms.scss
@@ -118,6 +118,69 @@
   }
 }
 
+/// Clearable form input. Modifies the bpk-input mixin.
+///
+/// @require {mixin} bpk-input
+///
+/// @example scss
+///   .selector {
+///     @include bpk-input();
+///     @include bpk-input--clearable();
+///   }
+
+@mixin bpk-input--clearable {
+  padding-right: $bpk-spacing-base;
+
+  @include bpk-rtl {
+    padding-left: $bpk-spacing-base;
+  }
+
+  &:focus {
+    background: $bpk-input-background;
+  }
+}
+
+/// Clearable form input container. Modifies the bpk-input mixin.
+///
+/// @require {mixin} bpk-input
+///
+/// @example scss
+///   .selector {
+///     @include bpk-input();
+///     @include bpk-input__container();
+///   }
+
+@mixin bpk-input__container {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+/// Clearable (clear button) form input. Modifies the bpk-input mixin.
+///
+/// @require {mixin} bpk-input
+///
+/// @example scss
+///   .selector {
+///     @include bpk-input();
+///     @include bpk-input__clear-button();
+///   }
+
+@mixin bpk-input__clear-button {
+  position: absolute;
+  right: $bpk-spacing-sm;
+  height: $bpk-input-height;
+
+  @include bpk-rtl {
+    right: inherit;
+    left: $bpk-spacing-sm;
+  }
+
+  &--large {
+    @include bpk-input--large;
+  }
+}
+
 /// Large form input. Modifies the bpk-input mixin.
 ///
 /// @require {mixin} bpk-input


### PR DESCRIPTION
* `BpkInput` now accepts `clearable`, `onClear` and `clearButtonLabel` props.
* `onClear` and `clearButtonLabel` are required if `clearable={true}`.
* When `clearable={true}`, a button appears when the field is focused and `value.length > 0`.
* As with modifying the input's value, actually doing the clearing is left to userland.
* However, I'm re-focussing the input when the clear button is pressed, as otherwise pressing it would un-focus it, which I think is a bad UX.
* If the input has a valid/invalid icon, the clear button will hide it when focused.
* I've set `tabIndex=-1` on the clear button to preserve tabbing between fields.
* Originally I used a `BpkCloseButton` for the button, but I needed to use a different icon (`close-circle`). After speaking with @jamesf3rguson we decided to make a `BpkClearButton` component but keep it inside this package, for now. The reason for this is that we may wish to revisit `BpkCloseButton` in future, potentially have it export `BpkClearButton` or that sort of thing.
* The userland `className` prop now gets applied to the outermost container. This shouldn't be a problem but worth highlighting.

* Removed `docked` prop from `input` and `select` readmes. As discussed with @matthewdavidson it's too 'magical' and easily breaks if inputs are in a container div. I also updated the docs site to no longer use `docked`.

**GIF**

![kapture 2018-01-25 at 11 20 25](https://user-images.githubusercontent.com/73652/35385866-c29d523c-01c1-11e8-91ec-7dc3df88e664.gif)

**Notes for reviewers**

* I'm not 100% happy with the styles - this is my first time modifying a web component this much, so I'm not exactly sure where we draw the line between what goes in mixins and what goes in the components own scss, so any feedback there is appreciated.

* To manage the button placement, when `clearable={true}` I wrap the input in a container div and then absolutely position the button. I don't think this will affect existing inputs, because 1) it only applies to ones with `clearable={true}` and 2) the container div has `display: inline-block` so as to match the `input` within.
