### PR TITLE
[BPK-1437] Remove state from animate height component

### DIFF
--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight.js
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-import { View, Platform, Animated } from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { View, Platform, Animated, ViewPropTypes } from 'react-native';
 import { animationDurationSm } from 'bpk-tokens/tokens/base.react.native';
 
 const COLLAPSED_HEIGHT = 0.01;
@@ -28,107 +28,110 @@ class BpkAnimateHeight extends React.Component {
     super(props);
 
     this.state = {
-      expanded: this.props.expanded,
       height: new Animated.Value(COLLAPSED_HEIGHT),
-      inTree: this.props.expanded,
-      expandAnimationInProgress: false,
     };
+
+    this.inTree = this.props.expanded;
+    this.expandAnimationInProgress = false;
 
     // overflow: hidden is not properly supported on Android,
     // which causes animation to look shoddy.
     // See https://facebook.github.io/react-native/releases/0.49/docs/layout-props.html#overflow
     this.animationDuration =
       Platform.OS === 'ios' ? props.animationDuration : 0;
-
-    this.componentWillReceiveProps = this.componentWillReceiveProps.bind(this);
-    this.setExpandedHeight = this.setExpandedHeight.bind(this);
-    this.onHeightAnimationComplete = this.onHeightAnimationComplete.bind(this);
-    this.performAnimation = this.performAnimation.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.expanded !== this.state.expanded) {
-      if (this.state.expanded) {
-        this.setState({ expanded: false });
-        this.performAnimation(COLLAPSED_HEIGHT, this.props.collapseDelay);
-      } else {
-        this.setState({ inTree: true, expandAnimationInProgress: true });
-      }
+    if (nextProps.expanded === this.props.expanded) {
+      return;
+    }
+
+    if (nextProps.expanded) {
+      this.inTree = true;
+      this.expandAnimationInProgress = true;
+    } else {
+      this.animate(COLLAPSED_HEIGHT, this.props.collapseDelay);
     }
   }
 
-  onHeightAnimationComplete() {
+  onHeightAnimationComplete = () => {
     if (typeof this.props.onAnimationComplete === 'function') {
       this.props.onAnimationComplete();
     }
+
     // eslint-disable-next-line no-underscore-dangle
     if (this.state.height._value - 0.01 < 0.00001) {
-      this.setState({ inTree: false });
+      this.inTree = false;
+      this.forceUpdate();
     }
-  }
+  };
 
-  setExpandedHeight(event) {
+  setExpandedHeight = event => {
     const { height } = event.nativeEvent.layout;
+
     if (height === 0) {
       return;
     }
-    if (!this.state.expandAnimationInProgress) {
+
+    if (this.expandAnimationInProgress) {
+      this.expandAnimationInProgress = false;
+      this.animate(height, this.props.expandDelay);
+    } else {
       this.setState({
         height: new Animated.Value(
-          this.state.expanded ? height : COLLAPSED_HEIGHT,
+          this.props.expanded ? height : COLLAPSED_HEIGHT,
         ),
       });
-    } else {
-      this.setState({ expanded: true, expandAnimationInProgress: false });
-      this.performAnimation(height, this.props.expandDelay);
     }
-  }
+  };
 
-  performAnimation(height, delay) {
+  animate = (height, delay) => {
     Animated.timing(this.state.height, {
       toValue: height,
       duration: this.animationDuration,
       delay,
     }).start(this.onHeightAnimationComplete);
-  }
+  };
 
   render() {
     const {
-      animationDuration,
-      expanded,
       children,
+      expanded, // not used in render
+      animationDuration,
       expandDelay,
       collapseDelay,
       onAnimationComplete,
+      style,
       ...rest
     } = this.props;
 
     const { height } = this.state;
 
-    return this.state.inTree ? (
-      <View {...rest}>
-        <Animated.View
-          style={{
-            overflow: 'hidden',
-            height,
-          }}
-        >
-          <View onLayout={event => this.setExpandedHeight(event)}>
-            {this.props.children}
-          </View>
-        </Animated.View>
-      </View>
+    return this.inTree ? (
+      <Animated.View
+        {...rest}
+        style={{
+          ...style,
+          overflow: 'hidden',
+          height,
+        }}
+      >
+        <View onLayout={event => this.setExpandedHeight(event)}>
+          {this.props.children}
+        </View>
+      </Animated.View>
     ) : null;
   }
 }
 
 BpkAnimateHeight.propTypes = {
-  animationDuration: PropTypes.number,
-  expanded: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
+  expanded: PropTypes.bool.isRequired,
+  animationDuration: PropTypes.number,
   expandDelay: PropTypes.number,
   collapseDelay: PropTypes.number,
   onAnimationComplete: PropTypes.func,
+  style: ViewPropTypes.style,
 };
 
 BpkAnimateHeight.defaultProps = {
@@ -136,6 +139,7 @@ BpkAnimateHeight.defaultProps = {
   expandDelay: 0,
   collapseDelay: 0,
   onAnimationComplete: null,
+  style: null,
 };
 
 export default BpkAnimateHeight;

--- a/native/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.android.js.snap
@@ -3,136 +3,125 @@
 exports[`Android BpkAnimateHeight should render correctly collapsed 1`] = `null`;
 
 exports[`Android BpkAnimateHeight should render correctly expanded 1`] = `
-<View>
-  <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
+<View
+  collapsable={undefined}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
-    <View
-      onLayout={[Function]}
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "sans-serif",
+            "fontSize": 16,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
     >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "rgb(82, 76, 97)",
-              "fontFamily": "sans-serif",
-              "fontSize": 16,
-              "fontWeight": "400",
-            },
-            Object {},
-          ]
-        }
-      >
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-      </Text>
-    </View>
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </Text>
   </View>
 </View>
 `;
 
 exports[`Android BpkAnimateHeight should render correctly with n children 1`] = `
-<View>
-  <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
+<View
+  collapsable={undefined}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
-    <View
-      onLayout={[Function]}
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "sans-serif",
+            "fontSize": 16,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
     >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "rgb(82, 76, 97)",
-              "fontFamily": "sans-serif",
-              "fontSize": 16,
-              "fontWeight": "400",
-            },
-            Object {},
-          ]
-        }
-      >
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-      </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "rgb(82, 76, 97)",
-              "fontFamily": "sans-serif",
-              "fontSize": 16,
-              "fontWeight": "400",
-            },
-            Object {},
-          ]
-        }
-      >
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-      </Text>
-    </View>
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "sans-serif",
+            "fontSize": 16,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
+    >
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </Text>
   </View>
 </View>
 `;
 
 exports[`Android BpkAnimateHeight should render correctly with user styling padding 1`] = `
 <View
+  collapsable={undefined}
   style={
     Object {
+      "height": 0.01,
       "marginBottom": 12,
+      "overflow": "hidden",
     }
   }
 >
   <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
+    onLayout={[Function]}
   >
-    <View
-      onLayout={[Function]}
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "sans-serif",
+            "fontSize": 16,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
     >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "rgb(82, 76, 97)",
-              "fontFamily": "sans-serif",
-              "fontSize": 16,
-              "fontWeight": "400",
-            },
-            Object {},
-          ]
-        }
-      >
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-      </Text>
-    </View>
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </Text>
   </View>
 </View>
 `;

--- a/native/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.ios.js.snap
@@ -3,136 +3,125 @@
 exports[`iOS BpkAnimateHeight should render correctly collapsed 1`] = `null`;
 
 exports[`iOS BpkAnimateHeight should render correctly expanded 1`] = `
-<View>
-  <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
+<View
+  collapsable={undefined}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
-    <View
-      onLayout={[Function]}
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 15,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
     >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "rgb(82, 76, 97)",
-              "fontFamily": "System",
-              "fontSize": 15,
-              "fontWeight": "400",
-            },
-            Object {},
-          ]
-        }
-      >
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-      </Text>
-    </View>
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </Text>
   </View>
 </View>
 `;
 
 exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
-<View>
-  <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
+<View
+  collapsable={undefined}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
-    <View
-      onLayout={[Function]}
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 15,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
     >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "rgb(82, 76, 97)",
-              "fontFamily": "System",
-              "fontSize": 15,
-              "fontWeight": "400",
-            },
-            Object {},
-          ]
-        }
-      >
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-      </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "rgb(82, 76, 97)",
-              "fontFamily": "System",
-              "fontSize": 15,
-              "fontWeight": "400",
-            },
-            Object {},
-          ]
-        }
-      >
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-      </Text>
-    </View>
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 15,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
+    >
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </Text>
   </View>
 </View>
 `;
 
 exports[`iOS BpkAnimateHeight should render correctly with user styling padding 1`] = `
 <View
