### PR TITLE
[BPK-1320] Remove line height from native BpkText

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 - bpk-component-card:
   - Added new prop `blank` which when set along with the use of `href` makes the card open the link in a new tab.
 
+**Fixed:**
+- react-native-bpk-component-text:
+  - Removed line height styles, allowing the built in native ones to be used instead.
+
 ## 2018-02-19 - Fix for janky RN banner alert animations & a visual update to `plus`, `minus` and `close` icons
 
 **Added:**

--- a/native/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.android.js.snap
@@ -27,7 +27,6 @@ exports[`Android BpkAnimateHeight should render correctly expanded 1`] = `
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]
@@ -65,7 +64,6 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]
@@ -84,7 +82,6 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]
@@ -128,7 +125,6 @@ exports[`Android BpkAnimateHeight should render correctly with user styling padd
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]

--- a/native/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.ios.js.snap
@@ -27,7 +27,6 @@ exports[`iOS BpkAnimateHeight should render correctly expanded 1`] = `
               "fontFamily": "System",
               "fontSize": 15,
               "fontWeight": "400",
-              "lineHeight": 20,
             },
             Object {},
           ]
@@ -65,7 +64,6 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
               "fontFamily": "System",
               "fontSize": 15,
               "fontWeight": "400",
-              "lineHeight": 20,
             },
             Object {},
           ]
@@ -84,7 +82,6 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
               "fontFamily": "System",
               "fontSize": 15,
               "fontWeight": "400",
-              "lineHeight": 20,
             },
             Object {},
           ]
@@ -128,7 +125,6 @@ exports[`iOS BpkAnimateHeight should render correctly with user styling padding 
               "fontFamily": "System",
               "fontSize": 15,
               "fontWeight": "400",
-              "lineHeight": 20,
             },
             Object {},
           ]

--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
@@ -103,7 +103,6 @@ exports[`Android BpkBannerAlert should accept user-stlying 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -221,7 +220,6 @@ exports[`Android BpkBannerAlert should accept user-stlying 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -339,7 +337,6 @@ exports[`Android BpkBannerAlert should accept user-stlying 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -457,7 +454,6 @@ exports[`Android BpkBannerAlert should accept user-stlying 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -576,7 +572,6 @@ exports[`Android BpkBannerAlert should render correctly 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -690,7 +685,6 @@ exports[`Android BpkBannerAlert should render correctly 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -804,7 +798,6 @@ exports[`Android BpkBannerAlert should render correctly 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -918,7 +911,6 @@ exports[`Android BpkBannerAlert should render correctly 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -1037,7 +1029,6 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -1200,7 +1191,6 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -1363,7 +1353,6 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -1526,7 +1515,6 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -1708,7 +1696,6 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -1871,7 +1858,6 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -2034,7 +2020,6 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -2197,7 +2182,6 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -2365,7 +2349,6 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -2407,7 +2390,6 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                               "fontFamily": "sans-serif",
                               "fontSize": 14,
                               "fontWeight": "400",
-                              "lineHeight": 20,
                             },
                             Object {},
                           ]
@@ -2571,7 +2553,6 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -2613,7 +2594,6 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                               "fontFamily": "sans-serif",
                               "fontSize": 14,
                               "fontWeight": "400",
-                              "lineHeight": 20,
                             },
                             Object {},
                           ]
@@ -2777,7 +2757,6 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -2819,7 +2798,6 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                               "fontFamily": "sans-serif",
                               "fontSize": 14,
                               "fontWeight": "400",
-                              "lineHeight": 20,
                             },
                             Object {},
                           ]
@@ -2983,7 +2961,6 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -3025,7 +3002,6 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                               "fontFamily": "sans-serif",
                               "fontSize": 14,
                               "fontWeight": "400",
-                              "lineHeight": 20,
                             },
                             Object {},
                           ]
@@ -3194,7 +3170,6 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -3236,7 +3211,6 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                               "fontFamily": "sans-serif",
                               "fontSize": 14,
                               "fontWeight": "400",
-                              "lineHeight": 20,
                             },
                             Object {},
                           ]
