### PR TITLE
[No JIRA] Centralize theme util

### DIFF
--- a/native/packages/react-native-bpk-component-navigation-bar/package.json
+++ b/native/packages/react-native-bpk-component-navigation-bar/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "bpk-tokens": "^26.7.5",
-    "lodash": "^4.17.4",
     "prop-types": "^15.5.8",
     "react-native-bpk-component-icon": "^1.5.0",
     "react-native-bpk-component-text": "^2.1.32",

--- a/native/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.android.js
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.android.js
@@ -27,7 +27,11 @@ import {
   ViewPropTypes,
 } from 'react-native';
 import BpkText from 'react-native-bpk-component-text';
-import { withTheme } from 'react-native-bpk-theming';
+import {
+  withTheme,
+  getThemeAttributes,
+  makeThemePropType,
+} from 'react-native-bpk-theming';
 import {
   colorBlue700,
   colorBlue500,
@@ -35,12 +39,7 @@ import {
 } from 'bpk-tokens/tokens/base.react.native';
 
 import BpkNavigationBarButtonAndroid from './BpkNavigationBarButtonAndroid.android';
-import {
-  type CommonTheme,
-  getThemeStyle,
-  makeThemePropType,
-  THEME_ATTRIBUTES,
-} from './common-types';
+import { type CommonTheme, THEME_ATTRIBUTES } from './common-types';
 
 const ANDROID_THEME_ATTRIBUTES = [
   ...THEME_ATTRIBUTES,
@@ -132,7 +131,7 @@ class BpkNavigationBar extends Component<Props, {}> {
 
   constructor(props) {
     super(props);
-    this.theme = getThemeStyle(
+    this.theme = getThemeAttributes(
       ANDROID_THEME_ATTRIBUTES,
       this.props.theme || {},
     );
@@ -143,7 +142,7 @@ class BpkNavigationBar extends Component<Props, {}> {
   }
 
   componentDidUpdate() {
-    this.theme = getThemeStyle(
+    this.theme = getThemeAttributes(
       ANDROID_THEME_ATTRIBUTES,
       this.props.theme || {},
     );

--- a/native/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.ios.js
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.ios.js
@@ -21,19 +21,18 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { type Element, StyleSheet, View, ViewPropTypes } from 'react-native';
 import BpkText from 'react-native-bpk-component-text';
-import { withTheme } from 'react-native-bpk-theming';
+import {
+  withTheme,
+  getThemeAttributes,
+  makeThemePropType,
+} from 'react-native-bpk-theming';
 import {
   colorGray50,
   colorGray100,
   colorGray700,
 } from 'bpk-tokens/tokens/base.react.native';
 
-import {
-  type CommonTheme,
-  getThemeStyle,
-  makeThemePropType,
-  THEME_ATTRIBUTES,
-} from './common-types';
+import { type CommonTheme, THEME_ATTRIBUTES } from './common-types';
 import BpkNavigationBarBackButtonIOS from './BpkNavigationBarBackButtonIOS';
 import BpkNavigationBarTextButtonIOS from './BpkNavigationBarTextButtonIOS';
 import BpkNavigationBarIconButtonIOS from './BpkNavigationBarIconButtonIOS';
@@ -134,7 +133,10 @@ class BpkNavigationBar extends Component<Props, {}> {
 
   constructor(props) {
     super(props);
-    this.theme = getThemeStyle(IOS_THEME_ATTRIBUTES, this.props.theme || {});
+    this.theme = getThemeAttributes(
+      IOS_THEME_ATTRIBUTES,
+      this.props.theme || {},
+    );
   }
 
   render() {

--- a/native/packages/react-native-bpk-component-navigation-bar/src/common-types.js
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/common-types.js
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 /* @flow */
-import _ from 'lodash';
-
 type StatusBarStyle = 'light-content' | 'dark-content';
 
 export type CommonTheme = {
@@ -25,57 +23,9 @@ export type CommonTheme = {
   navigationBarBackgroundColor: string,
   navigationBarTintColor: string,
 };
+
+// eslint-disable-next-line import/prefer-default-export
 export const THEME_ATTRIBUTES = [
   'navigationBarBackgroundColor',
   'navigationBarTintColor',
 ];
-
-const isValidTheme = (
-  requiredAttributes: Array<string>,
-  theme: Object,
-): boolean =>
-  requiredAttributes.reduce(
-    (valid, attribute) =>
-      _.has(theme, attribute) &&
-      (_.isBoolean(theme[attribute]) ||
-        _.isNumber(theme[attribute]) ||
-        !_.isEmpty(theme[attribute])) &&
-      valid,
-    true,
-  );
-
-export const makeThemePropType = (requiredAttributes: Array<string>) => (
-  props: Object,
-  propName: string,
-  componentName: string,
-) => {
-  const { theme } = props;
-  if (!theme) {
-    return false;
-  }
-
-  const validTheme = isValidTheme(requiredAttributes, theme);
-
-  if (!validTheme) {
-    return new Error(
-      `Invalid prop \`${propName}\` supplied to \`${componentName}\`. When supplying \`theme\` all the required theming attributes(\`${requiredAttributes.join(
-        ', ',
-      )}\`) must be supplied.`,
-    ); // eslint-disable-line max-len
-  }
-  return false;
-};
-
-export const getThemeStyle = (
-  requiredAttributes: Array<string>,
-  theme: Object,
-): ?Object => {
-  if (!isValidTheme(requiredAttributes, theme)) {
-    return null;
-  }
-
-  return requiredAttributes.reduce((result, attribute) => {
-    result[attribute] = theme[attribute]; // eslint-disable-line no-param-reassign
-    return result;
-  }, {});
-};

--- a/native/packages/react-native-bpk-theming/index.js
+++ b/native/packages/react-native-bpk-theming/index.js
@@ -19,7 +19,12 @@
 /* @flow */
 
 import BpkThemeProvider, { withTheme } from './src/BpkThemeProvider';
+import {
+  makeThemePropType,
+  getThemeAttributes,
+  isValidTheme,
+} from './src/util';
 
 export type { Theme } from './src/types';
 export default BpkThemeProvider;
-export { withTheme };
+export { withTheme, makeThemePropType, getThemeAttributes, isValidTheme };

--- a/native/packages/react-native-bpk-theming/package-lock.json
+++ b/native/packages/react-native-bpk-theming/package-lock.json
@@ -91,6 +91,11 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",

--- a/native/packages/react-native-bpk-theming/package.json
+++ b/native/packages/react-native-bpk-theming/package.json
@@ -14,6 +14,7 @@
     "react-native": ">= 0.47.0"
   },
   "dependencies": {
+    "lodash": "^4.17.4",
     "theming": "^1.1.0"
   },
   "devDependencies": {

--- a/native/packages/react-native-bpk-theming/src/util-test.js
+++ b/native/packages/react-native-bpk-theming/src/util-test.js
@@ -1,0 +1,103 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+import { isValidTheme, makeThemePropType, getThemeAttributes } from './util';
+
+const REQUIRED_ATTRIBUTES: Array<string> = [
+  'themeAttributeA',
+  'themeAttributeB',
+  'themeAttributeC',
+];
+
+const VALID_THEME = {
+  themeAttributeA: 'red',
+  themeAttributeB: 12,
+  themeAttributeC: true,
+  nonRequiredAttribute: 'green',
+};
+const INVALID_THEME = {
+  themeAttributeA: 'red',
+  themeAttributeC: true,
+  nonRequiredAttribute: 'green',
+};
+
+describe('isValidTheme', () => {
+  it('should validated themes that are valid', () => {
+    expect(isValidTheme(REQUIRED_ATTRIBUTES, VALID_THEME)).toBeTruthy();
+  });
+
+  it('should fail to validate invalid themes', () => {
+    expect(
+      // themeAttributeB is required, but missing in theme
+      isValidTheme(REQUIRED_ATTRIBUTES, INVALID_THEME),
+    ).toBeFalsy();
+  });
+});
+
+describe('makeThemePropType', () => {
+  let propType;
+  beforeEach(() => {
+    propType = makeThemePropType(REQUIRED_ATTRIBUTES);
+  });
+
+  it('should not fail when the theme is valid', () => {
+    expect(
+      propType(
+        { style: { color: 'red' }, theme: VALID_THEME },
+        'theme',
+        'TestComponent',
+      ),
+    ).toBeFalsy();
+  });
+
+  it('should not fail when no theme is given', () => {
+    expect(
+      propType({ style: { color: 'red' } }, 'theme', 'TestComponent'),
+    ).toBeFalsy();
+  });
+
+  it('should fail when the theme is invalid', () => {
+    expect(
+      propType(
+        { style: { color: 'red' }, theme: INVALID_THEME },
+        'theme',
+        'TestComponent',
+      ),
+    ).toEqual(
+      new Error(
+        'Invalid prop `theme` supplied to `TestComponent`. When supplying `theme` all the required theming attributes(`themeAttributeA, themeAttributeB, themeAttributeC`) must be supplied.',
+      ),
+    );
+  });
+});
+
+describe('getThemeAttributes', () => {
+  it('should return only the theme values if the theme is valid', () => {
+    const { themeAttributeA, themeAttributeB, themeAttributeC } = VALID_THEME;
+
+    expect(getThemeAttributes(REQUIRED_ATTRIBUTES, VALID_THEME)).toEqual({
+      themeAttributeA,
+      themeAttributeB,
+      themeAttributeC,
+    });
+  });
+
+  it('should return `null` if the theme is invalid', () => {
+    expect(getThemeAttributes(REQUIRED_ATTRIBUTES, INVALID_THEME)).toBeNull();
+  });
+});

--- a/native/packages/react-native-bpk-theming/src/util.js
+++ b/native/packages/react-native-bpk-theming/src/util.js
@@ -1,0 +1,71 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+import has from 'lodash/has';
+import isBoolean from 'lodash/isBoolean';
+import isNumber from 'lodash/isNumber';
+import isEmpty from 'lodash/isEmpty';
+
+export const isValidTheme = (
+  requiredAttributes: Array<string>,
+  theme: Object,
+): boolean =>
+  requiredAttributes.reduce(
+    (valid, attribute) =>
+      has(theme, attribute) &&
+      (isBoolean(theme[attribute]) ||
+        isNumber(theme[attribute]) ||
+        !isEmpty(theme[attribute])) &&
+      valid,
+    true,
+  );
+
+export const makeThemePropType = (requiredAttributes: Array<string>) => (
+  props: Object,
+  propName: string,
+  componentName: string,
+): Error | boolean => {
+  const { theme } = props;
+  if (!theme) {
+    return false;
+  }
+
+  const validTheme = isValidTheme(requiredAttributes, theme);
+
+  if (!validTheme) {
+    return new Error(
+      `Invalid prop \`${propName}\` supplied to \`${componentName}\`. When supplying \`theme\` all the required theming attributes(\`${requiredAttributes.join(
+        ', ',
+      )}\`) must be supplied.`,
+    ); // eslint-disable-line max-len
+  }
+  return false;
+};
+
+export const getThemeAttributes = (
+  requiredAttributes: Array<string>,
+  theme: Object,
+): ?Object => {
+  if (!isValidTheme(requiredAttributes, theme)) {
+    return null;
+  }
+
+  return requiredAttributes.reduce((result, attribute) => {
+    result[attribute] = theme[attribute]; // eslint-disable-line no-param-reassign
+    return result;
+  }, {});
+};


### PR DESCRIPTION
Move some theming utility functions to `react-native-bpk-theming` as
they fit better in there. No changelog entry because we don't expect
consumers to use these.