### PR TITLE
[BPK-1275] Fix duplicate id's on docs pages

### DIFF
--- a/packages/bpk-docs/src/components/DocsPageBuilder/DocsPageBuilder.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/DocsPageBuilder.js
@@ -50,7 +50,7 @@ const toNodes = children => {
   return isString(children) ? [<Paragraph>{children}</Paragraph>] : children;
 };
 
-const markdownToHTML = readmeString =>
+const markdownToHTML = (readmeString, headerPrefix = '') =>
   marked(
     readmeString
       .replace(/^#.*$/m, '') // remove first h1
@@ -59,7 +59,7 @@ const markdownToHTML = readmeString =>
       .replace(/^### /gm, '#### ') // replace h3 with h4
       .replace(/^## /gm, '### ') // replace h2 with h3
       .replace(/^# /gm, '## '), // replace h1 with h2
-    { renderer },
+    { renderer, headerPrefix },
   );
 
 const toSassdocLink = props => (
@@ -94,7 +94,9 @@ const ComponentExample = component => {
           {component.title} readme
         </Heading>,
         <BpkContentContainer
-          dangerouslySetInnerHTML={{ __html: markdownToHTML(component.readme) }}
+          dangerouslySetInnerHTML={{
+            __html: markdownToHTML(component.readme, `${component.id}-`),
+          }}
           bareHtml
         />,
       ])
@@ -128,7 +130,9 @@ const CustomSection = section => [
           Readme
         </Heading>,
         <BpkContentContainer
-          dangerouslySetInnerHTML={{ __html: markdownToHTML(section.readme) }}
+          dangerouslySetInnerHTML={{
+            __html: markdownToHTML(section.readme, `${section.id}-`),
+          }}
           bareHtml
         />,
       ])


### PR DESCRIPTION
Im using a secret `headerPrefix` api used in marked here: https://github.com/chjj/marked/blob/master/lib/marked.js#L825

Old:
![screen shot 2018-02-06 at 11 52 03](https://user-images.githubusercontent.com/1440090/35858414-3cb9da42-0b34-11e8-851b-ce4339bec490.png)

New:
![screen shot 2018-02-06 at 11 52 00](https://user-images.githubusercontent.com/1440090/35858419-4338306c-0b34-11e8-9f2f-3c411f9b1acd.png)

