### PR TITLE
[BPK-1371] Fix modal issue on iPad

### DIFF
--- a/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
+++ b/packages/bpk-scrim-utils/src/__snapshots__/withScrim-test.js.snap
@@ -11,6 +11,7 @@ exports[`BpkScrim render should render correctly 1`] = `
   />
   <TestComponent
     dialogRef={[Function]}
+    isIpad={false}
     isIphone={false}
     onClose={[Function]}
   />
@@ -28,6 +29,7 @@ exports[`BpkScrim render should render correctly when is iPhone 1`] = `
   />
   <TestComponent
     dialogRef={[Function]}
+    isIpad={false}
     isIphone={true}
     onClose={[Function]}
   />
@@ -45,6 +47,7 @@ exports[`BpkScrim render should render correctly with closeOnScrimClick as false
   />
   <TestComponent
     dialogRef={[Function]}
+    isIpad={false}
     isIphone={false}
     onClose={[Function]}
   />
@@ -62,6 +65,7 @@ exports[`BpkScrim render should render correctly with containerClassName 1`] = `
   />
   <TestComponent
     dialogRef={[Function]}
+    isIpad={false}
     isIphone={false}
     onClose={[Function]}
   />

--- a/packages/bpk-scrim-utils/src/scroll-utils.js
+++ b/packages/bpk-scrim-utils/src/scroll-utils.js
@@ -70,6 +70,26 @@ export const restoreScroll = () => {
   }
 };
 
+export const fixBody = () => {
+  const body = getBodyElement();
+
+  if (!body) {
+    return;
+  }
+
+  body.style.position = 'fixed';
+};
+
+export const unfixBody = () => {
+  const body = getBodyElement();
+
+  if (!body) {
+    return;
+  }
+
+  body.style.position = '';
+};
+
 export const lockScroll = () => {
   const body = getBodyElement();
 


### PR DESCRIPTION
Mobile safari running on an iPad exhibits many problems with the fixed
scrim used in the modal when the virtual keyboard is present. This
resolves many of these issues by adding `position: fixed` to the body
when the modal and other scrim using components are presented.

Things to consider:

- Does this have a negative effect anywhere we use the scrim?
- Should we make this configurable by the user or just always apply the fix?