### PR TITLE
[BPK-1400] Fix popover/tooltip compat with SSR OC

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,12 @@
 - react-native-bpk-component-nudger:
   - Introducing the React Native nudger component.
 
+**Fixed:**
+- bpk-component-popover:
+- bpk-component-tooltip:
+- bpk-component-datepicker:
+  - Fixed compatibility with server side OC
+
 ## 2018-03-08 - Android buttons can be icon only and button links can be disabled
 
 **Added:**

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -27,7 +27,7 @@ import {
 import { format } from 'bpk-component-calendar/src/date-utils';
 
 jest.mock(
-  './../node_modules/bpk-component-popover/node_modules/popper.js',
+  './../node_modules/bpk-component-popover/node_modules/@skyscanner/popper.js',
   () =>
     class Popper {
       scheduleUpdate = () => {};

--- a/packages/bpk-component-popover/package-lock.json
+++ b/packages/bpk-component-popover/package-lock.json
@@ -2,6 +2,11 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"@skyscanner/popper.js": {
+			"version": "1.12.9-beta.1",
+			"resolved": "https://registry.npmjs.org/@skyscanner/popper.js/-/popper.js-1.12.9-beta.1.tgz",
+			"integrity": "sha512-yXFrSHa2qsXXem8ZpsWjvBEiMIzPOhlVD7uIdwWuzKGyKCxuMFBlociYp6D5tGBVSmF7Mbq5YtXkefQD8ZVeAg=="
+		},
 		"a11y-focus-scope": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/a11y-focus-scope/-/a11y-focus-scope-1.1.3.tgz",
@@ -98,11 +103,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"popper.js": {
-			"version": "1.12.9",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
-			"integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
 		},
 		"promise": {
 			"version": "7.3.1",

--- a/packages/bpk-component-popover/package.json
+++ b/packages/bpk-component-popover/package.json
@@ -13,13 +13,13 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "@skyscanner/popper.js": "^1.12.9-beta.1",
     "a11y-focus-scope": "^1.1.3",
     "a11y-focus-store": "^1.0.0",
     "bpk-component-close-button": "^1.0.52",
     "bpk-component-link": "^1.1.5",
     "bpk-mixins": "^17.3.7",
     "bpk-react-utils": "^2.5.0",
-    "popper.js": "^1.12.9",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {

--- a/packages/bpk-component-popover/src/BpkPopoverPortal-test.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal-test.js
@@ -24,7 +24,7 @@ import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 
 jest.mock(
-  'popper.js',
+  '@skyscanner/popper.js',
   () =>
     class Popper {
       constructor(target, popover, options) {

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -18,7 +18,7 @@
 
 /* @flow */
 
-import Popper from 'popper.js';
+import Popper from '@skyscanner/popper.js';
 import PropTypes from 'prop-types';
 import React, { Component, type Node } from 'react';
 import focusStore from 'a11y-focus-store';

--- a/packages/bpk-component-tooltip/package-lock.json
+++ b/packages/bpk-component-tooltip/package-lock.json
@@ -2,6 +2,11 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"@skyscanner/popper.js": {
+			"version": "1.12.9-beta.1",
+			"resolved": "https://registry.npmjs.org/@skyscanner/popper.js/-/popper.js-1.12.9-beta.1.tgz",
+			"integrity": "sha512-yXFrSHa2qsXXem8ZpsWjvBEiMIzPOhlVD7uIdwWuzKGyKCxuMFBlociYp6D5tGBVSmF7Mbq5YtXkefQD8ZVeAg=="
+		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -79,11 +84,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"popper.js": {
-			"version": "1.12.9",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
-			"integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
 		},
 		"promise": {
 			"version": "7.3.1",

--- a/packages/bpk-component-tooltip/package.json
+++ b/packages/bpk-component-tooltip/package.json
@@ -13,9 +13,9 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "@skyscanner/popper.js": "^1.12.9-beta.1",
     "bpk-mixins": "^17.3.7",
     "bpk-react-utils": "^2.5.0",
-    "popper.js": "^1.12.9",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -18,7 +18,7 @@
 
 /* @flow */
 
-import Popper from 'popper.js';
+import Popper from '@skyscanner/popper.js';
 import PropTypes from 'prop-types';
 import React, { Component, type Node } from 'react';
 import { Portal, cssModules } from 'bpk-react-utils';


### PR DESCRIPTION
I've forked popper.js (see https://github.com/Skyscanner/popper.js) and published it to https://www.npmjs.com/package/@skyscanner/popper.js.

The fork contains a fix to remove the use of `global` which is problematic in OC server side rendering.

The offending code is marked for deprecation anyways, see https://github.com/FezVrasta/popper.js/blob/7ac2c0a96a0d084c3bed7dc47e7286f25f3289cf/packages/popper/src/index.js#L118