@@ -3400,7 +3374,6 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -3442,7 +3415,6 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                               "fontFamily": "sans-serif",
                               "fontSize": 14,
                               "fontWeight": "400",
-                              "lineHeight": 20,
                             },
                             Object {},
                           ]
@@ -3606,7 +3578,6 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -3648,7 +3619,6 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                               "fontFamily": "sans-serif",
                               "fontSize": 14,
                               "fontWeight": "400",
-                              "lineHeight": 20,
                             },
                             Object {},
                           ]
@@ -3812,7 +3782,6 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -3854,7 +3823,6 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                               "fontFamily": "sans-serif",
                               "fontSize": 14,
                               "fontWeight": "400",
-                              "lineHeight": 20,
                             },
                             Object {},
                           ]
@@ -4013,7 +3981,6 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -4131,7 +4098,6 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -4249,7 +4215,6 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -4367,7 +4332,6 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -4492,7 +4456,6 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -4610,7 +4573,6 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -4728,7 +4690,6 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,
@@ -4846,7 +4807,6 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
                         "fontFamily": "sans-serif",
                         "fontSize": 14,
                         "fontWeight": "400",
-                        "lineHeight": 20,
                       },
                       Object {
                         "flex": 1,

--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
@@ -113,7 +113,6 @@ exports[`iOS BpkBannerAlert should accept user-stlying 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -245,7 +244,6 @@ exports[`iOS BpkBannerAlert should accept user-stlying 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -377,7 +375,6 @@ exports[`iOS BpkBannerAlert should accept user-stlying 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -509,7 +506,6 @@ exports[`iOS BpkBannerAlert should accept user-stlying 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -642,7 +638,6 @@ exports[`iOS BpkBannerAlert should render correctly 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -770,7 +765,6 @@ exports[`iOS BpkBannerAlert should render correctly 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -898,7 +892,6 @@ exports[`iOS BpkBannerAlert should render correctly 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -1026,7 +1019,6 @@ exports[`iOS BpkBannerAlert should render correctly 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -1162,7 +1154,6 @@ exports[`iOS BpkBannerAlert should render correctly dismissable 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -1366,7 +1357,6 @@ exports[`iOS BpkBannerAlert should render correctly dismissable 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -1570,7 +1560,6 @@ exports[`iOS BpkBannerAlert should render correctly dismissable 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -1774,7 +1763,6 @@ exports[`iOS BpkBannerAlert should render correctly dismissable 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -2004,7 +1992,6 @@ exports[`iOS BpkBannerAlert should render correctly expandable 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -2202,7 +2189,6 @@ exports[`iOS BpkBannerAlert should render correctly expandable 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -2400,7 +2386,6 @@ exports[`iOS BpkBannerAlert should render correctly expandable 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -2598,7 +2583,6 @@ exports[`iOS BpkBannerAlert should render correctly expandable 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -2801,7 +2785,6 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -2898,7 +2881,6 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                             "fontFamily": "System",
                             "fontSize": 13,
                             "fontWeight": "400",
-                            "lineHeight": 18,
                           },
                           Object {},
                         ]
@@ -3046,7 +3028,6 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -3143,7 +3124,6 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                             "fontFamily": "System",
                             "fontSize": 13,
                             "fontWeight": "400",
-                            "lineHeight": 18,
                           },
                           Object {},
                         ]
@@ -3291,7 +3271,6 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -3388,7 +3367,6 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                             "fontFamily": "System",
                             "fontSize": 13,
                             "fontWeight": "400",
-                            "lineHeight": 18,
                           },
                           Object {},
                         ]
@@ -3536,7 +3514,6 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -3633,7 +3610,6 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                             "fontFamily": "System",
                             "fontSize": 13,
                             "fontWeight": "400",
-                            "lineHeight": 18,
                           },
                           Object {},
                         ]
@@ -3786,7 +3762,6 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -3883,7 +3858,6 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                             "fontFamily": "System",
                             "fontSize": 13,
                             "fontWeight": "400",
-                            "lineHeight": 18,
                           },
                           Object {},
                         ]
