### PR TITLE
datatable/fix: onRowClick to work with sorted rows.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-_Nothing yet ..._
+**Fixed:**
+- bpk-component-datatable
+  - Now `onRowClick` handler respects sorting of rows.
 
 ## 2018-01-30 - New dialog component, clearable inputs, alternate links and fullscreen modals!
 

--- a/packages/bpk-component-datatable/src/BpkDataTable-test.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable-test.js
@@ -186,6 +186,32 @@ describe('BpkDataTable', () => {
     expect(onRowClick).toHaveBeenCalledWith(rows[1]);
   });
 
+  it('onRowClick/bug: ensure handler is applied to the right element after sorting', () => {
+    const abcRows = [{ letter: 'Z' }, { letter: 'P' }, { letter: 'A' }];
+    const onRowClick = jest.fn();
+    const wrapper = mount(
+      <BpkDataTable
+        rows={abcRows}
+        height={200}
+        width={400}
+        onRowClick={onRowClick}
+      >
+        <BpkDataTableColumn label="Letter" dataKey="letter" width={100} />
+        <BpkDataTableColumn label="Letter" dataKey="letter" width={100} />
+      </BpkDataTable>,
+    );
+
+    // Select the last element in the table, which after sorting
+    // it will be letter Z so index 0.
+    wrapper
+      .find('.bpk-data-table__row')
+      .last()
+      .simulate('click');
+
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick).toHaveBeenCalledWith(abcRows[0]);
+  });
+
   it('should re-render when rows prop is updated', () => {
     const wrapper = mount(
       <BpkDataTable rows={rows} height={200} width={400}>

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -94,7 +94,7 @@ class BpkDataTable extends Component {
       this.setState({ rowSelected: index });
     }
     if (this.props.onRowClick !== undefined) {
-      this.props.onRowClick(this.props.rows[index]);
+      this.props.onRowClick(this.state.sortedList[index]);
     }
   }
 


### PR DESCRIPTION
Fixes bug where `onRowClick` event handler is not triggered with the corresponding clicked element on sorted lists.