### PR TITLE
Set svg fill colour in BpkText and BpkLink

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@
  - New `BpkDiallingCodeList` component.
 - react-native-bpk-component-badge:
   - Introducing the new React Native badge component.
+- bpk-component-text:
+  - SVGs inside `BpkText` will now automatically have their fill colour set to match the text colour.
+- bpk-component-link:
+  - SVGs inside `BpkLink` and `BpkButtonLink` will now automatically have their fill colour set to match the text colour.
 
 ## 2018-03-01 - Fix for Android button props
 

--- a/packages/bpk-component-link/src/bpk-link.scss
+++ b/packages/bpk-component-link/src/bpk-link.scss
@@ -28,4 +28,8 @@
   &--alternate {
     @include bpk-link--alternate;
   }
+
+  svg {
+    fill: currentColor;
+  }
 }

--- a/packages/bpk-component-text/src/BpkText.scss
+++ b/packages/bpk-component-text/src/BpkText.scss
@@ -30,4 +30,8 @@
   &--bold {
     @include bpk-text--bold;
   }
+
+  svg {
+    fill: currentColor;
+  }
 }


### PR DESCRIPTION
Some time ago `currentColor` was used as `fill` colour for svg's in `BpkButton` (see https://github.com/Skyscanner/backpack/pull/281/).

I think it makes sense to set it also for `BpkText` and `BpkLink` so if an icon is added as part of the text/link its colour is set by default to the text colour.