### PR TITLE
[BPK-1301] Increase close button touch area

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,18 @@
 
 _Nothing yet..._
 
+**Fixed:**
+
+- bpk-component-banner-alert: 2.0.6 => 2.0.7
+- bpk-component-chip: 2.0.0 => 2.0.1
+- bpk-component-close-button: 1.0.47 => 1.0.48
+- bpk-component-datepicker: 8.0.7 => 8.0.8
+- bpk-component-dialog: 1.0.1 => 1.0.2
+- bpk-component-drawer: 1.1.13 => 1.1.14
+- bpk-component-modal: 1.6.1 => 1.6.2
+- bpk-component-popover: 2.0.6 => 2.0.7
+  - Increased close button tap area for better touch support.
+
 ## 2018-02-09 - Fix for close button alignment in various components
 
 **Fixed:**

--- a/packages/bpk-component-close-button/src/bpk-close-button.scss
+++ b/packages/bpk-component-close-button/src/bpk-close-button.scss
@@ -27,6 +27,8 @@
   cursor: pointer;
   appearance: none;
 
+  @include bpk-touch-tappable;
+
   @include bpk-hover {
     color: $bpk-color-gray-700;
   }

--- a/packages/bpk-mixins/src/mixins/_utils.scss
+++ b/packages/bpk-mixins/src/mixins/_utils.scss
@@ -200,3 +200,27 @@
 
   @return $string;
 }
+
+/// Increases the tappabel area of the element to the
+/// minimum required for touch devices.
+///
+/// @content
+///
+/// @example scss
+///   .selector {
+///     @include bpk-touch-area;
+///   }
+
+@mixin bpk-touch-tappable {
+  position: relative;
+  outline-offset: -#{$bpk-spacing-xxl - $bpk-spacing-lg};
+
+  &::before {
+    position: absolute;
+    top: calc((-#{$bpk-spacing-xxl} / 2) + 50%);
+    left: calc((-#{$bpk-spacing-xxl} / 2) + 50%);
+    content: '';
+    width: $bpk-spacing-xxl;
+    height: $bpk-spacing-xxl;
+  }
+}


### PR DESCRIPTION
This increases the touch area to 42px * 42px while keeping the outline size down. 