### PR TITLE
[BPK-1426] Add better Android behaviour

### DIFF
--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerItem.android.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerItem.android.js
@@ -34,15 +34,24 @@ const styles = StyleSheet.create({
 
 const BpkPickerItem = props => {
   const { value, label, onPress, selected } = props;
+
+  const accessibilityTraits = ['button'];
+  if (selected) {
+    accessibilityTraits.push('selected');
+  }
+
   return (
-    <View style={styles.pickerItem}>
-      <BpkTouchableNativeFeedback
-        onPress={() => onPress && onPress(value)}
-        accessibilityLabel={label}
-      >
+    <BpkTouchableNativeFeedback
+      onPress={() => onPress && onPress(value)}
+      accessibilityComponentType="button"
+      accessibilityLabel={label}
+      accessibilityTraits={accessibilityTraits}
+      borderlessBackground={false}
+    >
+      <View style={styles.pickerItem}>
         <BpkText style={selected ? styles.selected : {}}>{label}</BpkText>
-      </BpkTouchableNativeFeedback>
-    </View>
+      </View>
+    </BpkTouchableNativeFeedback>
   );
 };
 

--- a/native/packages/react-native-bpk-component-picker/src/BpkPickerMenu.ios.js
+++ b/native/packages/react-native-bpk-component-picker/src/BpkPickerMenu.ios.js
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const PickerMenu = props => {
+const BpkPickerMenu = props => {
   const {
     visible,
     selectedValue,
@@ -69,7 +69,12 @@ const PickerMenu = props => {
     React.cloneElement(child, { key: child.props.value }),
   );
   return (
-    <Modal transparent visible={visible} animationType="slide">
+    <Modal
+      supportedOrientations={['portrait', 'landscape']}
+      transparent
+      visible={visible}
+      animationType="slide"
+    >
       <TouchableWithoutFeedback onPress={onClose}>
         <View style={styles.dismissOverlay} />
       </TouchableWithoutFeedback>
@@ -85,7 +90,7 @@ const PickerMenu = props => {
   );
 };
 
-PickerMenu.propTypes = {
+BpkPickerMenu.propTypes = {
   children: PropTypes.node.isRequired,
   doneLabel: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
@@ -94,9 +99,9 @@ PickerMenu.propTypes = {
   visible: PropTypes.bool,
 };
 
-PickerMenu.defaultProps = {
+BpkPickerMenu.defaultProps = {
   visible: false,
   selectedValue: null,
 };
 
-export default PickerMenu;
+export default BpkPickerMenu;

--- a/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
@@ -9,54 +9,127 @@ exports[`Android BpkPicker should render correctly 1`] = `
   visible={false}
 >
   <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       Object {
         "backgroundColor": "rgba(37, 32, 51, 0.8)",
-        "flex": 1,
-        "justifyContent": "center",
+        "height": "100%",
+        "left": 0,
+        "position": "absolute",
+        "top": 0,
+        "width": "100%",
       }
     }
-  >
-    <RCTScrollView
-      style={
+    testID={undefined}
+  />
+  <RCTScrollView
+    data={
+      Array [
         Object {
+          "index": 0,
+          "label": "foo",
+          "selected": false,
+          "value": "foo",
+        },
+        Object {
+          "index": 1,
+          "label": "bar",
+          "selected": false,
+          "value": "bar",
+        },
+      ]
+    }
+    disableVirtualization={false}
+    getItem={[Function]}
+    getItemCount={[Function]}
+    getItemLayout={[Function]}
+    horizontal={false}
+    initialNumToRender={6}
+    initialScrollIndex={0}
+    keyExtractor={[Function]}
+    maxToRenderPerBatch={10}
+    numColumns={1}
+    onContentSizeChange={[Function]}
+    onEndReachedThreshold={2}
+    onLayout={[Function]}
+    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
+    onScrollBeginDrag={[Function]}
+    onScrollEndDrag={[Function]}
+    renderItem={[Function]}
+    scrollEventThrottle={50}
+    stickyHeaderIndices={Array []}
+    style={
+      Array [
+        Object {
+          "alignSelf": "center",
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 2,
-          "flex": 0,
-          "margin": 16,
-          "maxHeight": 336,
-        }
-      }
-    >
-      <View>
+          "elevation": 5,
+          "top": "50%",
+          "width": "90%",
+        },
+        Object {
+          "marginTop": -56,
+          "maxHeight": 112,
+        },
+      ]
+    }
+    updateCellsBatchingPeriod={50}
+    viewabilityConfigCallbackPairs={Array []}
+    windowSize={21}
+  >
+    <View>
+      <View
+        onLayout={undefined}
+        style={null}
+      >
         <View
+          accessibilityComponentType="button"
+          accessibilityLabel="foo"
+          accessibilityTraits={
+            Array [
+              "button",
+            ]
+          }
+          accessible={true}
+          hitSlop={undefined}
+          nativeBackgroundAndroid={
+            Object {
+              "attribute": "selectableItemBackground",
+              "type": "ThemeAttrAndroid",
+            }
+          }
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "padding": 16,
             }
           }
+          testID={undefined}
         >
           <Text
-            accessibilityComponentType={undefined}
-            accessibilityLabel="foo"
-            accessibilityTraits={undefined}
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            hitSlop={undefined}
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackgroundBorderless",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
@@ -68,39 +141,49 @@ exports[`Android BpkPicker should render correctly 1`] = `
                 Object {},
               ]
             }
-            testID={undefined}
           >
             foo
           </Text>
         </View>
+      </View>
+      <View
+        onLayout={undefined}
+        style={null}
+      >
         <View
+          accessibilityComponentType="button"
+          accessibilityLabel="bar"
+          accessibilityTraits={
+            Array [
+              "button",
+            ]
+          }
+          accessible={true}
+          hitSlop={undefined}
+          nativeBackgroundAndroid={
+            Object {
+              "attribute": "selectableItemBackground",
+              "type": "ThemeAttrAndroid",
+            }
+          }
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "padding": 16,
             }
           }
+          testID={undefined}
         >
           <Text
-            accessibilityComponentType={undefined}
-            accessibilityLabel="bar"
-            accessibilityTraits={undefined}
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            hitSlop={undefined}
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackgroundBorderless",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
@@ -112,14 +195,13 @@ exports[`Android BpkPicker should render correctly 1`] = `
                 Object {},
               ]
             }
-            testID={undefined}
           >
             bar
           </Text>
         </View>
       </View>
-    </RCTScrollView>
-  </View>
+    </View>
+  </RCTScrollView>
 </Modal>
 `;
 
@@ -132,54 +214,128 @@ exports[`Android BpkPicker should render correctly with a selected value 1`] = `
   visible={false}
 >
   <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       Object {
         "backgroundColor": "rgba(37, 32, 51, 0.8)",
-        "flex": 1,
-        "justifyContent": "center",
+        "height": "100%",
+        "left": 0,
+        "position": "absolute",
+        "top": 0,
+        "width": "100%",
       }
     }
-  >
-    <RCTScrollView
-      style={
+    testID={undefined}
+  />
+  <RCTScrollView
+    data={
+      Array [
         Object {
+          "index": 0,
+          "label": "foo",
+          "selected": true,
+          "value": "foo",
+        },
+        Object {
+          "index": 1,
+          "label": "bar",
+          "selected": false,
+          "value": "bar",
+        },
+      ]
+    }
+    disableVirtualization={false}
+    getItem={[Function]}
+    getItemCount={[Function]}
+    getItemLayout={[Function]}
+    horizontal={false}
+    initialNumToRender={6}
+    initialScrollIndex={0}
+    keyExtractor={[Function]}
+    maxToRenderPerBatch={10}
+    numColumns={1}
+    onContentSizeChange={[Function]}
+    onEndReachedThreshold={2}
+    onLayout={[Function]}
+    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
+    onScrollBeginDrag={[Function]}
+    onScrollEndDrag={[Function]}
+    renderItem={[Function]}
+    scrollEventThrottle={50}
+    stickyHeaderIndices={Array []}
+    style={
+      Array [
+        Object {
+          "alignSelf": "center",
           "backgroundColor": "rgb(255, 255, 255)",
           "borderRadius": 2,
-          "flex": 0,
-          "margin": 16,
-          "maxHeight": 336,
-        }
-      }
-    >
-      <View>
+          "elevation": 5,
+          "top": "50%",
+          "width": "90%",
+        },
+        Object {
+          "marginTop": -56,
+          "maxHeight": 112,
+        },
+      ]
+    }
+    updateCellsBatchingPeriod={50}
+    viewabilityConfigCallbackPairs={Array []}
+    windowSize={21}
+  >
+    <View>
+      <View
+        onLayout={undefined}
+        style={null}
+      >
         <View
+          accessibilityComponentType="button"
+          accessibilityLabel="foo"
+          accessibilityTraits={
+            Array [
+              "button",
+              "selected",
+            ]
+          }
+          accessible={true}
+          hitSlop={undefined}
+          nativeBackgroundAndroid={
+            Object {
+              "attribute": "selectableItemBackground",
+              "type": "ThemeAttrAndroid",
+            }
+          }
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "padding": 16,
             }
           }
+          testID={undefined}
         >
           <Text
-            accessibilityComponentType={undefined}
-            accessibilityLabel="foo"
-            accessibilityTraits={undefined}
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            hitSlop={undefined}
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackgroundBorderless",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
@@ -193,39 +349,49 @@ exports[`Android BpkPicker should render correctly with a selected value 1`] = `
                 },
               ]
             }
-            testID={undefined}
           >
             foo
           </Text>
         </View>
+      </View>
+      <View
+        onLayout={undefined}
+        style={null}
+      >
         <View
+          accessibilityComponentType="button"
+          accessibilityLabel="bar"
+          accessibilityTraits={
+            Array [
+              "button",
+            ]
+          }
+          accessible={true}
+          hitSlop={undefined}
+          nativeBackgroundAndroid={
+            Object {
+              "attribute": "selectableItemBackground",
+              "type": "ThemeAttrAndroid",
+            }
+          }
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "padding": 16,
             }
           }
