### PR TITLE
[BPK-1376] BpkFlag component, BpkRadioIcon component

### DIFF
--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem.android.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem.android.js
@@ -21,7 +21,6 @@
 import { View, StyleSheet, TouchableNativeFeedback } from 'react-native';
 import React from 'react';
 import BpkText from 'react-native-bpk-component-text';
-import BpkIcon, { icons } from 'react-native-bpk-component-icon';
 import {
   spacingMd,
   spacingBase,
@@ -29,6 +28,8 @@ import {
   colorBlue500,
   colorGray100,
 } from 'bpk-tokens/tokens/base.react.native';
+import BpkFlag from './BpkFlag';
+import BpkRadioIcon from './BpkRadioIcon';
 import {
   type ListItemProps,
   LIST_ITEM_PROP_TYPES,
@@ -52,12 +53,6 @@ const styles = StyleSheet.create({
   text: {
     flex: 1,
     marginLeft: spacingLg,
-  },
-  flag: {
-    borderColor: colorGray100,
-    borderWidth: 1,
-    width: spacingLg,
-    height: spacingLg / 3 * 2, // 3:2 aspect ratio with width.
   },
   selected: {
     color: colorBlue500,
@@ -91,16 +86,6 @@ class BpkDialingCodeListItem extends React.Component<Props> {
   render() {
     const { dialingCode, flag, name, selected, ...rest } = this.props;
 
-    // Add sizing to the flag element. If not defined, fall back to a placeholder.
-    const styledFlag = flag ? (
-      React.cloneElement(flag, {
-        resizeMode: 'contain', // Preserves aspect ratio when resizing.
-        style: styles.flag,
-      })
-    ) : (
-      <View style={styles.flag} />
-    );
-
     const iconStyles = [styles.tick];
     if (selected) {
       iconStyles.push(styles.tickSelected);
@@ -116,7 +101,7 @@ class BpkDialingCodeListItem extends React.Component<Props> {
       >
         <View style={styles.listItem}>
           <View style={styles.content}>
-            {styledFlag}
+            <BpkFlag image={flag} />
             <BpkText
               textStyle="base"
               style={[styles.text, selected ? styles.selected : null]}
@@ -124,7 +109,7 @@ class BpkDialingCodeListItem extends React.Component<Props> {
               {dialingCode} {name}
             </BpkText>
           </View>
-          <BpkIcon small icon={icons.tick} style={iconStyles} />
+          <BpkRadioIcon selected={selected} />
         </View>
       </TouchableNativeFeedback>
     );

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem.ios.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkDialingCodeListItem.ios.js
@@ -27,8 +27,8 @@ import {
   spacingBase,
   spacingLg,
   colorBlue600,
-  colorGray100,
 } from 'bpk-tokens/tokens/base.react.native';
+import BpkFlag from './BpkFlag';
 import {
   type ListItemProps,
   LIST_ITEM_PROP_TYPES,
@@ -51,12 +51,6 @@ const styles = StyleSheet.create({
   text: {
     flex: 1,
     marginLeft: spacingLg,
-  },
-  flag: {
-    borderColor: colorGray100,
-    borderWidth: 1,
-    width: spacingLg,
-    height: spacingLg / 3 * 2, // 3:2 aspect ratio with width.
   },
   selected: {
     color: colorBlue600,
@@ -91,16 +85,6 @@ class BpkDialingCodeListItem extends React.Component<Props> {
   render() {
     const { dialingCode, flag, name, selected, ...rest } = this.props;
 
-    // Add sizing to the flag element. If not defined, fall back to a placeholder.
-    const styledFlag = flag ? (
-      React.cloneElement(flag, {
-        resizeMode: 'contain', // Preserves aspect ratio when resizing.
-        style: styles.flag,
-      })
-    ) : (
-      <View style={styles.flag} />
-    );
-
     const iconStyles = [styles.tick];
     if (selected) {
       iconStyles.push(styles.tickVisible);
@@ -115,7 +99,7 @@ class BpkDialingCodeListItem extends React.Component<Props> {
         {...rest}
       >
         <View style={styles.content}>
-          {styledFlag}
+          <BpkFlag image={flag} />
           <BpkText
             textStyle="lg"
             style={[styles.text, selected ? styles.selected : null]}

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkFlag-test.common.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkFlag-test.common.js
@@ -1,0 +1,39 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Image } from 'react-native';
+import renderer from 'react-test-renderer';
+import BpkFlag from './BpkFlag';
+
+const commonTests = () => {
+  jest.mock('Image', () => 'Image');
+  describe('BpkFlag', () => {
+    it('should render correctly', () => {
+      const tree = renderer.create(<BpkFlag />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with an image', () => {
+      const tree = renderer.create(<BpkFlag image={<Image />} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+};
+
+export default commonTests;

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkFlag-test.ios.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkFlag-test.ios.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkFlag-test.common';
+
+describe('iOS', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkFlag-test.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkFlag-test.js
@@ -1,0 +1,43 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkFlag-test.common';
+
+jest.mock('react-native', () => {
+  const reactNative = jest.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+  reactNative.TouchableNativeFeedback.SelectableBackground = jest.fn();
+
+  return reactNative;
+});
+
+jest.mock(
+  './../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('bpk-tokens/tokens/base.react.native', () =>
+  jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+describe('Android', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkFlag.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkFlag.js
@@ -1,0 +1,58 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import { View, StyleSheet } from 'react-native';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { spacingLg, colorGray100 } from 'bpk-tokens/tokens/base.react.native';
+import { type Flag } from './common-types';
+
+const styles = StyleSheet.create({
+  flag: {
+    borderColor: colorGray100,
+    borderWidth: 1,
+    width: spacingLg,
+    height: spacingLg / 3 * 2, // 3:2 aspect ratio with width.
+  },
+});
+
+type Props = {
+  image: ?Flag,
+};
+
+const BpkFlag = ({ image }: Props) =>
+  image ? (
+    React.cloneElement(image, {
+      resizeMode: 'contain', // Preserve aspect ratio when resizing.
+      style: styles.flag,
+    })
+  ) : (
+    <View style={styles.flag} />
+  );
+
+BpkFlag.propTypes = {
+  image: PropTypes.element,
+};
+
+BpkFlag.defaultProps = {
+  image: null,
+};
+
+export default BpkFlag;

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkRadioIcon-test.android.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkRadioIcon-test.android.js
@@ -1,0 +1,54 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BpkRadioIcon from './BpkRadioIcon';
+
+jest.mock('react-native', () => {
+  const reactNative = jest.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+
+  return reactNative;
+});
+
+jest.mock(
+  './../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('bpk-tokens/tokens/base.react.native', () =>
+  jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+describe('Android', () => {
+  describe('BpkRadioIcon', () => {
+    it('should render correctly', () => {
+      const tree = renderer.create(<BpkRadioIcon />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with "selected"', () => {
+      const tree = renderer.create(<BpkRadioIcon selected />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkRadioIcon.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkRadioIcon.js
@@ -1,0 +1,83 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import { View, StyleSheet } from 'react-native';
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  colorBlue500,
+  colorGray100,
+} from 'bpk-tokens/tokens/base.react.native';
+
+// Not using a token as this is replicating an Android native UI element.
+const radioSize = 20;
+const innerSize = radioSize / 2;
+
+const styles = StyleSheet.create({
+  outer: {
+    borderRadius: radioSize,
+    borderWidth: 2,
+    borderColor: colorGray100,
+    height: radioSize,
+    width: radioSize,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  outerSelected: {
+    borderColor: colorBlue500,
+  },
+  inner: {
+    backgroundColor: colorGray100,
+    borderRadius: innerSize,
+    height: innerSize,
+    width: innerSize,
+  },
+  innerSelected: {
+    backgroundColor: colorBlue500,
+  },
+});
+
+type Props = {
+  selected: ?boolean,
+};
+
+const BpkRadioIcon = ({ selected }: Props) => {
+  const outerStyle = [styles.outer];
+  const innerStyle = [styles.inner];
+  if (selected) {
+    outerStyle.push(styles.outerSelected);
+    innerStyle.push(styles.innerSelected);
+  }
+  return (
+    <View style={outerStyle}>
+      <View style={innerStyle} />
+    </View>
+  );
+};
+
+BpkRadioIcon.propTypes = {
+  selected: PropTypes.bool,
+};
+
+BpkRadioIcon.defaultProps = {
+  selected: false,
+};
+
+export default BpkRadioIcon;

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeListItem-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeListItem-test.android.js.snap
@@ -82,32 +82,34 @@ exports[`Android BpkDialingCodeListItem should render correctly 1`] = `
       United Kingdom
     </Text>
   </View>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
+  <View
     style={
       Array [
         Object {
-          "color": "rgb(82, 76, 97)",
-          "fontFamily": "BpkIcon",
-          "fontSize": 24,
-          "lineHeight": 24,
+          "alignItems": "center",
+          "borderColor": "rgb(230, 228, 235)",
+          "borderRadius": 20,
+          "borderWidth": 2,
+          "height": 20,
+          "justifyContent": "center",
+          "width": 20,
         },
-        Object {
-          "fontSize": 16,
-          "lineHeight": 16,
-        },
-        Array [
-          Object {
-            "color": "rgb(230, 228, 235)",
-          },
-        ],
       ]
     }
   >
-    
-  </Text>
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+            "borderRadius": 10,
+            "height": 10,
+            "width": 10,
+          },
+        ]
+      }
+    />
+  </View>
 </View>
 `;
 
@@ -194,32 +196,34 @@ exports[`Android BpkDialingCodeListItem should support the "flagImage" property 
       United Kingdom
     </Text>
   </View>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
+  <View
     style={
       Array [
         Object {
-          "color": "rgb(82, 76, 97)",
-          "fontFamily": "BpkIcon",
-          "fontSize": 24,
-          "lineHeight": 24,
+          "alignItems": "center",
+          "borderColor": "rgb(230, 228, 235)",
+          "borderRadius": 20,
+          "borderWidth": 2,
+          "height": 20,
+          "justifyContent": "center",
+          "width": 20,
         },
-        Object {
-          "fontSize": 16,
-          "lineHeight": 16,
-        },
-        Array [
-          Object {
-            "color": "rgb(230, 228, 235)",
-          },
-        ],
       ]
     }
   >
-    
-  </Text>
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+            "borderRadius": 10,
+            "height": 10,
+            "width": 10,
+          },
+        ]
+      }
+    />
+  </View>
 </View>
 `;
 
@@ -307,34 +311,39 @@ exports[`Android BpkDialingCodeListItem should support the "selected" property 1
       United Kingdom
     </Text>
   </View>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
+  <View
     style={
       Array [
         Object {
-          "color": "rgb(82, 76, 97)",
-          "fontFamily": "BpkIcon",
-          "fontSize": 24,
-          "lineHeight": 24,
+          "alignItems": "center",
+          "borderColor": "rgb(230, 228, 235)",
+          "borderRadius": 20,
+          "borderWidth": 2,
+          "height": 20,
+          "justifyContent": "center",
+          "width": 20,
         },
         Object {
-          "fontSize": 16,
-          "lineHeight": 16,
+          "borderColor": "rgb(0, 178, 214)",
         },
-        Array [
-          Object {
-            "color": "rgb(230, 228, 235)",
-          },
-          Object {
-            "color": "rgb(0, 178, 214)",
-          },
-        ],
       ]
     }
   >
-    
-  </Text>
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+            "borderRadius": 10,
+            "height": 10,
+            "width": 10,
+          },
+          Object {
+            "backgroundColor": "rgb(0, 178, 214)",
+          },
+        ]
+      }
+    />
+  </View>
 </View>
 `;

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkFlag-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkFlag-test.ios.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS BpkFlag should render correctly 1`] = `
+<View
+  style={
+    Object {
+      "borderColor": "rgb(230, 228, 235)",
+      "borderWidth": 1,
+      "height": 16,
+      "width": 24,
+    }
+  }
+/>
+`;
+
+exports[`iOS BpkFlag should render correctly with an image 1`] = `
+<Image
+  resizeMode="contain"
+  style={
+    Object {
+      "borderColor": "rgb(230, 228, 235)",
+      "borderWidth": 1,
+      "height": 16,
+      "width": 24,
+    }
+  }
+/>
+`;

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkFlag-test.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkFlag-test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkFlag should render correctly 1`] = `
+<View
+  style={
+    Object {
+      "borderColor": "rgb(230, 228, 235)",
+      "borderWidth": 1,
+      "height": 16,
+      "width": 24,
+    }
+  }
+/>
+`;
+
+exports[`Android BpkFlag should render correctly with an image 1`] = `
+<Image
+  resizeMode="contain"
+  style={
+    Object {
+      "borderColor": "rgb(230, 228, 235)",
+      "borderWidth": 1,
+      "height": 16,
+      "width": 24,
+    }
+  }
+/>
+`;

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkRadioIcon-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkRadioIcon-test.android.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkRadioIcon should render correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "borderColor": "rgb(230, 228, 235)",
+        "borderRadius": 20,
+        "borderWidth": 2,
+        "height": 20,
+        "justifyContent": "center",
+        "width": 20,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(230, 228, 235)",
+          "borderRadius": 10,
+          "height": 10,
+          "width": 10,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Android BpkRadioIcon should render correctly with "selected" 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "borderColor": "rgb(230, 228, 235)",
+        "borderRadius": 20,
+        "borderWidth": 2,
+        "height": 20,
+        "justifyContent": "center",
+        "width": 20,
+      },
+      Object {
+        "borderColor": "rgb(0, 178, 214)",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(230, 228, 235)",
+          "borderRadius": 10,
+          "height": 10,
+          "width": 10,
+        },
+        Object {
+          "backgroundColor": "rgb(0, 178, 214)",
+        },
+      ]
+    }
+  />
+</View>
+`;

--- a/native/packages/react-native-bpk-component-phone-input/src/common-types.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/common-types.js
@@ -23,6 +23,8 @@ import PropTypes from 'prop-types';
 
 export type Id = string;
 
+export type Flag = Element<typeof Component>;
+
 export type Code = {
   id: Id,
   dialingCode: string,
@@ -33,12 +35,12 @@ export type ListItemProps = {
   ...$Exact<Code>,
   onPress: ListItemProps => void,
   selected: boolean,
-  flag: ?Element<typeof Component>,
+  flag: ?Flag,
 };
 
 export type ListCommonProps = {
   codes: Array<Code>,
-  renderFlag: Code => ?Element<typeof Component>,
+  renderFlag: Code => ?Flag,
   onItemPress: ListItemProps => void,
   selectedId: ?string,
 };


### PR DESCRIPTION
* Made a `BpkRadioIcon` component, which is an RN implementation of Android's radio buttons. Applied it to the Android list item component.
* The flag component and logic was duplicated across iOS and Android, so I've abstracted it into its own component and added tests for it.

![screenshot_1520239534](https://user-images.githubusercontent.com/73652/36965462-9bbceaca-2051-11e8-945f-e21c55dfbeb2.png)
