### PR TITLE
[BPK-1404] fix measue warning

### DIFF
--- a/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.common.js
+++ b/native/packages/react-native-bpk-component-animate-height/src/BpkAnimateHeight-test.common.js
@@ -23,6 +23,9 @@ import BpkText from 'react-native-bpk-component-text';
 import BpkAnimateHeight from './BpkAnimateHeight';
 
 const commonTests = () => {
+  // Fake timer is needed to prevent Animation warning during the tests
+  jest.useFakeTimers();
+
   describe('BpkAnimateHeight', () => {
     const animateHeightContent = (
       <BpkText>

--- a/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade-test.common.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/AnimateAndFade-test.common.js
@@ -28,7 +28,8 @@ const child = (
 );
 
 const commonTests = () => {
-  jest.spyOn(Date, 'now').mockImplementation(() => 1503187200000);
+  // Fake timer is needed to prevent Animation warning during the tests
+  jest.useFakeTimers();
 
   describe('AnimateAndFade', () => {
     it('should render correctly', () => {

--- a/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
+++ b/native/packages/react-native-bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
@@ -26,9 +26,10 @@ import { ALERT_TYPES } from './common-types';
 import BpkBannerAlert from './BpkBannerAlert';
 
 const commonTests = () => {
-  describe('BpkBannerAlert', () => {
-    jest.spyOn(Date, 'now').mockImplementation(() => 1503187200000);
+  // Fake timer is needed to prevent Animation warning during the tests
+  jest.useFakeTimers();
 
+  describe('BpkBannerAlert', () => {
     Object.keys(ALERT_TYPES).forEach(alertType => {
       it(`should render correctly with type equal to ${alertType}`, () => {
         const tree = renderer


### PR DESCRIPTION
This fixes the warning 
```
  console.warn node_modules/react-native/jest/setup.js:99
    Calling .measure() in the test renderer environment is not supported. Instead, mock out your components that use findNodeHandle with replacements that don't rely on the native environment.
```

jest will load each file in the `__mocks__` folder, in this case the RN Animated module will be mocked.

The Native codebase has no more warning during tests now

![michael fassbender perfection gif-source](https://user-images.githubusercontent.com/3579758/38249427-83f19cd4-3743-11e8-88fd-dffb26db28c2.gif)
