### PR TITLE
Native picker component

### DIFF
--- a/native/packages/react-native-bpk-component-picker/index.js
+++ b/native/packages/react-native-bpk-component-picker/index.js
@@ -1,0 +1,24 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BpkPicker from './src/BpkPicker';
+import BpkPickerItem from './src/BpkPickerItem';
+import BpkPickerTrigger from './src/BpkPickerTrigger';
+
+export default BpkPicker;
+export { BpkPickerItem, BpkPickerTrigger };

--- a/native/packages/react-native-bpk-component-picker/package-lock.json
+++ b/native/packages/react-native-bpk-component-picker/package-lock.json
@@ -1,0 +1,302 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"brcast": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
+			"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"color-string": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+			"integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+			"requires": {
+				"color-name": "1.1.3",
+				"simple-swizzle": "0.2.2"
+			}
+		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.14"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"is-arrayish": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
+			"integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0="
+		},
+		"is-function": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "3.0.1"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.0",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+			"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"react-native-bpk-component-button-link": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-button-link/-/react-native-bpk-component-button-link-1.1.6.tgz",
+			"integrity": "sha512-5c51Hz1AJKDBKrjWz5FLcqxrp974dxkubvGaBP6cz9jfPhP1dWhS02S0PcXDC3o2ckNHvZXfi0gy9uDTJdW2Rg==",
+			"requires": {
+				"bpk-tokens": "26.7.5",
+				"lodash": "4.17.5",
+				"prop-types": "15.6.0",
+				"react-native-bpk-component-icon": "1.5.0",
+				"react-native-bpk-component-text": "2.1.32",
+				"react-native-bpk-component-touchable-native-feedback": "1.1.4",
+				"react-native-bpk-theming": "1.0.43"
+			},
+			"dependencies": {
+				"bpk-tokens": {
+					"version": "26.7.5",
+					"resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-26.7.5.tgz",
+					"integrity": "sha512-ta5eD0tjANg/Jqq4qAiqvRWN3sqWEroXFYQs+4Salwb7kjRuHDa0S+TmFQP2ELdg97xLSk2K5fFeHJLeZSEY5A==",
+					"requires": {
+						"color": "2.0.1"
+					}
+				},
+				"color": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+					"integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+					"requires": {
+						"color-convert": "1.9.1",
+						"color-string": "1.5.2"
+					}
+				}
+			}
+		},
+		"react-native-bpk-component-icon": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-icon/-/react-native-bpk-component-icon-1.5.0.tgz",
+			"integrity": "sha512-JWCqvP4W3QF+AcNpYBgZD1aH5tKpY0PAf0CbDUNL+mE1/qU8OZgjiT/9u5JVdJgv+EHP+lvt2SLZfx9L9evvSA==",
+			"requires": {
+				"bpk-svgs": "5.14.0",
+				"bpk-tokens": "26.7.5",
+				"prop-types": "15.6.0"
+			},
+			"dependencies": {
+				"bpk-svgs": {
+					"version": "5.14.0",
+					"resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-5.14.0.tgz",
+					"integrity": "sha512-TBSuzOfQBL5x+xs+oro1ee5nSy2+qApdig/XRW6xkPDF6m5oWw5Iaj30rCrVZCbFbmHPou5xWic/u9xkDLBuDQ=="
+				},
+				"bpk-tokens": {
+					"version": "26.7.5",
+					"resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-26.7.5.tgz",
+					"integrity": "sha512-ta5eD0tjANg/Jqq4qAiqvRWN3sqWEroXFYQs+4Salwb7kjRuHDa0S+TmFQP2ELdg97xLSk2K5fFeHJLeZSEY5A==",
+					"requires": {
+						"color": "2.0.1"
+					}
+				},
+				"color": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+					"integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+					"requires": {
+						"color-convert": "1.9.1",
+						"color-string": "1.5.2"
+					}
+				}
+			}
+		},
+		"react-native-bpk-component-text": {
+			"version": "2.1.32",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-text/-/react-native-bpk-component-text-2.1.32.tgz",
+			"integrity": "sha512-qw1FaXkwiZY0FDqymNxVwznfXXsvW9CrKHtdCAD8IxAmsdZOxsAafOtUZwcG3mooiNh9ieMfBwJCdWzai9k37Q==",
+			"requires": {
+				"bpk-tokens": "26.7.5",
+				"prop-types": "15.6.0"
+			},
+			"dependencies": {
+				"bpk-tokens": {
+					"version": "26.7.5",
+					"resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-26.7.5.tgz",
+					"integrity": "sha512-ta5eD0tjANg/Jqq4qAiqvRWN3sqWEroXFYQs+4Salwb7kjRuHDa0S+TmFQP2ELdg97xLSk2K5fFeHJLeZSEY5A==",
+					"requires": {
+						"color": "2.0.1"
+					}
+				},
+				"color": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+					"integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+					"requires": {
+						"color-convert": "1.9.1",
+						"color-string": "1.5.2"
+					}
+				}
+			}
+		},
+		"react-native-bpk-component-touchable-native-feedback": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-touchable-native-feedback/-/react-native-bpk-component-touchable-native-feedback-1.1.4.tgz",
+			"integrity": "sha512-THDzExxo59M2r7I38AS2InW8jUiq+kxVhAQih+vEY+8FOzgvXMA+s2DeKPXfbYFimNDMAoi26w2JiAcolanSSQ==",
+			"requires": {
+				"prop-types": "15.6.0"
+			}
+		},
+		"react-native-bpk-theming": {
+			"version": "1.0.43",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-theming/-/react-native-bpk-theming-1.0.43.tgz",
+			"integrity": "sha512-ZoxFMvqa+a1RI/k2HFGdG03/pgVP8oYY+nAbC46SRSq7RD3ttUJNDbZDPdzZEoR/1y/vP9/oemDD5p0+pi6TIQ==",
+			"requires": {
+				"theming": "1.3.0"
+			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"requires": {
+				"is-arrayish": "0.3.1"
+			}
+		},
+		"theming": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
+			"integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
+			"requires": {
+				"brcast": "3.0.1",
+				"is-function": "1.0.1",
+				"is-plain-object": "2.0.4",
+				"prop-types": "15.6.0"
+			}
+		},
+		"ua-parser-js": {
+			"version": "0.7.14",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
+			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		}
+	}
+}