+  collapsable={undefined}
   style={
     Object {
+      "height": 0.01,
       "marginBottom": 12,
+      "overflow": "hidden",
     }
   }
 >
   <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
+    onLayout={[Function]}
   >
-    <View
-      onLayout={[Function]}
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 15,
+            "fontWeight": "400",
+          },
+          Object {},
+        ]
+      }
     >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "rgb(82, 76, 97)",
-              "fontFamily": "System",
-              "fontSize": 15,
-              "fontWeight": "400",
-            },
-            Object {},
-          ]
-        }
-      >
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-      </Text>
-    </View>
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </Text>
   </View>
 </View>
 `;

--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.android.js.snap
@@ -4,38 +4,34 @@ exports[`Android AnimateAndFade should render correctly 1`] = `
 <View
   animateOnEnter={false}
   animateOnLeave={false}
+  collapsable={undefined}
   duration={200}
   show={true}
-  style={null}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
 >
   <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
         }
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
       >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-        >
-          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-        </Text>
-      </View>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+      </Text>
     </View>
   </View>
 </View>
@@ -45,38 +41,34 @@ exports[`Android AnimateAndFade should render correctly when show is false 1`] =
 <View
   animateOnEnter={false}
   animateOnLeave={false}
+  collapsable={undefined}
   duration={200}
   show={false}
-  style={null}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
 >
   <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
         }
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
       >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-        >
-          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-        </Text>
-      </View>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+      </Text>
     </View>
   </View>
 </View>
@@ -88,39 +80,35 @@ exports[`Android AnimateAndFade should render correctly with animateOnLeave 1`] 
 <View
   animateOnEnter={false}
   animateOnLeave={true}
+  collapsable={undefined}
   duration={200}
   show={true}
   shown={true}
-  style={null}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
 >
   <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
         }
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
       >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-        >
-          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-        </Text>
-      </View>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+      </Text>
     </View>
   </View>
 </View>

--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.ios.js.snap
@@ -4,38 +4,34 @@ exports[`iOS AnimateAndFade should render correctly 1`] = `
 <View
   animateOnEnter={false}
   animateOnLeave={false}
+  collapsable={undefined}
   duration={200}
   show={true}
-  style={null}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
 >
   <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
         }
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
       >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-        >
-          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-        </Text>
-      </View>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+      </Text>
     </View>
   </View>
 </View>
@@ -45,38 +41,34 @@ exports[`iOS AnimateAndFade should render correctly when show is false 1`] = `
 <View
   animateOnEnter={false}
   animateOnLeave={false}
+  collapsable={undefined}
   duration={200}
   show={false}
-  style={null}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
 >
   <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
         }
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
       >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-        >
-          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-        </Text>
-      </View>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+      </Text>
     </View>
   </View>
 </View>
