### PR TITLE
Add "withModalState" HOC to BpkModal

### DIFF
--- a/packages/bpk-component-modal/index.js
+++ b/packages/bpk-component-modal/index.js
@@ -20,8 +20,9 @@
 
 import BpkModal, { type Props } from './src/BpkModal';
 import themeAttributes from './src/themeAttributes';
+import withModalState from './src/withModalState';
 
 export type BpkModalProps = Props;
 
 export default BpkModal;
-export { themeAttributes };
+export { themeAttributes, withModalState };

--- a/packages/bpk-component-modal/src/withModalState.js
+++ b/packages/bpk-component-modal/src/withModalState.js
@@ -1,0 +1,103 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import React, { type Node, type ComponentType, Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { wrapDisplayName } from 'bpk-react-utils';
+
+const withModalState = (WrappedComponent: ComponentType<any>) => {
+  type Props = {
+    target: Node,
+    children: Node,
+    onOpen: ?() => void,
+    onClose: ?() => void,
+  };
+
+  type State = {
+    isOpen: boolean,
+  };
+
+  class component extends Component<Props, State> {
+    static propTypes = {
+      target: PropTypes.node.isRequired,
+      children: PropTypes.node.isRequired,
+      onOpen: PropTypes.func,
+      onClose: PropTypes.func,
+      isOpen: PropTypes.bool,
+    };
+
+    static defaultProps = {
+      onOpen: null,
+      onClose: null,
+      isOpen: false,
+    };
+
+    constructor(props: Props) {
+      super(props);
+
+      this.state = {
+        isOpen: false,
+      };
+    }
+
+    onOpen = () => {
+      this.setState({ isOpen: true });
+
+      if (this.props.onOpen) {
+        this.props.onOpen();
+      }
+    };
+
+    onClose = () => {
+      this.setState({ isOpen: false });
+
+      if (this.props.onClose) {
+        this.props.onClose();
+      }
+    };
+
+    render() {
+      const { target, children, isOpen, onClose, ...rest } = this.props;
+
+      /* eslint-disable jsx-a11y/click-events-have-key-events */
+      return (
+        <span>
+          <span onClick={this.onOpen} role="button" tabIndex="0">
+            {target}
+          </span>
+          <WrappedComponent
+            isOpen={this.state.isOpen}
+            onClose={this.onClose}
+            {...rest}
+          >
+            {children}
+          </WrappedComponent>
+        </span>
+      );
+      /* eslint-enable jsx-a11y/click-events-have-key-events */
+    }
+  }
+
+  component.displayName = wrapDisplayName(WrappedComponent, 'withModalState');
+
+  return component;
+};
+
+export default withModalState;

--- a/packages/bpk-component-modal/stories.js
+++ b/packages/bpk-component-modal/stories.js
@@ -26,7 +26,7 @@ import { cssModules, withDefaultProps } from 'bpk-react-utils';
 import BpkButton from 'bpk-component-button';
 import BpkText from 'bpk-component-text';
 
-import BpkModal from './index';
+import BpkModal, { withModalState } from './index';
 
 import STYLES from './stories.scss';
 
@@ -37,6 +37,8 @@ const Paragraph = withDefaultProps(BpkText, {
   tagName: 'p',
   className: getClassName('bpk-modal-paragraph'),
 });
+
+const BpkModalState = withModalState(BpkModal);
 
 type Props = {
   children: Node,
@@ -329,4 +331,26 @@ storiesOf('bpk-component-modal', module)
     >
       This is a default modal. You can put anything you want in here.
     </ModalContainer>
-  ));
+  ))
+  .add('With state HOC', () => {
+    const target = <BpkButton>Open modal</BpkButton>;
+    return (
+      <div id="modal-container">
+        <div id="application-container">
+          <BpkModalState
+            target={target}
+            id="my-modal"
+            className="my-classname"
+            title="Modal title"
+            closeText="Done"
+            getApplicationElement={() =>
+              document.getElementById('application-container')
+            }
+            renderTarget={() => document.getElementById('modal-container')}
+          >
+            This is a default modal. You can put anything you want in here.
+          </BpkModalState>
+        </div>
+      </div>
+    );
+  });


### PR DESCRIPTION
I think it would be useful to provide a HOC to manage default open/close events in `BpkModal`.

This HOC allows setting `onOpen` and `onClose` functions, so parent component could be still notified about the events (if needed), but at least wouldn't have to handle `isOpen` state.

I would like to get your feedback on the implementation (specially the part about `target` rendering (not sure if adding an `onClick` to a span is the best solution).

If/when you're happy with this, I'll update the documentation and add another HOC like this for BpkDialog.