+          testID={undefined}
         >
           <Text
-            accessibilityComponentType={undefined}
-            accessibilityLabel="bar"
-            accessibilityTraits={undefined}
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            hitSlop={undefined}
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackgroundBorderless",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
@@ -237,13 +403,12 @@ exports[`Android BpkPicker should render correctly with a selected value 1`] = `
                 Object {},
               ]
             }
-            testID={undefined}
           >
             bar
           </Text>
         </View>
       </View>
-    </RCTScrollView>
-  </View>
+    </View>
+  </RCTScrollView>
 </Modal>
 `;

--- a/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.ios.js.snap
@@ -4,6 +4,12 @@ exports[`iOS BpkPicker should render correctly 1`] = `
 <Modal
   animationType="slide"
   hardwareAccelerated={false}
+  supportedOrientations={
+    Array [
+      "portrait",
+      "landscape",
+    ]
+  }
   transparent={true}
   visible={false}
 >
@@ -172,6 +178,12 @@ exports[`iOS BpkPicker should render correctly with a selected value 1`] = `
 <Modal
   animationType="slide"
   hardwareAccelerated={false}
+  supportedOrientations={
+    Array [
+      "portrait",
+      "landscape",
+    ]
+  }
   transparent={true}
   visible={false}
 >

--- a/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerItem-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerItem-test.android.js.snap
@@ -2,33 +2,39 @@
 
 exports[`Android BpkPickerItem should render correctly 1`] = `
 <View
+  accessibilityComponentType="button"
+  accessibilityLabel="label"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "padding": 16,
     }
   }
+  testID={undefined}
 >
   <Text
-    accessibilityComponentType={undefined}
-    accessibilityLabel="label"
-    accessibilityTraits={undefined}
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
-    hitSlop={undefined}
-    nativeBackgroundAndroid={
-      Object {
-        "attribute": "selectableItemBackgroundBorderless",
-        "type": "ThemeAttrAndroid",
-      }
-    }
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       Array [
         Object {
@@ -40,7 +46,6 @@ exports[`Android BpkPickerItem should render correctly 1`] = `
         Object {},
       ]
     }
