### PR TITLE
[BPK-1491] Update avd to use a sane pixel density

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -284,11 +284,11 @@ $ANDROID_HOME/tools/bin/sdkmanager "system-images;android-24;google_apis;x86"
 Create an Android Virtual Device (AVD):
 
 ```
-$ANDROID_HOME/tools/bin/avdmanager create avd --name "bpk-avd" --package "system-images;android-24;google_apis;x86" --device "Nexus 5X"
+$ANDROID_HOME/tools/bin/avdmanager create avd --name "bpk-avd" --package "system-images;android-24;google_apis;x86" --device "Nexus 5"
 ```
 
 You should now have a functioning Android development environment, including a
-virtual device to run things on. You can run the AVD manually with `$ANDROID_HOME/tools/emulator -avd bpk-avd -dpi-device 420 -skin 1080x1920`,
+virtual device to run things on. You can run the AVD manually with `$ANDROID_HOME/tools/emulator -avd bpk-avd`,
 but `npm run android` will handle this for you, so it's not required.
 
 ### Storybook


### PR DESCRIPTION
I chose a Nexus 5 from this list: https://material.io/devices/

I based this on it being a flagship Google phone and it having an integer/whole number pixel density (this aids RN's inspector tool to report accurate measurements).

After this is merged I'll get every team member to run:

```
$ANDROID_HOME/tools/bin/avdmanager delete avd --name "bpk-avd"
$ANDROID_HOME/tools/bin/avdmanager create avd --name "bpk-avd" --package "system-images;android-24;google_apis;x86" --device "Nexus 5"
```

Ill alos follow up with a PR to update screenshots.