### PR TITLE
[BPK-1402] - Fix `closeOnScrimClick` behaviour

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,9 +14,14 @@
 
 - react-native-bpk-component-nudger:
   - Introducing the React Native nudger component.
-  
+
 - bpk-component-drawer:
   - Arbitrary props are now passed to drawer container
+
+**Fixed:**
+- bpk-component-dialog:
+- bpk-scrim-utils:
+  - Fixed `closeOnScrimClick` behaviour
 
 ## 2018-03-06 - New `BpkTouchableNativeFeedback` component
 

--- a/packages/bpk-component-dialog/stories.js
+++ b/packages/bpk-component-dialog/stories.js
@@ -83,11 +83,11 @@ class DialogContainer extends Component<Props, State> {
           <BpkButton onClick={this.onOpen}>Open dialog</BpkButton>
         </div>
         <BpkDialog
-          closeLabel={this.props.dismissible ? 'Close dialog' : null}
+          closeLabel="Close dialog"
           id="my-dialog"
           className="my-classname"
           isOpen={this.state.isOpen}
-          onClose={this.props.dismissible ? this.onClose : null}
+          onClose={this.onClose}
           getApplicationElement={() =>
             document.getElementById('application-container')
           }

--- a/packages/bpk-docs/src/pages/DialogsPage/DialogExamples.js
+++ b/packages/bpk-docs/src/pages/DialogsPage/DialogExamples.js
@@ -140,6 +140,7 @@ export class NonDismissibleDialogContainer extends Component<
           id="non-dissmissible-dialog"
           className="my-classname"
           isOpen={this.state.isOpen}
+          onClose={this.onClose}
           renderTarget={() => document.getElementById('application-container')}
           getApplicationElement={() => document.getElementById('portal-target')}
           dismissible={false}

--- a/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
+++ b/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BpkScrim render should render correctly 1`] = `
 <div
-  className="bpk-scrim-content "
+  className="bpk-scrim-content"
 >
   <div
     className="bpk-scrim"
@@ -10,17 +10,15 @@ exports[`BpkScrim render should render correctly 1`] = `
     onTouchStart={[Function]}
   />
   <TestComponent
-    closeOnScrimClick={true}
     dialogRef={[Function]}
     isIphone={false}
-    onClose={[Function]}
   />
 </div>
 `;
 
 exports[`BpkScrim render should render correctly when is iPhone 1`] = `
 <div
-  className="bpk-scrim-content bpk-scrim-content--iphone-fix "
+  className="bpk-scrim-content bpk-scrim-content--iphone-fix"
 >
   <div
     className="bpk-scrim"
@@ -28,10 +26,24 @@ exports[`BpkScrim render should render correctly when is iPhone 1`] = `
     onTouchStart={[Function]}
   />
   <TestComponent
-    closeOnScrimClick={true}
     dialogRef={[Function]}
     isIphone={true}
-    onClose={[Function]}
+  />
+</div>
+`;
+
+exports[`BpkScrim render should render correctly with closeOnScrimClick as false 1`] = `
+<div
+  className="bpk-scrim-content"
+>
+  <div
+    className="bpk-scrim"
+    onMouseDown={null}
+    onTouchStart={null}
+  />
+  <TestComponent
+    dialogRef={[Function]}
+    isIphone={false}
   />
 </div>
 `;
@@ -46,10 +58,8 @@ exports[`BpkScrim render should render correctly with containerClassName 1`] = `
     onTouchStart={[Function]}
   />
   <TestComponent
-    closeOnScrimClick={true}
     dialogRef={[Function]}
     isIphone={false}
-    onClose={[Function]}
   />
 </div>
 `;

--- a/packages/bpk-scrim-utils/src/withScrim-test.js
+++ b/packages/bpk-scrim-utils/src/withScrim-test.js
@@ -34,10 +34,12 @@ jest.mock('a11y-focus-scope', () => ({
   scopeFocus: jest.fn(),
   unscopeFocus: jest.fn(),
 }));
+
 jest.mock('a11y-focus-store', () => ({
   storeFocus: jest.fn(),
   restoreFocus: jest.fn(),
 }));
+
 jest.mock('./scroll-utils', () => ({
   lockScroll: jest.fn(),
   restoreScroll: jest.fn(),
@@ -88,6 +90,19 @@ describe('BpkScrim', () => {
             onClose={jest.fn()}
             getApplicationElement={jest.fn()}
             containerClassName="containerClassName"
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with closeOnScrimClick as false', () => {
+      const tree = renderer
+        .create(
+          <Component
+            onClose={jest.fn()}
+            getApplicationElement={jest.fn()}
+            closeOnScrimClick={false}
           />,
         )
         .toJSON();

--- a/packages/bpk-scrim-utils/src/withScrim.js
+++ b/packages/bpk-scrim-utils/src/withScrim.js
@@ -36,12 +36,6 @@ const getClassName = cssModules(STYLES);
 
 const withScrim = WrappedComponent => {
   class WithScrim extends Component {
-    constructor() {
-      super();
-
-      this.dialogRef = this.dialogRef.bind(this);
-    }
-
     componentDidMount() {
       const { isIphone, getApplicationElement } = this.props;
       const applicationElement = getApplicationElement();
@@ -83,40 +77,39 @@ const withScrim = WrappedComponent => {
       focusStore.restoreFocus();
     }
 
-    onClose = () => {
-      this.props.onClose();
-    };
-
-    dialogRef(ref) {
+    dialogRef = ref => {
       this.dialogElement = ref;
-    }
+    };
 
     render() {
       const {
-        isIphone,
         getApplicationElement,
+        onClose,
+        isIphone,
         containerClassName,
+        closeOnScrimClick,
         ...rest
       } = this.props;
 
       const classNames = [getClassName('bpk-scrim-content')];
+
       if (isIphone) {
         classNames.push(getClassName('bpk-scrim-content--iphone-fix'));
       }
-      classNames.push(containerClassName);
+
+      if (containerClassName) {
+        classNames.push(containerClassName);
+      }
 
       return (
-        /* eslint-disable jsx-a11y/no-static-element-interactions */
-        /* eslint-disable jsx-a11y/click-events-have-key-events */
         <div className={classNames.join(' ')}>
-          <BpkScrim onClose={this.onClose} />
+          <BpkScrim onClose={closeOnScrimClick ? onClose : null} />
           <WrappedComponent
             {...rest}
             isIphone={isIphone}
             dialogRef={this.dialogRef}
           />
         </div>
-        /* eslint-enable */
       );
     }
   }
@@ -136,7 +129,7 @@ const withScrim = WrappedComponent => {
     isIphone: /iPhone/i.test(
       typeof window !== 'undefined' ? window.navigator.platform : '',
     ),
-    containerClassName: '',
+    containerClassName: null,
     closeOnScrimClick: true,
   };
 


### PR DESCRIPTION
I originally though that the custom `onClose` prop type was also broken for the dialog, but it behaves as expected. The intended behaviour is that it warns if you don't provide an `onClose` handler and it's dismissible. 