### PR TITLE
[BPK-1376] DialingCodeList and DialingCodeListItem components

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
   - Introducing the new React Native button link component.
 - react-native-bpk-component-text-input:
   - Introduced a new `accessoryView` prop that enables rendering any view on the leading side of the text input.
+- react-native-bpk-component-phone-input:
+ - New `BpkDiallingCodeList` component.
 
 ## 2018-03-01 - Fix for Android button props
 

--- a/native/ios/native.xcodeproj/project.pbxproj
+++ b/native/ios/native.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -21,6 +22,7 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		28EA01A797384AA6BA660F6A /* libRCTRestart.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B3896E08C3804FF089E1E50B /* libRCTRestart.a */; };
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
@@ -37,10 +39,9 @@
 		60D802631F62BDF400FA4879 /* libBVLinearGradient.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 60D802431F62BDCA00FA4879 /* libBVLinearGradient.a */; };
 		6A4A4F4B8F7F4269A13BB2A7 /* BpkIcon.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 349CF328083441A0845E0C8D /* BpkIcon.ttf */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		8E33D9A4365E4F84826CF0C6 /* iconMapping.json in Resources */ = {isa = PBXBuildFile; fileRef = 3CA50A36B56148BD95AF98C2 /* iconMapping.json */; };
 		C8B831744C5A4256BD1B5010 /* BpkIcon.eot in Resources */ = {isa = PBXBuildFile; fileRef = 8C8F437769B54A038A210159 /* BpkIcon.eot */; };
 		E19140ED6394488C9626FE7A /* BpkIcon.woff in Resources */ = {isa = PBXBuildFile; fileRef = E436C94A65D1410092B05450 /* BpkIcon.woff */; };
-		8E33D9A4365E4F84826CF0C6 /* iconMapping.json in Resources */ = {isa = PBXBuildFile; fileRef = 3CA50A36B56148BD95AF98C2 /* iconMapping.json */; };
-		28EA01A797384AA6BA660F6A /* libRCTRestart.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B3896E08C3804FF089E1E50B /* libRCTRestart.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -247,6 +248,41 @@
 			remoteGlobalIDString = 3D383D621EBD27B9005632C8;
 			remoteInfo = "double-conversion-tvOS";
 		};
+		607D1B62204964EB0082F575 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EBF21BDC1FC498900052F4D5;
+			remoteInfo = jsinspector;
+		};
+		607D1B64204964EB0082F575 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EBF21BFA1FC4989A0052F4D5;
+			remoteInfo = "jsinspector-tvOS";
+		};
+		607D1B66204964EB0082F575 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9936F3131F5F2E4B0010BF04;
+			remoteInfo = privatedata;
+		};
+		607D1B68204964EB0082F575 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9936F32F1F5F2E5B0010BF04;
+			remoteInfo = "privatedata-tvOS";
+		};
+		607D1B6D204964EC0082F575 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0334EEA012364B5980516D8A /* RCTRestart.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3245CDED1BFEE35C00EABF68;
+			remoteInfo = RCTRestart;
+		};
 		60D802421F62BDCA00FA4879 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 60D8023D1F62BDCA00FA4879 /* BVLinearGradient.xcodeproj */;