@@ -4031,7 +4005,6 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -4128,7 +4101,6 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                             "fontFamily": "System",
                             "fontSize": 13,
                             "fontWeight": "400",
-                            "lineHeight": 18,
                           },
                           Object {},
                         ]
@@ -4276,7 +4248,6 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -4373,7 +4344,6 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                             "fontFamily": "System",
                             "fontSize": 13,
                             "fontWeight": "400",
-                            "lineHeight": 18,
                           },
                           Object {},
                         ]
@@ -4521,7 +4491,6 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                           "fontFamily": "System",
                           "fontSize": 13,
                           "fontWeight": "400",
-                          "lineHeight": 18,
                         },
                         Object {
                           "color": "rgb(82, 76, 97)",
@@ -4618,7 +4587,6 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                             "fontFamily": "System",
                             "fontSize": 13,
                             "fontWeight": "400",
-                            "lineHeight": 18,
                           },
                           Object {},
                         ]
@@ -4751,7 +4719,6 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -4883,7 +4850,6 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -5015,7 +4981,6 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -5147,7 +5112,6 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -5286,7 +5250,6 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -5418,7 +5381,6 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -5550,7 +5512,6 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",
@@ -5682,7 +5643,6 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
                         "fontFamily": "System",
                         "fontSize": 13,
                         "fontWeight": "400",
-                        "lineHeight": 18,
                       },
                       Object {
                         "color": "rgb(82, 76, 97)",

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -76,7 +76,6 @@ exports[`iOS BpkButton should render correctly 1`] = `
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -205,7 +204,6 @@ exports[`iOS BpkButton should render correctly with iconAlignment="leading" 1`] 
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -373,7 +371,6 @@ exports[`iOS BpkButton should render correctly with iconAlignment="trailing" 1`]
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -536,7 +533,6 @@ exports[`iOS BpkButton should render correctly with type="destructive" 1`] = `
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -658,7 +654,6 @@ exports[`iOS BpkButton should render correctly with type="featured" 1`] = `
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -777,7 +772,6 @@ exports[`iOS BpkButton should render correctly with type="primary" 1`] = `
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -902,7 +896,6 @@ exports[`iOS BpkButton should render correctly with type="secondary" 1`] = `
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -1132,7 +1125,6 @@ exports[`iOS BpkButton should support having an icon as well as a title 1`] = `
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -1422,7 +1414,6 @@ exports[`iOS BpkButton should support overwriting styles 1`] = `
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -1547,7 +1538,6 @@ exports[`iOS BpkButton should support the "disabled" property 1`] = `
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",
@@ -1682,7 +1672,6 @@ exports[`iOS BpkButton should support the "icon" and "large" property 1`] = `
               "fontFamily": "System",
               "fontSize": 17,
               "fontWeight": "400",
-              "lineHeight": 22,
             },
             Object {
               "fontWeight": "600",
@@ -1989,7 +1978,6 @@ exports[`iOS BpkButton should support the "large" and secondary property 1`] = `
               "fontFamily": "System",
               "fontSize": 17,
               "fontWeight": "400",
-              "lineHeight": 22,
             },
             Object {
               "fontWeight": "600",
@@ -2120,7 +2108,6 @@ exports[`iOS BpkButton should support the "large" property 1`] = `
               "fontFamily": "System",
               "fontSize": 17,
               "fontWeight": "400",
-              "lineHeight": 22,
             },
             Object {
               "fontWeight": "600",
@@ -2240,7 +2227,6 @@ exports[`iOS BpkButtonThemed should render correctly 1`] = `
               "fontFamily": "System",
               "fontSize": 13,
               "fontWeight": "400",
-              "lineHeight": 18,
             },
             Object {
               "fontWeight": "600",

--- a/native/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.android.js.snap
@@ -37,7 +37,6 @@ exports[`Android BpkCard should render correctly 1`] = `
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]
@@ -88,7 +87,6 @@ exports[`Android BpkCard should render correctly with arbitrary props 1`] = `
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]
@@ -142,7 +140,6 @@ exports[`Android BpkCard should render correctly with custom inner style 1`] = `
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]
@@ -199,7 +196,6 @@ exports[`Android BpkCard should render correctly with custom style 1`] = `
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]
@@ -252,7 +248,6 @@ exports[`Android BpkCard should render correctly with the "focused" state 1`] = 
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]
@@ -299,7 +294,6 @@ exports[`Android BpkCard should render correctly without padding 1`] = `
               "fontFamily": "sans-serif",
               "fontSize": 16,
               "fontWeight": "400",
-              "lineHeight": 24,
             },
             Object {},
           ]

--- a/native/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.ios.js.snap
@@ -55,7 +55,6 @@ exports[`iOS BpkCard should render correctly 1`] = `
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Object {},
         ]
