### PR TITLE
Pass "onClose" prop to the wrapped component in withScrim HOC

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@
 - bpk-component-tooltip:
 - bpk-component-datepicker:
   - Fixed compatibility with server side OC
+- bpk-scrim-utils:
+  - Pass `onClose` prop to the wrapped component in `withScrim` HOC
 
 ## 2018-03-08 - Android buttons can be icon only and button links can be disabled
 

--- a/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
+++ b/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
@@ -12,6 +12,7 @@ exports[`BpkScrim render should render correctly 1`] = `
   <TestComponent
     dialogRef={[Function]}
     isIphone={false}
+    onClose={[Function]}
   />
 </div>
 `;
@@ -28,6 +29,7 @@ exports[`BpkScrim render should render correctly when is iPhone 1`] = `
   <TestComponent
     dialogRef={[Function]}
     isIphone={true}
+    onClose={[Function]}
   />
 </div>
 `;
@@ -44,6 +46,7 @@ exports[`BpkScrim render should render correctly with closeOnScrimClick as false
   <TestComponent
     dialogRef={[Function]}
     isIphone={false}
+    onClose={[Function]}
   />
 </div>
 `;
@@ -60,6 +63,7 @@ exports[`BpkScrim render should render correctly with containerClassName 1`] = `
   <TestComponent
     dialogRef={[Function]}
     isIphone={false}
+    onClose={[Function]}
   />
 </div>
 `;

--- a/packages/bpk-scrim-utils/src/withScrim.js
+++ b/packages/bpk-scrim-utils/src/withScrim.js
@@ -108,6 +108,7 @@ const withScrim = WrappedComponent => {
             {...rest}
             isIphone={isIphone}
             dialogRef={this.dialogRef}
+            onClose={onClose}
           />
         </div>
       );


### PR DESCRIPTION
In this [previous PR](https://github.com/Skyscanner/backpack/pull/578) the `onClose` prop is being extracted and not send to `WrappedComponent` anymore, therefore modals can't be closed using the close button.

