### PR TITLE
[BPK-1389] Native nudger

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@
 - react-native-bpk-component-button:
   - Android now supports the `iconOnly` prop.
 
+- react-native-bpk-component-nudger:
+  - Introducing the React Native nudger component.
+
 ## 2018-03-06 - New `BpkTouchableNativeFeedback` component
 
 **Added:**

--- a/native/packages/react-native-bpk-component-nudger/index.js
+++ b/native/packages/react-native-bpk-component-nudger/index.js
@@ -1,0 +1,24 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import BpkNudger, { type Props } from './src/BpkNudger';
+
+export type BpkNudgerProps = Props;
+export default BpkNudger;

--- a/native/packages/react-native-bpk-component-nudger/package-lock.json
+++ b/native/packages/react-native-bpk-component-nudger/package-lock.json
@@ -1,0 +1,122 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"ua-parser-js": {
+			"version": "0.7.17",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		}
+	}
+}

--- a/native/packages/react-native-bpk-component-nudger/package.json
+++ b/native/packages/react-native-bpk-component-nudger/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "react-native-bpk-component-nudger",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "description": "Backpack React Native budger component.",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^16.0.0-alpha.1",
+    "react-native": ">= 0.47.0"
+  },
+  "devDependencies": {
+    "react-native-bpk-theming": "^1.0.36"
+  },
+  "dependencies": {
+    "bpk-tokens": "^26.7.4",
+    "lodash": "^4.17.5",
+    "prop-types": "^15.5.8",
+    "react-native-bpk-component-button": "^4.3.9",
+    "react-native-bpk-component-text": "^2.1.30",
+    "react-native-bpk-component-icon": "^1.3.5"
+  }
+}