--- a/native/packages/react-native-bpk-component-picker/package.json
+++ b/native/packages/react-native-bpk-component-picker/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-native-bpk-component-picker",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js",
+  "description": "Backpack React Native picker component.",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^16.0.0-alpha.1",
+    "react-native": ">= 0.47.0"
+  },
+  "dependencies": {
+    "bpk-tokens": "^26.7.5",
+    "prop-types": "^15.5.8",
+    "react-native-bpk-component-button-link": "^1.1.6",
+    "react-native-bpk-component-icon": "^1.5.0",
+    "react-native-bpk-component-text": "^2.1.32",
+    "react-native-bpk-component-touchable-native-feedback": "^1.1.4",
+    "react-native-bpk-component-touchable-overlay": "^1.0.14"
+  }
+}

--- a/native/packages/react-native-bpk-component-picker/readme.md
+++ b/native/packages/react-native-bpk-component-picker/readme.md
@@ -1,0 +1,122 @@
+# react-native-bpk-component-picker
+
+> Backpack React Native picker component.
+
+## Installation
+
+```sh
+npm install react-native-bpk-component-picker --save-dev
+```
+
+## Usage
+
+```js
+import React, { Component } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
+import BpkPicker, { BpkPickerItem, BpkPickerTrigger } from 'react-native-bpk-component-picker';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: spacingBase,
+  }
+});
+
+const AIRPORTS = [
+  {
+    value: '1',
+    label: 'Charles De Gaulle',
+  },
+  {
+    value: '2',
+    label: 'Paris Orly',
+  },
+  {
+    value: '3',
+    label: 'Beauvais-Tillé',
+  },
+];
+
+export default class App extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      value: null,
+      isOpen: false,
+    };
+
+    this.onOpen = this.onOpen.bind(this);
+    this.onClose = this.onClose.bind(this);
+    this.setValue = this.setValue.bind(this);
+  }
+
+  onOpen() {
+    this.setState({
+      isOpen: true,
+    });
+  }
+
+  onClose() {
+    this.setState({
+      isOpen: false,
+    });
+  }
+
+  setValue(value) {
+    this.setState({value});
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <BpkPickerTrigger
+          onPress={this.onOpen}
+          label={this.state.value || 'Choose an airport'}
+        />
+        <BpkPicker
+          isOpen={this.state.isOpen}
+          onClose={this.onClose}
+          selectedValue={this.state.value}
+          onValueChange={this.setValue}
+          doneLabel="Done"
+        >
+          <BpkPickerItem label="Choose an airport" />
+          { AIRPORTS.map(({value, label}) => (
+            <BpkPickerItem value={value} label={label} />
+          ))}
+        </BpkPicker>
+    );
+  }
+}
+```
+
+## Props
+
+### BpkPicker
+
+| Property             | PropType                              | Required | Default Value |
+| -----------          | ------------------------------------- | -------- | ------------- |
+| children             | node                                  | true     | -             |
+| doneLabel (iOS only) | string                                | true     | -             |
+| onClose              | func                                  | true     | -             |
+| onValueChange        | func                                  | true     | -             |
+| isOpen               | bool                                  | false    | false         |
+| selectedValue        | oneOfType(string, number)             | false    | null          |
+
+### BpkPickerItem
+
+| Property             | PropType                              | Required | Default Value |
+| -----------          | ------------------------------------- | -------- | ------------- |
+| label                | string                                | true     | -             |
+| value                | oneOfType(string, number)             | false    | null          |
+
+### BpkPickerTrigger
+
+| Property             | PropType                              | Required | Default Value |
+| -----------          | ------------------------------------- | -------- | ------------- |
+| onPress              | func                                  | true     | -             |
+| disabled             | bool                                  | false    | false         |
+| label                | oneOfType(string, element)            | false    | null          |

