### PR TITLE
[BPK-1346] Neo Docs Platform Switcher

### DIFF
--- a/packages/bpk-docs/src/components/DocsPageBuilder/NeoDocsPageBuilder.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/NeoDocsPageBuilder.js
@@ -197,13 +197,13 @@ const NeoDocsPageBuilder = props => {
     <BpkContentContainer
       className={getClassName(
         `bpkdocs-content-page--${
-          sections.length % 2 === 0 ? 'even' : 'odd'
+          sections.length % 2 === (props.wrapped ? 1 : 0) ? 'even' : 'odd'
         }-sections`,
       )}
     >
       <Helmet title={props.title} />
       <PageHead
-        title={props.title}
+        title={props.wrapped ? null : props.title}
         blurb={props.blurb}
         menu={
           props.showMenu &&
@@ -214,8 +214,9 @@ const NeoDocsPageBuilder = props => {
             }),
           )
         }
+        wrapped={props.wrapped}
       />
-      <AlternatingPageContent sections={sections} />
+      <AlternatingPageContent sections={sections} invert={props.wrapped} />
     </BpkContentContainer>
   );
 };
@@ -276,6 +277,7 @@ NeoDocsPageBuilder.propTypes = {
       donts: PropTypes.arrayOf(PropTypes.string.isRequired),
     }),
   }),