@@ -88,39 +80,35 @@ exports[`iOS AnimateAndFade should render correctly with animateOnLeave 1`] = `
 <View
   animateOnEnter={false}
   animateOnLeave={true}
+  collapsable={undefined}
   duration={200}
   show={true}
   shown={true}
-  style={null}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
 >
   <View
-    collapsable={undefined}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
         }
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
       >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-        >
-          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-        </Text>
-      </View>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+      </Text>
     </View>
   </View>
 </View>

--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
@@ -5,114 +5,107 @@ exports[`Android BpkBannerAlert should accept user-stlying 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(129, 123, 143)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(129, 123, 143)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Neutral alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Neutral alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -122,114 +115,107 @@ exports[`Android BpkBannerAlert should accept user-stlying 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(0, 215, 117)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(0, 215, 117)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Successful alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Successful alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -239,114 +225,107 @@ exports[`Android BpkBannerAlert should accept user-stlying 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 187, 0)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 187, 0)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Warn alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Warn alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -356,114 +335,107 @@ exports[`Android BpkBannerAlert should accept user-stlying 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 84, 82)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 84, 82)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Error alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Error alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -478,110 +450,106 @@ exports[`Android BpkBannerAlert should render correctly 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(129, 123, 143)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(129, 123, 143)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Neutral alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Neutral alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -591,110 +559,106 @@ exports[`Android BpkBannerAlert should render correctly 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(0, 215, 117)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(0, 215, 117)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Successful alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Successful alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -704,110 +668,106 @@ exports[`Android BpkBannerAlert should render correctly 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 187, 0)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 187, 0)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Warn alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Warn alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -817,110 +777,106 @@ exports[`Android BpkBannerAlert should render correctly 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 84, 82)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 84, 82)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Error alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Error alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -935,146 +891,90 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(129, 123, 143)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Neutral alert.
-                </Text>
-              </View>
-            </View>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(243, 242, 245)",
-                    "justifyContent": "center",
-                    "paddingRight": 24,
-                  },
-                  Object {
-                    "borderRadius": 2,
-                  },
-                ]
               }
             >
               <Text
-                accessibilityComponentType="button"
-                accessibilityLabel="Dismiss"
-                accessibilityTraits={undefined}
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
-                hitSlop={undefined}
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackgroundBorderless",
-                    "type": "ThemeAttrAndroid",
-                  }
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(129, 123, 143)",
+                      },
+                    ],
+                  ]
                 }
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
                   Array [
                     Object {
@@ -1084,18 +984,70 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
                       "fontWeight": "400",
                     },
                     Object {
-                      "fontFamily": "sans-serif-medium",
-                    },
-                    Object {
-                      "color": "rgb(0, 178, 214)",
+                      "flex": 1,
                     },
                   ]
                 }
-                testID={undefined}
               >
-                DISMISS
+                Neutral alert.
               </Text>
             </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "rgb(243, 242, 245)",
+                  "justifyContent": "center",
+                  "paddingRight": 24,
+                },
+                Object {
+                  "borderRadius": 2,
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityComponentType="button"
+              accessibilityLabel="Dismiss"
+              accessibilityTraits={undefined}
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              hitSlop={undefined}
+              nativeBackgroundAndroid={
+                Object {
+                  "attribute": "selectableItemBackgroundBorderless",
+                  "type": "ThemeAttrAndroid",
+                }
+              }
+              onLayout={undefined}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "fontFamily": "sans-serif-medium",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                ]
+              }
+              testID={undefined}
+            >
+              DISMISS
+            </Text>
           </View>
         </View>
       </View>
@@ -1104,146 +1056,90 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(0, 215, 117)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Successful alert.
-                </Text>
-              </View>
-            </View>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(243, 242, 245)",
-                    "justifyContent": "center",
-                    "paddingRight": 24,
-                  },
-                  Object {
-                    "borderRadius": 2,
-                  },
-                ]
               }
             >
               <Text
-                accessibilityComponentType="button"
-                accessibilityLabel="Dismiss"
-                accessibilityTraits={undefined}
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
-                hitSlop={undefined}
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackgroundBorderless",
-                    "type": "ThemeAttrAndroid",
-                  }
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(0, 215, 117)",
+                      },
+                    ],
+                  ]
                 }
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
                   Array [
                     Object {
@@ -1253,18 +1149,70 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
                       "fontWeight": "400",
                     },
                     Object {
-                      "fontFamily": "sans-serif-medium",
-                    },
-                    Object {
-                      "color": "rgb(0, 178, 214)",
+                      "flex": 1,
                     },
                   ]
                 }
-                testID={undefined}
               >
-                DISMISS
+                Successful alert.
               </Text>
             </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "rgb(243, 242, 245)",
+                  "justifyContent": "center",
+                  "paddingRight": 24,
+                },
+                Object {
+                  "borderRadius": 2,
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityComponentType="button"
+              accessibilityLabel="Dismiss"
+              accessibilityTraits={undefined}
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              hitSlop={undefined}
+              nativeBackgroundAndroid={
+                Object {
+                  "attribute": "selectableItemBackgroundBorderless",
+                  "type": "ThemeAttrAndroid",
+                }
+              }
+              onLayout={undefined}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "fontFamily": "sans-serif-medium",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                ]
+              }
+              testID={undefined}
+            >
+              DISMISS
+            </Text>
           </View>
         </View>
       </View>
@@ -1273,146 +1221,90 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 187, 0)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Warn alert.
-                </Text>
-              </View>
-            </View>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(243, 242, 245)",
-                    "justifyContent": "center",
-                    "paddingRight": 24,
-                  },
-                  Object {
-                    "borderRadius": 2,
-                  },
-                ]
               }
             >
               <Text
-                accessibilityComponentType="button"
-                accessibilityLabel="Dismiss"
-                accessibilityTraits={undefined}
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
-                hitSlop={undefined}
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackgroundBorderless",
-                    "type": "ThemeAttrAndroid",
-                  }
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 187, 0)",
+                      },
+                    ],
+                  ]
                 }
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
                   Array [
                     Object {
@@ -1422,18 +1314,70 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
                       "fontWeight": "400",
                     },
                     Object {
-                      "fontFamily": "sans-serif-medium",
-                    },
-                    Object {
-                      "color": "rgb(0, 178, 214)",
+                      "flex": 1,
                     },
                   ]
                 }
-                testID={undefined}
               >
-                DISMISS
+                Warn alert.
               </Text>
             </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "rgb(243, 242, 245)",
+                  "justifyContent": "center",
+                  "paddingRight": 24,
+                },
+                Object {
+                  "borderRadius": 2,
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityComponentType="button"
+              accessibilityLabel="Dismiss"
+              accessibilityTraits={undefined}
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              hitSlop={undefined}
+              nativeBackgroundAndroid={
+                Object {
+                  "attribute": "selectableItemBackgroundBorderless",
+                  "type": "ThemeAttrAndroid",
+                }
+              }
+              onLayout={undefined}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "fontFamily": "sans-serif-medium",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                ]
+              }
+              testID={undefined}
+            >
+              DISMISS
+            </Text>
           </View>
         </View>
       </View>
@@ -1442,146 +1386,90 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 84, 82)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Error alert.
-                </Text>
-              </View>
-            </View>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(243, 242, 245)",
-                    "justifyContent": "center",
-                    "paddingRight": 24,
-                  },
-                  Object {
-                    "borderRadius": 2,
-                  },
-                ]
               }
             >
               <Text
-                accessibilityComponentType="button"
-                accessibilityLabel="Dismiss"
-                accessibilityTraits={undefined}
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
-                hitSlop={undefined}
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackgroundBorderless",
-                    "type": "ThemeAttrAndroid",
-                  }
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 84, 82)",
+                      },
+                    ],
+                  ]
                 }
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
                   Array [
                     Object {
@@ -1591,18 +1479,70 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
                       "fontWeight": "400",
                     },
                     Object {
-                      "fontFamily": "sans-serif-medium",
-                    },
-                    Object {
-                      "color": "rgb(0, 178, 214)",
+                      "flex": 1,
                     },
                   ]
                 }
-                testID={undefined}
               >
-                DISMISS
+                Error alert.
               </Text>
             </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "rgb(243, 242, 245)",
+                  "justifyContent": "center",
+                  "paddingRight": 24,
+                },
+                Object {
+                  "borderRadius": 2,
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityComponentType="button"
+              accessibilityLabel="Dismiss"
+              accessibilityTraits={undefined}
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              hitSlop={undefined}
+              nativeBackgroundAndroid={
+                Object {
+                  "attribute": "selectableItemBackgroundBorderless",
+                  "type": "ThemeAttrAndroid",
+                }
+              }
+              onLayout={undefined}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "fontFamily": "sans-serif-medium",
+                  },
+                  Object {
+                    "color": "rgb(0, 178, 214)",
+                  },
+                ]
+              }
+              testID={undefined}
+            >
+              DISMISS
+            </Text>
           </View>
         </View>
       </View>
@@ -1616,131 +1556,67 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(129, 123, 143)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Neutral alert.
-                </Text>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -1760,15 +1636,75 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(129, 123, 143)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Neutral alert.
               </Text>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -1777,131 +1713,67 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(0, 215, 117)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Successful alert.
-                </Text>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -1921,15 +1793,75 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(0, 215, 117)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Successful alert.
               </Text>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -1938,131 +1870,67 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 187, 0)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Warn alert.
-                </Text>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -2082,15 +1950,75 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 187, 0)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Warn alert.
               </Text>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -2099,131 +2027,67 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 84, 82)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Error alert.
-                </Text>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -2243,15 +2107,75 @@ exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 84, 82)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Error alert.
               </Text>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -2265,173 +2189,67 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(129, 123, 143)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Neutral alert.
-                </Text>
-              </View>
-              <View>
-                <View
-                  collapsable={undefined}
-                  style={
-                    Object {
-                      "height": 0.01,
-                      "overflow": "hidden",
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  >
-                    <View
-                      style={
-                        Object {
-                          "paddingVertical": 4,
-                        }
-                      }
-                    >
-                      <Text
-                        accessible={true}
-                        allowFontScaling={true}
-                        ellipsizeMode="tail"
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgb(82, 76, 97)",
-                              "fontFamily": "sans-serif",
-                              "fontSize": 14,
-                              "fontWeight": "400",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -2451,15 +2269,115 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(129, 123, 143)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Neutral alert.
               </Text>
             </View>
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "height": 0.01,
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgb(82, 76, 97)",
+                          "fontFamily": "sans-serif",
+                          "fontSize": 14,
+                          "fontWeight": "400",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -2468,173 +2386,67 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(0, 215, 117)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Successful alert.
-                </Text>
-              </View>
-              <View>
-                <View
-                  collapsable={undefined}
-                  style={
-                    Object {
-                      "height": 0.01,
-                      "overflow": "hidden",
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  >
-                    <View
-                      style={
-                        Object {
-                          "paddingVertical": 4,
-                        }
-                      }
-                    >
-                      <Text
-                        accessible={true}
-                        allowFontScaling={true}
-                        ellipsizeMode="tail"
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgb(82, 76, 97)",
-                              "fontFamily": "sans-serif",
-                              "fontSize": 14,
-                              "fontWeight": "400",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -2654,15 +2466,115 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(0, 215, 117)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Successful alert.
               </Text>
             </View>
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "height": 0.01,
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgb(82, 76, 97)",
+                          "fontFamily": "sans-serif",
+                          "fontSize": 14,
+                          "fontWeight": "400",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -2671,173 +2583,67 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 187, 0)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Warn alert.
-                </Text>
-              </View>
-              <View>
-                <View
-                  collapsable={undefined}
-                  style={
-                    Object {
-                      "height": 0.01,
-                      "overflow": "hidden",
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  >
-                    <View
-                      style={
-                        Object {
-                          "paddingVertical": 4,
-                        }
-                      }
-                    >
-                      <Text
-                        accessible={true}
-                        allowFontScaling={true}
-                        ellipsizeMode="tail"
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgb(82, 76, 97)",
-                              "fontFamily": "sans-serif",
-                              "fontSize": 14,
-                              "fontWeight": "400",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -2857,15 +2663,115 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 187, 0)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Warn alert.
               </Text>
             </View>
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "height": 0.01,
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgb(82, 76, 97)",
+                          "fontFamily": "sans-serif",
+                          "fontSize": 14,
+                          "fontWeight": "400",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -2874,173 +2780,67 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 84, 82)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Error alert.
-                </Text>
-              </View>
-              <View>
-                <View
-                  collapsable={undefined}
-                  style={
-                    Object {
-                      "height": 0.01,
-                      "overflow": "hidden",
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  >
-                    <View
-                      style={
-                        Object {
-                          "paddingVertical": 4,
-                        }
-                      }
-                    >
-                      <Text
-                        accessible={true}
-                        allowFontScaling={true}
-                        ellipsizeMode="tail"
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgb(82, 76, 97)",
-                              "fontFamily": "sans-serif",
-                              "fontSize": 14,
-                              "fontWeight": "400",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -3060,15 +2860,115 @@ exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 84, 82)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Error alert.
               </Text>
             </View>
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "height": 0.01,
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgb(82, 76, 97)",
+                          "fontFamily": "sans-serif",
+                          "fontSize": 14,
+                          "fontWeight": "400",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -3082,173 +2982,67 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(129, 123, 143)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Neutral alert.
-                </Text>
-              </View>
-              <View>
-                <View
-                  collapsable={undefined}
-                  style={
-                    Object {
-                      "height": 0.01,
-                      "overflow": "hidden",
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  >
-                    <View
-                      style={
-                        Object {
-                          "paddingVertical": 4,
-                        }
-                      }
-                    >
-                      <Text
-                        accessible={true}
-                        allowFontScaling={true}
-                        ellipsizeMode="tail"
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgb(82, 76, 97)",
-                              "fontFamily": "sans-serif",
-                              "fontSize": 14,
-                              "fontWeight": "400",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -3268,15 +3062,115 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(129, 123, 143)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Neutral alert.
               </Text>
             </View>
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "height": 0.01,
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgb(82, 76, 97)",
+                          "fontFamily": "sans-serif",
+                          "fontSize": 14,
+                          "fontWeight": "400",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -3285,173 +3179,67 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(0, 215, 117)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Successful alert.
-                </Text>
-              </View>
-              <View>
-                <View
-                  collapsable={undefined}
-                  style={
-                    Object {
-                      "height": 0.01,
-                      "overflow": "hidden",
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  >
-                    <View
-                      style={
-                        Object {
-                          "paddingVertical": 4,
-                        }
-                      }
-                    >
-                      <Text
-                        accessible={true}
-                        allowFontScaling={true}
-                        ellipsizeMode="tail"
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgb(82, 76, 97)",
-                              "fontFamily": "sans-serif",
-                              "fontSize": 14,
-                              "fontWeight": "400",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -3471,15 +3259,115 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(0, 215, 117)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Successful alert.
               </Text>
             </View>
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "height": 0.01,
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgb(82, 76, 97)",
+                          "fontFamily": "sans-serif",
+                          "fontSize": 14,
+                          "fontWeight": "400",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -3488,173 +3376,67 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 187, 0)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Warn alert.
-                </Text>
-              </View>
-              <View>
-                <View
-                  collapsable={undefined}
-                  style={
-                    Object {
-                      "height": 0.01,
-                      "overflow": "hidden",
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  >
-                    <View
-                      style={
-                        Object {
-                          "paddingVertical": 4,
-                        }
-                      }
-                    >
-                      <Text
-                        accessible={true}
-                        allowFontScaling={true}
-                        ellipsizeMode="tail"
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgb(82, 76, 97)",
-                              "fontFamily": "sans-serif",
-                              "fontSize": 14,
-                              "fontWeight": "400",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -3674,15 +3456,115 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 187, 0)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Warn alert.
               </Text>
             </View>
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "height": 0.01,
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgb(82, 76, 97)",
+                          "fontFamily": "sans-serif",
+                          "fontSize": 14,
+                          "fontWeight": "400",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -3691,173 +3573,67 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
+          testID={undefined}
         >
           <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
-            testID={undefined}
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 84, 82)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Error alert.
-                </Text>
-              </View>
-              <View>
-                <View
-                  collapsable={undefined}
-                  style={
-                    Object {
-                      "height": 0.01,
-                      "overflow": "hidden",
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  >
-                    <View
-                      style={
-                        Object {
-                          "paddingVertical": 4,
-                        }
-                      }
-                    >
-                      <Text
-                        accessible={true}
-                        allowFontScaling={true}
-                        ellipsizeMode="tail"
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgb(82, 76, 97)",
-                              "fontFamily": "sans-serif",
-                              "fontSize": 14,
-                              "fontWeight": "400",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
@@ -3877,15 +3653,115 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
                       "fontSize": 16,
                       "lineHeight": 16,
                     },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 84, 82)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
                     Object {
-                      "paddingTop": 3,
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
                     },
                   ]
                 }
               >
-                
+                Error alert.
               </Text>
             </View>
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "height": 0.01,
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgb(82, 76, 97)",
+                          "fontFamily": "sans-serif",
+                          "fontSize": 14,
+                          "fontWeight": "400",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "justifyContent": "center",
+                "paddingRight": 24,
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingTop": 3,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
           </View>
         </View>
       </View>
@@ -3899,114 +3775,107 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={false}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(129, 123, 143)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(129, 123, 143)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Neutral alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Neutral alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -4016,114 +3885,107 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={false}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(0, 215, 117)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(0, 215, 117)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Successful alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Successful alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -4133,114 +3995,107 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={false}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 187, 0)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 187, 0)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Warn alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Warn alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -4250,114 +4105,107 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={false}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 84, 82)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 84, 82)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Error alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Error alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -4374,114 +4222,107 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(129, 123, 143)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(129, 123, 143)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Neutral alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Neutral alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -4491,114 +4332,107 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(0, 215, 117)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(0, 215, 117)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Successful alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Successful alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -4608,114 +4442,107 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 187, 0)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 187, 0)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Warn alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Warn alert.
+              </Text>
             </View>
           </View>
         </View>
@@ -4725,114 +4552,107 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <View
             style={
-              Array [
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ]
+              Object {
+                "backgroundColor": "rgb(243, 242, 245)",
+                "flex": 1,
+                "minHeight": 56,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "flex": 1,
-                  "minHeight": 56,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 16,
+                  "display": "flex",
+                  "flexDirection": "row",
                 }
               }
             >
-              <View
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
                 style={
-                  Object {
-                    "display": "flex",
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "BpkIcon",
+                      "fontSize": 24,
+                      "lineHeight": 24,
+                    },
+                    Object {
+                      "fontSize": 16,
+                      "lineHeight": 16,
+                    },
+                    Array [
+                      Object {
+                        "paddingRight": 4,
+                        "paddingTop": 3,
+                      },
+                      Object {
+                        "color": "rgb(255, 84, 82)",
+                      },
+                    ],
+                  ]
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "BpkIcon",
-                        "fontSize": 24,
-                        "lineHeight": 24,
-                      },
-                      Object {
-                        "fontSize": 16,
-                        "lineHeight": 16,
-                      },
-                      Array [
-                        Object {
-                          "paddingRight": 4,
-                          "paddingTop": 3,
-                        },
-                        Object {
-                          "color": "rgb(255, 84, 82)",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgb(82, 76, 97)",
-                        "fontFamily": "sans-serif",
-                        "fontSize": 14,
-                        "fontWeight": "400",
-                      },
-                      Object {
-                        "flex": 1,
-                      },
-                    ]
-                  }
-                >
-                  Error alert.
-                </Text>
-              </View>
+                
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "rgb(82, 76, 97)",
+                      "fontFamily": "sans-serif",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                Error alert.
+              </Text>
             </View>
           </View>
         </View>

--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
@@ -5,110 +5,103 @@ exports[`iOS BpkBannerAlert should accept user-stlying 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(178, 174, 189)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(178, 174, 189)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
+              Neutral alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -117,110 +110,103 @@ exports[`iOS BpkBannerAlert should accept user-stlying 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(0, 215, 117)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(0, 215, 117)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(0, 215, 117)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
+              Successful alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -229,110 +215,103 @@ exports[`iOS BpkBannerAlert should accept user-stlying 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 187, 0)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 187, 0)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 187, 0)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
+              Warn alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -341,110 +320,103 @@ exports[`iOS BpkBannerAlert should accept user-stlying 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 84, 82)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 84, 82)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 84, 82)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
+              Error alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -458,106 +430,102 @@ exports[`iOS BpkBannerAlert should render correctly 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(178, 174, 189)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(178, 174, 189)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
+              Neutral alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -566,106 +534,102 @@ exports[`iOS BpkBannerAlert should render correctly 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(0, 215, 117)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(0, 215, 117)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(0, 215, 117)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
+              Successful alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -674,106 +638,102 @@ exports[`iOS BpkBannerAlert should render correctly 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 187, 0)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 187, 0)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 187, 0)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
+              Warn alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -782,106 +742,102 @@ exports[`iOS BpkBannerAlert should render correctly 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 84, 82)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 84, 82)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 84, 82)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
+              Error alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -895,170 +851,166 @@ exports[`iOS BpkBannerAlert should render correctly dismissable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(178, 174, 189)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
                 Object {
-                  "borderColor": "rgb(178, 174, 189)",
+                  "paddingEnd": 32,
                 },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
                   },
                   Object {
-                    "paddingEnd": 32,
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Dismiss"
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "padding": 8,
-                  "position": "absolute",
-                  "right": 0,
-                }
+              Neutral alert.
+            </Text>
+          </View>
+          <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Dismiss"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "padding": 8,
+                "position": "absolute",
+                "right": 0,
               }