@@ -301,6 +337,7 @@
 		00E356EE1AD99517003FC87E /* Backpack Native Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Backpack Native Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* nativeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = nativeTests.m; sourceTree = "<group>"; };
+		0334EEA012364B5980516D8A /* RCTRestart.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTRestart.xcodeproj; path = "../node_modules/react-native-restart/ios/RCTRestart.xcodeproj"; sourceTree = "<group>"; };
 		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
 		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* native.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = native.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -314,16 +351,15 @@
 		2D02E47B1E0B4A5D006451C7 /* Backpack Native-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Backpack Native-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* Backpack Native-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Backpack Native-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		349CF328083441A0845E0C8D /* BpkIcon.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIcon.ttf; path = "../../packages/bpk-svgs/dist/font/BpkIcon.ttf"; sourceTree = "<group>"; };
+		3CA50A36B56148BD95AF98C2 /* iconMapping.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = iconMapping.json; path = "../../packages/bpk-svgs/dist/font/iconMapping.json"; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		60D8023D1F62BDCA00FA4879 /* BVLinearGradient.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BVLinearGradient.xcodeproj; path = "../packages/react-native-bpk-component-button/node_modules/react-native-linear-gradient/BVLinearGradient.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		8C8F437769B54A038A210159 /* BpkIcon.eot */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIcon.eot; path = "../../packages/bpk-svgs/dist/font/BpkIcon.eot"; sourceTree = "<group>"; };
+		B3896E08C3804FF089E1E50B /* libRCTRestart.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTRestart.a; sourceTree = "<group>"; };
 		D60ACAA41FD8532E009E5946 /* he-IL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "he-IL"; path = "he-IL.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
-		8C8F437769B54A038A210159 /* BpkIcon.eot */ = {isa = PBXFileReference; name = "BpkIcon.eot"; path = "../../packages/bpk-svgs/dist/font/BpkIcon.eot"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		E436C94A65D1410092B05450 /* BpkIcon.woff */ = {isa = PBXFileReference; name = "BpkIcon.woff"; path = "../../packages/bpk-svgs/dist/font/BpkIcon.woff"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		3CA50A36B56148BD95AF98C2 /* iconMapping.json */ = {isa = PBXFileReference; name = "iconMapping.json"; path = "../../packages/bpk-svgs/dist/font/iconMapping.json"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		0334EEA012364B5980516D8A /* RCTRestart.xcodeproj */ = {isa = PBXFileReference; name = "RCTRestart.xcodeproj"; path = "../node_modules/react-native-restart/ios/RCTRestart.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		B3896E08C3804FF089E1E50B /* libRCTRestart.a */ = {isa = PBXFileReference; name = "libRCTRestart.a"; path = "libRCTRestart.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		E436C94A65D1410092B05450 /* BpkIcon.woff */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIcon.woff; path = "../../packages/bpk-svgs/dist/font/BpkIcon.woff"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -484,10 +520,14 @@
 				3DAD3EAB1DF850E9000B6D8A /* libcxxreact.a */,
 				3DAD3EAD1DF850E9000B6D8A /* libjschelpers.a */,
 				3DAD3EAF1DF850E9000B6D8A /* libjschelpers.a */,
+				607D1B63204964EB0082F575 /* libjsinspector.a */,
+				607D1B65204964EB0082F575 /* libjsinspector-tvOS.a */,
 				604305F81F628EF50042A514 /* libthird-party.a */,
 				604305FA1F628EF50042A514 /* libthird-party.a */,
 				604305FC1F628EF50042A514 /* libdouble-conversion.a */,
 				604305FE1F628EF50042A514 /* libdouble-conversion.a */,
+				607D1B67204964EB0082F575 /* libprivatedata.a */,
+				607D1B69204964EB0082F575 /* libprivatedata-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -497,6 +537,22 @@
 			children = (
 				5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */,
 				5E9157351DD0AC6500FF2AA8 /* libRCTAnimation.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		607D1B3C204964E80082F575 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				B3896E08C3804FF089E1E50B /* libRCTRestart.a */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		607D1B6A204964EB0082F575 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				607D1B6E204964EC0082F575 /* libRCTRestart.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -556,6 +612,7 @@
 				00E356EF1AD99517003FC87E /* nativeTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				C683A34A61E64F6BB02CDA07 /* Resources */,
+				607D1B3C204964E80082F575 /* Recovered References */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -724,6 +781,10 @@
 				{
 					ProductGroup = 00C302D41ABCB9D200DB3ED1 /* Products */;
 					ProjectRef = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
+				},
+				{
+					ProductGroup = 607D1B6A204964EB0082F575 /* Products */;
+					ProjectRef = 0334EEA012364B5980516D8A /* RCTRestart.xcodeproj */;
 				},
 				{
 					ProductGroup = 139105B71AF99BAD00B5F7CC /* Products */;
@@ -946,6 +1007,41 @@
 			remoteRef = 604305FD1F628EF50042A514 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		607D1B63204964EB0082F575 /* libjsinspector.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjsinspector.a;
+			remoteRef = 607D1B62204964EB0082F575 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		607D1B65204964EB0082F575 /* libjsinspector-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libjsinspector-tvOS.a";
+			remoteRef = 607D1B64204964EB0082F575 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		607D1B67204964EB0082F575 /* libprivatedata.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libprivatedata.a;
+			remoteRef = 607D1B66204964EB0082F575 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		607D1B69204964EB0082F575 /* libprivatedata-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libprivatedata-tvOS.a";
+			remoteRef = 607D1B68204964EB0082F575 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		607D1B6E204964EC0082F575 /* libRCTRestart.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTRestart.a;
+			remoteRef = 607D1B6D204964EC0082F575 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		60D802431F62BDCA00FA4879 /* libBVLinearGradient.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1134,16 +1230,16 @@
 				INFOPLIST_FILE = nativeTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/native.app/native";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
 			};
 			name = Debug;
 		};
@@ -1155,16 +1251,16 @@
 				INFOPLIST_FILE = nativeTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/native.app/native";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
 			};
 			name = Release;
 		};
@@ -1221,6 +1317,10 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "native-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -1230,10 +1330,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
 			};
 			name = Debug;
 		};
@@ -1251,6 +1347,10 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "native-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -1260,10 +1360,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
 			};
 			name = Release;
 		};
@@ -1280,15 +1376,15 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "native-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.native-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/native-tvOS.app/native-tvOS";
 				TVOS_DEPLOYMENT_TARGET = 10.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
 			};
 			name = Debug;
 		};
@@ -1305,15 +1401,15 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "native-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.native-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/native-tvOS.app/native-tvOS";
 				TVOS_DEPLOYMENT_TARGET = 10.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
 			};
 			name = Release;
 		};

--- a/native/packages/react-native-bpk-component-phone-input/index.js
+++ b/native/packages/react-native-bpk-component-phone-input/index.js
@@ -1,0 +1,28 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import BpkDialingCodeList, { type Props } from './src/BpkDialingCodeList';
+
+export type BpkDialingCodeListProps = Props;
+
+// TODO this opt-out can be removed once phone input is implemented,
+// as it will be the default export.
+// eslint-disable-next-line import/prefer-default-export
+export { BpkDialingCodeList };

--- a/native/packages/react-native-bpk-component-phone-input/package-lock.json
+++ b/native/packages/react-native-bpk-component-phone-input/package-lock.json
@@ -1,0 +1,186 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"bpk-svgs": {
+			"version": "5.12.3",
+			"resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-5.12.3.tgz",
+			"integrity": "sha512-v0C/1bxTdM/Vxs/wEFO803TjEhB8hdK+8AVhpQWQuf5k8Ym90XH3hEydUE+0vc2CSUmPOwAZ2p5A1u0WVlmApg=="
+		},
+		"bpk-tokens": {
+			"version": "26.7.4",
+			"resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-26.7.4.tgz",
+			"integrity": "sha512-ZUQPacqs0RBC9xk8xDC4KtAJLGL6T2YALmnhj+Q0+52F0OkXWIx7JuHk6N6eXgG9fd0RPo0Y2IxtO9/5Ag1GCQ==",
+			"requires": {
+				"color": "2.0.1"
+			},
+			"dependencies": {
+				"color": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+					"integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+					"requires": {
+						"color-convert": "1.9.1",
+						"color-string": "1.5.2"
+					}
+				}
+			}
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"color-string": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+			"integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+			"requires": {
+				"color-name": "1.1.3",
+				"simple-swizzle": "0.2.2"
+			}
+		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"is-arrayish": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
+			"integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"react-native-bpk-component-icon": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-icon/-/react-native-bpk-component-icon-1.3.5.tgz",
+			"integrity": "sha512-0Vr1m3kAqmpjpDnfYIlkGdfRIu57guLQ4R69z4MMgThy5QD/ncwJnr8GfsxUSWi1AOmh9figFGo3svHl4NmmuA==",
+			"requires": {
+				"bpk-svgs": "5.12.3",
+				"bpk-tokens": "26.7.4",
+				"prop-types": "15.6.1"
+			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"requires": {
+				"is-arrayish": "0.3.1"
+			}
+		},
+		"ua-parser-js": {
+			"version": "0.7.17",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		}
+	}
+}

--- a/native/packages/react-native-bpk-component-phone-input/package.json
+++ b/native/packages/react-native-bpk-component-phone-input/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "react-native-bpk-component-phone-input",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "description": "Backpack React Native phone input component.",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^16.0.0-alpha.1",
+    "react-native": ">= 0.47.0"
+  },
+  "dependencies": {
+    "bpk-tokens": "^26.7.4",
+    "prop-types": "^15.5.8",
+    "react-native-bpk-component-text": "^2.1.30",
+    "react-native-bpk-component-touchable-overlay": "^1.0.12",
+    "react-native-bpk-component-icon": "^1.3.5"
+  }
+}

--- a/native/packages/react-native-bpk-component-phone-input/readme.md
+++ b/native/packages/react-native-bpk-component-phone-input/readme.md
@@ -1,0 +1,63 @@
+# react-native-bpk-component-phone-input
+
+> Backpack React Native telephone input component.
+
+## Installation
+
+```sh
+npm install react-native-bpk-component-phone-input --save-dev
+```
+
+## BpkDialingCodeList
+
+### Usage
+
+```js
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import { BpkDialingCodeList } from 'react-native-bpk-component-phone-input';
+
+const CODES = [
+  { id: 'DZ', dialingCode: '+213', name: 'Algeria' },
+  { id: 'CA', dialingCode: '+1', name: 'Canada' },
+  { id: 'CD', dialingCode: '+243', name: 'Democratic Republic of the Congo' },
+  { id: 'IT', dialingCode: '+39', name: 'Italy' },
+  { id: 'JP', dialingCode: '+81', name: 'Japan' },
+  { id: 'SE', dialingCode: '+46', name: 'Sweden' },
+  { id: 'GB', dialingCode: '+44', name: 'United Kingdom' },
+];
+
+const FLAG_IMAGES = {
+  'DZ': '/resources/algeria.png',
+  'CA': '/resources/canada.png',
+  'CD': '/resources/drcongo.png',
+  'IT': '/resources/italy.png',
+  'JP': '/resources/japan.png',
+  'SE': '/resources/sweden.png',
+  'GB': '/resources/uk.png',
+};
+
+export default class App extends Component {
+  render() {
+    return (
+      <BpkDialingCodeList
+        codes={CODES}
+        selectedId="CD"
+        onItemPress={code => console.log(code.id)}
+        renderFlag={code => <Image source={require(FLAG_IMAGES[code.id])} />}
+      />
+    );
+  }
+}
+```
+
+### Props
+
+
+| Property                    | PropType                                                    | Required | Default Value |
+| --------------------------- | ----------------------------------------------------------- | -------- | ------------- |
+| codes                       | arrayOf({id, diallingCode, name})                           | true     | -             |
+| onItemPress                 | func                                                        | true     | -             |
+| renderFlag                  | func                                                        | true     | -             |
+| selectedId                  | string                                                      | false    | null          |
+

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList-test.android.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList-test.android.js
@@ -1,0 +1,47 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkDialingCodeList-test.common';
+
+jest.mock('react-native', () => {
+  const reactNative = jest.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+  reactNative.TouchableNativeFeedback.SelectableBackground = jest.fn();
+
+  return reactNative;
+});
+
+jest.mock(
+  './../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('bpk-tokens/tokens/base.react.native', () =>
+  jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('./BpkDialingCodeList', () =>
+  jest.requireActual('./BpkDialingCodeList.android.js'),
+);
+
+describe('Android', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList-test.common.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList-test.common.js
@@ -1,0 +1,76 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Image } from 'react-native';
+import renderer from 'react-test-renderer';
+import BpkDialingCodeList from './BpkDialingCodeList';
+
+const onPressFn = jest.fn();
+
+const CODES = [
+  {
+    id: '0',
+    dialingCode: '0',
+    name: 'Zero',
+  },
+  {
+    id: '1',
+    dialingCode: '1',
+    name: 'One',
+  },
+  {
+    id: '2',
+    dialingCode: '2',
+    name: 'Two',
+  },
+];
+
+const commonTests = () => {
+  jest.mock('Image', () => 'Image');
+  describe('BpkDialingCodeList', () => {
+    it('should render correctly', () => {
+      const tree = renderer
+        .create(
+          <BpkDialingCodeList
+            codes={CODES}
+            onItemPress={onPressFn}
+            renderFlag={() => <Image />}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with "selectedId" set', () => {
+      const tree = renderer
+        .create(
+          <BpkDialingCodeList
+            codes={CODES}
+            onItemPress={onPressFn}
+            selectedId="0"
+            renderFlag={() => <Image />}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+};
+
+export default commonTests;

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList-test.ios.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList-test.ios.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkDialingCodeList-test.common';
+
+describe('iOS', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList.android.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList.android.js
@@ -1,0 +1,70 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import { View, StyleSheet, FlatList } from 'react-native';
+import React from 'react';
+import { spacingMd, colorGray100 } from 'bpk-tokens/tokens/base.react.native';
+import BpkDialingCodeListItem from './BpkDialingCodeListItem';
+import {
+  type ListCommonProps,
+  LIST_COMMON_PROP_TYPES,
+  LIST_COMMON_DEFAULT_PROPS,
+} from './common-types';
+
+const styles = StyleSheet.create({
+  separator: {
+    flex: 1,
+    height: 1,
+    backgroundColor: colorGray100,
+    marginHorizontal: spacingMd,
+  },
+});
+
+export type Props = {
+  ...$Exact<ListCommonProps>,
+};
+
+const BpkDialingCodeList = ({
+  codes,
+  onItemPress,
+  renderFlag,
+  selectedId,
+}: Props) => (
+  <FlatList
+    data={codes}
+    renderItem={({ item }) => (
+      <BpkDialingCodeListItem
+        {...item}
+        selected={selectedId === item.id}
+        onPress={() => {
+          onItemPress(item);
+        }}
+        flag={renderFlag(item)}
+      />
+    )}
+    keyExtractor={item => item.id}
+    ItemSeparatorComponent={() => <View style={styles.separator} />}
+  />
+);
+
+BpkDialingCodeList.propTypes = LIST_COMMON_PROP_TYPES;
+BpkDialingCodeList.defaultProps = LIST_COMMON_DEFAULT_PROPS;
+
+export default BpkDialingCodeList;

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList.ios.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeList.ios.js
@@ -1,0 +1,115 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import { View, StyleSheet, SectionList } from 'react-native';
+import React from 'react';
+import { groupBy } from 'lodash';
+import BpkText from 'react-native-bpk-component-text';
+import {
+  colorGray50,
+  colorGray100,
+  spacingSm,
+  spacingBase,
+} from 'bpk-tokens/tokens/base.react.native';
+import BpkDialingCodeListItem from './BpkDialingCodeListItem';
+import {
+  type ListCommonProps,
+  LIST_COMMON_PROP_TYPES,
+  LIST_COMMON_DEFAULT_PROPS,
+} from './common-types';
+
+const styles = StyleSheet.create({
+  sectionHeader: {
+    paddingVertical: spacingSm,
+    paddingHorizontal: spacingBase,
+    backgroundColor: colorGray50,
+  },
+  separator: {
+    flex: 1,
+    height: 1,
+    backgroundColor: colorGray100,
+    marginLeft: spacingBase,
+  },
+});
+
+/*
+Takes data in the format:
+[
+  {name: 'Foo'},
+  {name: 'Bar'},
+  {name: 'Baz'},
+]
+
+and returns:
+[
+  {
+    title: 'F',
+    data: [{name: 'Foo'}],
+  },
+  {
+    title: 'B',
+    data: [{name: 'Bar'}, {name: 'Baz'}],
+  },
+]
+*/
+const convertCodesIntoSections = data => {
+  const alphabetisedList = groupBy(data, x => x.name[0].toLowerCase());
+  return Object.keys(alphabetisedList).map(letter => ({
+    title: letter.toUpperCase(),
+    data: alphabetisedList[letter],
+  }));
+};
+
+export type Props = {
+  ...$Exact<ListCommonProps>,
+};
+
+const BpkDialingCodeList = ({
+  codes,
+  onItemPress,
+  renderFlag,
+  selectedId,
+}: Props) => (
+  <SectionList
+    sections={convertCodesIntoSections(codes)}
+    renderItem={({ item }) => (
+      <BpkDialingCodeListItem
+        {...item}
+        selected={selectedId === item.id}
+        onPress={() => {
+          onItemPress(item);
+        }}
+        flag={renderFlag(item)}
+      />
+    )}
+    renderSectionHeader={({ section }) => (
+      <BpkText emphasize textStyle="lg" style={styles.sectionHeader}>
+        {section.title}
+      </BpkText>
+    )}
+    keyExtractor={item => item.id}
+    ItemSeparatorComponent={() => <View style={styles.separator} />}
+  />
+);
+
+BpkDialingCodeList.propTypes = LIST_COMMON_PROP_TYPES;
+BpkDialingCodeList.defaultProps = LIST_COMMON_DEFAULT_PROPS;
+
+export default BpkDialingCodeList;

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem-test.android.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem-test.android.js
@@ -1,0 +1,53 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkDialingCodeListItem-test.common';
+
+jest.mock('react-native', () => {
+  const reactNative = jest.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+  reactNative.TouchableNativeFeedback.SelectableBackground = jest.fn();
+
+  return reactNative;
+});
+
+jest.mock('TouchableNativeFeedback', () =>
+  jest.requireActual(
+    'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js',
+  ),
+);
+
+jest.mock(
+  './../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('bpk-tokens/tokens/base.react.native', () =>
+  jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('./BpkDialingCodeListItem', () =>
+  jest.requireActual('./BpkDialingCodeListItem.android.js'),
+);
+
+describe('Android', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem-test.common.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem-test.common.js
@@ -1,0 +1,75 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Image } from 'react-native';
+import renderer from 'react-test-renderer';
+import BpkDialingCodeListItem from './BpkDialingCodeListItem';
+
+const onPressFn = jest.fn();
+
+const commonTests = () => {
+  jest.mock('Image', () => 'Image');
+  describe('BpkDialingCodeListItem', () => {
+    it('should render correctly', () => {
+      const tree = renderer
+        .create(
+          <BpkDialingCodeListItem
+            id="44"
+            dialingCode="44"
+            name="United Kingdom"
+            onPress={onPressFn}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should support the "selected" property', () => {
+      const tree = renderer
+        .create(
+          <BpkDialingCodeListItem
+            id="44"
+            dialingCode="44"
+            name="United Kingdom"
+            onPress={onPressFn}
+            selected
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should support the "flagImage" property', () => {
+      const tree = renderer
+        .create(
+          <BpkDialingCodeListItem
+            id="44"
+            dialingCode="44"
+            name="United Kingdom"
+            onPress={onPressFn}
+            flag={<Image />}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+};
+
+export default commonTests;

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem-test.ios.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem-test.ios.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkDialingCodeListItem-test.common';
+
+describe('iOS', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem.android.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem.android.js
@@ -1,0 +1,134 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import { View, StyleSheet, TouchableNativeFeedback } from 'react-native';
+import React from 'react';
+import BpkText from 'react-native-bpk-component-text';
+import BpkIcon, { icons } from 'react-native-bpk-component-icon';
+import {
+  spacingMd,
+  spacingBase,
+  spacingLg,
+  colorBlue500,
+  colorGray100,
+} from 'bpk-tokens/tokens/base.react.native';
+import {
+  type ListItemProps,
+  LIST_ITEM_PROP_TYPES,
+  LIST_ITEM_COMMON_DEFAULT_PROPS,
+} from './common-types';
+
+const styles = StyleSheet.create({
+  listItem: {
+    flex: 1,
+    flexDirection: 'row',
+    paddingHorizontal: spacingMd,
+    paddingVertical: spacingBase,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  content: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  text: {
+    flex: 1,
+    marginLeft: spacingLg,
+  },
+  flag: {
+    borderColor: colorGray100,
+    borderWidth: 1,
+    width: spacingLg,
+    height: spacingLg / 3 * 2, // 3:2 aspect ratio with width.
+  },
+  selected: {
+    color: colorBlue500,
+  },
+  tick: {
+    color: colorGray100,
+  },
+  tickSelected: {
+    color: colorBlue500,
+  },
+});
+
+type Props = {
+  ...$Exact<ListItemProps>,
+};
+
+/*
+This is *not* a functional component for optimisation reasons.
+Implementing `shouldComponentUpdate` to only take the `selected`
+prop into account allows the `onPress` functionality in long lists
+to be much faster.
+*/
+class BpkDialingCodeListItem extends React.Component<Props> {
+  static propTypes = LIST_ITEM_PROP_TYPES;
+  static defaultProps = LIST_ITEM_COMMON_DEFAULT_PROPS;
+
+  shouldComponentUpdate(nextProps: Props) {
+    return nextProps.selected !== this.props.selected;
+  }
+
+  render() {
+    const { dialingCode, flag, name, selected, ...rest } = this.props;
+
+    // Add sizing to the flag element. If not defined, fall back to a placeholder.
+    const styledFlag = flag ? (
+      React.cloneElement(flag, {
+        resizeMode: 'contain', // Preserves aspect ratio when resizing.
+        style: styles.flag,
+      })
+    ) : (
+      <View style={styles.flag} />
+    );
+
+    const iconStyles = [styles.tick];
+    if (selected) {
+      iconStyles.push(styles.tickSelected);
+    }
+
+    return (
+      <TouchableNativeFeedback
+        background={TouchableNativeFeedback.SelectableBackground()}
+        accessibilityComponentType="button"
+        accessibilityLabel={`${dialingCode} ${name}`}
+        accessibilityTraits={['button']}
+        {...rest}
+      >
+        <View style={styles.listItem}>
+          <View style={styles.content}>
+            {styledFlag}
+            <BpkText
+              textStyle="base"
+              style={[styles.text, selected ? styles.selected : null]}
+            >
+              {dialingCode} {name}
+            </BpkText>
+          </View>
+          <BpkIcon small icon={icons.tick} style={iconStyles} />
+        </View>
+      </TouchableNativeFeedback>
+    );
+  }
+}
+
+export default BpkDialingCodeListItem;

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem.ios.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem.ios.js
@@ -1,0 +1,132 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import { View, StyleSheet } from 'react-native';
+import React from 'react';
+import BpkText from 'react-native-bpk-component-text';
+import BpkTouchableOverlay from 'react-native-bpk-component-touchable-overlay';
+import BpkIcon, { icons } from 'react-native-bpk-component-icon';
+import {
+  spacingBase,
+  spacingLg,
+  colorBlue600,
+  colorGray100,
+} from 'bpk-tokens/tokens/base.react.native';
+import {
+  type ListItemProps,
+  LIST_ITEM_PROP_TYPES,
+  LIST_ITEM_COMMON_DEFAULT_PROPS,
+} from './common-types';
+
+const styles = StyleSheet.create({
+  listItem: {
+    flex: 1,
+    flexDirection: 'row',
+    padding: spacingBase,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  content: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  text: {
+    flex: 1,
+    marginLeft: spacingLg,
+  },
+  flag: {
+    borderColor: colorGray100,
+    borderWidth: 1,
+    width: spacingLg,
+    height: spacingLg / 3 * 2, // 3:2 aspect ratio with width.
+  },
+  selected: {
+    color: colorBlue600,
+  },
+  tick: {
+    color: colorBlue600,
+    opacity: 0,
+  },
+  tickVisible: {
+    opacity: 1,
+  },
+});
+
+type Props = {
+  ...$Exact<ListItemProps>,
+};
+
+/*
+This is *not* a functional component for optimisation reasons.
+Implementing `shouldComponentUpdate` to only take the `selected`
+prop into account allows the `onPress` functionality in long lists
+to be much faster.
+*/
+class BpkDialingCodeListItem extends React.Component<Props> {
+  static propTypes = LIST_ITEM_PROP_TYPES;
+  static defaultProps = LIST_ITEM_COMMON_DEFAULT_PROPS;
+
+  shouldComponentUpdate(nextProps: Props) {
+    return nextProps.selected !== this.props.selected;
+  }
+
+  render() {
+    const { dialingCode, flag, name, selected, ...rest } = this.props;
+
+    // Add sizing to the flag element. If not defined, fall back to a placeholder.
+    const styledFlag = flag ? (
+      React.cloneElement(flag, {
+        resizeMode: 'contain', // Preserves aspect ratio when resizing.
+        style: styles.flag,
+      })
+    ) : (
+      <View style={styles.flag} />
+    );
+
+    const iconStyles = [styles.tick];
+    if (selected) {
+      iconStyles.push(styles.tickVisible);
+    }
+
+    return (
+      <BpkTouchableOverlay
+        accessibilityComponentType="button"
+        accessibilityLabel={`${dialingCode} ${name}`}
+        accessibilityTraits={['button']}
+        style={styles.listItem}
+        {...rest}
+      >
+        <View style={styles.content}>
+          {styledFlag}
+          <BpkText
+            textStyle="lg"
+            style={[styles.text, selected ? styles.selected : null]}
+          >
+            {dialingCode} {name}
+          </BpkText>
+        </View>
+        <BpkIcon small icon={icons.tick} style={iconStyles} />
+      </BpkTouchableOverlay>
+    );
+  }
+}
+
+export default BpkDialingCodeListItem;

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.android.js.snap
@@ -1,0 +1,894 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkDialingCodeList should render correctly 1`] = `
+<RCTScrollView
+  ItemSeparatorComponent={[Function]}
+  data={
+    Array [
+      Object {
+        "dialingCode": "0",
+        "id": "0",
+        "name": "Zero",
+      },
+      Object {
+        "dialingCode": "1",
+        "id": "1",
+        "name": "One",
+      },
+      Object {
+        "dialingCode": "2",
+        "id": "2",
+        "name": "Two",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="0 Zero"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 20,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            0
+             
+            Zero
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+            "flex": 1,
+            "height": 1,
+            "marginHorizontal": 8,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="1 One"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 20,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            1
+             
+            One
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+            "flex": 1,
+            "height": 1,
+            "marginHorizontal": 8,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="2 Two"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 20,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            2
+             
+            Two
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Android BpkDialingCodeList should render correctly with "selectedId" set 1`] = `
+<RCTScrollView
+  ItemSeparatorComponent={[Function]}
+  data={
+    Array [
+      Object {
+        "dialingCode": "0",
+        "id": "0",
+        "name": "Zero",
+      },
+      Object {
+        "dialingCode": "1",
+        "id": "1",
+        "name": "One",
+      },
+      Object {
+        "dialingCode": "2",
+        "id": "2",
+        "name": "Two",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="0 Zero"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 20,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  Object {
+                    "color": "rgb(0, 157, 189)",
+                  },
+                ],
+              ]
+            }
+          >
+            0
+             
+            Zero
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+                Object {
+                  "opacity": 1,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+            "flex": 1,
+            "height": 1,
+            "marginHorizontal": 8,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="1 One"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 20,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            1
+             
+            One
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+            "flex": 1,
+            "height": 1,
+            "marginHorizontal": 8,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="2 Two"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 20,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            2
+             
+            Two
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.ios.js.snap
@@ -1,0 +1,1170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS BpkDialingCodeList should render correctly 1`] = `
+<RCTScrollView
+  ItemSeparatorComponent={undefined}
+  data={
+    Array [
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "0",
+            "id": "0",
+            "name": "Zero",
+          },
+        ],
+        "title": "Z",
+      },
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "1",
+            "id": "1",
+            "name": "One",
+          },
+        ],
+        "title": "O",
+      },
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "2",
+            "id": "2",
+            "name": "Two",
+          },
+        ],
+        "title": "T",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  onViewableItemsChanged={undefined}
+  renderItem={[Function]}
+  renderSectionHeader={[Function]}
+  scrollEventThrottle={50}
+  sections={
+    Array [
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "0",
+            "id": "0",
+            "name": "Zero",
+          },
+        ],
+        "title": "Z",
+      },
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "1",
+            "id": "1",
+            "name": "One",
+          },
+        ],
+        "title": "O",
+      },
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "2",
+            "id": "2",
+            "name": "Two",
+          },
+        ],
+        "title": "T",
+      },
+    ]
+  }
+  stickyHeaderIndices={
+    Array [
+      0,
+      3,
+      6,
+    ]
+  }
+  stickySectionHeadersEnabled={true}
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "System",
+              "fontSize": 17,
+              "fontWeight": "400",
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "paddingHorizontal": 16,
+              "paddingVertical": 4,
+            },
+          ]
+        }
+      >
+        Z
+      </Text>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="0 Zero"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 17,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            0
+             
+            Zero
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    />
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "System",
+              "fontSize": 17,
+              "fontWeight": "400",
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "paddingHorizontal": 16,
+              "paddingVertical": 4,
+            },
+          ]
+        }
+      >
+        O
+      </Text>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="1 One"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 17,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            1
+             
+            One
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    />
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "System",
+              "fontSize": 17,
+              "fontWeight": "400",
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "paddingHorizontal": 16,
+              "paddingVertical": 4,
+            },
+          ]
+        }
+      >
+        T
+      </Text>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="2 Two"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 17,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            2
+             
+            Two
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`] = `
+<RCTScrollView
+  ItemSeparatorComponent={undefined}
+  data={
+    Array [
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "0",
+            "id": "0",
+            "name": "Zero",
+          },
+        ],
+        "title": "Z",
+      },
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "1",
+            "id": "1",
+            "name": "One",
+          },
+        ],
+        "title": "O",
+      },
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "2",
+            "id": "2",
+            "name": "Two",
+          },
+        ],
+        "title": "T",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  onViewableItemsChanged={undefined}
+  renderItem={[Function]}
+  renderSectionHeader={[Function]}
+  scrollEventThrottle={50}
+  sections={
+    Array [
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "0",
+            "id": "0",
+            "name": "Zero",
+          },
+        ],
+        "title": "Z",
+      },
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "1",
+            "id": "1",
+            "name": "One",
+          },
+        ],
+        "title": "O",
+      },
+      Object {
+        "data": Array [
+          Object {
+            "dialingCode": "2",
+            "id": "2",
+            "name": "Two",
+          },
+        ],
+        "title": "T",
+      },
+    ]
+  }
+  stickyHeaderIndices={
+    Array [
+      0,
+      3,
+      6,
+    ]
+  }
+  stickySectionHeadersEnabled={true}
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "System",
+              "fontSize": 17,
+              "fontWeight": "400",
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "paddingHorizontal": 16,
+              "paddingVertical": 4,
+            },
+          ]
+        }
+      >
+        Z
+      </Text>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="0 Zero"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 17,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  Object {
+                    "color": "rgb(0, 157, 189)",
+                  },
+                ],
+              ]
+            }
+          >
+            0
+             
+            Zero
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+                Object {
+                  "opacity": 1,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    />
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "System",
+              "fontSize": 17,
+              "fontWeight": "400",
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "paddingHorizontal": 16,
+              "paddingVertical": 4,
+            },
+          ]
+        }
+      >
+        O
+      </Text>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="1 One"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 17,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            1
+             
+            One
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    />
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "System",
+              "fontSize": 17,
+              "fontWeight": "400",
+            },
+            Object {
+              "fontWeight": "600",
+            },
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "paddingHorizontal": 16,
+              "paddingVertical": 4,
+            },
+          ]
+        }
+      >
+        T
+      </Text>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="2 Two"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": 16,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            resizeMode="contain"
+            style={
+              Object {
+                "borderColor": "rgb(230, 228, 235)",
+                "borderWidth": 1,
+                "height": 16,
+                "width": 24,
+              }
+            }
+          />
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 17,
+                  "fontWeight": "400",
+                },
+                Array [
+                  Object {
+                    "flex": 1,
+                    "marginLeft": 24,
+                  },
+                  null,
+                ],
+              ]
+            }
+          >
+            2
+             
+            Two
+          </Text>
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Object {
+                  "color": "rgb(0, 157, 189)",
+                  "opacity": 0,
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(37, 32, 51)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    />
+  </View>
+</RCTScrollView>
+`;

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeListItem-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeListItem-test.android.js.snap
@@ -1,0 +1,340 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkDialingCodeListItem should render correctly 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel="44 United Kingdom"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "paddingHorizontal": 8,
+      "paddingVertical": 16,
+    }
+  }
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 1,
+          "height": 16,
+          "width": 24,
+        }
+      }
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "sans-serif",
+            "fontSize": 16,
+            "fontWeight": "400",
+          },
+          Array [
+            Object {
+              "flex": 1,
+              "marginLeft": 24,
+            },
+            null,
+          ],
+        ]
+      }
+    >
+      44
+       
+      United Kingdom
+    </Text>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+        Array [
+          Object {
+            "color": "rgb(230, 228, 235)",
+          },
+        ],
+      ]
+    }
+  >
+    
+  </Text>
+</View>
+`;
+
+exports[`Android BpkDialingCodeListItem should support the "flagImage" property 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel="44 United Kingdom"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "paddingHorizontal": 8,
+      "paddingVertical": 16,
+    }
+  }
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Image
+      resizeMode="contain"
+      style={
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 1,
+          "height": 16,
+          "width": 24,
+        }
+      }
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "sans-serif",
+            "fontSize": 16,
+            "fontWeight": "400",
+          },
+          Array [
+            Object {
+              "flex": 1,
+              "marginLeft": 24,
+            },
+            null,
+          ],
+        ]
+      }
+    >
+      44
+       
+      United Kingdom
+    </Text>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+        Array [
+          Object {
+            "color": "rgb(230, 228, 235)",
+          },
+        ],
+      ]
+    }
+  >
+    
+  </Text>
+</View>
+`;
+
+exports[`Android BpkDialingCodeListItem should support the "selected" property 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel="44 United Kingdom"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "paddingHorizontal": 8,
+      "paddingVertical": 16,
+    }
+  }
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 1,
+          "height": 16,
+          "width": 24,
+        }
+      }
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "sans-serif",
+            "fontSize": 16,
+            "fontWeight": "400",
+          },
+          Array [
+            Object {
+              "flex": 1,
+              "marginLeft": 24,
+            },
+            Object {
+              "color": "rgb(0, 178, 214)",
+            },
+          ],
+        ]
+      }
+    >
+      44
+       
+      United Kingdom
+    </Text>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+        Array [
+          Object {
+            "color": "rgb(230, 228, 235)",
+          },
+          Object {
+            "color": "rgb(0, 178, 214)",
+          },
+        ],
+      ]
+    }
+  >
+    
+  </Text>
+</View>
+`;

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeListItem-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeListItem-test.ios.js.snap
@@ -1,0 +1,373 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS BpkDialingCodeListItem should render correctly 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel="44 United Kingdom"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "padding": 16,
+    }
+  }
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 1,
+          "height": 16,
+          "width": 24,
+        }
+      }
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 17,
+            "fontWeight": "400",
+          },
+          Array [
+            Object {
+              "flex": 1,
+              "marginLeft": 24,
+            },
+            null,
+          ],
+        ]
+      }
+    >
+      44
+       
+      United Kingdom
+    </Text>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+        Array [
+          Object {
+            "color": "rgb(0, 157, 189)",
+            "opacity": 0,
+          },
+        ],
+      ]
+    }
+  >
+    
+  </Text>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`iOS BpkDialingCodeListItem should support the "flagImage" property 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel="44 United Kingdom"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "padding": 16,
+    }
+  }
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Image
+      resizeMode="contain"
+      style={
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 1,
+          "height": 16,
+          "width": 24,
+        }
+      }
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 17,
+            "fontWeight": "400",
+          },
+          Array [
+            Object {
+              "flex": 1,
+              "marginLeft": 24,
+            },
+            null,
+          ],
+        ]
+      }
+    >
+      44
+       
+      United Kingdom
+    </Text>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+        Array [
+          Object {
+            "color": "rgb(0, 157, 189)",
+            "opacity": 0,
+          },
+        ],
+      ]
+    }
+  >
+    
+  </Text>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`iOS BpkDialingCodeListItem should support the "selected" property 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel="44 United Kingdom"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "padding": 16,
+    }
+  }
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 1,
+          "height": 16,
+          "width": 24,
+        }
+      }
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 17,
+            "fontWeight": "400",
+          },
+          Array [
+            Object {
+              "flex": 1,
+              "marginLeft": 24,
+            },
+            Object {
+              "color": "rgb(0, 157, 189)",
+            },
+          ],
+        ]
+      }
+    >
+      44
+       
+      United Kingdom
+    </Text>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+        Array [
+          Object {
+            "color": "rgb(0, 157, 189)",
+            "opacity": 0,
+          },
+          Object {
+            "opacity": 1,
+          },
+        ],
+      ]
+    }
+  >
+    
+  </Text>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;

