### PR TITLE
bpkDataTable: supports changing column used for initial sorting.

### DIFF
--- a/packages/bpk-component-datatable/readme.md
+++ b/packages/bpk-component-datatable/readme.md
@@ -46,15 +46,15 @@ Supports all properties defined in [`Table`](https://github.com/bvaughn/react-vi
 in addition to the following:
 
 
-| Property     | PropType                    | Required | Default Value        |
-| ------------ | --------------------------- | -------- | -------------------- |
-| rows         | arrayOf(Object)             | true     | -                    |
-| children     | arrayOf(BpkDataTableColumn) | true     | -                    |
-| height       | number                      | true     | -                    |
-| width        | number                      | false    | full width of parent |
-| headerHeight | number                      | false    | 60                   |
-| rowHeight    | number                      | false    | 60                   |
-
+| Property               | PropType                    | Required | Default Value        |
+| ---------------------- | --------------------------- | -------- | -------------------- |
+| rows                   | arrayOf(Object)             | true     | -                    |
+| children               | arrayOf(BpkDataTableColumn) | true     | -                    |
+| height                 | number                      | true     | -                    |
+| width                  | number                      | false    | full width of parent |
+| headerHeight           | number                      | false    | 60                   |
+| rowHeight              | number                      | false    | 60                   |
+| defaultColumnSortIndex | number                      | false    | 0                    |
 
 
 ### BpkDataTableColumn

--- a/packages/bpk-component-datatable/src/BpkDataTable-test.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable-test.js
@@ -19,6 +19,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
+import { SortDirection } from 'react-virtualized/dist/commonjs/Table';
+
 import BpkDataTable from './BpkDataTable';
 import BpkDataTableColumn from './BpkDataTableColumn';
 
@@ -229,5 +231,34 @@ describe('BpkDataTable', () => {
 
     wrapper.setProps({ rows: [rows[0]] });
     expect(wrapper.find('.bpk-data-table__row')).toHaveLength(2);
+  });
+
+  it('Default table is sorted by the column specified in the index', () => {
+    const abcRows = [
+      { letter: 'A', number: 1 },
+      { letter: 'B', number: 2 },
+      { letter: 'C', number: 3 },
+    ];
+    const wrapper = mount(
+      <BpkDataTable
+        rows={abcRows}
+        height={200}
+        width={400}
+        defaultColumnSortIndex={1}
+      >
+        <BpkDataTableColumn label="Letter" dataKey="letter" width={100} />
+        <BpkDataTableColumn
+          label="Number"
+          dataKey="number"
+          width={100}
+          defaultSortDirection={SortDirection.DESC}
+        />
+      </BpkDataTable>,
+    );
+
+    // Select the last element in the table, when sorting by default on 2nd
+    // column it will be A1.
+    const firstRow = wrapper.find('.bpk-data-table__row').at(1);
+    expect(firstRow.text()).toBe('C3');
   });
 });

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -60,11 +60,16 @@ const sortList = ({ sortBy, sortDirection, list }) => {
 };
 
 class BpkDataTable extends Component {
-  constructor({ rows, children }) {
+  constructor({ rows, children, defaultColumnSortIndex }) {
     super();
 
-    const sortBy = children.length > 0 ? children[0].props.dataKey : undefined;
-    const sortDirection = SortDirection.ASC;
+    const sortBy =
+      children.length > 0
+        ? children[defaultColumnSortIndex].props.dataKey
+        : undefined;
+    const sortDirection =
+      children[defaultColumnSortIndex].props.defaultSortDirection ||
+      SortDirection.ASC;
     const sortedList = sortList({ sortBy, sortDirection, list: rows });
 
     this.state = {
@@ -185,6 +190,7 @@ BpkDataTable.propTypes = {
   width: PropTypes.number,
   headerHeight: PropTypes.number,
   className: PropTypes.string,
+  defaultColumnSortIndex: PropTypes.number,
 };
 
 BpkDataTable.defaultProps = {
@@ -193,6 +199,7 @@ BpkDataTable.defaultProps = {
   headerHeight: 60,
   rowHeight: 60,
   gridStyle: { direction: undefined }, // This is required for rows to automatically respect rtl
+  defaultColumnSortIndex: 0,
 };
 
 export default BpkDataTable;


### PR DESCRIPTION
With this new optional parameter, the user can customize which
column is used to sort the table on the initial render.

If the value is not provided, the first column is used.