+  wrapped: PropTypes.bool,
 };
 
 NeoDocsPageBuilder.defaultProps = {
@@ -288,6 +290,7 @@ NeoDocsPageBuilder.defaultProps = {
   customSections: null,
   sassdocId: null,
   usageTable: null,
+  wrapped: false,
 };
 
 export default NeoDocsPageBuilder;

--- a/packages/bpk-docs/src/components/neo/AlternatingPageContent/AlternatingPageContent.js
+++ b/packages/bpk-docs/src/components/neo/AlternatingPageContent/AlternatingPageContent.js
@@ -25,6 +25,7 @@ import STYLES from './AlternatingPageContent.scss';
 const getClassName = cssModules(STYLES);
 
 type Props = {
+  invert: boolean,
   sections: Array<?Node>,
 };
 
@@ -32,13 +33,16 @@ const AlternatingPageContent = (props: Props) => (
   <section className={getClassName('bpkdocs-alternating-content')}>
     {React.Children.toArray(
       props.sections.filter(x => x).map((section, i) => {
-        const isEven = i % 2 === 0;
+        const useAlternateStyle = i % 2 === (props.invert ? 1 : 0);
         const classNames = [
           getClassName('bpkdocs-alternating-content__section'),
-          isEven
-            ? getClassName('bpkdocs-alternating-content__section--even')
-            : getClassName('bpkdocs-alternating-content__section--odd'),
         ];
+
+        if (useAlternateStyle) {
+          classNames.push(
+            getClassName('bpkdocs-alternating-content__section--alternate'),
+          );
+        }
 
         return <div className={classNames.join(' ')}>{section}</div>;
       }),

--- a/packages/bpk-docs/src/components/neo/DocsPageWrapper/Blurb.js
+++ b/packages/bpk-docs/src/components/neo/DocsPageWrapper/Blurb.js
@@ -14,21 +14,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-@import '~bpk-mixins';
+*/
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+import PropTypes from 'prop-types';
+import React from 'react';
+import isString from 'lodash/isString';
+import Paragraph from '../Paragraph';
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+const Blurb = ({ content }) =>
+  isString(content) ? <Paragraph>{content}</Paragraph> : <div>{content}</div>;
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+Blurb.propTypes = {
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+};
 
+export default Blurb;

--- a/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.js
+++ b/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.js
@@ -1,0 +1,121 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import BpkContentContainer from 'bpk-component-content-container';
+import BpkHorizontalNav, {
+  BpkHorizontalNavItem,
+} from 'bpk-component-horizontal-nav';
+import BpkSmallMobileIcon from 'bpk-component-icon/sm/mobile';
+import BpkSmallWindowIcon from 'bpk-component-icon/sm/window';
+import { withButtonAlignment } from 'bpk-component-icon';
+import { cssModules } from 'bpk-react-utils';
+
+import Heading from './../Heading';
+import Blurb from './Blurb';
+import STYLES from './DocsPageWrapper.scss';
+
+const getClassName = cssModules(STYLES);
+
+const AlignedBpkSmallMobileIcon = withButtonAlignment(BpkSmallMobileIcon);
+const AlignedBpkSmallWindowIcon = withButtonAlignment(BpkSmallWindowIcon);
+
+const childrenPropType = PropTypes.oneOfType([
+  PropTypes.arrayOf(PropTypes.node),
+  PropTypes.node,
+]);
+
+const contentShape = PropTypes.oneOfType([PropTypes.string, childrenPropType]);
+
+class DocsPageWrapper extends React.Component {
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    blurb: contentShape,
+    webSubpage: PropTypes.element,
+    nativeSubpage: PropTypes.element,
+  };
+
+  static defaultProps = {
+    blurb: null,
+    webSubpage: null,
+    nativeSubpage: null,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { selected: 'native' };
+  }
+
+  render() {
+    const { blurb, nativeSubpage, title, webSubpage } = this.props;
+
+    const showPlatformSwitcher = webSubpage && nativeSubpage;
+    const selectedSubpage = webSubpage || nativeSubpage;
+
+    return (
+      <BpkContentContainer className={getClassName('bpkdocs-page-wrapper')}>
+        <div className={getClassName('bpkdocs-page-wrapper__inner')}>
+          <Heading level="h1">{title}</Heading>
+          {blurb && <Blurb content={blurb} />}
+        </div>
+        {showPlatformSwitcher && (
+          <div>
+            <BpkHorizontalNav
+              className={getClassName(
+                'bpkdocs-page-wrapper__platform-switcher',
+              )}
+            >
+              <BpkHorizontalNavItem
+                name="native"
+                selected={this.state.selected === 'native'}
+                onClick={() => this.setState({ selected: 'native' })}
+              >
+                <AlignedBpkSmallMobileIcon
+                  className={getClassName(
+                    'bpkdocs-page-wrapper__platform-icon',
+                  )}
+                />
+                Native
+              </BpkHorizontalNavItem>
+              <BpkHorizontalNavItem
+                name="web"
+                selected={this.state.selected === 'web'}
+                onClick={() => this.setState({ selected: 'web' })}
+              >
+                <AlignedBpkSmallWindowIcon
+                  className={getClassName(
+                    'bpkdocs-page-wrapper__platform-icon',
+                  )}
+                />
+                Web
+              </BpkHorizontalNavItem>
+            </BpkHorizontalNav>
+            <div>
+              {this.state.selected === 'native' && nativeSubpage}
+              {this.state.selected === 'web' && webSubpage}
+            </div>
+          </div>
+        )}
+        {!showPlatformSwitcher && selectedSubpage}
+      </BpkContentContainer>
+    );
+  }
+}
+
+export default DocsPageWrapper;

--- a/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.scss
+++ b/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.scss
@@ -14,21 +14,22 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 @import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+.bpkdocs-page-wrapper {
+  background-color: $bpk-color-white;
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+  &__inner {
+    padding: $bpk-spacing-xs * 10;
+    padding-bottom: 0;
+  }
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
+  &__platform-switcher {
+    padding: 0 $bpk-spacing-xs * 10;
+  }
+
+  &__platform-icon {
+    margin-right: $bpk-spacing-sm;
   }
 }
-

--- a/packages/bpk-docs/src/components/neo/DocsPageWrapper/index.js
+++ b/packages/bpk-docs/src/components/neo/DocsPageWrapper/index.js
@@ -15,20 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+import DocsPageWrapper from './DocsPageWrapper';
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
-
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default DocsPageWrapper;

--- a/packages/bpk-docs/src/components/neo/PageHead/PageHead.js
+++ b/packages/bpk-docs/src/components/neo/PageHead/PageHead.js
@@ -46,24 +46,31 @@ type MenuItem = {
 type Props = {
   title: string,
   blurb: string | Node,
+  wrapped: boolean,
   menu: ?Array<MenuItem>,
 };
-const PageHead = (props: Props) => (
-  <section className={getClassName('bpkdocs-page-head')}>
-    <div className={getClassName('bpkdocs-page-head__content')}>
-      <Heading level="h1">{props.title}</Heading>
-      {toNodes(props.blurb)}
-      {props.menu && (
-        <BpkList>
-          {props.menu.map(({ title, href }) => (
-            <BpkListItem key={`menu-item-${href.substr(1)}`}>
-              <BpkLink href={href}>{title}</BpkLink>
-            </BpkListItem>
-          ))}
-        </BpkList>
-      )}
-    </div>
-  </section>
-);
+const PageHead = (props: Props) => {
+  const contentClassNames = [getClassName('bpkdocs-page-head__content')];
+  if (props.wrapped) {
+    contentClassNames.push(getClassName('bpkdocs-page-head__content--wrapped'));
+  }
+  return (
+    <section className={getClassName('bpkdocs-page-head')}>
+      <div className={contentClassNames.join(' ')}>
+        {props.title && <Heading level="h1">{props.title}</Heading>}
+        {props.blurb && toNodes(props.blurb)}
+        {props.menu && (
+          <BpkList>
+            {props.menu.map(({ title, href }) => (
+              <BpkListItem key={`menu-item-${href.substr(1)}`}>
+                <BpkLink href={href}>{title}</BpkLink>
+              </BpkListItem>
+            ))}
+          </BpkList>
+        )}
+      </div>
+    </section>
+  );
+};
 
 export default PageHead;

--- a/packages/bpk-docs/src/components/neo/PageHead/PageHead.scss
+++ b/packages/bpk-docs/src/components/neo/PageHead/PageHead.scss
@@ -26,5 +26,9 @@
     @include bpk-breakpoint-mobile {
       padding: $bpk-spacing-lg;
     }
+
+    &--wrapped {
+      background-color: $bpk-color-gray-50;
+    }
   }
 }

--- a/packages/bpk-docs/src/layouts/NeoSideNavLayout/SideNavLayout.scss
+++ b/packages/bpk-docs/src/layouts/NeoSideNavLayout/SideNavLayout.scss
@@ -38,5 +38,6 @@
 
   &__main {
     min-width: 0;
+    flex: 1;
   }
 }

--- a/packages/bpk-docs/src/pages/BannerAlertsPage/BannerAlertsPage.js
+++ b/packages/bpk-docs/src/pages/BannerAlertsPage/BannerAlertsPage.js
@@ -390,7 +390,7 @@ const components = [
   },
 ];
 