@@ -141,7 +140,6 @@ exports[`iOS BpkCard should render correctly with arbitrary props 1`] = `
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Object {},
         ]
@@ -230,7 +228,6 @@ exports[`iOS BpkCard should render correctly with custom inner style 1`] = `
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Object {},
         ]
@@ -319,7 +316,6 @@ exports[`iOS BpkCard should render correctly with custom style 1`] = `
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Object {},
         ]
@@ -414,7 +410,6 @@ exports[`iOS BpkCard should render correctly with the "focused" state 1`] = `
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Object {},
         ]
@@ -497,7 +492,6 @@ exports[`iOS BpkCard should render correctly without padding 1`] = `
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Object {},
         ]

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
@@ -36,7 +36,6 @@ exports[`iOS BpkHorizontalNavItem should render correctly 1`] = `
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Array [
             Object {
@@ -106,7 +105,6 @@ exports[`iOS BpkHorizontalNavItem should render correctly with "selected" prop 1
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Array [
             Object {
@@ -179,7 +177,6 @@ exports[`iOS BpkHorizontalNavItem should render correctly with "spaceAround" pro
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Array [
             Object {
@@ -249,7 +246,6 @@ exports[`iOS BpkHorizontalNavItem should render correctly with arbitrary props 1
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Array [
             Object {
@@ -323,7 +319,6 @@ exports[`iOS BpkHorizontalNavItem should render correctly with custom "style" pr
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Array [
             Object {
@@ -393,7 +388,6 @@ exports[`iOS BpkHorizontalNavItem should support theming 1`] = `
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "lineHeight": 20,
           },
           Array [
             Object {

--- a/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -722,7 +722,6 @@ exports[`RTL BpkTextInput should render correctly with valid false and a validat
           "fontFamily": "System",
           "fontSize": 11,
           "fontWeight": "400",
-          "lineHeight": 13,
         },
         Object {
           "color": "rgb(255, 84, 82)",

--- a/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -722,7 +722,6 @@ exports[`Android BpkTextInput should render correctly with valid false and a val
           "fontFamily": "sans-serif",
           "fontSize": 12,
           "fontWeight": "400",
-          "lineHeight": 18,
         },
         Object {
           "color": "rgb(255, 84, 82)",

--- a/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -722,7 +722,6 @@ exports[`iOS BpkTextInput should render correctly with valid false and a validat
           "fontFamily": "System",
           "fontSize": 11,
           "fontWeight": "400",
-          "lineHeight": 13,
         },
         Object {
           "color": "rgb(255, 84, 82)",

--- a/native/packages/react-native-bpk-component-text-input/src/styles.js
+++ b/native/packages/react-native-bpk-component-text-input/src/styles.js
@@ -28,22 +28,22 @@ import {
   fontFamily,
   spacingMd,
   spacingSm,
+  lineHeightSm,
+  lineHeightBase,
   textBaseFontSize,
   textBaseFontWeight,
-  textBaseLineHeight,
   textSmFontSize,
   textSmFontWeight,
-  textSmLineHeight,
 } from 'bpk-tokens/tokens/base.react.native';
 
 const INPUT_RANGE = [0, 1];
 
 // To increase the vertical spacing a bit.
-const minHeight = textBaseLineHeight + spacingMd;
+const minHeight = lineHeightBase + spacingMd;
 
 const styles = StyleSheet.create({
   container: {
-    paddingTop: textSmLineHeight,
+    paddingTop: lineHeightSm,
   },
   input: {
     flex: 1,
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
     minHeight,
     fontSize: textBaseFontSize,
     fontWeight: textBaseFontWeight,
-    lineHeight: textBaseLineHeight,
+    lineHeight: lineHeightBase,
     color: colorGray700,
     borderBottomWidth: 0,
     textAlign: I18nManager.isRTL ? 'right' : 'left',
@@ -98,7 +98,7 @@ const getLabelStyle = (
     }),
     top: animatedLabelValue.interpolate({
       inputRange: INPUT_RANGE,
-      outputRange: [0, textSmLineHeight + (spacingSm - borderSizeSm)],
+      outputRange: [0, lineHeightSm + (spacingSm - borderSizeSm)],
     }),
     fontSize: animatedLabelValue.interpolate({
       inputRange: INPUT_RANGE,
@@ -106,7 +106,7 @@ const getLabelStyle = (
     }),
     lineHeight: animatedLabelValue.interpolate({
       inputRange: INPUT_RANGE,
-      outputRange: [textSmLineHeight, textBaseLineHeight],
+      outputRange: [lineHeightSm, lineHeightBase],
     }),
     fontWeight: animatedLabelValue.interpolate({
       inputRange: INPUT_RANGE,

--- a/native/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText.js
@@ -26,22 +26,16 @@ import {
   textEmphasizedFontWeight,
   textXsFontSize,
   textXsFontWeight,
-  textXsLineHeight,
   textSmFontSize,
   textSmFontWeight,
-  textSmLineHeight,
   textBaseFontSize,
   textBaseFontWeight,
-  textBaseLineHeight,
   textLgFontSize,
   textLgFontWeight,
-  textLgLineHeight,
   textXlFontSize,
   textXlFontWeight,
-  textXlLineHeight,
   textXxlFontSize,
   textXxlFontWeight,
-  textXxlLineHeight,
 } from 'bpk-tokens/tokens/base.react.native';
 
 import { emphasizePropType, stylePropType } from './customPropTypes';
@@ -51,22 +45,16 @@ const TEXT_STYLES = ['xs', 'sm', 'base', 'lg', 'xl', 'xxl'];
 const TEXT_TOKENS = {
   textXsFontSize,
   textXsFontWeight,
-  textXsLineHeight,
   textSmFontSize,
   textSmFontWeight,
-  textSmLineHeight,
   textBaseFontSize,
   textBaseFontWeight,
-  textBaseLineHeight,
   textLgFontSize,
   textLgFontWeight,
-  textLgLineHeight,
   textXlFontSize,
   textXlFontWeight,
-  textXlLineHeight,
   textXxlFontSize,
   textXxlFontWeight,
-  textXxlLineHeight,
 };
 
 const getStyleByTextStyle = textStyle => {
@@ -74,7 +62,6 @@ const getStyleByTextStyle = textStyle => {
 
   const {
     [`text${camelCasedStyle}FontSize`]: fontSize,
-    [`text${camelCasedStyle}LineHeight`]: lineHeight,
     [`text${camelCasedStyle}FontWeight`]: fontWeight,
   } = TEXT_TOKENS;
 
@@ -82,7 +69,6 @@ const getStyleByTextStyle = textStyle => {
     color: colorGray700,
     fontFamily,
     fontSize,
-    lineHeight,
     fontWeight,
   };
 };

--- a/native/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.android.js.snap
@@ -12,7 +12,6 @@ exports[`Android BpkText should render correctly 1`] = `
         "fontFamily": "sans-serif",
         "fontSize": 16,
         "fontWeight": "400",
-        "lineHeight": 24,
       },
       Object {},
     ]
@@ -34,7 +33,6 @@ exports[`Android BpkText should render correctly with \`emphasize\` prop 1`] = `
         "fontFamily": "sans-serif",
         "fontSize": 16,
         "fontWeight": "400",
-        "lineHeight": 24,
       },
       Object {
         "fontFamily": "sans-serif-medium",
@@ -59,7 +57,6 @@ exports[`Android BpkText should render correctly with textStyle="base" 1`] = `
         "fontFamily": "sans-serif",
         "fontSize": 16,
         "fontWeight": "400",
-        "lineHeight": 24,
       },
       Object {},
     ]
@@ -81,7 +78,6 @@ exports[`Android BpkText should render correctly with textStyle="lg" 1`] = `
         "fontFamily": "sans-serif",
         "fontSize": 20,
         "fontWeight": "400",
-        "lineHeight": 28,
       },
       Object {},
     ]
@@ -103,7 +99,6 @@ exports[`Android BpkText should render correctly with textStyle="sm" 1`] = `
         "fontFamily": "sans-serif",
         "fontSize": 14,
         "fontWeight": "400",
-        "lineHeight": 20,
       },
       Object {},
     ]
@@ -125,7 +120,6 @@ exports[`Android BpkText should render correctly with textStyle="xl" 1`] = `
         "fontFamily": "sans-serif",
         "fontSize": 24,
         "fontWeight": "400",
-        "lineHeight": 32,
       },
       Object {},
     ]
@@ -147,7 +141,6 @@ exports[`Android BpkText should render correctly with textStyle="xs" 1`] = `
         "fontFamily": "sans-serif",
         "fontSize": 12,
         "fontWeight": "400",
-        "lineHeight": 18,
       },
       Object {},
     ]
@@ -169,7 +162,6 @@ exports[`Android BpkText should render correctly with textStyle="xxl" 1`] = `
         "fontFamily": "sans-serif",
         "fontSize": 34,
         "fontWeight": "400",
-        "lineHeight": 40,
       },
       Object {},
     ]
@@ -191,7 +183,6 @@ exports[`Android BpkText should support overwriting styles 1`] = `
         "fontFamily": "sans-serif",
         "fontSize": 16,
         "fontWeight": "400",
-        "lineHeight": 24,
       },
       Object {
         "color": "red",

--- a/native/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.ios.js.snap
@@ -12,7 +12,6 @@ exports[`iOS BpkText should render correctly 1`] = `
         "fontFamily": "System",
         "fontSize": 15,
         "fontWeight": "400",
-        "lineHeight": 20,
       },
       Object {},
     ]
@@ -34,7 +33,6 @@ exports[`iOS BpkText should render correctly with \`emphasize\` prop 1`] = `
         "fontFamily": "System",
         "fontSize": 15,
         "fontWeight": "400",
-        "lineHeight": 20,
       },
       Object {
         "fontWeight": "600",
@@ -59,7 +57,6 @@ exports[`iOS BpkText should render correctly with textStyle="base" 1`] = `
         "fontFamily": "System",
         "fontSize": 15,
         "fontWeight": "400",
-        "lineHeight": 20,
       },
       Object {},
     ]
@@ -81,7 +78,6 @@ exports[`iOS BpkText should render correctly with textStyle="lg" 1`] = `
         "fontFamily": "System",
         "fontSize": 17,
         "fontWeight": "400",
-        "lineHeight": 22,
       },
       Object {},
     ]
@@ -103,7 +99,6 @@ exports[`iOS BpkText should render correctly with textStyle="sm" 1`] = `
         "fontFamily": "System",
         "fontSize": 13,
         "fontWeight": "400",
-        "lineHeight": 18,
       },
       Object {},
     ]
@@ -125,7 +120,6 @@ exports[`iOS BpkText should render correctly with textStyle="xl" 1`] = `
         "fontFamily": "System",
         "fontSize": 20,
         "fontWeight": "400",
-        "lineHeight": 24,
       },
       Object {},
     ]
@@ -147,7 +141,6 @@ exports[`iOS BpkText should render correctly with textStyle="xs" 1`] = `
         "fontFamily": "System",
         "fontSize": 11,
         "fontWeight": "400",
-        "lineHeight": 13,
       },
       Object {},
     ]
@@ -169,7 +162,6 @@ exports[`iOS BpkText should render correctly with textStyle="xxl" 1`] = `
         "fontFamily": "System",
         "fontSize": 34,
         "fontWeight": "700",
-        "lineHeight": 41,
       },
       Object {},
     ]
@@ -191,7 +183,6 @@ exports[`iOS BpkText should support overwriting styles 1`] = `
         "fontFamily": "System",
         "fontSize": 15,
         "fontWeight": "400",
-        "lineHeight": 20,
       },
       Object {
         "color": "red",

--- a/native/packages/react-native-bpk-component-touchable-overlay/src/__snapshots__/BpkTouchableOverlay-test.js.snap
+++ b/native/packages/react-native-bpk-component-touchable-overlay/src/__snapshots__/BpkTouchableOverlay-test.js.snap
@@ -29,7 +29,6 @@ exports[`BpkTouchableOverlay should render correctly 1`] = `
           "fontFamily": "System",
           "fontSize": 15,
           "fontWeight": "400",
-          "lineHeight": 20,
         },
         Object {},
       ]
@@ -85,7 +84,6 @@ exports[`BpkTouchableOverlay should render correctly with arbitrary props 1`] = 
           "fontFamily": "System",
           "fontSize": 15,
           "fontWeight": "400",
-          "lineHeight": 20,
         },
         Object {},
       ]
@@ -141,7 +139,6 @@ exports[`BpkTouchableOverlay should render correctly with border radius props 1`
           "fontFamily": "System",
           "fontSize": 15,
           "fontWeight": "400",
-          "lineHeight": 20,
         },
         Object {},
       ]
@@ -200,7 +197,6 @@ exports[`BpkTouchableOverlay should render correctly with custom overlay styles 
           "fontFamily": "System",
           "fontSize": 15,
           "fontWeight": "400",
-          "lineHeight": 20,
         },
         Object {},
       ]