--- a/native/packages/react-native-bpk-component-nudger/readme.md
+++ b/native/packages/react-native-bpk-component-nudger/readme.md
@@ -1,0 +1,57 @@
+# react-native-bpk-component-nudger
+
+> Backpack React Native nudger component.
+
+## Installation
+
+```sh
+npm install react-native-bpk-component-nudger --save-dev
+```
+
+## Usage
+
+```js
+import React, { Component } from 'react';
+import BpkNudger from 'react-native-bpk-component-nudger';
+
+export default class App extends Component {
+ constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+    this.state = { value: 1 };
+  }
+
+  handleChange(value) {
+    this.setState({ value });
+  }
+
+  render() {
+    return (
+      <BpkNudger
+        min={1}
+        max={10}
+        value={this.state.value}
+        onChange={this.handleChange}
+        decreaseButtonLabel="Decrease"
+        increaseButtonLabel="Increase"
+      />
+    );
+  }
+}
+```
+
+## Props
+
+| Property              | PropType                              | Required | Default Value |
+| --------------------- | ------------------------------------- | -------- | ------------- |
+| decreaseButtonLabel   | string                                | true     | -             |
+| increaseButtonLabel   | string                                | true     | -             |
+| max                   | number                                | true     | -             |
+| min                   | number                                | true     | -             |
+| onChange              | func                                  | true     | -             |
+| value                 | number                                | true     | -             |
+| theme                 | See [Theme Props](#theme-props) below | false    | null          |
+
+## Theme Props
+
+Same as [secondary button](/components/native/buttons#theme-props).

--- a/native/packages/react-native-bpk-component-nudger/src/BpkNudger-test.android.js
+++ b/native/packages/react-native-bpk-component-nudger/src/BpkNudger-test.android.js
@@ -1,0 +1,56 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import commonTests from './BpkNudger-test.common';
+
+jest.mock('react-native', () => {
+  const reactNative = jest.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+
+  return reactNative;
+});
+
+jest.mock('TouchableNativeFeedback', () =>
+  jest.requireActual(
+    'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js',
+  ),
+);
+
+jest.mock(
+  './../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('bpk-tokens/tokens/base.react.native', () =>
+  jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('react-native-bpk-component-button', () =>
+  jest.requireActual(
+    'react-native-bpk-component-button/src/BpkButton.android.js',
+  ),
+);
+
+describe('Android', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-nudger/src/BpkNudger-test.common.js
+++ b/native/packages/react-native-bpk-component-nudger/src/BpkNudger-test.common.js
@@ -1,0 +1,140 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BpkThemeProvider from 'react-native-bpk-theming';
+
+import BpkNudger from './BpkNudger';
+
+const commonTests = () => {
+  describe('BpkNudger', () => {
+    it('should render correctly', () => {
+      const onPressFn = jest.fn();
+      const tree = renderer
+        .create(
+          <BpkNudger
+            min={1}
+            max={9}
+            value={3}
+            decreaseButtonLabel="Decrease"
+            increaseButtonLabel="Increase"
+            onChange={onPressFn}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly when value is less than min', () => {
+      const onPressFn = jest.fn();
+      const tree = renderer
+        .create(
+          <BpkNudger
+            min={3}
+            max={9}
+            value={1}
+            decreaseButtonLabel="Decrease"
+            increaseButtonLabel="Increase"
+            onChange={onPressFn}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly when value is greater than max', () => {
+      const onPressFn = jest.fn();
+      const tree = renderer
+        .create(
+          <BpkNudger
+            min={1}
+            max={3}
+            value={5}
+            decreaseButtonLabel="Decrease"
+            increaseButtonLabel="Increase"
+            onChange={onPressFn}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly when value is a not an integer', () => {
+      const onPressFn = jest.fn();
+      const tree = renderer
+        .create(
+          <BpkNudger
+            min={1}
+            max={9}
+            value={0.5}
+            decreaseButtonLabel="Decrease"
+            increaseButtonLabel="Increase"
+            onChange={onPressFn}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should support theming', () => {
+      const onPressFn = jest.fn();
+      const theme = {
+        buttonSecondaryTextColor: 'red',
+        buttonSecondaryBackgroundColor: 'yellow',
+        buttonSecondaryBorderColor: 'blue',
+      };
+      const tree = renderer
+        .create(
+          <BpkThemeProvider theme={theme}>
+            <BpkNudger
+              min={1}
+              max={9}
+              value={3}
+              decreaseButtonLabel="Decrease"
+              increaseButtonLabel="Increase"
+              onChange={onPressFn}
+            />
+          </BpkThemeProvider>,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should disable theming if the required attribute is omitted', () => {
+      const onPressFn = jest.fn();
+      const theme = {};
+      const tree = renderer
+        .create(
+          <BpkThemeProvider theme={theme} type="primary">
+            <BpkNudger
+              min={1}
+              max={9}
+              value={3}
+              decreaseButtonLabel="Decrease"
+              increaseButtonLabel="Increase"
+              onChange={onPressFn}
+            />
+          </BpkThemeProvider>,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+};
+export default commonTests;

--- a/native/packages/react-native-bpk-component-nudger/src/BpkNudger-test.ios.js
+++ b/native/packages/react-native-bpk-component-nudger/src/BpkNudger-test.ios.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkNudger-test.common';
+
+describe('iOS', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-nudger/src/BpkNudger.js
+++ b/native/packages/react-native-bpk-component-nudger/src/BpkNudger.js
@@ -1,0 +1,113 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import { StyleSheet, View, ViewPropTypes } from 'react-native';
+import PropTypes from 'prop-types';
+import { clamp } from 'lodash';
+import BpkButton from 'react-native-bpk-component-button';
+import BpkText from 'react-native-bpk-component-text';
+import { icons } from 'react-native-bpk-component-icon';
+import { spacingSm, spacingLg } from 'bpk-tokens/tokens/base.react.native';
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  buttonMinus: {
+    marginRight: spacingSm,
+  },
+  buttonPlus: {
+    marginLeft: spacingSm,
+  },
+  text: {
+    minWidth: spacingLg,
+    textAlign: 'center',
+  },
+});
+
+export type Props = {
+  decreaseButtonLabel: string,
+  increaseButtonLabel: string,
+  max: number,
+  min: number,
+  onChange: number => void,
+  value: number,
+  style: ?(Object | Array<Object>),
+};
+
+const BpkNudger = (props: Props) => {
+  const {
+    decreaseButtonLabel,
+    increaseButtonLabel,
+    max,
+    min,
+    onChange,
+    style,
+    value,
+  } = props;
+
+  const adjustedValue = Math.floor(clamp(value, min, max));
+  const decreaseDisabled = adjustedValue <= min;
+  const increaseDisabled = adjustedValue >= max;
+
+  return (
+    <View style={[styles.wrapper, style]}>
+      <BpkButton
+        disabled={decreaseDisabled}
+        type="secondary"
+        iconOnly
+        icon={icons.minus}
+        onPress={() => onChange(adjustedValue - 1)}
+        title={decreaseButtonLabel}
+        style={styles.buttonMinus}
+      />
+      <BpkText textStyle="lg" emphasize style={styles.text}>
+        {adjustedValue}
+      </BpkText>
+      <BpkButton
+        disabled={increaseDisabled}
+        type="secondary"
+        iconOnly
+        icon={icons.plus}
+        onPress={() => onChange(adjustedValue + 1)}
+        title={increaseButtonLabel}
+        style={styles.buttonPlus}
+      />
+    </View>
+  );
+};
+
+BpkNudger.propTypes = {
+  decreaseButtonLabel: PropTypes.string.isRequired,
+  increaseButtonLabel: PropTypes.string.isRequired,
+  max: PropTypes.number.isRequired,
+  min: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.number.isRequired,
+  style: ViewPropTypes.style,
+};
+
+BpkNudger.defaultProps = {
+  style: null,
+};
+
+export default BpkNudger;

--- a/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
@@ -1,0 +1,1757 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkNudger should disable theming if the required attribute is omitted 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "transparent",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 20,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontFamily": "sans-serif-medium",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "transparent",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkNudger should render correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "transparent",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 20,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontFamily": "sans-serif-medium",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "transparent",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkNudger should render correctly when value is a not an integer 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          undefined,
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+          "disabled",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  Object {
+                    "color": "rgb(178, 174, 189)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 20,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontFamily": "sans-serif-medium",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    1
+  </Text>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "transparent",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkNudger should render correctly when value is greater than max 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "transparent",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 20,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontFamily": "sans-serif-medium",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          undefined,
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+          "disabled",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  Object {
+                    "color": "rgb(178, 174, 189)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkNudger should render correctly when value is less than min 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          undefined,
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+          "disabled",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "rgb(230, 228, 235)",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  Object {
+                    "color": "rgb(178, 174, 189)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 20,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontFamily": "sans-serif-medium",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "transparent",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkNudger should support theming 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "yellow",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {
+                  "color": "red",
+                },
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 20,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontFamily": "sans-serif-medium",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackgroundBorderless",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "backgroundColor": "yellow",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                    "lineHeight": 13,
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {
+                  "color": "red",
+                },
+                Array [
+                  Object {
+                    "lineHeight": 16,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
@@ -1,0 +1,1977 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS BpkNudger should disable theming if the required attribute is omitted 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <BVLinearGradient
+    colors={
+      Array [
+        4294967295,
+        4294967295,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "System",
+          "fontSize": 17,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontWeight": "600",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <BVLinearGradient
+    colors={
+      Array [
+        4294967295,
+        4294967295,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+</View>
+`;
+
+exports[`iOS BpkNudger should render correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <BVLinearGradient
+    colors={
+      Array [
+        4294967295,
+        4294967295,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "System",
+          "fontSize": 17,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontWeight": "600",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <BVLinearGradient
+    colors={
+      Array [
+        4294967295,
+        4294967295,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+</View>
+`;
+
+exports[`iOS BpkNudger should render correctly when value is a not an integer 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <BVLinearGradient
+    colors={
+      Array [
+        4293321963,
+        4293321963,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          undefined,
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+          "disabled",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  Object {
+                    "color": "rgb(178, 174, 189)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "System",
+          "fontSize": 17,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontWeight": "600",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    1
+  </Text>
+  <BVLinearGradient
+    colors={
+      Array [
+        4294967295,
+        4294967295,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+</View>
+`;
+
+exports[`iOS BpkNudger should render correctly when value is greater than max 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <BVLinearGradient
+    colors={
+      Array [
+        4294967295,
+        4294967295,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "System",
+          "fontSize": 17,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontWeight": "600",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <BVLinearGradient
+    colors={
+      Array [
+        4293321963,
+        4293321963,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          undefined,
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+          "disabled",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  Object {
+                    "color": "rgb(178, 174, 189)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+</View>
+`;
+
+exports[`iOS BpkNudger should render correctly when value is less than min 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <BVLinearGradient
+    colors={
+      Array [
+        4293321963,
+        4293321963,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          undefined,
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+          "disabled",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "borderColor": "transparent",
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  Object {
+                    "color": "rgb(178, 174, 189)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "System",
+          "fontSize": 17,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontWeight": "600",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <BVLinearGradient
+    colors={
+      Array [
+        4294967295,
+        4294967295,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {},
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {},
+                Array [
+                  null,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+</View>
+`;
+
+exports[`iOS BpkNudger should support theming 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      null,
+    ]
+  }
+>
+  <BVLinearGradient
+    colors={
+      Array [
+        4294967040,
+        4294967040,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Decrease"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "borderColor": "blue",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {
+                  "color": "red",
+                },
+                Array [
+                  null,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "System",
+          "fontSize": 17,
+          "fontWeight": "400",
+        },
+        Object {
+          "fontWeight": "600",
+        },
+        Object {
+          "minWidth": 24,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    3
+  </Text>
+  <BVLinearGradient
+    colors={
+      Array [
+        4294967040,
+        4294967040,
+      ]
+    }
+    end={undefined}
+    locations={null}
+    start={undefined}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+          },
+          Object {
+            "width": 32,
+          },
+        ],
+        Object {
+          "marginLeft": 4,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityComponentType="button"
+      accessibilityLabel="Increase"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={true}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            Object {
+              "borderRadius": 40,
+              "height": 32,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            },
+            Object {
+              "borderColor": "rgb(230, 228, 235)",
+              "borderWidth": 2,
+              "paddingHorizontal": 10,
+              "paddingVertical": 6,
+            },
+            Object {
+              "paddingHorizontal": 0,
+            },
+          ],
+          Object {
+            "borderColor": "blue",
+          },
+        ]
+      }
+      testID={undefined}
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "lineHeight": 24,
+              },
+              Object {
+                "fontSize": 16,
+                "lineHeight": 16,
+              },
+              Array [
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "color": "rgb(255, 255, 255)",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                  undefined,
+                ],
+                Object {
+                  "color": "red",
+                },
+                Array [
+                  null,
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgb(37, 32, 51)",
+              "bottom": 0,
+              "flex": 1,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "borderRadius": 40,
+            },
+          ]
+        }
+      />
+    </View>
+  </BVLinearGradient>
+</View>
+`;

--- a/native/packages/react-native-bpk-component-nudger/stories.js
+++ b/native/packages/react-native-bpk-component-nudger/stories.js
@@ -1,0 +1,157 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React, { Component } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import { action } from '@storybook/addon-actions';
+import BpkThemeProvider from 'react-native-bpk-theming';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
+import themeAttributes from '../../storybook/themeAttributes';
+import { StorySubheading } from '../../storybook/TextStyles';
+import BpkNudger from './index';
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  nudgerStory: {
+    marginBottom: spacingBase,
+  },
+});
+
+class StatefulBpkNudger extends Component<{}, { value: number }> {
+  constructor() {
+    super();
+    this.state = { value: 1 };
+  }
+  handleChange = value => {
+    this.setState({ value });
+  };
+  render() {
+    return (
+      <BpkNudger
+        value={this.state.value}
+        min={-10}
+        max={10}
+        decreaseButtonLabel="Decrease"
+        increaseButtonLabel="Increase"
+        onChange={this.handleChange}
+      />
+    );
+  }
+}
+
+const generateStoryNudgers = () => (
+  <View style={styles.wrapper}>
+    <View style={styles.nudgerStory}>
+      <StorySubheading>Standard</StorySubheading>
+      <BpkNudger
+        value={3}
+        min={1}
+        max={9}
+        decreaseButtonLabel="Decrease"
+        increaseButtonLabel="Increase"
+        onChange={action('changed')}
+      />
+    </View>
+    <View style={styles.nudgerStory}>
+      <StorySubheading>Minus disabled</StorySubheading>
+      <BpkNudger
+        value={1}
+        min={1}
+        max={9}
+        decreaseButtonLabel="Decrease"
+        increaseButtonLabel="Increase"
+        onChange={action('changed')}
+      />
+    </View>
+    <View style={styles.nudgerStory}>
+      <StorySubheading>Plus disabled</StorySubheading>
+      <BpkNudger
+        value={9}
+        min={1}
+        max={9}
+        decreaseButtonLabel="Decrease"
+        increaseButtonLabel="Increase"
+        onChange={action('changed')}
+      />
+    </View>
+  </View>
+);
+
+storiesOf('BpkNudger', module)
+  .add('docs:default', () => generateStoryNudgers())
+  .add('Themed', () => (
+    <BpkThemeProvider theme={themeAttributes}>
+      {generateStoryNudgers()}
+    </BpkThemeProvider>
+  ))
+  .add('Stateful example', () => <StatefulBpkNudger />)
+  .add('Edge cases', () => (
+    <View style={styles.wrapper}>
+      <View style={styles.nudgerStory}>
+        <StorySubheading>High value</StorySubheading>
+        <BpkNudger
+          value={999999}
+          min={1}
+          max={999999}
+          decreaseButtonLabel="Decrease"
+          increaseButtonLabel="Increase"
+          onChange={action('changed')}
+        />
+      </View>
+      <View style={styles.nudgerStory}>
+        <StorySubheading>value=1, min=5, max=9</StorySubheading>
+        <BpkNudger
+          value={1}
+          min={5}
+          max={9}
+          decreaseButtonLabel="Decrease"
+          increaseButtonLabel="Increase"
+          onChange={action('changed')}
+        />
+      </View>
+      <View style={styles.nudgerStory}>
+        <StorySubheading>value=9, min=1, max=5</StorySubheading>
+        <BpkNudger
+          value={1}
+          min={5}
+          max={9}
+          decreaseButtonLabel="Decrease"
+          increaseButtonLabel="Increase"
+          onChange={action('changed')}
+        />
+      </View>
+      <View style={styles.nudgerStory}>
+        <StorySubheading>value=0.5, min=1, max=9</StorySubheading>
+        <BpkNudger
+          value={0.5}
+          min={1}
+          max={9}
+          decreaseButtonLabel="Decrease"
+          increaseButtonLabel="Increase"
+          onChange={action('changed')}
+        />
+      </View>
+    </View>
+  ));

--- a/native/storybook/storybook.js
+++ b/native/storybook/storybook.js
@@ -82,6 +82,7 @@ configure(() => {
   require('../packages/react-native-bpk-component-card/stories');
   require('../packages/react-native-bpk-component-horizontal-nav/stories');
   require('../packages/react-native-bpk-component-icon/stories');
+  require('../packages/react-native-bpk-component-nudger/stories');
   require('../packages/react-native-bpk-component-phone-input/stories');
   require('../packages/react-native-bpk-component-spinner/stories');
   require('../packages/react-native-bpk-component-star-rating/stories');


### PR DESCRIPTION
## Notes
* API is pretty much the same as the web version.
* I expect we'll need to change the Android version to use `BpkButtonLink` instead, because the design has the disabled button greyed out, but with no grey background. `BpkButtonLink` doesn't support `iconOnly` so if so, that'll need to come first.

## Screenshots

### Android
![screenshot_1520443176](https://user-images.githubusercontent.com/73652/37107236-bad90a2a-222b-11e8-95d8-9bebce606d5f.png)

### iOS
![simulator screen shot - iphone se - 2018-03-07 at 17 19 52](https://user-images.githubusercontent.com/73652/37107247-c11b0316-222b-11e8-8cfe-58e230ab8b78.png)

## To do
* [x] Rebase once #568 is merged
* [x] Boilerplate
* [x] Implementation
* [x] Readme
* [x] Storybook
* [x] Changelog
* [x] Tests
* [x] Check RTL
* [x] Theming support via the secondary buttons
* [x] Flow