-              testID={undefined}
+            }
+            testID={undefined}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
           </View>
         </View>
       </View>
@@ -1067,170 +1019,166 @@ exports[`iOS BpkBannerAlert should render correctly dismissable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(0, 215, 117)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
                 Object {
-                  "borderColor": "rgb(0, 215, 117)",
+                  "paddingEnd": 32,
                 },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
                   },
                   Object {
-                    "paddingEnd": 32,
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(0, 215, 117)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Dismiss"
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "padding": 8,
-                  "position": "absolute",
-                  "right": 0,
-                }
+              Successful alert.
+            </Text>
+          </View>
+          <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Dismiss"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "padding": 8,
+                "position": "absolute",
+                "right": 0,
               }
-              testID={undefined}
+            }
+            testID={undefined}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
           </View>
         </View>
       </View>
@@ -1239,170 +1187,166 @@ exports[`iOS BpkBannerAlert should render correctly dismissable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 187, 0)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
                 Object {
-                  "borderColor": "rgb(255, 187, 0)",
+                  "paddingEnd": 32,
                 },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
                   },
                   Object {
-                    "paddingEnd": 32,
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 187, 0)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Dismiss"
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "padding": 8,
-                  "position": "absolute",
-                  "right": 0,
-                }
+              Warn alert.
+            </Text>
+          </View>
+          <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Dismiss"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "padding": 8,
+                "position": "absolute",
+                "right": 0,
               }