--- a/native/packages/react-native-bpk-component-picker/src/BpkPicker-test.android.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPicker-test.android.js
@@ -1,0 +1,56 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkPicker-test.common';
+
+jest.mock('react-native', () => {
+  const reactNative = require.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+
+  return reactNative;
+});
+
+jest.mock('TouchableNativeFeedback', () =>
+  jest.requireActual(
+    'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js',
+  ),
+);
+
+jest.mock(
+  './../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('bpk-tokens/tokens/base.react.native', () =>
+  require.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('./BpkPickerMenu', () =>
+  jest.requireActual('./BpkPickerMenu.android.js'),
+);
+
+jest.mock('./BpkPickerItem', () =>
+  jest.requireActual('./BpkPickerItem.android.js'),
+);
+
+describe('Android', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-picker/src/BpkPicker-test.common.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPicker-test.common.js
@@ -1,0 +1,55 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import BpkPicker from './BpkPicker';
+import BpkPickerItem from './BpkPickerItem';
+
+const commonTests = () => {
+  describe('BpkPicker', () => {
+    const emptyFn = () => null;
+
+    it('should render correctly', () => {
+      const testRenderer = TestRenderer.create(
+        <BpkPicker onValueChange={emptyFn} onClose={emptyFn} doneLabel="Done">
+          <BpkPickerItem label="foo" value="foo" />
+          <BpkPickerItem label="bar" value="bar" />
+        </BpkPicker>,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+
+    it('should render correctly with a selected value', () => {
+      const testRenderer = TestRenderer.create(
+        <BpkPicker
+          onValueChange={emptyFn}
+          onClose={emptyFn}
+          doneLabel="Done"
+          selectedValue="foo"
+        >
+          <BpkPickerItem label="foo" value="foo" />
+          <BpkPickerItem label="bar" value="bar" />
+        </BpkPicker>,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+  });
+};
+
+export default commonTests;

--- a/native/packages/react-native-bpk-component-picker/src/BpkPicker-test.ios.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPicker-test.ios.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkPicker-test.common';
+
+describe('iOS', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-picker/src/BpkPicker.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPicker.js
@@ -1,0 +1,60 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import BpkPickerMenu from './BpkPickerMenu';
+
+const BpkPicker = props => {
+  const {
+    children,
+    doneLabel,
+    isOpen,
+    onValueChange,
+    selectedValue,
+    ...rest
+  } = props;
+
+  return (
+    <BpkPickerMenu
+      {...rest}
+      doneLabel={doneLabel}
+      onValueChange={onValueChange}
+      selectedValue={selectedValue}
+      visible={isOpen}
+    >
+      {children}
+    </BpkPickerMenu>
+  );
+};
+
+BpkPicker.propTypes = {
+  children: PropTypes.node.isRequired,
+  doneLabel: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onValueChange: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool,
+  selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+BpkPicker.defaultProps = {
+  isOpen: false,
+  selectedValue: null,
+};
+
+export default BpkPicker;

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerItem-test.android.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerItem-test.android.js
@@ -1,0 +1,70 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import BpkPickerItem from './BpkPickerItem.android';
+
+jest.mock('react-native', () => {
+  const reactNative = require.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+
+  return reactNative;
+});
+
+jest.mock('TouchableNativeFeedback', () =>
+  jest.requireActual(
+    'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js',
+  ),
+);
+
+jest.mock(
+  './../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('bpk-tokens/tokens/base.react.native', () =>
+  require.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+describe('Android', () => {
+  describe('BpkPickerItem', () => {
+    it('should render correctly', () => {
+      const testRenderer = TestRenderer.create(
+        <BpkPickerItem label="label" value="value" />,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+    it('should render correctly with the selected prop', () => {
+      const testRenderer = TestRenderer.create(
+        <BpkPickerItem label="label" value="value" selected />,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+    it('should render correctly with an onPress function', () => {
+      const onPressFn = jest.fn();
+      const testRenderer = TestRenderer.create(
+        <BpkPickerItem label="label" value="value" onPress={onPressFn} />,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+  });
+});

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerItem.android.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerItem.android.js
@@ -1,0 +1,62 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import PropTypes from 'prop-types';
+import BpkText from 'react-native-bpk-component-text';
+import BpkTouchableNativeFeedback from 'react-native-bpk-component-touchable-native-feedback';
+import { colorBlue500, spacingBase } from 'bpk-tokens/tokens/base.react.native';
+
+const styles = StyleSheet.create({
+  pickerItem: {
+    padding: spacingBase,
+  },
+  selected: {
+    color: colorBlue500,
+  },
+});
+
+const BpkPickerItem = props => {
+  const { value, label, onPress, selected } = props;
+  return (
+    <View style={styles.pickerItem}>
+      <BpkTouchableNativeFeedback
+        onPress={() => onPress && onPress(value)}
+        accessibilityLabel={label}
+      >
+        <BpkText style={selected ? styles.selected : {}}>{label}</BpkText>
+      </BpkTouchableNativeFeedback>
+    </View>
+  );
+};
+
+BpkPickerItem.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onPress: PropTypes.func,
+  selected: PropTypes.bool,
+};
+
+BpkPickerItem.defaultProps = {
+  selected: false,
+  onPress: null,
+  value: null,
+};
+
+export default BpkPickerItem;

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerItem.ios.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerItem.ios.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Picker } from 'react-native';
+
+const BpkPickerItem = Picker.Item;
+
+export default BpkPickerItem;

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerMenu.android.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerMenu.android.js
@@ -1,0 +1,90 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Modal, View, StyleSheet, ScrollView } from 'react-native';
+import PropTypes from 'prop-types';
+import { setOpacity } from 'bpk-tokens';
+import {
+  borderRadiusSm,
+  colorGray900,
+  colorWhite,
+  lineHeightBase,
+  spacingBase,
+} from 'bpk-tokens/tokens/base.react.native';
+
+const rowsToDisplay = 6;
+
+const maxListHeight =
+  // eslint-disable-next-line no-mixed-operators
+  (2 * spacingBase + lineHeightBase) * rowsToDisplay;
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: setOpacity(colorGray900, 0.8),
+    justifyContent: 'center',
+  },
+  list: {
+    backgroundColor: colorWhite,
+    borderRadius: borderRadiusSm,
+    maxHeight: maxListHeight,
+    margin: spacingBase,
+    flex: 0,
+  },
+});
+
+const PickerMenu = props => {
+  const { visible, children, onValueChange, onClose, selectedValue } = props;
+  const pickerItems = React.Children.map(children, (child, index) =>
+    React.cloneElement(child, {
+      selected: selectedValue && selectedValue === child.props.value,
+      onPress: value => {
+        onValueChange(value, index);
+        onClose();
+      },
+    }),
+  );
+  return (
+    <Modal
+      transparent
+      visible={visible}
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <ScrollView style={styles.list}>{pickerItems}</ScrollView>
+      </View>
+    </Modal>
+  );
+};
+
+PickerMenu.propTypes = {
+  visible: PropTypes.bool,
+  selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  children: PropTypes.node.isRequired,
+  onValueChange: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+PickerMenu.defaultProps = {
+  visible: false,
+  selectedValue: null,
+};
+
+export default PickerMenu;

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerMenu.ios.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerMenu.ios.js
@@ -1,0 +1,102 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  Modal,
+  Picker,
+  View,
+  StyleSheet,
+  TouchableWithoutFeedback,
+} from 'react-native';
+import PropTypes from 'prop-types';
+import BpkButtonLink from 'react-native-bpk-component-button-link';
+import {
+  colorGray50,
+  colorGray200,
+  spacingSm,
+  spacingMd,
+} from 'bpk-tokens/tokens/base.react.native';
+
+const styles = StyleSheet.create({
+  dismissOverlay: {
+    flex: 1,
+  },
+  modal: {
+    flexDirection: 'column',
+    width: '100%',
+    backgroundColor: colorGray200,
+    position: 'absolute',
+    bottom: 0,
+  },
+  modalHeader: {
+    flex: 1,
+    paddingVertical: spacingSm * 0.5,
+    paddingHorizontal: spacingMd,
+    flexDirection: 'row',
+    backgroundColor: colorGray50,
+    borderTopWidth: 1,
+    borderColor: colorGray200,
+    justifyContent: 'flex-end',
+  },
+});
+
+const PickerMenu = props => {
+  const {
+    visible,
+    selectedValue,
+    children,
+    onValueChange,
+    onClose,
+    doneLabel,
+  } = props;
+  const pickerItems = React.Children.map(children, child =>
+    React.cloneElement(child, { key: child.props.value }),
+  );
+  return (
+    <Modal transparent visible={visible} animationType="slide">
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View style={styles.dismissOverlay} />
+      </TouchableWithoutFeedback>
+      <View style={styles.modal}>
+        <View style={styles.modalHeader}>
+          <BpkButtonLink title={doneLabel} onPress={onClose} />
+        </View>
+        <Picker selectedValue={selectedValue} onValueChange={onValueChange}>
+          {pickerItems}
+        </Picker>
+      </View>
+    </Modal>
+  );
+};
+
+PickerMenu.propTypes = {
+  children: PropTypes.node.isRequired,
+  doneLabel: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onValueChange: PropTypes.func.isRequired,
+  selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  visible: PropTypes.bool,
+};
+
+PickerMenu.defaultProps = {
+  visible: false,
+  selectedValue: null,
+};
+
+export default PickerMenu;

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerTrigger-test.android.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerTrigger-test.android.js
@@ -1,0 +1,48 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkPickerTrigger-test.common';
+
+jest.mock('react-native', () => {
+  const reactNative = require.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+
+  return reactNative;
+});
+
+jest.mock('TouchableNativeFeedback', () =>
+  jest.requireActual(
+    'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js',
+  ),
+);
+
+jest.mock(
+  './../node_modules/react-native-bpk-component-text/node_modules/bpk-tokens/tokens/base.react.native',
+  () => require.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('bpk-tokens/tokens/base.react.native', () =>
+  require.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+describe('Android', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerTrigger-test.common.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerTrigger-test.common.js
@@ -1,0 +1,68 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import TestRenderer from 'react-test-renderer';
+import BpkPickerTrigger from './BpkPickerTrigger';
+
+const commonTests = () => {
+  describe('BpkPickerTrigger', () => {
+    const emptyFn = () => null;
+    it('should render correctly', () => {
+      const testRenderer = TestRenderer.create(
+        <BpkPickerTrigger onPress={emptyFn} />,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+
+    it('should render correctly with a text label', () => {
+      const testRenderer = TestRenderer.create(
+        <BpkPickerTrigger label="label" onPress={emptyFn} />,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+
+    it('should render correctly with an element label', () => {
+      const testRenderer = TestRenderer.create(
+        <BpkPickerTrigger label={<View />} onPress={emptyFn} />,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+
+    it('should render correctly with the disabled prop', () => {
+      const testRenderer = TestRenderer.create(
+        <BpkPickerTrigger disabled label="label" onPress={emptyFn} />,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+
+    it('should render correctly with custom styles', () => {
+      const testRenderer = TestRenderer.create(
+        <BpkPickerTrigger
+          label="label"
+          onPress={emptyFn}
+          style={{ marginTop: 10 }}
+        />,
+      );
+      expect(testRenderer.toJSON()).toMatchSnapshot();
+    });
+  });
+};
+
+export default commonTests;

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerTrigger-test.ios.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerTrigger-test.ios.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkPickerTrigger-test.common';
+
+describe('iOS', () => {
+  commonTests();
+});

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerTrigger.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerTrigger.js
@@ -1,0 +1,101 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Platform, StyleSheet, View, ViewPropTypes } from 'react-native';
+import PropTypes from 'prop-types';
+import BpkTouchableOverlay from 'react-native-bpk-component-touchable-overlay';
+import BpkTouchableNativeFeedback from 'react-native-bpk-component-touchable-native-feedback';
+import BpkText from 'react-native-bpk-component-text';
+import BpkIcon, { icons } from 'react-native-bpk-component-icon';
+import {
+  colorGray100,
+  borderSizeSm,
+  spacingSm,
+} from 'bpk-tokens/tokens/base.react.native';
+
+const styles = StyleSheet.create({
+  trigger: {
+    flexDirection: 'row',
+    borderColor: colorGray100,
+    borderBottomWidth: borderSizeSm,
+    justifyContent: 'space-between',
+    paddingVertical: spacingSm,
+  },
+  disabled: {
+    color: colorGray100,
+  },
+});
+
+const TouchablePlatformComponent = Platform.select({
+  ios: BpkTouchableOverlay,
+  android: BpkTouchableNativeFeedback,
+});
+
+const BpkPickerTrigger = props => {
+  const { disabled, label, onPress, style, ...rest } = props;
+
+  let content = label;
+  if (label && typeof label === 'string') {
+    content = (
+      <BpkText style={disabled ? styles.disabled : {}}>{content}</BpkText>
+    );
+  }
+
+  const platformProps = {};
+
+  if (Platform.OS === 'android') {
+    platformProps.borderlessBackground = false;
+  }
+
+  const accessibilityTraits = ['button'];
+  if (disabled) {
+    accessibilityTraits.push('disabled');
+  }
+
+  return (
+    <TouchablePlatformComponent
+      disabled={disabled}
+      style={style}
+      onPress={onPress}
+      accessibilityComponentType="button"
+      accessibilityTraits={accessibilityTraits}
+      {...platformProps}
+    >
+      <View style={styles.trigger} {...rest}>
+        {content}
+        <BpkIcon icon={icons['arrow-down']} small />
+      </View>
+    </TouchablePlatformComponent>
+  );
+};
+
+BpkPickerTrigger.propTypes = {
+  onPress: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  style: ViewPropTypes.style,
+};
+
+BpkPickerTrigger.defaultProps = {
+  disabled: false,
+  label: null,
+  style: null,
+};
+
+export default BpkPickerTrigger;

--- a/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
@@ -1,0 +1,249 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkPicker should render correctly 1`] = `
+<Modal
+  animationType="fade"
+  hardwareAccelerated={false}
+  onRequestClose={[Function]}
+  transparent={true}
+  visible={false}
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "rgba(37, 32, 51, 0.8)",
+        "flex": 1,
+        "justifyContent": "center",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        Object {
+          "backgroundColor": "rgb(255, 255, 255)",
+          "borderRadius": 2,
+          "flex": 0,
+          "margin": 16,
+          "maxHeight": 336,
+        }
+      }
+    >
+      <View>
+        <View
+          style={
+            Object {
+              "padding": 16,
+            }
+          }
+        >
+          <Text
+            accessibilityComponentType={undefined}
+            accessibilityLabel="foo"
+            accessibilityTraits={undefined}
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            hitSlop={undefined}
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackgroundBorderless",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                },
+                Object {},
+              ]
+            }
+            testID={undefined}
+          >
+            foo
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "padding": 16,
+            }
+          }
+        >
+          <Text
+            accessibilityComponentType={undefined}
+            accessibilityLabel="bar"
+            accessibilityTraits={undefined}
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            hitSlop={undefined}
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackgroundBorderless",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                },
+                Object {},
+              ]
+            }
+            testID={undefined}
+          >
+            bar
+          </Text>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+</Modal>
+`;
+
+exports[`Android BpkPicker should render correctly with a selected value 1`] = `
+<Modal
+  animationType="fade"
+  hardwareAccelerated={false}
+  onRequestClose={[Function]}
+  transparent={true}
+  visible={false}
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "rgba(37, 32, 51, 0.8)",
+        "flex": 1,
+        "justifyContent": "center",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        Object {
+          "backgroundColor": "rgb(255, 255, 255)",
+          "borderRadius": 2,
+          "flex": 0,
+          "margin": 16,
+          "maxHeight": 336,
+        }
+      }
+    >
+      <View>
+        <View
+          style={
+            Object {
+              "padding": 16,
+            }
+          }
+        >
+          <Text
+            accessibilityComponentType={undefined}
+            accessibilityLabel="foo"
+            accessibilityTraits={undefined}
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            hitSlop={undefined}
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackgroundBorderless",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "color": "rgb(0, 178, 214)",
+                },
+              ]
+            }
+            testID={undefined}
+          >
+            foo
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "padding": 16,
+            }
+          }
+        >
+          <Text
+            accessibilityComponentType={undefined}
+            accessibilityLabel="bar"
+            accessibilityTraits={undefined}
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            hitSlop={undefined}
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackgroundBorderless",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                },
+                Object {},
+              ]
+            }
+            testID={undefined}
+          >
+            bar
+          </Text>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+</Modal>
+`;

--- a/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.ios.js.snap
@@ -1,0 +1,337 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS BpkPicker should render correctly 1`] = `
+<Modal
+  animationType="slide"
+  hardwareAccelerated={false}
+  transparent={true}
+  visible={false}
+>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+    testID={undefined}
+  />
+  <View
+    style={
+      Object {
+        "backgroundColor": "rgb(204, 201, 212)",
+        "bottom": 0,
+        "flexDirection": "column",
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "rgb(243, 242, 245)",
+          "borderColor": "rgb(204, 201, 212)",
+          "borderTopWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "paddingHorizontal": 8,
+          "paddingVertical": 2,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "borderRadius": 4,
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityComponentType="button"
+          accessibilityLabel="Done"
+          accessibilityTraits={
+            Array [
+              "button",
+            ]
+          }
+          accessible={true}
+          collapsable={undefined}
+          hasTVPreferredFocus={undefined}
+          hitSlop={undefined}
+          isTVSelectable={true}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID={undefined}
+          tvParallaxProperties={undefined}
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "paddingVertical": 8,
+                },
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "fontWeight": "600",
+                  },
+                  Array [
+                    Object {
+                      "color": "rgb(0, 178, 214)",
+                    },
+                  ],
+                ]
+              }
+            >
+              Done
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={undefined}
+    >
+      <RCTPicker
+        items={
+          Array [
+            Object {
+              "label": "foo",
+              "textColor": undefined,
+              "value": "foo",
+            },
+            Object {
+              "label": "bar",
+              "textColor": undefined,
+              "value": "bar",
+            },
+          ]
+        }
+        onChange={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        selectedIndex={0}
+        style={
+          Array [
+            Object {
+              "height": 216,
+            },
+            undefined,
+          ]
+        }
+      />
+    </View>
+  </View>
+</Modal>
+`;
+
+exports[`iOS BpkPicker should render correctly with a selected value 1`] = `
+<Modal
+  animationType="slide"
+  hardwareAccelerated={false}
+  transparent={true}
+  visible={false}
+>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+    testID={undefined}
+  />
+  <View
+    style={
+      Object {
+        "backgroundColor": "rgb(204, 201, 212)",
+        "bottom": 0,
+        "flexDirection": "column",
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "rgb(243, 242, 245)",
+          "borderColor": "rgb(204, 201, 212)",
+          "borderTopWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "paddingHorizontal": 8,
+          "paddingVertical": 2,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "borderRadius": 4,
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityComponentType="button"
+          accessibilityLabel="Done"
+          accessibilityTraits={
+            Array [
+              "button",
+            ]
+          }
+          accessible={true}
+          collapsable={undefined}
+          hasTVPreferredFocus={undefined}
+          hitSlop={undefined}
+          isTVSelectable={true}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID={undefined}
+          tvParallaxProperties={undefined}
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "paddingVertical": 8,
+                },
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "fontWeight": "600",
+                  },
+                  Array [
+                    Object {
+                      "color": "rgb(0, 178, 214)",
+                    },
+                  ],
+                ]
+              }
+            >
+              Done
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={undefined}
+    >
+      <RCTPicker
+        items={
+          Array [
+            Object {
+              "label": "foo",
+              "textColor": undefined,
+              "value": "foo",
+            },
+            Object {
+              "label": "bar",
+              "textColor": undefined,
+              "value": "bar",
+            },
+          ]
+        }
+        onChange={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        selectedIndex={0}
+        style={
+          Array [
+            Object {
+              "height": 216,
+            },
+            undefined,
+          ]
+        }
+      />
+    </View>
+  </View>
+</Modal>
+`;

--- a/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerItem-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerItem-test.android.js.snap
@@ -1,0 +1,144 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkPickerItem should render correctly 1`] = `
+<View
+  style={
+    Object {
+      "padding": 16,
+    }
+  }
+>
+  <Text
+    accessibilityComponentType={undefined}
+    accessibilityLabel="label"
+    accessibilityTraits={undefined}
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    hitSlop={undefined}
+    nativeBackgroundAndroid={
+      Object {
+        "attribute": "selectableItemBackgroundBorderless",
+        "type": "ThemeAttrAndroid",
+      }
+    }
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 16,
+          "fontWeight": "400",
+        },
+        Object {},
+      ]
+    }
+    testID={undefined}
+  >
+    label
+  </Text>
+</View>
+`;
+
+exports[`Android BpkPickerItem should render correctly with an onPress function 1`] = `
+<View
+  style={
+    Object {
+      "padding": 16,
+    }
+  }
+>
+  <Text
+    accessibilityComponentType={undefined}
+    accessibilityLabel="label"
+    accessibilityTraits={undefined}
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    hitSlop={undefined}
+    nativeBackgroundAndroid={
+      Object {
+        "attribute": "selectableItemBackgroundBorderless",
+        "type": "ThemeAttrAndroid",
+      }
+    }
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 16,
+          "fontWeight": "400",
+        },
+        Object {},
+      ]
+    }
+    testID={undefined}
+  >
+    label
+  </Text>
+</View>
+`;
+
+exports[`Android BpkPickerItem should render correctly with the selected prop 1`] = `
+<View
+  style={
+    Object {
+      "padding": 16,
+    }
+  }
+>
+  <Text
+    accessibilityComponentType={undefined}
+    accessibilityLabel="label"
+    accessibilityTraits={undefined}
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    hitSlop={undefined}
+    nativeBackgroundAndroid={
+      Object {
+        "attribute": "selectableItemBackgroundBorderless",
+        "type": "ThemeAttrAndroid",
+      }
+    }
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 16,
+          "fontWeight": "400",
+        },
+        Object {
+          "color": "rgb(0, 178, 214)",
+        },
+      ]
+    }
+    testID={undefined}
+  >
+    label
+  </Text>
+</View>
+`;

--- a/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerTrigger-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerTrigger-test.android.js.snap
@@ -1,0 +1,354 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkPickerTrigger should render correctly 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "borderBottomWidth": 1,
+      "borderColor": "rgb(230, 228, 235)",
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "paddingVertical": 4,
+    }
+  }
+  testID={undefined}
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+      ]
+    }
+  >
+    
+  </Text>
+</View>
+`;
+
+exports[`Android BpkPickerTrigger should render correctly with a text label 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "borderBottomWidth": 1,
+      "borderColor": "rgb(230, 228, 235)",
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "paddingVertical": 4,
+    }
+  }
+  testID={undefined}
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 16,
+          "fontWeight": "400",
+        },
+        Object {},
+      ]
+    }
+  >
+    label
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+      ]
+    }
+  >
+    
+  </Text>
+</View>
+`;
+
+exports[`Android BpkPickerTrigger should render correctly with an element label 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "borderBottomWidth": 1,
+      "borderColor": "rgb(230, 228, 235)",
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "paddingVertical": 4,
+    }
+  }
+  testID={undefined}
+>
+  <View />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+      ]
+    }
+  >
+    
+  </Text>
+</View>
+`;
+
+exports[`Android BpkPickerTrigger should render correctly with custom styles 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "borderBottomWidth": 1,
+      "borderColor": "rgb(230, 228, 235)",
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "paddingVertical": 4,
+    }
+  }
+  testID={undefined}
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 16,
+          "fontWeight": "400",
+        },
+        Object {},
+      ]
+    }
+  >
+    label
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+      ]
+    }
+  >
+    
+  </Text>
+</View>
+`;
+
+exports[`Android BpkPickerTrigger should render correctly with the disabled prop 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+      "disabled",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "borderBottomWidth": 1,
+      "borderColor": "rgb(230, 228, 235)",
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "paddingVertical": 4,
+    }
+  }
+  testID={undefined}
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 16,
+          "fontWeight": "400",
+        },
+        Object {
+          "color": "rgb(230, 228, 235)",
+        },
+      ]
+    }
+  >
+    label
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "BpkIcon",
+          "fontSize": 24,
+          "lineHeight": 24,
+        },
+        Object {
+          "fontSize": 16,
+          "lineHeight": 16,
+        },
+      ]
+    }
+  >
+    
+  </Text>
+</View>
+`;

--- a/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerTrigger-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerTrigger-test.ios.js.snap
@@ -1,0 +1,433 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS BpkPickerTrigger should render correctly 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={null}
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "borderBottomWidth": 1,
+        "borderColor": "rgb(230, 228, 235)",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "paddingVertical": 4,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "lineHeight": 24,
+          },
+          Object {
+            "fontSize": 16,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`iOS BpkPickerTrigger should render correctly with a text label 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={null}
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "borderBottomWidth": 1,
+        "borderColor": "rgb(230, 228, 235)",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "paddingVertical": 4,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 15,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
+    >
+      label
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "lineHeight": 24,
+          },
+          Object {
+            "fontSize": 16,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`iOS BpkPickerTrigger should render correctly with an element label 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={null}
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "borderBottomWidth": 1,
+        "borderColor": "rgb(230, 228, 235)",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "paddingVertical": 4,
+      }
+    }
+  >
+    <View />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "lineHeight": 24,
+          },
+          Object {
+            "fontSize": 16,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`iOS BpkPickerTrigger should render correctly with custom styles 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "marginTop": 10,
+    }
+  }
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "borderBottomWidth": 1,
+        "borderColor": "rgb(230, 228, 235)",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "paddingVertical": 4,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 15,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
+    >
+      label
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "lineHeight": 24,
+          },
+          Object {
+            "fontSize": 16,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`iOS BpkPickerTrigger should render correctly with the disabled prop 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel={undefined}
+  accessibilityTraits={
+    Array [
+      "button",
+      "disabled",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={null}
+  testID={undefined}
+>
+  <View
+    style={
+      Object {
+        "borderBottomWidth": 1,
+        "borderColor": "rgb(230, 228, 235)",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "paddingVertical": 4,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 15,
+            "fontWeight": "400",
+          },
+          Object {
+            "color": "rgb(230, 228, 235)",
+          },
+        ]
+      }
+    >
+      label
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "lineHeight": 24,
+          },
+          Object {
+            "fontSize": 16,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;

--- a/native/packages/react-native-bpk-component-picker/stories.js
+++ b/native/packages/react-native-bpk-component-picker/stories.js
@@ -1,0 +1,146 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component } from 'react';
+import { StyleSheet, View, ViewPropTypes } from 'react-native';
+import PropTypes from 'prop-types';
+import { storiesOf } from '@storybook/react-native';
+import { action } from '@storybook/addon-actions';
+import BpkText from 'react-native-bpk-component-text';
+import {
+  colorGreen500,
+  spacingBase,
+  spacingMd,
+} from 'bpk-tokens/tokens/base.react.native';
+import CenterDecorator from '../../storybook/CenterDecorator';
+import { StorySubheading } from '../../storybook/TextStyles';
+
+import BpkPicker, { BpkPickerItem, BpkPickerTrigger } from './index';
+
+const styles = StyleSheet.create({
+  picker: {
+    marginBottom: spacingBase,
+  },
+  triggerElementWithPrice: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  priceText: {
+    color: colorGreen500,
+    paddingRight: spacingMd,
+  },
+});
+
+class StatefulBpkPicker extends Component {
+  static propTypes = {
+    disabled: PropTypes.bool,
+    selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    style: ViewPropTypes.style,
+  };
+
+  static defaultProps = {
+    disabled: false,
+    selectedValue: null,
+    style: null,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false,
+      value: props.selectedValue,
+    };
+  }
+
+  openPicker = () => {
+    this.setState({ isOpen: true });
+  };
+
+  closePicker = () => {
+    this.setState({ isOpen: false });
+  };
+
+  updateValue = value => {
+    this.setState({ value });
+  };
+
+  render() {
+    const { disabled, selectedValue, style, ...rest } = this.props;
+    const data = {
+      1: 'Option 1',
+      2: 'Option 2',
+      3: 'Option 3',
+      4: 'Option 4',
+      5: 'Option 5',
+      6: 'Option 6',
+      7: 'Option 7',
+      8: 'Option 8',
+    };
+    return (
+      <View style={style}>
+        <BpkPickerTrigger
+          disabled={disabled}
+          label={data[this.state.value] || 'Choose an option'}
+          onPress={this.openPicker}
+        />
+        <BpkPicker
+          isOpen={this.state.isOpen}
+          onClose={this.closePicker}
+          selectedValue={this.state.value}
+          onValueChange={this.updateValue}
+          doneLabel="Done"
+          {...rest}
+        >
+          <BpkPickerItem label="Choose an option" />
+          {Object.keys(data).map(key => (
+            <BpkPickerItem key={key} value={key} label={data[key]} />
+          ))}
+        </BpkPicker>
+      </View>
+    );
+  }
+}
+
+storiesOf('react-native-bpk-component-picker', module)
+  .addDecorator(CenterDecorator)
+  .add('docs:default', () => (
+    <View>
+      <StorySubheading>No selected value</StorySubheading>
+      <StatefulBpkPicker style={styles.picker} />
+
+      <StorySubheading>With a selected value</StorySubheading>
+      <StatefulBpkPicker selectedValue="3" style={styles.picker} />
+
+      <StorySubheading>Disabled</StorySubheading>
+      <StatefulBpkPicker disabled style={styles.picker} />
+
+      <StorySubheading>
+        Using components within BpkPickerTrigger
+      </StorySubheading>
+      <BpkPickerTrigger
+        onPress={action('BpkPickerTrigger pressed.')}
+        label={
+          <View style={styles.triggerElementWithPrice}>
+            <BpkText>Flight</BpkText>
+            <BpkText style={styles.priceText}>EUR 100</BpkText>
+          </View>
+        }
+      />
+    </View>
+  ));

--- a/native/storybook/storybook.js
+++ b/native/storybook/storybook.js
@@ -56,11 +56,12 @@ configure(() => {
   require('../packages/react-native-bpk-component-nudger/stories');
   require('../packages/react-native-bpk-component-panel/stories');
   require('../packages/react-native-bpk-component-phone-input/stories');
+  require('../packages/react-native-bpk-component-picker/stories');
   require('../packages/react-native-bpk-component-spinner/stories');
   require('../packages/react-native-bpk-component-star-rating/stories');
   require('../packages/react-native-bpk-component-switch/stories');
-  require('../packages/react-native-bpk-component-text-input/stories');
   require('../packages/react-native-bpk-component-text/stories');
+  require('../packages/react-native-bpk-component-text-input/stories');
   require('../packages/react-native-bpk-component-touchable-overlay/stories');
   require('../packages/react-native-bpk-component-touchable-native-feedback/stories');
   require('../packages/react-native-bpk-theming/stories');


### PR DESCRIPTION
A copy of https://github.com/Skyscanner/backpack/pull/551.

There are still some things that need to be done, there are cards for this, and they can be done in follow up stories.

## Details
**All** statefulness has been removed, now, like with modals, users handle whether the picker is open or closed, the value, etc.

There are three public facing components:

* `BpkPicker`: The wrapper component.
* `BpkPickerItem`: On iOS, this is an aliased `Picker.Item`. On Android it is a `View` that will be used in the dialog.
* `BpkPickerTrigger`: This can be optionally used by consumers as a component for rendering the trigger element. It adds the underline and the arrow icon. Can take either a string or an element. This will be split into its own package in a subsequent PR.

The components match the underlying RN `Picker` API as closely as possible.

## Example usage

```
<View>
  <BpkPickerTrigger label={this.state.value} onPress={() => this.setState({isOpen: true})} />
  <BpkPicker 
    isOpen={this.state.isOpen}
    onClose={() => this.setState({isOpen: false})}
    selectedValue={this.state.value}
    onValueChange={value => this.setState({ value})}
    doneLabel="Done"
  >
      <BpkPickerItem label="One" value="1" />
      <BpkPickerItem label="Two" value="2" />
      <BpkPickerItem label="Three" value="3" />
  </BpkPicker>
</View>
```

## Screenshots

![screenshot_1521545963](https://user-images.githubusercontent.com/73652/37652415-5c8cea74-2c33-11e8-9a35-f6208bb6cb37.png)

![simulator screen shot - iphone 6 - 2018-03-20 at 11 39 22](https://user-images.githubusercontent.com/73652/37652417-6012c5d8-2c33-11e8-950a-449f6b6f4466.png)


