### PR TITLE
[NO-JIRA] Update java install instructions in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -245,10 +245,12 @@ In future, we intend to automate more of this to reduce the number of steps requ
 brew install watchman
 ```
 
-##### Java
+## Java 8
+Java 8 is required. Other versions may not work!
 
 ```
-brew cask install java
+brew tap caskroom/versions
+brew cask install java8
 ```
 
 ##### Android Studio and SDK


### PR DESCRIPTION
`brew cask install java` no longer installs Java 8 (as it is not the latest version. Java 8 is required to run the emulators, however. Java 9 causes the process to blow up with a very unhelpful error message. Therefore, the “getting-started” guide needs updating.