### PR TITLE
[BPK-1424] expose small prop in BpkNavigationItem

### DIFF
--- a/native/packages/react-native-bpk-component-horizontal-nav/readme.md
+++ b/native/packages/react-native-bpk-component-horizontal-nav/readme.md
@@ -70,6 +70,7 @@ export default class App extends Component {
 | onPress             | func                                  | true     | -             |
 | title               | string                                | true     | -             |
 | accessibilityLabel  | string                                | false    | props.title   |
+| small               | bool                                  | false    | false         |
 | disabled            | bool                                  | false    | false         |
 | theme               | See [Theme Props](#theme-props) below | false    | null          |
 

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.common.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.common.js
@@ -62,6 +62,17 @@ const commonTests = () => {
       expect(tree).toMatchSnapshot();
     });
 
+    it('should render correctly with "small" prop', () => {
+      const tree = renderer
+        .create(
+          <BpkHorizontalNavItem id="0" title="Nav" onPress={onPressFn} small>
+            My nav content.
+          </BpkHorizontalNavItem>,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
     it('should render correctly with custom "style" prop', () => {
       const tree = renderer
         .create(

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -23,6 +23,7 @@ import {
   colorGray300,
   colorGray700,
   colorBlue700,
+  spacingSm,
   spacingMd,
   spacingBase,
 } from 'bpk-tokens/tokens/base.react.native';
@@ -45,6 +46,9 @@ const styles = StyleSheet.create({
   selectedText: {
     color: colorBlue700,
   },
+  smallText: {
+    paddingVertical: spacingSm,
+  },
 });
 
 const BpkHorizontalNavItem = props => {
@@ -54,11 +58,13 @@ const BpkHorizontalNavItem = props => {
     selected,
     style,
     theme,
+    small,
     title,
     ...rest
   } = props;
 
   const accessibilityTraits = ['button'];
+  const textSize = small ? 'sm' : 'base';
   const textStyles = [styles.text];
 
   if (disabled) {
@@ -75,6 +81,9 @@ const BpkHorizontalNavItem = props => {
       textStyles.push(themeStyles.selectedText);
     }
   }
+  if (small) {
+    textStyles.push(styles.smallText);
+  }
 
   const isAndroid = Platform.OS === 'android';
   const Touchable = isAndroid
@@ -82,7 +91,6 @@ const BpkHorizontalNavItem = props => {
     : BpkTouchableOverlay;
   const formattedTitle = isAndroid ? title.toUpperCase() : title;
   const platformProps = isAndroid ? { borderlessBackground: false } : {};
-
   return (
     <Touchable
       accessibilityComponentType="button"
@@ -93,7 +101,9 @@ const BpkHorizontalNavItem = props => {
       {...rest}
     >
       <View style={style}>
-        <BpkText style={textStyles}>{formattedTitle}</BpkText>
+        <BpkText style={textStyles} textStyle={textSize}>
+          {formattedTitle}
+        </BpkText>
       </View>
     </Touchable>
   );
@@ -107,6 +117,7 @@ const propTypes = {
   disabled: PropTypes.bool,
   selected: PropTypes.bool,
   style: ViewPropTypes.style,
+  small: PropTypes.bool,
   theme: themePropType,
 };
 
@@ -116,6 +127,7 @@ BpkHorizontalNavItem.defaultProps = {
   accessibilityLabel: null,
   disabled: false,
   selected: false,
+  small: false,
   style: null,
   theme: null,
 };

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.android.js.snap
@@ -111,6 +111,63 @@ exports[`Android BpkHorizontalNavItem should render correctly with "selected" pr
 </View>
 `;
 
+exports[`Android BpkHorizontalNavItem should render correctly with "small" prop 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel="Nav"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={null}
+  testID={undefined}
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "rgb(82, 76, 97)",
+          "fontFamily": "sans-serif",
+          "fontSize": 14,
+          "fontWeight": "400",
+        },
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "paddingHorizontal": 16,
+            "paddingVertical": 8,
+          },
+          Object {
+            "paddingVertical": 4,
+          },
+        ],
+      ]
+    }
+  >
+    NAV
+  </Text>
+</View>
+`;
+
 exports[`Android BpkHorizontalNavItem should render correctly with "spaceAround" prop 1`] = `
 <View
   accessibilityComponentType="button"

--- a/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
@@ -141,6 +141,78 @@ exports[`iOS BpkHorizontalNavItem should render correctly with "selected" prop 1
 </View>
 `;
 
+exports[`iOS BpkHorizontalNavItem should render correctly with "small" prop 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel="Nav"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={null}
+  testID={undefined}
+>
+  <View
+    style={null}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 13,
+            "fontWeight": "400",
+          },
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "paddingHorizontal": 16,
+              "paddingVertical": 8,
+            },
+            Object {
+              "paddingVertical": 4,
+            },
+          ],
+        ]
+      }
+    >
+      Nav
+    </Text>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
 exports[`iOS BpkHorizontalNavItem should render correctly with "spaceAround" prop 1`] = `
 <View
   accessibilityComponentType="button"

--- a/native/packages/react-native-bpk-component-horizontal-nav/stories.js
+++ b/native/packages/react-native-bpk-component-horizontal-nav/stories.js
@@ -70,12 +70,13 @@ class ManagedNav extends React.Component {
 }
 
 const StoryNav = props => {
-  const { items, ...rest } = props;
+  const { items, small, ...rest } = props;
   return (
     <BpkHorizontalNav selectedId="1" {...rest}>
       {[...Array(items)].map((_, index) => (
         <BpkHorizontalNavItem
           title="Item"
+          small={small}
           id={index.toString()}
           key={index.toString()}
           onPress={action(`Nav item ${index} pressed`)}
@@ -84,6 +85,7 @@ const StoryNav = props => {
       <BpkHorizontalNavItem
         title="Disabled Item"
         disabled
+        small={small}
         id="disabled"
         onPress={() => {}}
       />
@@ -92,9 +94,11 @@ const StoryNav = props => {
 };
 StoryNav.propTypes = {
   items: PropTypes.number,
+  small: PropTypes.bool,
 };
 StoryNav.defaultProps = {
   items: 2,
+  small: false,
 };
 
 storiesOf('react-native-bpk-component-horizontal-nav', module)
@@ -115,6 +119,30 @@ storiesOf('react-native-bpk-component-horizontal-nav', module)
         <BpkHorizontalNavItem
           title="Car hire"
           id="2"
+          onPress={action('Nav item three pressed')}
+        />
+      </BpkHorizontalNav>
+    </View>
+  ))
+  .add('docs:small-font', () => (
+    <View style={styles.bottomMargin}>
+      <BpkHorizontalNav selectedId="1">
+        <BpkHorizontalNavItem
+          title="Flights"
+          id="0"
+          small
+          onPress={action('Nav item one pressed')}
+        />
+        <BpkHorizontalNavItem
+          title="Hotels"
+          id="1"
+          small
+          onPress={action('Nav item two pressed')}
+        />
+        <BpkHorizontalNavItem
+          title="Car hire"
+          id="2"
+          small
           onPress={action('Nav item three pressed')}
         />
       </BpkHorizontalNav>
@@ -158,6 +186,10 @@ storiesOf('react-native-bpk-component-horizontal-nav', module)
       <View style={styles.bottomMargin}>
         <StorySubheading>Space Around, Overflowing</StorySubheading>
         <StoryNav items={5} spaceAround />
+      </View>
+      <View style={styles.bottomMargin}>
+        <StorySubheading>Small font size</StorySubheading>
+        <StoryNav items={5} small />
       </View>
       <View style={styles.bottomMargin}>
         <StorySubheading>Themed</StorySubheading>


### PR DESCRIPTION
I've also added inline comments; one thing @shaundon mentioned is to pass the small prop to the Nav components rather than Item, I tough was a good idea in the beginnign, but adding it to the item makes the intent clear so I went for it

![screenshot_1521211569](https://user-images.githubusercontent.com/3579758/37526996-d0b85978-2928-11e8-9de3-f911cdda0b04.png)
![simulator screen shot - iphone 6 - 2018-03-16 at 14 46 08](https://user-images.githubusercontent.com/3579758/37526997-d0cf7158-2928-11e8-837c-8b7bc971cf97.png)
