### PR TITLE
[BPK-1286] Add className prop support to RTL and grid toggles

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,11 @@
 # Backpack changelog
 
 ## Unreleased
-_Nothing Yet_
+
+**Added:**
+- bpk-component-grid-toggle:
+- bpk-component-rtl-toggle:
+  - `className` prop is now accepted.
 
 ## 2018-02-08 - Breaking changes on chip component, update accordion and datatable
 **Breaking:**

--- a/packages/bpk-component-grid-toggle/readme.md
+++ b/packages/bpk-component-grid-toggle/readme.md
@@ -23,4 +23,5 @@ export default () => (
 
 | Property         | PropType | Required | Default Value |
 | ---------------- | -------- | -------- | ------------- |
+| className        | string   | false    | null          |
 | targetContainer  | string   | false    | 'body'        |

--- a/packages/bpk-component-grid-toggle/src/BpkGridToggle-test.js
+++ b/packages/bpk-component-grid-toggle/src/BpkGridToggle-test.js
@@ -33,4 +33,9 @@ describe('BpkGridToggle', () => {
     tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with the className prop', () => {
+    const tree = renderer.create(<BpkGridToggle className="foo" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
+++ b/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
@@ -70,6 +70,7 @@ class BpkGridToggle extends React.Component {
   }
 
   render() {
+    const { className } = this.props;
     const { gridEnabled } = this.state;
     const onOrOff = gridEnabled ? 'off' : 'on';
 
@@ -77,6 +78,7 @@ class BpkGridToggle extends React.Component {
       <BpkButtonLink
         title="Keyboard Shortcut: ctrl + cmd + g"
         onClick={this.toggleGrid}
+        className={className}
       >
         Baseline grid {onOrOff}
       </BpkButtonLink>
@@ -86,10 +88,12 @@ class BpkGridToggle extends React.Component {
 
 BpkGridToggle.propTypes = {
   targetContainer: PropTypes.string,
+  className: PropTypes.string,
 };
 
 BpkGridToggle.defaultProps = {
   targetContainer: 'body',
+  className: null,
 };
 
 export default BpkGridToggle;

--- a/packages/bpk-component-grid-toggle/src/__snapshots__/BpkGridToggle-test.js.snap
+++ b/packages/bpk-component-grid-toggle/src/__snapshots__/BpkGridToggle-test.js.snap
@@ -23,3 +23,15 @@ exports[`BpkGridToggle should render correctly when toggled 1`] = `
   off
 </button>
 `;
+
+exports[`BpkGridToggle should render correctly with the className prop 1`] = `
+<button
+  className="bpk-link foo"
+  onClick={[Function]}
+  title="Keyboard Shortcut: ctrl + cmd + g"
+  type="button"
+>
+  Baseline grid 
+  on
+</button>
+`;

--- a/packages/bpk-component-rtl-toggle/readme.md
+++ b/packages/bpk-component-rtl-toggle/readme.md
@@ -18,3 +18,9 @@ export default () => (
   <BpkRtlToggle />
 );
 ```
+
+## Props
+
+| Property         | PropType | Required | Default Value |
+| ---------------- | -------- | -------- | ------------- |
+| className        | string   | false    | null          |

--- a/packages/bpk-component-rtl-toggle/src/BpkRtlToggle-test.js
+++ b/packages/bpk-component-rtl-toggle/src/BpkRtlToggle-test.js
@@ -33,4 +33,9 @@ describe('BpkRtlToggle', () => {
     tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with the className prop', () => {
+    const tree = renderer.create(<BpkRtlToggle className="foo" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-rtl-toggle/src/BpkRtlToggle.js
+++ b/packages/bpk-component-rtl-toggle/src/BpkRtlToggle.js
@@ -17,6 +17,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { BpkButtonLink } from 'bpk-component-link';
 import { getHtmlElement, DIRECTIONS, DIRECTION_CHANGE_EVENT } from './utils';
 
@@ -67,17 +68,27 @@ class BpkRtlToggle extends React.Component {
   }
 
   render() {
+    const { className } = this.props;
     const onOrOff = this.state.direction === DIRECTIONS.RTL ? 'off' : 'on';
 
     return (
       <BpkButtonLink
         title="Keyboard Shortcut: ctrl + cmd + r"
         onClick={this.toggleRtl}
+        className={className}
       >
         RTL {onOrOff}
       </BpkButtonLink>
     );
   }
 }
+
+BpkRtlToggle.propTypes = {
+  className: PropTypes.string,
+};
+
+BpkRtlToggle.defaultProps = {
+  className: null,
+};
 
 export default BpkRtlToggle;

--- a/packages/bpk-component-rtl-toggle/src/__snapshots__/BpkRtlToggle-test.js.snap
+++ b/packages/bpk-component-rtl-toggle/src/__snapshots__/BpkRtlToggle-test.js.snap
@@ -23,3 +23,15 @@ exports[`BpkRtlToggle should render correctly when toggled 1`] = `
   off
 </button>
 `;
+
+exports[`BpkRtlToggle should render correctly with the className prop 1`] = `
+<button
+  className="bpk-link foo"
+  onClick={[Function]}
+  title="Keyboard Shortcut: ctrl + cmd + r"
+  type="button"
+>
+  RTL 
+  off
+</button>
+`;


### PR DESCRIPTION
This is so that I can add margins to them for the docs footer redesign, but good to have in general.