-              testID={undefined}
+            }
+            testID={undefined}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
           </View>
         </View>
       </View>
@@ -1411,170 +1355,166 @@ exports[`iOS BpkBannerAlert should render correctly dismissable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 84, 82)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
                 Object {
-                  "borderColor": "rgb(255, 84, 82)",
+                  "paddingEnd": 32,
                 },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
                   },
                   Object {
-                    "paddingEnd": 32,
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 84, 82)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Dismiss"
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "padding": 8,
-                  "position": "absolute",
-                  "right": 0,
-                }
+              Error alert.
+            </Text>
+          </View>
+          <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Dismiss"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "padding": 8,
+                "position": "absolute",
+                "right": 0,
               }
-              testID={undefined}
+            }
+            testID={undefined}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
           </View>
         </View>
       </View>
@@ -1588,160 +1528,156 @@ exports[`iOS BpkBannerAlert should render correctly expandable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(178, 174, 189)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(178, 174, 189)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
+              Neutral alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
           </View>
         </View>
       </View>
@@ -1750,160 +1686,156 @@ exports[`iOS BpkBannerAlert should render correctly expandable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(0, 215, 117)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(0, 215, 117)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(0, 215, 117)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
+              Successful alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
           </View>
         </View>
       </View>
@@ -1912,160 +1844,156 @@ exports[`iOS BpkBannerAlert should render correctly expandable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 187, 0)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 187, 0)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 187, 0)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
+              Warn alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
           </View>
         </View>
       </View>
