### PR TITLE
[BPK-1437] Remove redundant snapshot tests from banner alert

### DIFF
--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
@@ -17,288 +17,96 @@
 */
 
 import React from 'react';
-import { View } from 'react-native';
 import renderer from 'react-test-renderer';
 import BpkText from 'react-native-bpk-component-text';
-import BpkBannerAlert from './BpkBannerAlert';
+
 import ALERT_TYPES from './AlertTypes';
+import BpkBannerAlert from './BpkBannerAlert';
 
 const commonTests = () => {
   describe('BpkBannerAlert', () => {
-    Date.now = jest.fn(() => 1503187200000);
-    it('should render correctly', () => {
+    jest.spyOn(Date, 'now').mockImplementation(() => 1503187200000);
+
+    Object.keys(ALERT_TYPES).forEach(alertType => {
+      it(`should render correctly with type equal to ${alertType}`, () => {
+        const tree = renderer
+          .create(
+            <BpkBannerAlert
+              type={ALERT_TYPES[alertType]}
+              message={`${alertType} alert.`}
+            />,
+          )
+          .toJSON();
+        expect(tree).toMatchSnapshot();
+      });
+    });
+
+    it('should render correctly with dismissable', () => {
       const tree = renderer
         .create(
-          <View>
-            <BpkBannerAlert
-              type={ALERT_TYPES.NEUTRAL}
-              message="Neutral alert."
-            />
-            <BpkBannerAlert
-              type={ALERT_TYPES.SUCCESS}
-              message="Successful alert."
-            />
-            <BpkBannerAlert type={ALERT_TYPES.WARN} message="Warn alert." />
-            <BpkBannerAlert type={ALERT_TYPES.ERROR} message="Error alert." />
-          </View>,
+          <BpkBannerAlert
+            type={ALERT_TYPES.NEUTRAL}
+            message="Neutral alert."
+            dismissable
+            dismissButtonLabel="Dismiss"
+            onDismiss={() => null}
+          />,
         )
         .toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('should render correctly dismissable', () => {
+    it('should render correctly with children provided (expandable)', () => {
       const tree = renderer
         .create(
-          <View>
-            <BpkBannerAlert
-              type={ALERT_TYPES.NEUTRAL}
-              message="Neutral alert."
-              dismissable
-              dismissButtonLabel="Dismiss"
-            />
-            <BpkBannerAlert
-              type={ALERT_TYPES.SUCCESS}
-              message="Successful alert."
-              dismissable
-              dismissButtonLabel="Dismiss"
-            />
-            <BpkBannerAlert
-              type={ALERT_TYPES.WARN}
-              message="Warn alert."
-              dismissable
-              dismissButtonLabel="Dismiss"
-            />
-            <BpkBannerAlert
-              type={ALERT_TYPES.ERROR}
-              message="Error alert."
-              dismissable
-              dismissButtonLabel="Dismiss"
-            />
-          </View>,
+          <BpkBannerAlert
+            type={ALERT_TYPES.NEUTRAL}
+            message="Neutral alert."
+            toggleExpandedButtonLabel="Expand"
+          >
+            <BpkText textStyle="sm">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
+              sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
+              nec erat condimentum dapibus. Nunc diam augue, egestas id egestas
+              ut, facilisis nec mi. Donec et congue odio, nec laoreet est.
+              Integer rhoncus varius arcu, a fringilla libero laoreet at.
+            </BpkText>
+          </BpkBannerAlert>,
         )
         .toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('should render correctly expandable', () => {
+    it('should render correctly with expanded', () => {
       const tree = renderer
         .create(
-          <View>
-            <BpkBannerAlert
-              type={ALERT_TYPES.NEUTRAL}
-              message="Neutral alert."
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-            <BpkBannerAlert
-              type={ALERT_TYPES.SUCCESS}
-              message="Successful alert."
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-            <BpkBannerAlert
-              type={ALERT_TYPES.WARN}
-              message="Warn alert."
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-            <BpkBannerAlert
-              type={ALERT_TYPES.ERROR}
-              message="Error alert."
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-          </View>,
+          <BpkBannerAlert
+            type={ALERT_TYPES.NEUTRAL}
+            message="Neutral alert."
+            toggleExpandedButtonLabel="Expand"
+            expanded
+          >
+            <BpkText textStyle="sm">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
+              sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
+              nec erat condimentum dapibus. Nunc diam augue, egestas id egestas
+              ut, facilisis nec mi. Donec et congue odio, nec laoreet est.
+              Integer rhoncus varius arcu, a fringilla libero laoreet at.
+            </BpkText>
+          </BpkBannerAlert>,
         )
         .toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('should render correctly expanded', () => {
+    it('should accept userland styling', () => {
       const tree = renderer
         .create(
-          <View>
-            <BpkBannerAlert
-              type={ALERT_TYPES.NEUTRAL}
-              message="Neutral alert."
-              expanded
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-            <BpkBannerAlert
-              type={ALERT_TYPES.SUCCESS}
-              message="Successful alert."
-              expanded
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-            <BpkBannerAlert
-              type={ALERT_TYPES.WARN}
-              message="Warn alert."
-              expanded
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-            <BpkBannerAlert
-              type={ALERT_TYPES.ERROR}
-              message="Error alert."
-              expanded
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-          </View>,
-        )
-        .toJSON();
-      expect(tree).toMatchSnapshot();
-    });
-
-    it('should render correctly long text', () => {
-      const tree = renderer
-        .create(
-          <View>
-            <BpkBannerAlert
-              type={ALERT_TYPES.NEUTRAL}
-              message="Neutral alert."
-              expanded
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-            <BpkBannerAlert
-              type={ALERT_TYPES.SUCCESS}
-              message="Successful alert."
-              expanded
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-            <BpkBannerAlert
-              type={ALERT_TYPES.WARN}
-              message="Warn alert."
-              expanded
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-            <BpkBannerAlert
-              type={ALERT_TYPES.ERROR}
-              message="Error alert."
-              expanded
-              toggleExpandedButtonLabel="Expand"
-            >
-              <BpkText textStyle="sm">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
-                sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam
-                nec erat condimentum dapibus. Nunc diam augue, egestas id
-                egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet
-                est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </BpkText>
-            </BpkBannerAlert>
-          </View>,
-        )
-        .toJSON();
-      expect(tree).toMatchSnapshot();
-    });
-
-    it('should accept user-stlying', () => {
-      const tree = renderer
-        .create(
-          <View>
-            <BpkBannerAlert
-              style={{ width: 50 }}
-              type={ALERT_TYPES.NEUTRAL}
-              message="Neutral alert."
-            />
-            <BpkBannerAlert
-              style={{ width: 50 }}
-              type={ALERT_TYPES.SUCCESS}
-              message="Successful alert."
-            />
-            <BpkBannerAlert
-              style={{ width: 50 }}
-              type={ALERT_TYPES.WARN}
-              message="Warn alert."
-            />
-            <BpkBannerAlert
-              style={{ width: 50 }}
-              type={ALERT_TYPES.ERROR}
-              message="Error alert."
-            />
-          </View>,
+          <BpkBannerAlert
+            style={{ width: 50 }}
+            type={ALERT_TYPES.NEUTRAL}
+            message="Neutral alert."
+          />,
         )
         .toJSON();
       expect(tree).toMatchSnapshot();
@@ -307,32 +115,11 @@ const commonTests = () => {
     it('should render correctly when not shown', () => {
       const tree = renderer
         .create(
-          <View>
-            <BpkBannerAlert
-              show={false}
-              style={{ width: 50 }}
-              type={ALERT_TYPES.NEUTRAL}
-              message="Neutral alert."
-            />
-            <BpkBannerAlert
-              show={false}
-              style={{ width: 50 }}
-              type={ALERT_TYPES.SUCCESS}
-              message="Successful alert."
-            />
-            <BpkBannerAlert
-              show={false}
-              style={{ width: 50 }}
-              type={ALERT_TYPES.WARN}
-              message="Warn alert."
-            />
-            <BpkBannerAlert
-              show={false}
-              style={{ width: 50 }}
-              type={ALERT_TYPES.ERROR}
-              message="Error alert."
-            />
-          </View>,
+          <BpkBannerAlert
+            show={false}
+            type={ALERT_TYPES.NEUTRAL}
+            message="Neutral alert."
+          />,
         )
         .toJSON();
       expect(tree).toMatchSnapshot();
@@ -341,32 +128,11 @@ const commonTests = () => {
     it('should render correctly with animateOnEnter', () => {
       const tree = renderer
         .create(
-          <View>
-            <BpkBannerAlert
-              animateOnEnter
-              style={{ width: 50 }}
-              type={ALERT_TYPES.NEUTRAL}
-              message="Neutral alert."
-            />
-            <BpkBannerAlert
-              animateOnEnter
-              style={{ width: 50 }}
-              type={ALERT_TYPES.SUCCESS}
-              message="Successful alert."
-            />
-            <BpkBannerAlert
-              animateOnEnter
-              style={{ width: 50 }}
-              type={ALERT_TYPES.WARN}
-              message="Warn alert."
-            />
-            <BpkBannerAlert
-              animateOnEnter
-              style={{ width: 50 }}
-              type={ALERT_TYPES.ERROR}
-              message="Error alert."
-            />
-          </View>,
+          <BpkBannerAlert
+            animateOnEnter
+            type={ALERT_TYPES.NEUTRAL}
+            message="Neutral alert."
+          />,
         )
         .toJSON();
       expect(tree).toMatchSnapshot();
@@ -375,32 +141,11 @@ const commonTests = () => {
     it('should render correctly with animateOnLeave', () => {
       const tree = renderer
         .create(
-          <View>
-            <BpkBannerAlert
-              animateOnLeave
-              style={{ width: 50 }}
-              type={ALERT_TYPES.NEUTRAL}
-              message="Neutral alert."
-            />
-            <BpkBannerAlert
-              animateOnLeave
-              style={{ width: 50 }}
-              type={ALERT_TYPES.SUCCESS}
-              message="Successful alert."
-            />
-            <BpkBannerAlert
-              animateOnLeave
-              style={{ width: 50 }}
-              type={ALERT_TYPES.WARN}
-              message="Warn alert."
-            />
-            <BpkBannerAlert
-              animateOnLeave
-              style={{ width: 50 }}
-              type={ALERT_TYPES.ERROR}
-              message="Error alert."
-            />
-          </View>,
+          <BpkBannerAlert
+            animateOnLeave
+            type={ALERT_TYPES.NEUTRAL}
+            message="Neutral alert."
+          />,
         )
         .toJSON();
       expect(tree).toMatchSnapshot();
@@ -449,9 +194,11 @@ const commonTests = () => {
     });
 
     it('should not throw if alert type not provided', () => {
-      jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+      jest.spyOn(console, 'error').mockImplementation(() => null);
+
       const willThrow = () =>
         renderer.create(<BpkBannerAlert message="Neutral alert." />);
+
       expect(willThrow).not.toThrow();
     });
   });

--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
@@ -1,1033 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Android BpkBannerAlert should accept user-stlying 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+exports[`Android BpkBannerAlert should accept userland styling 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+      "width": 50,
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
         }
       >
         <View
           style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
           }
         >
           <View
             style={
               Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
                 "display": "flex",
                 "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
               }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`Android BpkBannerAlert should render correctly 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
-                },
-                Object {
-                  "borderRadius": 2,
-                },
-              ]
             }
           >
             <Text
-              accessibilityComponentType="button"
-              accessibilityLabel="Dismiss"
-              accessibilityTraits={undefined}
               accessible={true}
               allowFontScaling={true}
               ellipsizeMode="tail"
-              hitSlop={undefined}
-              nativeBackgroundAndroid={
-                Object {
-                  "attribute": "selectableItemBackgroundBorderless",
-                  "type": "ThemeAttrAndroid",
-                }
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "paddingRight": 4,
+                      "paddingTop": 3,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
               }
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
                 Array [
                   Object {
@@ -1037,2730 +98,12 @@ exports[`Android BpkBannerAlert should render correctly dismissable 1`] = `
                     "fontWeight": "400",
                   },
                   Object {
-                    "fontFamily": "sans-serif-medium",
-                  },
-                  Object {
-                    "color": "rgb(0, 178, 214)",
-                  },
-                ]
-              }
-              testID={undefined}
-            >
-              DISMISS
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
-                },
-                Object {
-                  "borderRadius": 2,
-                },
-              ]
-            }
-          >
-            <Text
-              accessibilityComponentType="button"
-              accessibilityLabel="Dismiss"
-              accessibilityTraits={undefined}
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              hitSlop={undefined}
-              nativeBackgroundAndroid={
-                Object {
-                  "attribute": "selectableItemBackgroundBorderless",
-                  "type": "ThemeAttrAndroid",
-                }
-              }
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "sans-serif",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "fontFamily": "sans-serif-medium",
-                  },
-                  Object {
-                    "color": "rgb(0, 178, 214)",
-                  },
-                ]
-              }
-              testID={undefined}
-            >
-              DISMISS
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
-                },
-                Object {
-                  "borderRadius": 2,
-                },
-              ]
-            }
-          >
-            <Text
-              accessibilityComponentType="button"
-              accessibilityLabel="Dismiss"
-              accessibilityTraits={undefined}
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              hitSlop={undefined}
-              nativeBackgroundAndroid={
-                Object {
-                  "attribute": "selectableItemBackgroundBorderless",
-                  "type": "ThemeAttrAndroid",
-                }
-              }
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "sans-serif",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "fontFamily": "sans-serif-medium",
-                  },
-                  Object {
-                    "color": "rgb(0, 178, 214)",
-                  },
-                ]
-              }
-              testID={undefined}
-            >
-              DISMISS
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "rgb(243, 242, 245)",
-                  "justifyContent": "center",
-                  "paddingRight": 24,
-                },
-                Object {
-                  "borderRadius": 2,
-                },
-              ]
-            }
-          >
-            <Text
-              accessibilityComponentType="button"
-              accessibilityLabel="Dismiss"
-              accessibilityTraits={undefined}
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              hitSlop={undefined}
-              nativeBackgroundAndroid={
-                Object {
-                  "attribute": "selectableItemBackgroundBorderless",
-                  "type": "ThemeAttrAndroid",
-                }
-              }
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "sans-serif",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "fontFamily": "sans-serif-medium",
-                  },
-                  Object {
-                    "color": "rgb(0, 178, 214)",
-                  },
-                ]
-              }
-              testID={undefined}
-            >
-              DISMISS
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`Android BpkBannerAlert should render correctly expandable 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
+                    "flex": 1,
                   },
                 ]
               }
             >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`Android BpkBannerAlert should render correctly expanded 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
-            <View
-              collapsable={undefined}
-              style={
-                Object {
-                  "height": 0.01,
-                  "overflow": "hidden",
-                }
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <View
-                  style={
-                    Object {
-                      "paddingVertical": 4,
-                    }
-                  }
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "sans-serif",
-                          "fontSize": 14,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
-            <View
-              collapsable={undefined}
-              style={
-                Object {
-                  "height": 0.01,
-                  "overflow": "hidden",
-                }
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <View
-                  style={
-                    Object {
-                      "paddingVertical": 4,
-                    }
-                  }
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "sans-serif",
-                          "fontSize": 14,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
-            <View
-              collapsable={undefined}
-              style={
-                Object {
-                  "height": 0.01,
-                  "overflow": "hidden",
-                }
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <View
-                  style={
-                    Object {
-                      "paddingVertical": 4,
-                    }
-                  }
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "sans-serif",
-                          "fontSize": 14,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
-            <View
-              collapsable={undefined}
-              style={
-                Object {
-                  "height": 0.01,
-                  "overflow": "hidden",
-                }
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <View
-                  style={
-                    Object {
-                      "paddingVertical": 4,
-                    }
-                  }
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "sans-serif",
-                          "fontSize": 14,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`Android BpkBannerAlert should render correctly long text 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
-            <View
-              collapsable={undefined}
-              style={
-                Object {
-                  "height": 0.01,
-                  "overflow": "hidden",
-                }
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <View
-                  style={
-                    Object {
-                      "paddingVertical": 4,
-                    }
-                  }
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "sans-serif",
-                          "fontSize": 14,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
-            <View
-              collapsable={undefined}
-              style={
-                Object {
-                  "height": 0.01,
-                  "overflow": "hidden",
-                }
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <View
-                  style={
-                    Object {
-                      "paddingVertical": 4,
-                    }
-                  }
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "sans-serif",
-                          "fontSize": 14,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
-            <View
-              collapsable={undefined}
-              style={
-                Object {
-                  "height": 0.01,
-                  "overflow": "hidden",
-                }
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <View
-                  style={
-                    Object {
-                      "paddingVertical": 4,
-                    }
-                  }
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "sans-serif",
-                          "fontSize": 14,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          accessibilityComponentType="button"
-          accessibilityLabel="Expand"
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-          testID={undefined}
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
-            <View
-              collapsable={undefined}
-              style={
-                Object {
-                  "height": 0.01,
-                  "overflow": "hidden",
-                }
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <View
-                  style={
-                    Object {
-                      "paddingVertical": 4,
-                    }
-                  }
-                >
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgb(82, 76, 97)",
-                          "fontFamily": "sans-serif",
-                          "fontSize": 14,
-                          "fontWeight": "400",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "justifyContent": "center",
-                "paddingRight": 24,
-              }
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingTop": 3,
-                  },
-                ]
-              }
-            >
-              
+              Neutral alert.
             </Text>
           </View>
         </View>
@@ -3771,442 +114,109 @@ exports[`Android BpkBannerAlert should render correctly long text 1`] = `
 `;
 
 exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={false}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={false}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
         }
       >
         <View
           style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
           }
         >
           <View
             style={
               Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={false}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
                 "display": "flex",
                 "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
               }
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "paddingRight": 4,
+                      "paddingTop": 3,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={false}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
+                  },
+                ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={false}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
+              Neutral alert.
+            </Text>
           </View>
         </View>
       </View>
@@ -4215,445 +225,1088 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
 </View>
 `;
 
-exports[`Android BpkBannerAlert should render correctly with animateOnEnter 1`] = `<View />`;
+exports[`Android BpkBannerAlert should render correctly with animateOnEnter 1`] = `null`;
 
 exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+<View
+  animateOnEnter={false}
+  animateOnLeave={true}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
         }
       >
         <View
           style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
           }
         >
           <View
             style={
               Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
+                "display": "flex",
+                "flexDirection": "row",
               }
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "paddingRight": 4,
+                      "paddingTop": 3,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(129, 123, 143)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Neutral alert.
-              </Text>
-            </View>
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
+                  },
+                ]
+              }
+            >
+              Neutral alert.
+            </Text>
           </View>
         </View>
       </View>
     </View>
   </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+</View>
+`;
+
+exports[`Android BpkBannerAlert should render correctly with children provided (expandable) 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
+        accessibilityComponentType="button"
+        accessibilityLabel="Expand"
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
         }
+        testID={undefined}
       >
         <View
           style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
           }
         >
           <View
             style={
               Object {
+                "display": "flex",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "paddingRight": 4,
+                      "paddingTop": 3,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
+                  },
+                ]
+              }
+            >
+              Neutral alert.
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "justifyContent": "center",
+              "paddingRight": 24,
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Object {
+                  "paddingTop": 3,
+                },
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkBannerAlert should render correctly with dismissable 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={true}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+  >
+    <View
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "paddingRight": 4,
+                      "paddingTop": 3,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
+                  },
+                ]
+              }
+            >
+              Neutral alert.
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
                 "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
+                "justifyContent": "center",
+                "paddingRight": 24,
+              },
+              Object {
+                "borderRadius": 2,
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityComponentType="button"
+            accessibilityLabel="Dismiss"
+            accessibilityTraits={undefined}
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            hitSlop={undefined}
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackgroundBorderless",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "fontFamily": "sans-serif-medium",
+                },
+                Object {
+                  "color": "rgb(0, 178, 214)",
+                },
+              ]
+            }
+            testID={undefined}
+          >
+            DISMISS
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+  >
+    <View
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
+    >
+      <View
+        accessibilityComponentType="button"
+        accessibilityLabel="Expand"
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "paddingRight": 4,
+                      "paddingTop": 3,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
+                  },
+                ]
+              }
+            >
+              Neutral alert.
+            </Text>
+          </View>
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "height": 0.01,
+                "overflow": "hidden",
               }
             }
           >
             <View
-              style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
-              }
+              onLayout={[Function]}
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
+              <View
                 style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
+                  Object {
+                    "paddingVertical": 4,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
                     Array [
                       Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
+                        "color": "rgb(82, 76, 97)",
+                        "fontFamily": "sans-serif",
+                        "fontSize": 14,
+                        "fontWeight": "400",
                       },
-                      Object {
-                        "color": "rgb(0, 215, 117)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
+                      Object {},
+                    ]
+                  }
+                >
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "justifyContent": "center",
+              "paddingRight": 24,
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Object {
+                  "paddingTop": 3,
+                },
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkBannerAlert should render correctly with type equal to ERROR 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+  >
+    <View
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
                   Array [
                     Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
+                      "paddingRight": 4,
+                      "paddingTop": 3,
                     },
                     Object {
-                      "flex": 1,
+                      "color": "rgb(255, 84, 82)",
                     },
-                  ]
-                }
-              >
-                Successful alert.
-              </Text>
-            </View>
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
+                  },
+                ]
+              }
+            >
+              ERROR alert.
+            </Text>
           </View>
         </View>
       </View>
     </View>
   </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+</View>
+`;
+
+exports[`Android BpkBannerAlert should render correctly with type equal to NEUTRAL 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
         }
       >
         <View
           style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
           }
         >
           <View
             style={
               Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
+                "display": "flex",
+                "flexDirection": "row",
               }
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "paddingRight": 4,
+                      "paddingTop": 3,
+                    },
+                    Object {
+                      "color": "rgb(129, 123, 143)",
+                    },
+                  ],
+                ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
-                    },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 187, 0)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Warn alert.
-              </Text>
-            </View>
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
+                  },
+                ]
+              }
+            >
+              NEUTRAL alert.
+            </Text>
           </View>
         </View>
       </View>
     </View>
   </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+</View>
+`;
+
+exports[`Android BpkBannerAlert should render correctly with type equal to SUCCESS 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
         }
       >
         <View
           style={
-            Array [
-              Object {
-                "display": "flex",
-                "flexDirection": "row",
-              },
-            ]
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
           }
         >
           <View
             style={
               Object {
-                "backgroundColor": "rgb(243, 242, 245)",
-                "flex": 1,
-                "minHeight": 56,
-                "paddingHorizontal": 24,
-                "paddingVertical": 16,
+                "display": "flex",
+                "flexDirection": "row",
               }
             }
           >
-            <View
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
               style={
-                Object {
-                  "display": "flex",
-                  "flexDirection": "row",
-                }
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
+                  Array [
+                    Object {
+                      "paddingRight": 4,
+                      "paddingTop": 3,
+                    },
+                    Object {
+                      "color": "rgb(0, 215, 117)",
+                    },
+                  ],
+                ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
+                  },
+                ]
+              }
+            >
+              SUCCESS alert.
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkBannerAlert should render correctly with type equal to WARN 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+  >
+    <View
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "backgroundColor": "rgb(243, 242, 245)",
+              "flex": 1,
+              "minHeight": 56,
+              "paddingHorizontal": 24,
+              "paddingVertical": 16,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "BpkIcon",
+                    "fontSize": 24,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "fontSize": 16,
+                    "lineHeight": 16,
+                  },
                   Array [
                     Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "BpkIcon",
-                      "fontSize": 24,
-                      "lineHeight": 24,
+                      "paddingRight": 4,
+                      "paddingTop": 3,
                     },
                     Object {
-                      "fontSize": 16,
-                      "lineHeight": 16,
+                      "color": "rgb(255, 187, 0)",
                     },
-                    Array [
-                      Object {
-                        "paddingRight": 4,
-                        "paddingTop": 3,
-                      },
-                      Object {
-                        "color": "rgb(255, 84, 82)",
-                      },
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "sans-serif",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                    },
-                    Object {
-                      "flex": 1,
-                    },
-                  ]
-                }
-              >
-                Error alert.
-              </Text>
-            </View>
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(82, 76, 97)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                  },
+                  Object {
+                    "flex": 1,
+                  },
+                ]
+              }
+            >
+              WARN alert.
+            </Text>
           </View>
         </View>
       </View>

--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
@@ -1,3704 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`iOS BpkBannerAlert should accept user-stlying 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+exports[`iOS BpkBannerAlert should accept userland styling 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+      "width": 50,
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(178, 174, 189)",
+            },
+            null,
+          ]
         }
       >
         <View
           style={
             Array [
               Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
               },
-              Object {
-                "borderColor": "rgb(178, 174, 189)",
-              },
-              null,
             ]
           }
         >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(129, 123, 143)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Neutral alert.
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(0, 215, 117)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(0, 215, 117)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Successful alert.
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 187, 0)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 187, 0)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Warn alert.
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 84, 82)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 84, 82)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Error alert.
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`iOS BpkBannerAlert should render correctly 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(178, 174, 189)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(129, 123, 143)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Neutral alert.
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(0, 215, 117)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(0, 215, 117)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Successful alert.
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 187, 0)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 187, 0)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Warn alert.
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 84, 82)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 84, 82)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Error alert.
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`iOS BpkBannerAlert should render correctly dismissable 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(178, 174, 189)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-                Object {
-                  "paddingEnd": 32,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(129, 123, 143)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Neutral alert.
-            </Text>
-          </View>
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Dismiss"
-            accessibilityTraits={undefined}
+          <Text
             accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "padding": 8,
-                "position": "absolute",
-                "right": 0,
-              }
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(0, 215, 117)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
+            allowFontScaling={true}
+            ellipsizeMode="tail"
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
                 },
                 Object {
-                  "paddingEnd": 32,
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Array [
+                  Object {
+                    "marginEnd": 4,
+                  },
+                  Object {
+                    "color": "rgb(129, 123, 143)",
+                  },
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
                 },
               ]
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(0, 215, 117)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Successful alert.
-            </Text>
-          </View>
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Dismiss"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "padding": 8,
-                "position": "absolute",
-                "right": 0,
-              }
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 187, 0)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-                Object {
-                  "paddingEnd": 32,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 187, 0)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Warn alert.
-            </Text>
-          </View>
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Dismiss"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "padding": 8,
-                "position": "absolute",
-                "right": 0,
-              }
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 84, 82)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-                Object {
-                  "paddingEnd": 32,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 84, 82)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Error alert.
-            </Text>
-          </View>
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Dismiss"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "padding": 8,
-                "position": "absolute",
-                "right": 0,
-              }
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`iOS BpkBannerAlert should render correctly expandable 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(178, 174, 189)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(129, 123, 143)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Neutral alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(0, 215, 117)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(0, 215, 117)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Successful alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 187, 0)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 187, 0)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Warn alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 84, 82)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 84, 82)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Error alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`iOS BpkBannerAlert should render correctly expanded 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(178, 174, 189)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(129, 123, 143)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Neutral alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            collapsable={undefined}
-            style={
-              Object {
-                "height": 0.01,
-                "overflow": "hidden",
-                "padding": 8,
-                "paddingTop": 0,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(0, 215, 117)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(0, 215, 117)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Successful alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            collapsable={undefined}
-            style={
-              Object {
-                "height": 0.01,
-                "overflow": "hidden",
-                "padding": 8,
-                "paddingTop": 0,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 187, 0)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 187, 0)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Warn alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            collapsable={undefined}
-            style={
-              Object {
-                "height": 0.01,
-                "overflow": "hidden",
-                "padding": 8,
-                "paddingTop": 0,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 84, 82)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 84, 82)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Error alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            collapsable={undefined}
-            style={
-              Object {
-                "height": 0.01,
-                "overflow": "hidden",
-                "padding": 8,
-                "paddingTop": 0,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(178, 174, 189)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(129, 123, 143)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Neutral alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            collapsable={undefined}
-            style={
-              Object {
-                "height": 0.01,
-                "overflow": "hidden",
-                "padding": 8,
-                "paddingTop": 0,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(0, 215, 117)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(0, 215, 117)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Successful alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            collapsable={undefined}
-            style={
-              Object {
-                "height": 0.01,
-                "overflow": "hidden",
-                "padding": 8,
-                "paddingTop": 0,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 187, 0)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 187, 0)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Warn alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            collapsable={undefined}
-            style={
-              Object {
-                "height": 0.01,
-                "overflow": "hidden",
-                "padding": 8,
-                "paddingTop": 0,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 84, 82)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="Expand"
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-            testID={undefined}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 84, 82)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Error alert.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Object {
-                    "paddingStart": 8,
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                Array [
-                  Object {
-                    "backgroundColor": "rgb(37, 32, 51)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "left": 0,
-                    "opacity": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            collapsable={undefined}
-            style={
-              Object {
-                "height": 0.01,
-                "overflow": "hidden",
-                "padding": 8,
-                "paddingTop": 0,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "rgb(82, 76, 97)",
-                      "fontFamily": "System",
-                      "fontSize": 13,
-                      "fontWeight": "400",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
-              </Text>
-            </View>
-          </View>
+            Neutral alert.
+          </Text>
         </View>
       </View>
     </View>
@@ -3707,402 +109,722 @@ exports[`iOS BpkBannerAlert should render correctly long text 1`] = `
 `;
 
 exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={false}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={false}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(178, 174, 189)",
+            },
+            null,
+          ]
         }
       >
         <View
           style={
             Array [
               Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
               },
-              Object {
-                "borderColor": "rgb(178, 174, 189)",
-              },
-              null,
             ]
           }
         >
-          <View
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Array [
+                  Object {
+                    "marginEnd": 4,
+                  },
+                  Object {
+                    "color": "rgb(129, 123, 143)",
+                  },
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
                 },
               ]
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(129, 123, 143)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Neutral alert.
-            </Text>
-          </View>
+            Neutral alert.
+          </Text>
         </View>
       </View>
     </View>
   </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={false}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+</View>
+`;
+
+exports[`iOS BpkBannerAlert should render correctly with animateOnEnter 1`] = `null`;
+
+exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={true}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(178, 174, 189)",
+            },
+            null,
+          ]
         }
       >
         <View
           style={
             Array [
               Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
               },
-              Object {
-                "borderColor": "rgb(0, 215, 117)",
-              },
-              null,
             ]
           }
         >
-          <View
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Array [
+                  Object {
+                    "marginEnd": 4,
+                  },
+                  Object {
+                    "color": "rgb(129, 123, 143)",
+                  },
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
                 },
               ]
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(0, 215, 117)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Successful alert.
-            </Text>
-          </View>
+            Neutral alert.
+          </Text>
         </View>
       </View>
     </View>
   </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={false}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+</View>
+`;
+
+exports[`iOS BpkBannerAlert should render correctly with children provided (expandable) 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(178, 174, 189)",
+            },
+            null,
+          ]
         }
       >
         <View
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
               },
-              Object {
-                "borderColor": "rgb(255, 187, 0)",
-              },
-              null,
             ]
           }
+          testID={undefined}
         >
-          <View
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Array [
+                  Object {
+                    "marginEnd": 4,
+                  },
+                  Object {
+                    "color": "rgb(129, 123, 143)",
+                  },
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
                 },
               ]
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 187, 0)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Warn alert.
-            </Text>
-          </View>
+            Neutral alert.
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Object {
+                  "paddingStart": 8,
+                },
+              ]
+            }
+          >
+            
+          </Text>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "rgb(37, 32, 51)",
+                  "bottom": 0,
+                  "flex": 1,
+                  "left": 0,
+                  "opacity": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+          />
         </View>
       </View>
     </View>
   </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={false}
