### PR TITLE
[FSS-3569] - Add possibility to set fullScreen for modal dialog

### DIFF
--- a/packages/bpk-component-modal/readme.md
+++ b/packages/bpk-component-modal/readme.md
@@ -88,6 +88,7 @@ class App extends Component {
 | renderTarget          | func     | false    | null             |
 | wide                  | bool     | false    | false            |
 | fullScreenOnMobile    | bool     | false    | true             |
+| fullScreen            | bool     | false    | false            |
 | closeOnScrimClick     | bool     | false    | true             |
 | showHeader            | bool     | false    | true             |
 | closeOnEscPressed     | bool     | false    | true             |

--- a/packages/bpk-component-modal/src/BpkModal.js
+++ b/packages/bpk-component-modal/src/BpkModal.js
@@ -125,8 +125,6 @@ BpkModal.defaultProps = {
   target: null,
   closeOnScrimClick: true,
   closeOnEscPressed: true,
-  fullScreenOnMobile: true,
-  fullScreen: false,
 };
 
 export default BpkModal;

--- a/packages/bpk-component-modal/src/BpkModal.js
+++ b/packages/bpk-component-modal/src/BpkModal.js
@@ -65,6 +65,7 @@ const BpkModal = (props: Props) => {
     target,
     renderTarget,
     fullScreenOnMobile,
+    fullScreen,
     closeOnScrimClick,
     closeOnEscPressed,
     ...rest
@@ -72,8 +73,12 @@ const BpkModal = (props: Props) => {
 
   const containerClass = [getClassName('bpk-modal__container')];
 
-  if (fullScreenOnMobile) {
+  if (fullScreen) {
     containerClass.push(getClassName('bpk-modal__container--full-screen'));
+  } else if (fullScreenOnMobile) {
+    containerClass.push(
+      getClassName('bpk-modal__container--full-screen-mobile'),
+    );
   }
 
   return (
@@ -87,6 +92,7 @@ const BpkModal = (props: Props) => {
       <ScrimBpkModalDialog
         onClose={onClose}
         fullScreenOnMobile={fullScreenOnMobile}
+        fullScreen={fullScreen}
         closeOnScrimClick={closeOnScrimClick}
         containerClassName={containerClass.join(' ')}
         {...rest}
@@ -119,6 +125,8 @@ BpkModal.defaultProps = {
   target: null,
   closeOnScrimClick: true,
   closeOnEscPressed: true,
+  fullScreenOnMobile: true,
+  fullScreen: false,
 };
 
 export default BpkModal;

--- a/packages/bpk-component-modal/src/BpkModalDialog-test.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog-test.js
@@ -49,6 +49,7 @@ describe('BpkModalDialog', () => {
           dialogRef={jest.fn()}
           isIphone={false}
           fullScreenOnMobile
+          fullScreen={false}
         >
           Modal content
         </BpkModalDialog>,
@@ -70,6 +71,7 @@ describe('BpkModalDialog', () => {
           dialogRef={jest.fn()}
           isIphone={false}
           fullScreenOnMobile
+          fullScreen={false}
         >
           Modal content
         </BpkModalDialog>,
@@ -92,6 +94,7 @@ describe('BpkModalDialog', () => {
           dialogRef={jest.fn()}
           isIphone={false}
           fullScreenOnMobile
+          fullScreen={false}
         >
           Modal content
         </BpkModalDialog>,
@@ -114,6 +117,7 @@ describe('BpkModalDialog', () => {
           dialogRef={jest.fn()}
           isIphone={false}
           fullScreenOnMobile
+          fullScreen={false}
         >
           Modal content
         </BpkModalDialog>,
@@ -134,6 +138,7 @@ describe('BpkModalDialog', () => {
           dialogRef={jest.fn()}
           isIphone
           fullScreenOnMobile
+          fullScreen={false}
         >
           Modal content
         </BpkModalDialog>,
@@ -153,6 +158,28 @@ describe('BpkModalDialog', () => {
           closeEvents={closeEvents}
           dialogRef={jest.fn()}
           fullScreenOnMobile={false}
+          fullScreen={false}
+          isIphone={false}
+        >
+          Modal content
+        </BpkModalDialog>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly when it is fullscreen', () => {
+    const tree = renderer
+      .create(
+        <BpkModalDialog
+          id="my-modal"
+          title="Modal title"
+          onClose={jest.fn()}
+          closeLabel="Close"
+          closeEvents={closeEvents}
+          dialogRef={jest.fn()}
+          fullScreenOnMobile={false}
+          fullScreen
           isIphone={false}
         >
           Modal content

--- a/packages/bpk-component-modal/src/BpkModalDialog.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog.js
@@ -33,7 +33,6 @@ const getClassName = cssModules(STYLES);
 export type Props = {
   id: string,
   children: Node,
-  onClose: (event: SyntheticEvent<>) => void,
   wide: boolean,
   isIphone: boolean,
   showHeader: boolean,
@@ -124,7 +123,6 @@ BpkModalDialog.propTypes = {
   id: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   isIphone: PropTypes.bool.isRequired,
-  fullScreen: PropTypes.bool.isRequired,
   dialogRef: PropTypes.func.isRequired,
   closeEvents: PropTypes.shape({
     onTouchStart: PropTypes.func,
@@ -142,6 +140,7 @@ BpkModalDialog.propTypes = {
   wide: PropTypes.bool,
   showHeader: PropTypes.bool,
   fullScreenOnMobile: PropTypes.bool,
+  fullScreen: PropTypes.bool,
 };
 
 BpkModalDialog.defaultProps = {
@@ -153,6 +152,7 @@ BpkModalDialog.defaultProps = {
   wide: false,
   showHeader: true,
   fullScreenOnMobile: true,
+  fullScreen: false,
 };
 
 export default BpkModalDialog;

--- a/packages/bpk-component-modal/src/BpkModalDialog.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog.js
@@ -33,10 +33,12 @@ const getClassName = cssModules(STYLES);
 export type Props = {
   id: string,
   children: Node,
+  onClose: (event: SyntheticEvent<>) => void,
   wide: boolean,
   isIphone: boolean,
   showHeader: boolean,
   fullScreenOnMobile: boolean,
+  fullScreen: boolean,
   dialogRef: (ref: ?HTMLElement) => void,
   onClose: ?(event: SyntheticEvent<>) => void,
   className: ?string,
@@ -66,8 +68,10 @@ const BpkModalDialog = (props: Props) => {
     classNames.push(getClassName('bpk-modal--iphone-fix'));
   }
 
-  if (props.fullScreenOnMobile) {
+  if (props.fullScreen) {
     classNames.push(getClassName('bpk-modal--full-screen'));
+  } else if (props.fullScreenOnMobile) {
+    classNames.push(getClassName('bpk-modal--full-screen-mobile'));
   }
 
   const headingId = `bpk-modal-heading-${props.id}`;
@@ -120,6 +124,7 @@ BpkModalDialog.propTypes = {
   id: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   isIphone: PropTypes.bool.isRequired,
+  fullScreen: PropTypes.bool.isRequired,
   dialogRef: PropTypes.func.isRequired,
   closeEvents: PropTypes.shape({
     onTouchStart: PropTypes.func,

--- a/packages/bpk-component-modal/src/__snapshots__/BpkModal-test.js.snap
+++ b/packages/bpk-component-modal/src/__snapshots__/BpkModal-test.js.snap
@@ -12,11 +12,11 @@ exports[`BpkModal should render correctly in the given target if renderTarget is
         class="bpk-scrim"
       />
       <div
-        class="bpk-scrim-content bpk-modal__container bpk-modal__container--full-screen"
+        class="bpk-scrim-content bpk-modal__container bpk-modal__container--full-screen-mobile"
       >
         <section
           aria-labelledby="bpk-modal-heading-my-modal"
-          class="bpk-modal bpk-modal--full-screen"
+          class="bpk-modal bpk-modal--full-screen-mobile"
           id="my-modal"
           role="dialog"
           tabindex="-1"

--- a/packages/bpk-component-modal/src/__snapshots__/BpkModalDialog-test.js.snap
+++ b/packages/bpk-component-modal/src/__snapshots__/BpkModalDialog-test.js.snap
@@ -3,7 +3,7 @@
 exports[`BpkModalDialog should render correctly 1`] = `
 <section
   aria-labelledby="bpk-modal-heading-my-modal"
-  className="bpk-modal bpk-modal--full-screen"
+  className="bpk-modal bpk-modal--full-screen-mobile"
   id="my-modal"
   onMouseDown={[Function]}
   onMouseMove={[Function]}
@@ -72,7 +72,7 @@ exports[`BpkModalDialog should render correctly 1`] = `
 exports[`BpkModalDialog should render correctly when is iPhone 1`] = `
 <section
   aria-labelledby="bpk-modal-heading-my-modal"
-  className="bpk-modal bpk-modal--iphone-fix bpk-modal--full-screen"
+  className="bpk-modal bpk-modal--iphone-fix bpk-modal--full-screen-mobile"
   id="my-modal"
   onMouseDown={[Function]}
   onMouseMove={[Function]}
@@ -210,7 +210,76 @@ exports[`BpkModalDialog should render correctly when it does not fills the scree
 exports[`BpkModalDialog should render correctly when it has a className 1`] = `
 <section
   aria-labelledby="bpk-modal-heading-my-modal"
-  className="bpk-modal my-classname bpk-modal--full-screen"
+  className="bpk-modal my-classname bpk-modal--full-screen-mobile"
+  id="my-modal"
+  onMouseDown={[Function]}
+  onMouseMove={[Function]}
+  onMouseUp={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  role="dialog"
+  tabIndex="-1"
+>
+  <header
+    className="bpk-modal__header"
+  >
+    <h2
+      className="bpk-modal__heading"
+      id="bpk-modal-heading-my-modal"
+    >
+      Modal title
+    </h2>
+     
+    <button
+      aria-label="Close"
+      className="bpk-close-button bpk-modal__close-button"
+      onClick={[Function]}
+      title="Close"
+      type="button"
+    >
+      <span
+        style={
+          Object {
+            "display": "inline-block",
+            "lineHeight": "1.125rem",
+            "marginTop": "0.1875rem",
+            "verticalAlign": "top",
+          }
+        }
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.8 12l4.9-4.9c.4-.4.4-1 0-1.4l-1.4-1.4c-.4-.4-1-.4-1.4 0L12 9.2l-4.9-5c-.4-.4-1-.4-1.4 0L4.2 5.6c-.4.4-.4 1 0 1.4l5 5-4.9 4.9c-.4.4-.4 1 0 1.4l1.4 1.4c.4.4 1 .4 1.4 0l4.9-4.9 4.9 4.9c.4.4 1 .4 1.4 0l1.4-1.4c.4-.4.4-1 0-1.4L14.8 12z"
+          />
+        </svg>
+      </span>
+    </button>
+  </header>
+  <div
+    className="bpk-modal__content"
+  >
+    Modal content
+  </div>
+</section>
+`;
+
+exports[`BpkModalDialog should render correctly when it is fullscreen 1`] = `
+<section
+  aria-labelledby="bpk-modal-heading-my-modal"
+  className="bpk-modal bpk-modal--full-screen"
   id="my-modal"
   onMouseDown={[Function]}
   onMouseMove={[Function]}
@@ -279,7 +348,7 @@ exports[`BpkModalDialog should render correctly when it has a className 1`] = `
 exports[`BpkModalDialog should render correctly with closeText prop 1`] = `
 <section
   aria-labelledby="bpk-modal-heading-my-modal"
-  className="bpk-modal my-classname bpk-modal--full-screen"
+  className="bpk-modal my-classname bpk-modal--full-screen-mobile"
   id="my-modal"
   onMouseDown={[Function]}
   onMouseMove={[Function]}
@@ -319,7 +388,7 @@ exports[`BpkModalDialog should render correctly with closeText prop 1`] = `
 exports[`BpkModalDialog should render correctly with wide prop 1`] = `
 <section
   aria-labelledby="bpk-modal-heading-my-modal"
-  className="bpk-modal bpk-modal--wide my-classname bpk-modal--full-screen"
+  className="bpk-modal bpk-modal--wide my-classname bpk-modal--full-screen-mobile"
   id="my-modal"
   onMouseDown={[Function]}
   onMouseMove={[Function]}

--- a/packages/bpk-component-modal/src/bpk-modal-dialog.scss
+++ b/packages/bpk-component-modal/src/bpk-modal-dialog.scss
@@ -18,6 +18,12 @@
 
 @import '~bpk-mixins/index';
 
+@mixin fullscreen() {
+  margin: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
 .bpk-modal {
   z-index: $bpk-zindex-modal;
   width: 100%;
@@ -32,12 +38,16 @@
   @include bpk-box-shadow-xl;
   @include bpk-border-radius-sm;
 
-  &--full-screen {
+  &--full-screen-mobile {
     @include bpk-breakpoint-mobile {
-      margin: 0;
-      border-radius: 0;
-      box-shadow: none;
+      @include fullscreen;
     }
+  }
+
+  &--full-screen {
+    min-width: 100%;
+
+    @include fullscreen;
   }
 
   &--wide {

--- a/packages/bpk-component-modal/src/bpk-modal-dialog.scss
+++ b/packages/bpk-component-modal/src/bpk-modal-dialog.scss
@@ -45,7 +45,7 @@
   }
 
   &--full-screen {
-    min-width: 100%;
+    max-width: none;
 
     @include fullscreen;
   }

--- a/packages/bpk-component-modal/src/bpk-modal.scss
+++ b/packages/bpk-component-modal/src/bpk-modal.scss
@@ -19,7 +19,7 @@
 @import '~bpk-mixins/index';
 
 @mixin fullscreen() {
-  display: block;
+  display: flex;
   padding: 0;
   background-color: $bpk-modal-background-color;
 }

--- a/packages/bpk-component-modal/src/bpk-modal.scss
+++ b/packages/bpk-component-modal/src/bpk-modal.scss
@@ -18,6 +18,12 @@
 
 @import '~bpk-mixins/index';
 
+@mixin fullscreen() {
+  display: block;
+  padding: 0;
+  background-color: $bpk-modal-background-color;
+}
+
 .bpk-modal__container {
   display: flex;
   padding: $bpk-spacing-base;
@@ -27,11 +33,13 @@
     display: block;
   }
 
-  &--full-screen {
+  &--full-screen-mobile {
     @include bpk-breakpoint-mobile {
-      display: block;
-      padding: 0;
-      background-color: $bpk-modal-background-color;
+      @include fullscreen;
     }
+  }
+
+  &--full-screen {
+    @include fullscreen;
   }
 }

--- a/packages/bpk-component-modal/stories.js
+++ b/packages/bpk-component-modal/stories.js
@@ -319,4 +319,14 @@ storiesOf('bpk-component-modal', module)
     >
       This is a default modal. You can put anything you want in here.
     </ModalContainer>
+  ))
+  .add('Full screen', () => (
+    <ModalContainer
+      title="Modal title"
+      closeText="Done"
+      buttonText="Open modal"
+      fullScreen
+    >
+      This is a default modal. You can put anything you want in here.
+    </ModalContainer>
   ));


### PR DESCRIPTION
- adds the possibility to have a modal dialog as fullscreen for the desktop and mobile with `fullScreen` parameter 
- if `fullscreen` is defined it trumps `fullScreenOnMobile`  