-    testID={undefined}
   >
     label
   </Text>
@@ -49,33 +54,39 @@ exports[`Android BpkPickerItem should render correctly 1`] = `
 
 exports[`Android BpkPickerItem should render correctly with an onPress function 1`] = `
 <View
+  accessibilityComponentType="button"
+  accessibilityLabel="label"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "padding": 16,
     }
   }
+  testID={undefined}
 >
   <Text
-    accessibilityComponentType={undefined}
-    accessibilityLabel="label"
-    accessibilityTraits={undefined}
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
-    hitSlop={undefined}
-    nativeBackgroundAndroid={
-      Object {
-        "attribute": "selectableItemBackgroundBorderless",
-        "type": "ThemeAttrAndroid",
-      }
-    }
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       Array [
         Object {
@@ -87,7 +98,6 @@ exports[`Android BpkPickerItem should render correctly with an onPress function 
         Object {},
       ]
     }
-    testID={undefined}
   >
     label
   </Text>
@@ -96,33 +106,40 @@ exports[`Android BpkPickerItem should render correctly with an onPress function 
 
 exports[`Android BpkPickerItem should render correctly with the selected prop 1`] = `
 <View
+  accessibilityComponentType="button"
+  accessibilityLabel="label"
+  accessibilityTraits={
+    Array [
+      "button",
+      "selected",
+    ]
+  }
+  accessible={true}
+  hitSlop={undefined}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "padding": 16,
     }
   }
+  testID={undefined}
 >
   <Text
-    accessibilityComponentType={undefined}
-    accessibilityLabel="label"
-    accessibilityTraits={undefined}
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
-    hitSlop={undefined}
-    nativeBackgroundAndroid={
-      Object {
-        "attribute": "selectableItemBackgroundBorderless",
-        "type": "ThemeAttrAndroid",
-      }
-    }
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       Array [
         Object {
@@ -136,7 +153,6 @@ exports[`Android BpkPickerItem should render correctly with the selected prop 1`
         },
       ]
     }
-    testID={undefined}
   >
     label
   </Text>

--- a/native/packages/react-native-bpk-component-picker/stories.js
+++ b/native/packages/react-native-bpk-component-picker/stories.js
@@ -125,7 +125,7 @@ storiesOf('react-native-bpk-component-picker', module)
       <StatefulBpkPicker style={styles.picker} />
 
       <StorySubheading>With a selected value</StorySubheading>
-      <StatefulBpkPicker selectedValue="3" style={styles.picker} />
+      <StatefulBpkPicker selectedValue="1" style={styles.picker} />
 
       <StorySubheading>Disabled</StorySubheading>
       <StatefulBpkPicker disabled style={styles.picker} />


### PR DESCRIPTION
* When there are fewer than six options the picker is now longer full of empty space.
* The scrim is now interactive, it closes the picker when pressed.
* Picker items now have the correct ripple.
* Selected picker item is now always on screen on load, by using `initialScrollIndex` property of `FlatList`.
* Modal width and elevation now matches default Android styles.
* Now works in landscape mode on iOS.

**Note:** I don't love the magic numbers in use to calculate row height, but it's needed for `getItemLayout` and calculating the picker size. In the refactor card this should be optimised to be less fragile to styles changing.