-    collapsable={undefined}
-    duration={200}
-    show={false}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+</View>
+`;
+
+exports[`iOS BpkBannerAlert should render correctly with dismissable 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={true}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(178, 174, 189)",
+            },
+            null,
+          ]
         }
       >
         <View
           style={
             Array [
               Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
               },
               Object {
-                "borderColor": "rgb(255, 84, 82)",
+                "paddingEnd": 32,
               },
-              null,
             ]
           }
         >
-          <View
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Array [
+                  Object {
+                    "marginEnd": 4,
+                  },
+                  Object {
+                    "color": "rgb(129, 123, 143)",
+                  },
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
                 },
               ]
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
+            Neutral alert.
+          </Text>
+        </View>
+        <View
+          accessibilityComponentType="button"
+          accessibilityLabel="Dismiss"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "padding": 8,
+              "position": "absolute",
+              "right": 0,
+            }
+          }
+          testID={undefined}
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+              ]
+            }
+          >
+            
+          </Text>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "rgb(37, 32, 51)",
+                  "bottom": 0,
+                  "flex": 1,
+                  "left": 0,
+                  "opacity": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+  >
+    <View
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(178, 174, 189)",
+            },
+            null,
+          ]
+        }
+      >
+        <View
+          accessibilityComponentType="button"
+          accessibilityLabel="Expand"
+          accessibilityTraits={undefined}
+          accessible={true}
+          hitSlop={undefined}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
+              },
+            ]
+          }
+          testID={undefined}
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
                 Array [
                   Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
+                    "marginEnd": 4,
                   },
                   Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
