### PR TITLE
[BPK-1347] Preserve context in portals

### DIFF
--- a/packages/bpk-react-utils/src/Portal.js
+++ b/packages/bpk-react-utils/src/Portal.js
@@ -16,10 +16,14 @@
  * limitations under the License.
  */
 
+import {
+  unstable_renderSubtreeIntoContainer, // eslint-disable-line camelcase
+  unmountComponentAtNode,
+  findDOMNode,
+} from 'react-dom';
+import { Component } from 'react';
 import assign from 'object-assign';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { render, unmountComponentAtNode, findDOMNode } from 'react-dom';
 
 const KEYCODES = {
   ESCAPE: 27,
@@ -243,11 +247,16 @@ class Portal extends Component {
     const missesExpectedTarget = this.props.target && !this.getTargetElement();
 
     if (this.portalElement && !missesExpectedTarget) {
-      render(this.props.children, this.portalElement, () => {
-        if (this.props.isOpen) {
-          this.props.onRender(this.portalElement, this.getTargetElement());
-        }
-      });
+      unstable_renderSubtreeIntoContainer(
+        this,
+        this.props.children,
+        this.portalElement,
+        () => {
+          if (this.props.isOpen) {
+            this.props.onRender(this.portalElement, this.getTargetElement());
+          }
+        },
+      );
     }
   }
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -3,3 +3,14 @@
 **Added:**
 - react-native-bpk-component-pagination-dots:
   - Introducing the React Native pagination dots component.
+
+**Fixed:**
+- bpk-component-dialog:
+- bpk-component-drawer:
+- bpk-component-modal:
+- bpk-component-popover:
+- bpk-component-tooltip:
+  - Context is now preserved in components passed to `children`.
+
+- bpk-react-utils:
+  - The `Portal` component now preserves context in it's `children` prop


### PR DESCRIPTION
Our portals don't preserve react context in their trees.

Previous github issue on react: https://github.com/facebook/react/issues/8262.

Live demo here: https://codesandbox.io/s/2xzrn05rnr