--- a/native/packages/react-native-bpk-component-phone-input/src/common-types.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/common-types.js
@@ -1,0 +1,73 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import { Component, type Element } from 'react';
+import PropTypes from 'prop-types';
+
+export type Id = string;
+
+export type Code = {
+  id: Id,
+  dialingCode: string,
+  name: string,
+};
+
+export type ListItemProps = {
+  ...$Exact<Code>,
+  onPress: ListItemProps => void,
+  selected: boolean,
+  flag: ?Element<typeof Component>,
+};
+
+export type ListCommonProps = {
+  codes: Array<Code>,
+  renderFlag: Code => ?Element<typeof Component>,
+  onItemPress: ListItemProps => void,
+  selectedId: ?string,
+};
+
+export const CODE_PROP_TYPES = {
+  id: PropTypes.string.isRequired,
+  dialingCode: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+export const LIST_ITEM_PROP_TYPES = {
+  ...CODE_PROP_TYPES,
+  onPress: PropTypes.func.isRequired,
+  flag: PropTypes.element,
+  selected: PropTypes.bool,
+};
+
+export const LIST_COMMON_PROP_TYPES = {
+  codes: PropTypes.arrayOf(PropTypes.shape(...CODE_PROP_TYPES)).isRequired,
+  onItemPress: PropTypes.func.isRequired,
+  renderFlag: PropTypes.func.isRequired,
+  selectedId: PropTypes.string,
+};
+
+export const LIST_COMMON_DEFAULT_PROPS = {
+  selectedId: null,
+};
+
+export const LIST_ITEM_COMMON_DEFAULT_PROPS = {
+  flag: null,
+  selected: false,
+};

--- a/native/packages/react-native-bpk-component-phone-input/stories.js
+++ b/native/packages/react-native-bpk-component-phone-input/stories.js
@@ -1,0 +1,159 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import { Image } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import { action } from '@storybook/addon-actions';
+
+import { BpkDialingCodeList } from './index';
+import BpkDialingCodeListItem from './src/BpkDialingCodeListItem';
+
+// Sample dialing codes, with some long ones to demonstrate how the
+// component handles them.
+// Out of order on purpose to demonstrate how the component
+// sorts them alphabetically.
+const codes = [
+  { id: 'DZ', dialingCode: '+213', name: 'Algeria' },
+  { id: 'AD', dialingCode: '+376', name: 'Andorra' },
+  { id: 'AU', dialingCode: '+61', name: 'Australia' },
+  { id: 'BE', dialingCode: '+32', name: 'Belgium' },
+  { id: 'CA', dialingCode: '+1', name: 'Canada' },
+  { id: 'CD', dialingCode: '+243', name: 'Democratic Republic of the Congo' },
+  { id: 'EG', dialingCode: '+20', name: 'Egypt' },
+  { id: 'IS', dialingCode: '+354', name: 'Iceland' },
+  {
+    id: 'IPTCS',
+    dialingCode: '+991',
+    name:
+      'International Telecommunications Public Correspondence Service trial (IPTCS)',
+  },
+  { id: 'IT', dialingCode: '+39', name: 'Italy' },
+  { id: 'JP81', dialingCode: '+81', name: 'Japan' },
+  {
+    id: 'VC',
+    dialingCode: '+1784',
+    name: 'Saint Vincent and the Grenadines',
+  },
+  { id: 'SE', dialingCode: '+46', name: 'Sweden' },
+  { id: 'GB', dialingCode: '+44', name: 'United Kingdom' },
+  { id: 'VI', dialingCode: '+1340', name: 'United States Virgin Islands' },
+  { id: 'WK', dialingCode: '+99', name: 'Wakanda' },
+];
+
+const flags = {
+  CA:
+    'https://upload.wikimedia.org/wikipedia/en/thumb/c/cf/Flag_of_Canada.svg/1000px-Flag_of_Canada.svg.png',
+  EG:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Flag_of_Egypt.svg/900px-Flag_of_Egypt.svg.png',
+  BE:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/9/92/Flag_of_Belgium_%28civil%29.svg/450px-Flag_of_Belgium_%28civil%29.svg.png',
+  DZ:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/7/77/Flag_of_Algeria.svg/900px-Flag_of_Algeria.svg.png',
+  CD:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Flag_of_the_Democratic_Republic_of_the_Congo.svg/800px-Flag_of_the_Democratic_Republic_of_the_Congo.svg.png',
+  IS:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Flag_of_Iceland.svg/800px-Flag_of_Iceland.svg.png',
+  AD:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Flag_of_Andorra.svg/800px-Flag_of_Andorra.svg.png',
+};
+
+class StatefulBpkDialingCodeList extends React.Component<
+  {},
+  {
+    selectedId: ?string,
+  },
+> {
+  constructor() {
+    super();
+    this.state = { selectedId: 'AU' };
+  }
+  render() {
+    return (
+      <BpkDialingCodeList
+        codes={codes}
+        selectedId={this.state.selectedId}
+        onItemPress={item => {
+          action(`${item.name} selected`);
+          this.setState({ selectedId: item.id });
+        }}
+        renderFlag={item =>
+          flags[item.id] ? <Image source={{ uri: flags[item.id] }} /> : null
+        }
+      />
+    );
+  }
+}
+
+storiesOf('BpkDialingCodeList', module).add('Example List', () => (
+  <StatefulBpkDialingCodeList />
+));
+
+storiesOf('BpkDialingCodeListItem', module)
+  .add('Standard', () => (
+    <BpkDialingCodeListItem
+      id="44"
+      dialingCode="44"
+      name="United Kingdom"
+      onPress={action('Standard BpkDialingCodeListItem pressed.')}
+    />
+  ))
+  .add('Selected', () => (
+    <BpkDialingCodeListItem
+      id="44"
+      dialingCode="44"
+      name="United Kingdom"
+      onPress={action('Standard BpkDialingCodeListItem pressed.')}
+      selected
+    />
+  ))
+  .add('With flag', () => (
+    <BpkDialingCodeListItem
+      id="44"
+      dialingCode="44"
+      name="United Kingdom"
+      onPress={action('Standard BpkDialingCodeListItem pressed.')}
+      flag={
+        <Image
+          source={{
+            uri:
+              'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Flag_of_the_Democratic_Republic_of_the_Congo.svg/800px-Flag_of_the_Democratic_Republic_of_the_Congo.svg.png',
+          }}
+        />
+      }
+    />
+  ))
+  .add('Selected with flag', () => (
+    <BpkDialingCodeListItem
+      id="44"
+      dialingCode="44"
+      name="United Kingdom"
+      onPress={action('Standard BpkDialingCodeListItem pressed.')}
+      selected
+      flag={
+        <Image
+          source={{
+            uri:
+              'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Flag_of_the_Democratic_Republic_of_the_Congo.svg/800px-Flag_of_the_Democratic_Republic_of_the_Congo.svg.png',
+          }}
+        />
+      }
+    />
+  ));

--- a/native/storybook/storybook.js
+++ b/native/storybook/storybook.js
@@ -81,6 +81,7 @@ configure(() => {
   require('../packages/react-native-bpk-component-card/stories');
   require('../packages/react-native-bpk-component-horizontal-nav/stories');
   require('../packages/react-native-bpk-component-icon/stories');
+  require('../packages/react-native-bpk-component-phone-input/stories');
   require('../packages/react-native-bpk-component-spinner/stories');
   require('../packages/react-native-bpk-component-star-rating/stories');
   require('../packages/react-native-bpk-component-switch/stories');


### PR DESCRIPTION
# Overview
Adds `BpkDialingCodeList` and `BpkDialingCodeListItem` components.

# Example Usage

## `BpkDialingCodeListItem`
```
<BpkDiallngCodeListItem
    id="44"
    dialingCode="44"
    name="United Kingdom"
    onPress={action('BpkDialingCodeListItem pressed.')}
    flag={
      <Image
        source={{
          uri: 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Flag_of_the_Democratic_Republic_of_the_Congo.svg/800px-Flag_of_the_Democratic_Republic_of_the_Congo.svg.png',
        }}
      />
    }
/>
```
Note that an instance of `Image` is passed in. I did it this way so that consumers are free to choose whichever type of image source they want: https://facebook.github.io/react-native/docs/images.html.

## `BpkDialingCodeList`
```
const CODES = [
  {
    id: '0',
    dialingCode: '0',
    name: 'Zero',
  },
  {
    id: '1',
    dialingCode: '1',
    name: 'One',
  },
  {
    id: '2',
    dialingCode: '2',
    name: 'Two',
  },
];

<BpkDialingCodeList
  codes={CODES}
  onItemPress={(item) => {
    action(`${item.name} selected`);
  }}
  selectedId="0"
/>
```
* `selectedId` is not required.
* consumers can use `onItemPress` to handle state.

* See storybook for a stateful example.

# Other info

## Android radios
The wireframe for Android looks like this:
![screen shot 2018-03-01 at 15 54 28](https://user-images.githubusercontent.com/73652/36854409-d72c693c-1d68-11e8-8912-8c1f07384cf4.png)

However, React Native doesn't appear to expose these radio buttons (I could be wrong, still making sure). So for now I've used the tick icon, like we have on iOS. We should decide as a squad what to do about this, whether we just add a new icon or what.

## Storybook images
In the storybook, I'm using direct links to Wikipedia for the flags. This probably isn't the best, but I don't love the idea of adding a load of flags to the repo just for this. I'm open to any suggestions!

# GIFs!!

## iOS
![kapture 2018-03-01 at 15 57 46](https://user-images.githubusercontent.com/73652/36854625-5ace0e26-1d69-11e8-9600-af3750a09ea9.gif)

## Android
![kapture 2018-03-01 at 15 58 52](https://user-images.githubusercontent.com/73652/36854671-78cb517c-1d69-11e8-9d1b-51629a1ca2c4.gif)

# To do
* [x] Boilerplate
* [x] Rendering properly
* [x] Selection rendering
* [x] Render tick (iOS)
* [x] Render radios (Android)
* [x] Flag support
* [x] Flags in storybook example
* [x] Tests
* [x] Changelog
* [x] Fix that one Flow error I can't get rid of!
* [x] RTL
* [x] a11y
* [x] Rebase
* [x] Test on different screen sizes