### PR TITLE
[NOJIRA] Ensure base stylesheet globals are never scoped by css modules

### DIFF
--- a/packages/bpk-stylesheets/index.scss
+++ b/packages/bpk-stylesheets/index.scss
@@ -42,22 +42,22 @@ body {
   font-size: $bpk-font-size-base;
   line-height: $bpk-line-height-base;
 
-  &.scaffold-font-size {
+  :global(&.scaffold-font-size) {
     font-size: 13px; /* stylelint-disable-line unit-blacklist, scale-unlimited/declaration-strict-value */
   }
 
-  &.enable-font-smoothing {
+  :global(&.enable-font-smoothing) {
     -webkit-font-smoothing: antialiased;
   }
 }
 
-.hidden,
-.hide {
+:global(.hidden),
+:global(.hide) {
   @include bpk-hidden;
 }
 
-.visuallyhidden,
-.visually-hidden {
+:global(.visuallyhidden),
+:global(.visually-hidden) {
   @include bpk-visually-hidden;
 
   &.focusable {
@@ -65,11 +65,11 @@ body {
   }
 }
 
-.invisible {
+:global(.invisible) {
   @include bpk-invisible;
 }
 
-.clearfix {
+:global(.clearfix) {
   @include bpk-clearfix;
 }
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -14,3 +14,6 @@
 
 - bpk-react-utils:
   - The `Portal` component now preserves context in it's `children` prop
+
+- bpk-stylesheets:
+  - Prevent globals (`.hidden`, `.clearfix`) from being scoped by css modules


### PR DESCRIPTION
This could happen when consumers do this in a `backpack-react-scripts` project:

```js
import 'bpk-stylesheets';
```

The `scss` files referenced inside would be processed through css modules and global utility classes (which tbh are frowned upon now) would be scoped.

An example of this in action is here: http://js.skyscnr.com/sttc/oc-registry/components/base-stylesheet/0.0.4/build/static/css/main.1e3e53e5.css