+                    "color": "rgb(129, 123, 143)",
                   },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 84, 82)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
+                },
+              ]
+            }
+          >
+            Neutral alert.
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Object {
+                  "paddingStart": 8,
+                },
+              ]
+            }
+          >
+            
+          </Text>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "rgb(37, 32, 51)",
+                  "bottom": 0,
+                  "flex": 1,
+                  "left": 0,
+                  "opacity": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+          />
+        </View>
+        <View
+          collapsable={undefined}
+          style={
+            Object {
+              "height": 0.01,
+              "overflow": "hidden",
+              "padding": 8,
+              "paddingTop": 0,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+          >
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -4115,13 +837,11 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
                     "fontSize": 13,
                     "fontWeight": "400",
                   },
-                  Object {
-                    "flex": 1,
-                  },
+                  Object {},
                 ]
               }
             >
-              Error alert.
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
             </Text>
           </View>
         </View>
@@ -4131,426 +851,427 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
 </View>
 `;
 
-exports[`iOS BpkBannerAlert should render correctly with animateOnEnter 1`] = `<View />`;
+exports[`iOS BpkBannerAlert should render correctly with type equal to ERROR 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+  >
+    <View
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(255, 84, 82)",
+            },
+            null,
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
+              },
+            ]
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Array [
+                  Object {
+                    "marginEnd": 4,
+                  },
+                  Object {
+                    "color": "rgb(255, 84, 82)",
+                  },
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
+                },
+              ]
+            }
+          >
+            ERROR alert.
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
 
-exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
-<View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+exports[`iOS BpkBannerAlert should render correctly with type equal to NEUTRAL 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(178, 174, 189)",
+            },
+            null,
+          ]
         }
       >
         <View
           style={
             Array [
               Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
               },
-              Object {
-                "borderColor": "rgb(178, 174, 189)",
-              },
-              null,
             ]
           }
         >
-          <View
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Array [
+                  Object {
+                    "marginEnd": 4,
+                  },
+                  Object {
+                    "color": "rgb(129, 123, 143)",
+                  },
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
                 },
               ]
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(129, 123, 143)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Neutral alert.
-            </Text>
-          </View>
+            NEUTRAL alert.
+          </Text>
         </View>
       </View>
     </View>
   </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+</View>
+`;
+
+exports[`iOS BpkBannerAlert should render correctly with type equal to SUCCESS 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(0, 215, 117)",
+            },
+            null,
+          ]
         }
       >
         <View
           style={
             Array [
               Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
               },
-              Object {
-                "borderColor": "rgb(0, 215, 117)",
-              },
-              null,
             ]
           }
         >
-          <View
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Array [
+                  Object {
+                    "marginEnd": 4,
+                  },
+                  Object {
+                    "color": "rgb(0, 215, 117)",
+                  },
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
                 },
               ]
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(0, 215, 117)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Successful alert.
-            </Text>
-          </View>
+            SUCCESS alert.
+          </Text>
         </View>
       </View>
     </View>
   </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
+</View>
+`;
+
+exports[`iOS BpkBannerAlert should render correctly with type equal to WARN 1`] = `
+<View
+  animateOnEnter={false}
+  animateOnLeave={false}
+  collapsable={undefined}
+  duration={200}
+  show={true}
+  style={
+    Object {
+      "height": 0.01,
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    onLayout={[Function]}
   >
     <View
-      onLayout={[Function]}
+      collapsable={undefined}
+      style={
+        Object {
+          "opacity": 0.01,
+        }
+      }
     >
       <View
-        collapsable={undefined}
         style={
-          Object {
-            "opacity": 0.01,
-          }
+          Array [
+            Object {
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "minHeight": 32,
+            },
+            Object {
+              "borderColor": "rgb(255, 187, 0)",
+            },
+            null,
+          ]
         }
       >
         <View
           style={
             Array [
               Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 7,
               },
-              Object {
-                "borderColor": "rgb(255, 187, 0)",
-              },
-              null,
             ]
           }
         >
-          <View
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "BpkIcon",
+                  "fontSize": 24,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "fontSize": 16,
+                  "lineHeight": 16,
+                },
+                Array [
+                  Object {
+                    "marginEnd": 4,
+                  },
+                  Object {
+                    "color": "rgb(255, 187, 0)",
+                  },
+                ],
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "rgb(82, 76, 97)",
+                  "fontFamily": "System",
+                  "fontSize": 13,
+                  "fontWeight": "400",
+                },
+                Object {
+                  "flex": 1,
                 },
               ]
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 187, 0)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Warn alert.
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    animateOnEnter={false}
-    animateOnLeave={true}
-    collapsable={undefined}
-    duration={200}
-    show={true}
-    style={
-      Object {
-        "height": 0.01,
-        "overflow": "hidden",
-        "width": 50,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    >
-      <View
-        collapsable={undefined}
-        style={
-          Object {
-            "opacity": 0.01,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 4,
-                "borderWidth": 1,
-                "minHeight": 32,
-              },
-              Object {
-                "borderColor": "rgb(255, 84, 82)",
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "paddingHorizontal": 8,
-                  "paddingVertical": 7,
-                },
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "BpkIcon",
-                    "fontSize": 24,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "fontSize": 16,
-                    "lineHeight": 16,
-                  },
-                  Array [
-                    Object {
-                      "marginEnd": 4,
-                    },
-                    Object {
-                      "color": "rgb(255, 84, 82)",
-                    },
-                  ],
-                ]
-              }
-            >
-              
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(82, 76, 97)",
-                    "fontFamily": "System",
-                    "fontSize": 13,
-                    "fontWeight": "400",
-                  },
-                  Object {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              Error alert.
-            </Text>
-          </View>
+            WARN alert.
+          </Text>
         </View>
       </View>
     </View>

--- a/native/packages/react-native-bpk-component-navigation-bar/package-lock.json
+++ b/native/packages/react-native-bpk-component-navigation-bar/package-lock.json
@@ -58,11 +58,6 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
-		"lodash": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",


### PR DESCRIPTION
As titled - there is no need to test every prop with each alert type permutation. It's "good enough" to test them with one alert type.

Snapshot tests become less valuable when one slight change ends up failing hundreds of tests. The more cognitive load for the contributor / reviewer means more chance of issues slipping through.