### PR TITLE
[BPK-1405] Fix autosuggest id when used inside BpkFieldset

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 **Fixed:**
 - bpk-component-modal:
   - Fix bug on iPad when virtual keyboards is used in a modal.
+- bpk-component-fieldset:
+  - When wrapping a BpkAutosuggest in a BpkFieldset, the label's `for` attribute will now be correctly set from the Autosuggest's `inputProps` prop.
 
 ## 2018-03-22 - Native Picker Component
 

--- a/packages/bpk-component-fieldset/src/BpkFieldset.js
+++ b/packages/bpk-component-fieldset/src/BpkFieldset.js
@@ -60,9 +60,14 @@ const BpkFieldset = (props: Props) => {
     return null;
   }
 
+  let childId = children.props.id;
+  if (children.props.inputProps && children.props.inputProps.id) {
+    childId = children.props.inputProps.id;
+  }
+
   const classNames = [getClassName('bpk-fieldset')];
-  const validationMessageId = `${children.props.id}_validation_message`;
-  const descriptionId = `${children.props.id}_description`;
+  const validationMessageId = `${childId}_validation_message`;
+  const descriptionId = `${childId}_description`;
 
   // Explicit check for false primitive value as undefined is
   // treated as neither valid nor invalid
@@ -99,11 +104,7 @@ const BpkFieldset = (props: Props) => {
   return (
     <fieldset className={classNames.join(' ')} {...rest}>
       {!isCheckbox && (
-        <BpkLabel
-          htmlFor={children.props.id}
-          required={required}
-          disabled={disabled}
-        >
+        <BpkLabel htmlFor={childId} required={required} disabled={disabled}>
           {label}
         </BpkLabel>
       )}

--- a/packages/bpk-docs/src/pages/FieldsetsPage/FieldsetsPage.js
+++ b/packages/bpk-docs/src/pages/FieldsetsPage/FieldsetsPage.js
@@ -26,6 +26,9 @@ import readme from 'bpk-component-fieldset/readme.md';
 import PropTypes from 'prop-types';
 import React, { cloneElement, Component } from 'react';
 import { cssModules } from 'bpk-react-utils';
+import BpkAutosuggest, {
+  BpkAutosuggestSuggestion,
+} from 'bpk-component-autosuggest';
 
 import STYLES from './fieldsets-page.scss';
 import * as ROUTES from './../../constants/routes';
@@ -34,6 +37,151 @@ import Paragraph from './../../components/Paragraph';
 
 const getClassName = cssModules(STYLES);
 
+const offices = [
+  {
+    name: 'Barcelona',
+    code: 'BCN',
+    country: 'Spain',
+  },
+  {
+    name: 'Beijing',
+    code: 'Any',
+    country: 'China',
+  },
+  {
+    name: 'Budapest',
+    code: 'BUD',
+    country: 'Hungary',
+  },
+  {
+    name: 'Edinburgh',
+    code: 'EDI',
+    country: 'United Kingdom',
+  },
+  {
+    name: 'Glasgow',
+    code: 'Any',
+    country: 'United Kingdom',
+    indent: true,
+  },
+  {
+    name: 'London',
+    code: 'Any',
+    country: 'United Kingdom',
+  },
+  {
+    name: 'Miami, FL',
+    code: 'Any',
+    country: 'United States',
+  },
+  {
+    name: "Shenzhen Bao'an International",
+    code: 'SZX',
+    country: 'China',
+  },
+  {
+    name: 'Singapore Changi',
+    code: 'SIN',
+    country: 'Singapore',
+  },
+  {
+    name: 'Sofia',
+    code: 'SOF',
+    country: 'Bulgaria',
+  },
+];
+
+const getSuggestions = value => {
+  const inputValue = value.trim().toLowerCase();
+  const inputLength = inputValue.length;
+
+  return inputLength === 0
+    ? []
+    : offices.filter(
+        office => office.name.toLowerCase().indexOf(inputValue) !== -1,
+      );
+};
+
+const getSuggestionValue = suggestion =>
+  `${suggestion.name} (${suggestion.code})`;
+
+let instances = 0;
+
+class AutosuggestExample extends Component {
+  constructor() {
+    super();
+
+    instances += instances;
+
+    this.state = {
+      value: '',
+      suggestions: [],
+    };
+
+    this.onChange = this.onChange.bind(this);
+    this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(
+      this,
+    );
+    this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(
+      this,
+    );
+  }
+
+  onChange(e, { newValue }) {
+    this.setState({
+      value: newValue,
+    });
+  }
+
+  onSuggestionsFetchRequested({ value }) {
+    this.setState({
+      suggestions: getSuggestions(value),
+    });
+  }
+
+  onSuggestionsClearRequested() {
+    this.setState({
+      suggestions: [],
+    });
+  }
+
+  render() {
+    const { value, suggestions } = this.state;
+
+    const inputProps = {
+      id: 'carhire-search-controls-location-pick-up',
+      name: 'my_autosuggest',
+      value,
+      placeholder: 'Enter a destination name',
+      onChange: this.onChange,
+    };
+
+    return (
+      <FieldsetContainer
+        label="Destination"
+        validationMessage="Please select a destination."
+        validStates={[true, false]}
+        description="The final price will be adjusted based on your selection"
+      >
+        <BpkAutosuggest
+          suggestions={suggestions}
+          onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+          onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+          getSuggestionValue={getSuggestionValue}
+          renderSuggestion={suggestion => (
+            <BpkAutosuggestSuggestion
+              value={getSuggestionValue(suggestion)}
+              indent={suggestion.indent}
+            />
+          )}
+          inputProps={inputProps}
+        />
+      </FieldsetContainer>
+    );
+  }
+}
+
+// eslint-disable-next-line react/no-multi-comp
 class FieldsetContainer extends Component {
   constructor() {
     super();
@@ -150,6 +298,11 @@ const components = [
         </BpkSelect>
       </FieldsetContainer>,
     ],
+  },
+  {
+    id: 'autosuggest',
+    title: 'Autosuggests',
+    examples: [<AutosuggestExample />],
   },
   {
     id: 'checkboxes',


### PR DESCRIPTION
For purposes of recreating this bug and testing changes, I added an autosuggest example to the Fieldsets page. I haven't removed it again, as there may be value in leaving it there. 

I thought about making the necessary change within `BpkAutosuggest`, but being a wrapper component it is not easy. I have therefore added a fix in the BpkFieldset which uses the value of `children.props.inputProps.id` if available. If not, it will use `children.props.id` as normal.