-const BannerAlertsPage = ({ ...rest }: { [string]: any[] }) => (
+const BannerAlertsPage = ({ ...rest }: { [string]: any }) => (
   <DocsPageBuilder
     title="Banner alerts"
     blurb={[

--- a/packages/bpk-docs/src/pages/ButtonsPage/ButtonsPage.js
+++ b/packages/bpk-docs/src/pages/ButtonsPage/ButtonsPage.js
@@ -300,7 +300,7 @@ const customSections = [
   },
 ];
 
-const ButtonsPage = ({ ...rest }: { [string]: any[] }) => (
+const ButtonsPage = ({ ...rest }: { [string]: any }) => (
   <DocsPageBuilder
     title="Buttons"
     blurb={[

--- a/packages/bpk-docs/src/pages/NativeBadgePage/NativeBadgePage.js
+++ b/packages/bpk-docs/src/pages/NativeBadgePage/NativeBadgePage.js
@@ -98,7 +98,7 @@ const components = [
   },
 ];
 
-const NativeTextPage = ({ ...rest }) => (
+const NativeBadgePage = ({ ...rest }) => (
   <DocsPageBuilder
     title="Badges"
     blurb={[
@@ -115,4 +115,4 @@ const NativeTextPage = ({ ...rest }) => (
   />
 );
 
-export default NativeTextPage;
+export default NativeBadgePage;

--- a/packages/bpk-docs/src/pages/NeoBadgePage/BadgePage.js
+++ b/packages/bpk-docs/src/pages/NeoBadgePage/BadgePage.js
@@ -1,0 +1,44 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
+
+import WebBadge from '../BadgePage';
+import NativeBadge from '../NativeBadgePage';
+
+const NeoBadgePage = () => (
+  <DocsPageWrapper
+    title="Badge"
+    blurb={[
+      <Paragraph>
+        Badges are labels which hold small amounts of information. They are
+        available in a number of colors to signify different meanings. Badges
+        are most often used as counters, such as an indication of unread
+        notifications.
+      </Paragraph>,
+    ]}
+    webSubpage={<WebBadge wrapped />}
+    nativeSubpage={<NativeBadge wrapped />}
+  />
+);
+
+export default NeoBadgePage;

--- a/packages/bpk-docs/src/pages/NeoBadgePage/index.js
+++ b/packages/bpk-docs/src/pages/NeoBadgePage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './BadgePage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoBannerAlertPage/BannerAlertPage.js
+++ b/packages/bpk-docs/src/pages/NeoBannerAlertPage/BannerAlertPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../BannerAlertsPage';
+import Native from '../NativeBannerAlertPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo Banner Alert"
+    blurb={[<Paragraph>Blurb for the neo banner alert page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoBannerAlertPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoBannerAlertPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './BannerAlertPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoButtonPage/ButtonPage.js
+++ b/packages/bpk-docs/src/pages/NeoButtonPage/ButtonPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import WebButtons from '../ButtonsPage';
+import NativeButtons from '../NativeButtonPage';
 
+const NeoButtonPage = () => (
+  <DocsPageWrapper
+    title="Neo Button"
+    blurb={[<Paragraph>Blurb for the neo button page.</Paragraph>]}
+    webSubpage={<WebButtons wrapped />}
+    nativeSubpage={<NativeButtons wrapped />}
+  />
+);
+
+export default NeoButtonPage;

--- a/packages/bpk-docs/src/pages/NeoButtonPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoButtonPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './ButtonPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoCardPage/CardPage.js
+++ b/packages/bpk-docs/src/pages/NeoCardPage/CardPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../CardsPage';
+import Native from '../NativeCardsPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo Card"
+    blurb={[<Paragraph>Blurb for the neo card page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoCardPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoCardPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './CardPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoHorizontalNavPage/HorizontalNavPage.js
+++ b/packages/bpk-docs/src/pages/NeoHorizontalNavPage/HorizontalNavPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../HorizontalNavPage';
+import Native from '../NativeHorizontalNavPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo Horizontal Nav"
+    blurb={[<Paragraph>Blurb for the neo horizontal nav page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoHorizontalNavPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoHorizontalNavPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './HorizontalNavPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoIconPage/IconPage.js
+++ b/packages/bpk-docs/src/pages/NeoIconPage/IconPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../IconsPage';
+import Native from '../NativeIconsPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo Icon"
+    blurb={[<Paragraph>Blurb for the neo icon page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoIconPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoIconPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './IconPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoLinkPage/LinkPage.js
+++ b/packages/bpk-docs/src/pages/NeoLinkPage/LinkPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../LinksPage';
+import Native from '../NativeButtonLinkPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo Link"
+    blurb={[<Paragraph>Blurb for the neo link page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoLinkPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoLinkPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './LinkPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoNudgerPage/NudgerPage.js
+++ b/packages/bpk-docs/src/pages/NeoNudgerPage/NudgerPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../NudgersPage';
+import Native from '../NativeNudgerPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo nudger"
+    blurb={[<Paragraph>Blurb for the neo nudger page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoNudgerPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoNudgerPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './NudgerPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoPanelPage/PanelPage.js
+++ b/packages/bpk-docs/src/pages/NeoPanelPage/PanelPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../PanelsPage';
+import Native from '../NativePanelsPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo panel"
+    blurb={[<Paragraph>Blurb for the neo panel page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoPanelPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoPanelPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './PanelPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoSpinnerPage/SpinnerPage.js
+++ b/packages/bpk-docs/src/pages/NeoSpinnerPage/SpinnerPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../SpinnersPage';
+import Native from '../NativeSpinnerPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo spinner"
+    blurb={[<Paragraph>Blurb for the neo spinner page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoSpinnerPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoSpinnerPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './SpinnerPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoStarRatingPage/StarRatingPage.js
+++ b/packages/bpk-docs/src/pages/NeoStarRatingPage/StarRatingPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../StarRatingPage';
+import Native from '../NativeStarRatingPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo star rating"
+    blurb={[<Paragraph>Blurb for the neo star rating page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoStarRatingPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoStarRatingPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './StarRatingPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/pages/NeoTextPage/TextPage.js
+++ b/packages/bpk-docs/src/pages/NeoTextPage/TextPage.js
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import React from 'react';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import Paragraph from './../../components/Paragraph';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
+import Web from '../TextPage';
+import Native from '../NativeTextPage';
 
+const Page = () => (
+  <DocsPageWrapper
+    title="Neo text"
+    blurb={[<Paragraph>Blurb for the neo text page.</Paragraph>]}
+    webSubpage={<Web wrapped />}
+    nativeSubpage={<Native wrapped />}
+  />
+);
+
+export default Page;

--- a/packages/bpk-docs/src/pages/NeoTextPage/index.js
+++ b/packages/bpk-docs/src/pages/NeoTextPage/index.js
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import '~bpk-mixins';
 
-.bpkdocs-alternating-content {
-  &__section {
-    padding: $bpk-spacing-lg * 2;
-    background-color: $bpk-color-gray-100;
+/* @flow */
 
-    @include bpk-breakpoint-mobile {
-      padding: $bpk-spacing-lg;
-    }
+import page from './TextPage';
 
-    &--alternate {
-      background-color: $bpk-color-gray-50;
-    }
-  }
-}
-
+export default page;

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -114,6 +114,19 @@ import NativeTextPage from './../pages/NativeTextPage';
 import NativeTouchableOverlayPage from './../pages/NativeTouchableOverlayPage';
 import NativeTouchableNativeFeedbackPage from './../pages/NativeTouchableNativeFeedbackPage';
 
+import NeoBadgePage from './../pages/NeoBadgePage';
+import NeoBannerAlertPage from './../pages/NeoBannerAlertPage';
+import NeoButtonPage from './../pages/NeoButtonPage';
+import NeoCardPage from './../pages/NeoCardPage';
+import NeoHorizontalNavPage from './../pages/NeoHorizontalNavPage';
+import NeoIconPage from './../pages/NeoIconPage';
+import NeoLinkPage from './../pages/NeoLinkPage';
+import NeoNudgerPage from './../pages/NeoNudgerPage';
+import NeoPanelPage from './../pages/NeoPanelPage';
+import NeoSpinnerPage from './../pages/NeoSpinnerPage';
+import NeoStarRatingPage from './../pages/NeoStarRatingPage';
+import NeoTextPage from './../pages/NeoTextPage';
+
 import {
   GridColumnDemoPage,
   GridOffsetDemoPage,
@@ -122,11 +135,11 @@ import {
 // eslint-disable-next-line import/no-webpack-loader-syntax
 const iconsSvgs = require('!!file-loader?name=[name].[hash].zip!zip-it-loader!./../../../bpk-svgs/src/icons/icons');
 
+const isNeo = !!process.env.BPK_NEO;
+
 const Routes = (
   <Route path={ROUTES.HOME} component={DefaultLayout}>
-    <IndexRoute
-      component={withRouter(process.env.BPK_NEO ? NeoHomePage : HomePage)}
-    />
+    <IndexRoute component={withRouter(isNeo ? NeoHomePage : HomePage)} />
 
     <Route path={ROUTES.USING_BACKPACK} component={UsingLayout}>
       <IndexRedirect to={ROUTES.GETTING_STARTED} />
@@ -156,8 +169,11 @@ const Routes = (
       <IndexRedirect to={ROUTES.WEB_COMPONENTS} />
       <Route path={ROUTES.WEB_COMPONENTS}>
         <IndexRedirect to={ROUTES.ACCORDIONS} />
-        <Route path={ROUTES.TEXT} component={TextPage} />
-        <Route path={ROUTES.LINKS} component={LinksPage} />
+        <Route path={ROUTES.TEXT} component={isNeo ? NeoTextPage : TextPage} />
+        <Route
+          path={ROUTES.LINKS}
+          component={isNeo ? NeoLinkPage : LinksPage}
+        />
         <Route path={ROUTES.LISTS} component={ListsPage} />
         <Route
           path={ROUTES.DESCRIPTION_LISTS}
@@ -166,16 +182,37 @@ const Routes = (
         <Route path={ROUTES.TABLES} component={TablesPage} />
         <Route path={ROUTES.BLOCKQUOTES} component={BlockquotesPage} />
         <Route path={ROUTES.CODE} component={CodePage} />
-        <Route path={ROUTES.BUTTONS} component={ButtonsPage} />
-        <Route path={ROUTES.ICONS} component={IconsPage} />
-        <Route path={ROUTES.SPINNERS} component={SpinnersPage} />
+        <Route
+          path={ROUTES.BUTTONS}
+          component={isNeo ? NeoButtonPage : ButtonsPage}
+        />
+        <Route
+          path={ROUTES.ICONS}
+          component={isNeo ? NeoIconPage : IconsPage}
+        />
+        <Route
+          path={ROUTES.SPINNERS}
+          component={isNeo ? NeoSpinnerPage : SpinnersPage}
+        />
         <Route path={ROUTES.FORMS} component={FormsPage} />
-        <Route path={ROUTES.CARDS} component={CardsPage} />
+        <Route
+          path={ROUTES.CARDS}
+          component={isNeo ? NeoCardPage : CardsPage}
+        />
         <Route path={ROUTES.CHIPS} component={ChipsPage} />
-        <Route path={ROUTES.BADGE} component={BadgePage} />
-        <Route path={ROUTES.PANELS} component={PanelsPage} />
+        <Route
+          path={ROUTES.BADGE}
+          component={isNeo ? NeoBadgePage : BadgePage}
+        />
+        <Route
+          path={ROUTES.PANELS}
+          component={isNeo ? NeoPanelPage : PanelsPage}
+        />
         <Route path={ROUTES.IMAGES} component={ImagesPage} />
-        <Route path={ROUTES.BANNER_ALERTS} component={BannerAlertsPage} />
+        <Route
+          path={ROUTES.BANNER_ALERTS}
+          component={isNeo ? NeoBannerAlertPage : BannerAlertsPage}
+        />
         <Route
           path={ROUTES.MOBILE_SCROLL_CONTAINER}
           component={MobileScrollContainerPage}
@@ -187,14 +224,23 @@ const Routes = (
         <Route path={ROUTES.DATEPICKER} component={DatepickerPage} />
         <Route path={ROUTES.TOOLTIPS} component={TooltipsPage} />
         <Route path={ROUTES.ACCORDIONS} component={AccordionsPage} />
-        <Route path={ROUTES.NUDGERS} component={NudgersPage} />
+        <Route
+          path={ROUTES.NUDGERS}
+          component={isNeo ? NeoNudgerPage : NudgersPage}
+        />
         <Route path={ROUTES.PROGRESS} component={ProgressPage} />
         <Route path={ROUTES.PAGINATION} component={PaginationPage} />
         <Route path={ROUTES.TICKETS} component={TicketsPage} />
-        <Route path={ROUTES.HORIZONTAL_NAV} component={HorizontalNavPage} />
+        <Route
+          path={ROUTES.HORIZONTAL_NAV}
+          component={isNeo ? NeoHorizontalNavPage : HorizontalNavPage}
+        />
         <Route path={ROUTES.FIELDSETS} component={FieldsetsPage} />
         <Route path={ROUTES.BARCHARTS} component={BarchartsPage} />
-        <Route path={ROUTES.STAR_RATING} component={StarRatingPage} />
+        <Route
+          path={ROUTES.STAR_RATING}
+          component={isNeo ? NeoStarRatingPage : StarRatingPage}
+        />
         <Route path={ROUTES.BREAKPOINTS} component={BreakpointsPage} />
         <Route path={ROUTES.HORIZONTAL_GRID} component={HorizontalGridPage} />
         <Route path={ROUTES.SLIDERS} component={SlidersPage} />


### PR DESCRIPTION
* This is just the platform switcher.
* There's a new `DocsPageWrapper` component which can take a web and native subpage as props, then renders a page with them under a horizontal nav.
* For every component that is on both web and native, there's a new 'Neo' page, which uses `DocsPageWrapper` and imports the web and native pages, then renders them.

Still to do (in future PRs)
* ~The alternating colours still needs to be tweaked.~
* The sidebar needs to be changed to no longer have a web/native split.
* URLs need to change from `/components/web/foo` to `/components/foo`.
* **post docs site release** we can merge the new `Neo` folders with the existing ones.