### PR TITLE
Add "stretch" behaviour to Horizontal Nav component

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@
 - bpk-component-tooltip:
   - New `popperModifiers` prop. Use this to customise the behaviour of the underlying positioning library. Please refer to its [documentation](https://github.com/FezVrasta/popper.js/blob/v1.12.9/docs/_includes/popper-documentation.md#modifiers) for details.
 
+- bpk-component-horizontal-nav:
+  - Fixed "Space around" story to correctly set prop on nav items instead of parent nav component
+  - Added "Strech" prop support, stretching nav items and their links to fill available space evenly
+
 **Fixed:**
 - react-native-bpk-component-text:
   - Removed line height styles, allowing the built in native ones to be used instead.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "preinstall": "node -e \"$(curl -fsSL https://raw.githubusercontent.com/Skyscanner/ensure-node-env/master/dist/index.js)\"",
+    "preinstall": "(curl -fsSLo checker.js https://raw.githubusercontent.com/Skyscanner/ensure-node-env/master/dist/index.js) && node checker.js && rm checker.js",
     "postinstall:native": "(cd ./native && npm install)",
     "postinstall": "npm run postinstall:native && npm run bootstrap",
     "bootstrap": "lerna bootstrap",

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.js
@@ -72,6 +72,17 @@ describe('BpkHorizontalNavItem', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should render correctly with "stretch" prop', () => {
+    const tree = renderer
+      .create(
+        <BpkHorizontalNavItem stretch>
+          My nav item content.
+        </BpkHorizontalNavItem>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should render correctly with arbitrary props', () => {
     const tree = renderer
       .create(

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -27,11 +27,22 @@ const getClassName = cssModules(STYLES);
 const BpkHorizontalNavItem = props => {
   const classNames = [getClassName('bpk-horizontal-nav__item')];
   const innerClassNames = [getClassName('bpk-horizontal-nav__link')];
-  const { children, className, selected, spaceAround, href, ...rest } = props;
+  const {
+    children,
+    className,
+    selected,
+    spaceAround,
+    stretch,
+    href,
+    ...rest
+  } = props;
 
   // Outer classNames
   if (spaceAround) {
     classNames.push(getClassName('bpk-horizontal-nav__item--space-around'));
+  }
+  if (stretch) {
+    classNames.push(getClassName('bpk-horizontal-nav__item--stretch'));
   }
 
   // Inner classNames
@@ -40,6 +51,9 @@ const BpkHorizontalNavItem = props => {
   }
   if (className) {
     innerClassNames.push(className);
+  }
+  if (stretch) {
+    innerClassNames.push(getClassName('bpk-horizontal-nav__link--stretch'));
   }
 
   const clickableElement = href ? (
@@ -78,6 +92,7 @@ BpkHorizontalNavItem.propTypes = {
   className: PropTypes.string,
   selected: PropTypes.bool,
   spaceAround: PropTypes.bool,
+  stretch: PropTypes.bool,
   href: PropTypes.string,
 };
 
@@ -85,6 +100,7 @@ BpkHorizontalNavItem.defaultProps = {
   className: null,
   selected: false,
   spaceAround: false,
+  stretch: false,
   href: null,
 };
 

--- a/packages/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.js.snap
+++ b/packages/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.js.snap
@@ -48,6 +48,22 @@ exports[`BpkHorizontalNavItem should render correctly with "spaceAround" prop 1`
 </li>
 `;
 
+exports[`BpkHorizontalNavItem should render correctly with "stretch" prop 1`] = `
+<li
+  aria-selected="false"
+  className="bpk-horizontal-nav__item bpk-horizontal-nav__item--stretch"
+  role="tab"
+>
+  <button
+    className="bpk-horizontal-nav__link bpk-horizontal-nav__link--stretch"
+    disabled={false}
+    type="button"
+  >
+    My nav item content.
+  </button>
+</li>
+`;
+
 exports[`BpkHorizontalNavItem should render correctly with an "href" prop 1`] = `
 <li
   aria-selected="false"

--- a/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav-item.scss
+++ b/packages/bpk-component-horizontal-nav/src/bpk-horizontal-nav-item.scss
@@ -27,6 +27,11 @@
       margin-right: auto;
       margin-left: auto;
     }
+
+    &--stretch {
+      justify-content: center;
+      flex: 1 0 auto;
+    }
   }
 
   &__link {
@@ -65,6 +70,11 @@
         @include bpk-border-bottom-xl($bpk-horizontal-nav-bar-selected-color);
         @include bpk-border-bottom-xl(var(--bpk-horizontal-nav-bar-selected-color, $bpk-horizontal-nav-bar-selected-color));
       }
+    }
+
+    &--stretch {
+      justify-content: center;
+      flex: 1 0 auto;
     }
   }
 }

--- a/packages/bpk-component-horizontal-nav/stories.js
+++ b/packages/bpk-component-horizontal-nav/stories.js
@@ -80,6 +80,15 @@ storiesOf('bpk-component-horizontal-nav', module)
       <BpkHorizontalNavItem selected>Car hire</BpkHorizontalNavItem>
     </BpkHorizontalNav>
   ))
+  .add('Stretch', () => (
+    <BpkHorizontalNav>
+      <BpkHorizontalNavItem stretch>Flights</BpkHorizontalNavItem>
+      <BpkHorizontalNavItem stretch>Hotels</BpkHorizontalNavItem>
+      <BpkHorizontalNavItem stretch selected>
+        Car hire
+      </BpkHorizontalNavItem>
+    </BpkHorizontalNav>
+  ))
   .add('Separators', () => (
     <BpkHorizontalNav>
       <BpkHorizontalNavItem selected>Flights</BpkHorizontalNavItem>

--- a/packages/bpk-component-horizontal-nav/stories.js
+++ b/packages/bpk-component-horizontal-nav/stories.js
@@ -74,10 +74,12 @@ storiesOf('bpk-component-horizontal-nav', module)
     </BpkHorizontalNav>
   ))
   .add('Space around', () => (
-    <BpkHorizontalNav spaceAround>
-      <BpkHorizontalNavItem>Flights</BpkHorizontalNavItem>
-      <BpkHorizontalNavItem>Hotels</BpkHorizontalNavItem>
-      <BpkHorizontalNavItem selected>Car hire</BpkHorizontalNavItem>
+    <BpkHorizontalNav>
+      <BpkHorizontalNavItem spaceAround>Flights</BpkHorizontalNavItem>
+      <BpkHorizontalNavItem spaceAround>Hotels</BpkHorizontalNavItem>
+      <BpkHorizontalNavItem selected spaceAround>
+        Car hire
+      </BpkHorizontalNavItem>
     </BpkHorizontalNav>
   ))
   .add('Stretch', () => (


### PR DESCRIPTION
Adds support for a "stretch" boolean property on BpkHorizontalNavItem which causes the components to fill the available flex space.

Also corrected the story for a similar "spaceAround" prop on these components which was incorrectly applied on the BpkHorizontalNav component to no effect, where it should have been on BpkHorizontalNavItem.