@@ -2074,160 +2002,156 @@ exports[`iOS BpkBannerAlert should render correctly expandable 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 84, 82)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 84, 82)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 84, 82)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
+              Error alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
           </View>
         </View>
       </View>
@@ -2241,99 +2165,171 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(178, 174, 189)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(178, 174, 189)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
+              Neutral alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "height": 0.01,
+                "overflow": "hidden",
+                "padding": 8,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2346,95 +2342,12 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                       "fontSize": 13,
                       "fontWeight": "400",
                     },
-                    Object {
-                      "flex": 1,
-                    },
+                    Object {},
                   ]
                 }
               >
-                Neutral alert.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
               </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
-            <View
-              style={
-                Object {
-                  "padding": 8,
-                  "paddingTop": 0,
-                }
-              }
-            >
-              <View
-                collapsable={undefined}
-                style={
-                  Object {
-                    "height": 0.01,
-                    "overflow": "hidden",
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "System",
-                          "fontSize": 13,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
             </View>
           </View>
         </View>
@@ -2444,99 +2357,171 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(0, 215, 117)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(0, 215, 117)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(0, 215, 117)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
+              Successful alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "height": 0.01,
+                "overflow": "hidden",
+                "padding": 8,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2549,95 +2534,12 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                       "fontSize": 13,
                       "fontWeight": "400",
                     },
-                    Object {
-                      "flex": 1,
-                    },
+                    Object {},
                   ]
                 }
               >
-                Successful alert.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
               </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
-            <View
-              style={
-                Object {
-                  "padding": 8,
-                  "paddingTop": 0,
-                }
-              }
-            >
-              <View
-                collapsable={undefined}
-                style={
-                  Object {
-                    "height": 0.01,
-                    "overflow": "hidden",
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "System",
-                          "fontSize": 13,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
             </View>
           </View>
         </View>
@@ -2647,99 +2549,171 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 187, 0)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 187, 0)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 187, 0)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
+              Warn alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "height": 0.01,
+                "overflow": "hidden",
+                "padding": 8,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2752,95 +2726,12 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                       "fontSize": 13,
                       "fontWeight": "400",
                     },
-                    Object {
-                      "flex": 1,
-                    },
+                    Object {},
                   ]
                 }
               >
-                Warn alert.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
               </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
-            <View
-              style={
-                Object {
-                  "padding": 8,
-                  "paddingTop": 0,
-                }
-              }
-            >
-              <View
-                collapsable={undefined}
-                style={
-                  Object {
-                    "height": 0.01,
-                    "overflow": "hidden",
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "System",
-                          "fontSize": 13,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
             </View>
           </View>
         </View>
@@ -2850,99 +2741,171 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 84, 82)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 84, 82)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 84, 82)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
+              Error alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "height": 0.01,
+                "overflow": "hidden",
+                "padding": 8,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2955,95 +2918,12 @@ exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
                       "fontSize": 13,
                       "fontWeight": "400",
                     },
-                    Object {
-                      "flex": 1,
-                    },
+                    Object {},
                   ]
                 }
               >
-                Error alert.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
               </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
-            <View
-              style={
-                Object {
-                  "padding": 8,
-                  "paddingTop": 0,
-                }
-              }
-            >
-              <View
-                collapsable={undefined}
-                style={
-                  Object {
-                    "height": 0.01,
-                    "overflow": "hidden",
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "System",
-                          "fontSize": 13,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
             </View>
           </View>
         </View>
@@ -3058,99 +2938,171 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(178, 174, 189)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(178, 174, 189)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
+              Neutral alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "height": 0.01,
+                "overflow": "hidden",
+                "padding": 8,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3163,95 +3115,12 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                       "fontSize": 13,
                       "fontWeight": "400",
                     },
-                    Object {
-                      "flex": 1,
-                    },
+                    Object {},
                   ]
                 }
               >
-                Neutral alert.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
               </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
-            <View
-              style={
-                Object {
-                  "padding": 8,
-                  "paddingTop": 0,
-                }
-              }
-            >
-              <View
-                collapsable={undefined}
-                style={
-                  Object {
-                    "height": 0.01,
-                    "overflow": "hidden",
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "System",
-                          "fontSize": 13,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
             </View>
           </View>
         </View>
@@ -3261,99 +3130,171 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(0, 215, 117)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(0, 215, 117)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(0, 215, 117)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
+              Successful alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "height": 0.01,
+                "overflow": "hidden",
+                "padding": 8,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3366,95 +3307,12 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                       "fontSize": 13,
                       "fontWeight": "400",
                     },
-                    Object {
-                      "flex": 1,
-                    },
+                    Object {},
                   ]
                 }
               >
-                Successful alert.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
               </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
-            <View
-              style={
-                Object {
-                  "padding": 8,
-                  "paddingTop": 0,
-                }
-              }
-            >
-              <View
-                collapsable={undefined}
-                style={
-                  Object {
-                    "height": 0.01,
-                    "overflow": "hidden",
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "System",
-                          "fontSize": 13,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
             </View>
           </View>
         </View>
@@ -3464,99 +3322,171 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 187, 0)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 187, 0)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 187, 0)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
+              Warn alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "height": 0.01,
+                "overflow": "hidden",
+                "padding": 8,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3569,95 +3499,12 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                       "fontSize": 13,
                       "fontWeight": "400",
                     },
-                    Object {
-                      "flex": 1,
-                    },
+                    Object {},
                   ]
                 }
               >
-                Warn alert.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
               </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
-            <View
-              style={
-                Object {
-                  "padding": 8,
-                  "paddingTop": 0,
-                }
-              }
-            >
-              <View
-                collapsable={undefined}
-                style={
-                  Object {
-                    "height": 0.01,
-                    "overflow": "hidden",
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "System",
-                          "fontSize": 13,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
             </View>
           </View>
         </View>
@@ -3667,99 +3514,171 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={true}
-    style={null}
+    style={
+      Object {
+        "height": 0.01,
+        "overflow": "hidden",
+      }
+    }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 84, 82)",
+              },
+              null,
+            ]
           }
         >
           <View
+            accessibilityComponentType="button"
+            accessibilityLabel="Expand"
+            accessibilityTraits={undefined}
+            accessible={true}
+            hitSlop={undefined}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 84, 82)",
-                },
-                null,
               ]
             }
+            testID={undefined}
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Expand"
-              accessibilityTraits={undefined}
+            <Text
               accessible={true}
-              hitSlop={undefined}
-              nativeID={undefined}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 84, 82)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
-              testID={undefined}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
+              Error alert.
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Object {
+                    "paddingStart": 8,
+                  },
+                ]
+              }
+            >
+              
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgb(37, 32, 51)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "height": 0.01,
+                "overflow": "hidden",
+                "padding": 8,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3772,95 +3691,12 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
                       "fontSize": 13,
                       "fontWeight": "400",
                     },
-                    Object {
-                      "flex": 1,
-                    },
+                    Object {},
                   ]
                 }
               >
-                Error alert.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
               </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Object {
-                      "paddingStart": 8,
-                    },
-                  ]
-                }
-              >
-                
-              </Text>
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "rgb(37, 32, 51)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-              />
-            </View>
-            <View
-              style={
-                Object {
-                  "padding": 8,
-                  "paddingTop": 0,
-                }
-              }
-            >
-              <View
-                collapsable={undefined}
-                style={
-                  Object {
-                    "height": 0.01,
-                    "overflow": "hidden",
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "System",
-                          "fontSize": 13,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
             </View>
           </View>
         </View>
@@ -3875,110 +3711,103 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={false}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(178, 174, 189)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(178, 174, 189)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
+              Neutral alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -3987,110 +3816,103 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={false}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(0, 215, 117)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(0, 215, 117)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(0, 215, 117)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
+              Successful alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -4099,110 +3921,103 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={false}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 187, 0)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 187, 0)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 187, 0)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
+              Warn alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -4211,110 +4026,103 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={false}
+    collapsable={undefined}
     duration={200}
     show={false}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 84, 82)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 84, 82)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 84, 82)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
+              Error alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -4330,110 +4138,103 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(178, 174, 189)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(178, 174, 189)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
+              Neutral alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -4442,110 +4243,103 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(0, 215, 117)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(0, 215, 117)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(0, 215, 117)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
+              Successful alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -4554,110 +4348,103 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 187, 0)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 187, 0)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 187, 0)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
+              Warn alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -4666,110 +4453,103 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
   <View
     animateOnEnter={false}
     animateOnLeave={true}
+    collapsable={undefined}
     duration={200}
     show={true}
     style={
       Object {
+        "height": 0.01,
+        "overflow": "hidden",
         "width": 50,
       }
     }
   >
     <View
-      collapsable={undefined}
-      style={
-        Object {
-          "height": 0.01,
-          "overflow": "hidden",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        onLayout={[Function]}
+        collapsable={undefined}
+        style={
+          Object {
+            "opacity": 0.01,
+          }
+        }
       >
         <View
-          collapsable={undefined}
           style={
-            Object {
-              "opacity": 0.01,
-            }
+            Array [
+              Object {
+                "borderRadius": 4,
+                "borderWidth": 1,
+                "minHeight": 32,
+              },
+              Object {
+                "borderColor": "rgb(255, 84, 82)",
+              },
+              null,
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "borderRadius": 4,
-                  "borderWidth": 1,
-                  "minHeight": 32,
+                  "flexDirection": "row",
+                  "paddingHorizontal": 8,
+                  "paddingVertical": 7,
                 },
-                Object {
-                  "borderColor": "rgb(255, 84, 82)",
-                },
-                null,
               ]
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 7,
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "marginEnd": 4,
+                    },
+                    Object {
+                      "color": "rgb(255, 84, 82)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "System",
+                    "fontSize": 13,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
                   },
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "marginEnd": 4,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
+              Error alert.
+            </Text>
           </View>
         </View>
       </View>


### PR DESCRIPTION
The animate height component has a lot of unnecessary renders - this is mostly due to keeping things in state that don't belong in state.

This PR attempts to remove as much from state as possible.

Also removed an extraneous view.