### PR TITLE
[BPK-1369] Tweak new homepage design

### DIFF
--- a/packages/bpk-docs/src/constants/_neo-home-page-variables.scss
+++ b/packages/bpk-docs/src/constants/_neo-home-page-variables.scss
@@ -19,7 +19,7 @@
 
 $bpk-logo-offset: $bpk-one-pixel-rem * 58;
 
-$bpk-outer-container-width-desktop: $bpk-breakpoint-desktop - (2 * $bpk-logo-offset);
+$bpk-outer-container-width-desktop: $bpk-breakpoint-desktop;
 $bpk-center-content-width-desktop: $bpk-outer-container-width-desktop;
 
 // Cards
@@ -43,7 +43,7 @@ $bpk-caption-container-height-mobile: $bpk-card-height-mobile - $bpk-image-heigh
 $bpk-card-spacing-mobile: $bpk-spacing-md;
 
 @mixin bpk-home-page-center-content {
-  width: calc(100% - (2 * #{$bpk-logo-offset}) - (2 * #{$bpk-spacing-xl}));
+  width: calc(100% - (2 * #{$bpk-spacing-xl}));
   max-width: $bpk-center-content-width-desktop;
 
   @media (max-width: $bpk-breakpoint-desktop) {

--- a/packages/bpk-docs/src/pages/NeoHomePage/home-page.scss
+++ b/packages/bpk-docs/src/pages/NeoHomePage/home-page.scss
@@ -22,7 +22,7 @@
 .bpkdocs-home-page {
   &__hero {
     display: flex;
-    padding: ($bpk-spacing-xl * 2) $bpk-spacing-xl ($bpk-spacing-xl * 3);
+    padding: ($bpk-spacing-xl * 2) $bpk-spacing-xl ($bpk-spacing-xl * 4);
     flex-direction: column;
     justify-content: center;
     background-color: $bpk-color-blue-500;
@@ -41,13 +41,13 @@
       margin: 0 auto;
 
       @include bpk-breakpoint-above-tablet {
-        width: calc(100% - (2 * #{$bpk-logo-offset}));
+        width: 100%;
         max-width: $bpk-center-content-width-desktop;
       }
     }
 
     &-blurb {
-      width: 60%;
+      width: 55%;
 
       @include bpk-text-xl;
 
@@ -65,7 +65,7 @@
 
   &__hero-logo-container {
     display: flex;
-    width: calc(100% - (2 * #{$bpk-logo-offset}));
+    width: 100%;
     max-width: $bpk-center-content-width-desktop;
     margin: 0 auto $bpk-spacing-xl * 2;
     justify-content: space-between;
@@ -88,8 +88,6 @@
 
     @include bpk-breakpoint-above-tablet {
       position: relative;
-      // HACK: Ensures the B in Backpack aligns with other centered content
-      left: -#{$bpk-logo-offset};
       height: $bpk-spacing-xs * 8;
       // HACK: Ensure the baseline of `bpkdocs-home-page__hero-updated` aligns with
       // the logo baseline


### PR DESCRIPTION
In accordance with @willhg, I've widened the content to occupy the maximum width available under our current breakpoints. I've also pulled in the Backpack logo to remove the overhang (for now) to provide more space to play with.

Here's how it looks at different widths - you can see it just widens things slightly. I've not included tablet and mobile widths as they're unaffected by this.

| Viewport width (px) | Before this PR | After this PR |
| ---: | --- | --- |
| 1440 |![screen shot 2018-02-21 at 10 59 28](https://user-images.githubusercontent.com/73652/36476615-52997e3a-16f6-11e8-84cb-f5fa2e52b27b.png) | ![screen shot 2018-02-21 at 10 51 09](https://user-images.githubusercontent.com/73652/36476228-324ffcc2-16f5-11e8-9b22-c27f742fb27b.png)
| 1024 | ![screen shot 2018-02-21 at 10 58 32](https://user-images.githubusercontent.com/73652/36476563-325814a6-16f6-11e8-91f4-e306e24645ce.png) | ![screen shot 2018-02-21 at 10 52 11](https://user-images.githubusercontent.com/73652/36476259-4ee0b502-16f5-11e8-9255-062488562587.png)