@@ -263,7 +259,6 @@ exports[`BpkTouchableOverlay should render correctly with custom style prop 1`] 
           "fontFamily": "System",
           "fontSize": 15,
           "fontWeight": "400",
-          "lineHeight": 20,
         },
         Object {},
       ]

--- a/packages/bpk-tokens/src/android/base/typography.json
+++ b/packages/bpk-tokens/src/android/base/typography.json
@@ -86,7 +86,10 @@
     "TEXT_XS_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XS}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_SM_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
@@ -101,7 +104,10 @@
     "TEXT_SM_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_SM}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_BASE_FONT_SIZE": {
       "value": "{!FONT_SIZE_BASE}",
@@ -116,7 +122,10 @@
     "TEXT_BASE_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_BASE}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_LG_FONT_SIZE": {
       "value": "{!FONT_SIZE_LG}",
@@ -131,7 +140,10 @@
     "TEXT_LG_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_LG}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_XL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XL}",
@@ -146,7 +158,10 @@
     "TEXT_XL_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XL}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_XXL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXL}",
@@ -161,7 +176,10 @@
     "TEXT_XXL_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XXL}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_MEDIUM}",

--- a/packages/bpk-tokens/src/ios/base/typography.json
+++ b/packages/bpk-tokens/src/ios/base/typography.json
@@ -81,7 +81,10 @@
     "TEXT_XS_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XS}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_SM_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
@@ -96,7 +99,10 @@
     "TEXT_SM_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_SM}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_BASE_FONT_SIZE": {
       "value": "{!FONT_SIZE_BASE}",
@@ -111,7 +117,10 @@
     "TEXT_BASE_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_BASE}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_LG_FONT_SIZE": {
       "value": "{!FONT_SIZE_LG}",
@@ -126,7 +135,10 @@
     "TEXT_LG_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_LG}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_XL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XL}",
@@ -141,7 +153,10 @@
     "TEXT_XL_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XL}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_XXL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXL}",
@@ -156,7 +171,10 @@
     "TEXT_XXL_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XXL}",
       "type": "size",
-      "category": "line-heights"
+      "category": "line-heights",
+      "meta": {
+        "deprecated": true
+      }
     },
     "TEXT_EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_SEMIBOLD}",


### PR DESCRIPTION
* Removed line height from BpkText.
* Deprecated the tokens.
* Updated snapshots to reflect this.