### PR TITLE
[BPK-1346] Sidebar desegregation and new routes

### DIFF
--- a/packages/bpk-docs/src/constants/routes.js
+++ b/packages/bpk-docs/src/constants/routes.js
@@ -113,3 +113,59 @@ export const THEMING = '/components/utilities/theming';
 // MISC
 export const GRID_COLUMN_DEMO = '/grid-column-demo';
 export const GRID_OFFSET_DEMO = '/grid-offset-demo';
+
+// Neo components.
+// components/
+export const NEO_TEXT = '/components/text';
+export const NEO_LINK = '/components/link';
+export const NEO_LIST = '/components/list';
+export const NEO_DESCRIPTION_LIST = '/components/description-list';
+export const NEO_TABLE = '/components/table';
+export const NEO_BLOCKQUOTE = '/components/blockquote';
+export const NEO_CODE = '/components/code';
+export const NEO_BUTTON = '/components/button';
+export const NEO_ICON = '/components/icon';
+export const NEO_SPINNER = '/components/spinner';
+export const NEO_FORM = '/components/form';
+export const NEO_CARD = '/components/card';
+export const NEO_CHIP = '/components/chip';
+export const NEO_BADGE = '/components/badge';
+export const NEO_PANEL = '/components/panel';
+export const NEO_IMAGE = '/components/image';
+export const NEO_BANNER_ALERT = '/components/banner-alert';
+export const NEO_MOBILE_SCROLL_CONTAINER =
+  '/components/mobile-scroll-container';
+export const NEO_MODAL = '/components/modal';
+export const NEO_AUTOSUGGEST = '/components/autosuggest';
+export const NEO_POPOVER = '/components/popover';
+export const NEO_CALENDAR = '/components/calendar';
+export const NEO_DATEPICKER = '/components/datepicker';
+export const NEO_TOOLTIP = '/components/tooltip';
+export const NEO_ACCORDION = '/components/accordion';
+export const NEO_NUDGER = '/components/nudger';
+export const NEO_PROGRESS = '/components/progress';
+export const NEO_TICKET = '/components/ticket';
+export const NEO_HORIZONTAL_NAV = '/components/horizontal-nav';
+export const NEO_FIELDSET = '/components/fieldset';
+export const NEO_BARCHART = '/components/barchart';
+export const NEO_PAGINATION = '/components/pagination';
+export const NEO_STAR_RATING = '/components/star-rating';
+export const NEO_BREAKPOINT = '/components/breakpoint';
+export const NEO_HORIZONTAL_GRID = '/components/horizontal-grid';
+export const NEO_SLIDER = '/components/slider';
+export const NEO_DRAWER = '/components/drawer';
+export const NEO_DIALOG = '/components/dialog';
+
+// components/native/
+export const NEO_NATIVE_INPUT = '/components/text-input';
+export const NEO_NATIVE_NAVIGATION_BAR = '/components/navigation-bar';
+export const NEO_NATIVE_PAGINATION_DOT = '/components/pagination-dot';
+export const NEO_NATIVE_PHONE_INPUT = '/components/phone-input';
+export const NEO_NATIVE_PICKER = '/components/picker';
+export const NEO_NATIVE_SWITCH = '/components/switch';
+export const NEO_NATIVE_TOUCHABLE_OVERLAY = '/components/touchable-overlay';
+export const NEO_NATIVE_TOUCHABLE_NATIVE_FEEDBACK =
+  '/components/touchable-native-feedback';
+
+export const NEO_ALIGNMENT = '/components/alignment';
+export const NEO_THEMING = '/components/theming';

--- a/packages/bpk-docs/src/layouts/NeoSideNavLayout/NavList.js
+++ b/packages/bpk-docs/src/layouts/NeoSideNavLayout/NavList.js
@@ -67,9 +67,6 @@ type NavListCategoryPropType = {
 
 const NavListCategory = (props: NavListCategoryPropType) => (
   <li className={getClassName('bpkdocs-side-nav-list__list-item')}>
-    <span className={getClassName('bpkdocs-side-nav-list__category-name')}>
-      {props.category}
-    </span>
     <ul className={getClassName('bpkdocs-side-nav-list__category-list')}>
       {(props.sort ? sortLinks(props.links) : props.links).map(link => (
         <NavListItem key={link.id} {...link} onClick={props.onClick} />

--- a/packages/bpk-docs/src/layouts/NeoSideNavLayout/Sidebar.js
+++ b/packages/bpk-docs/src/layouts/NeoSideNavLayout/Sidebar.js
@@ -82,15 +82,7 @@ export default (props: Props) => {
           className={getClassName('bpkdocs-sidebar__section-list')}
         />
         <NavList
-          links={links.filter(
-            link =>
-              [
-                activeSection,
-                ...(activeSection === 'COMPONENTS'
-                  ? ['NATIVE', 'UTILITIES']
-                  : []),
-              ].indexOf(link.id) !== -1,
-          )}
+          links={links.filter(link => [activeSection].indexOf(link.id) !== -1)}
           dimmed={sectionListExpanded}
           onClick={onMobileModalClose}
         />

--- a/packages/bpk-docs/src/layouts/NeoSideNavLayout/links-sorter-test.js
+++ b/packages/bpk-docs/src/layouts/NeoSideNavLayout/links-sorter-test.js
@@ -20,28 +20,32 @@ import sortLinks from './links-sorter';
 
 describe('links-sorter', () => {
   it('should sort alphabetically', () => {
-    const links = [{ id: 'c' }, { id: 'a' }, { id: 'b' }];
+    const links = [{ children: 'c' }, { children: 'a' }, { children: 'b' }];
 
-    expect(sortLinks(links)).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+    expect(sortLinks(links)).toEqual([
+      { children: 'a' },
+      { children: 'b' },
+      { children: 'c' },
+    ]);
   });
 
   it('should secondary sort by route existence', () => {
     const links = [
-      { id: 'c' },
-      { id: 'a' },
-      { id: 'b' },
-      { id: 'd', route: '/path/to/d' },
-      { id: 'f', route: '/path/to/f' },
-      { id: 'e', route: '/path/to/e' },
+      { children: 'c' },
+      { children: 'a' },
+      { children: 'b' },
+      { children: 'd', route: '/path/to/d' },
+      { children: 'f', route: '/path/to/f' },
+      { children: 'e', route: '/path/to/e' },
     ];
 
     expect(sortLinks(links)).toEqual([
-      { id: 'd', route: '/path/to/d' },
-      { id: 'e', route: '/path/to/e' },
-      { id: 'f', route: '/path/to/f' },
-      { id: 'a' },
-      { id: 'b' },
-      { id: 'c' },
+      { children: 'd', route: '/path/to/d' },
+      { children: 'e', route: '/path/to/e' },
+      { children: 'f', route: '/path/to/f' },
+      { children: 'a' },
+      { children: 'b' },
+      { children: 'c' },
     ]);
   });
 });

--- a/packages/bpk-docs/src/layouts/NeoSideNavLayout/links-sorter.js
+++ b/packages/bpk-docs/src/layouts/NeoSideNavLayout/links-sorter.js
@@ -22,14 +22,14 @@ export default links =>
     const bHasRoute = !!b.route;
 
     if (aHasRoute === bHasRoute) {
-      const aId = a.id.toLowerCase();
-      const bId = b.id.toLowerCase();
+      const aName = a.children.toLowerCase();
+      const bName = b.children.toLowerCase();
 
-      if (aId < bId) {
+      if (aName < bName) {
         return -1;
       }
 
-      if (aId > bId) {
+      if (aName > bName) {
         return 1;
       }
 

--- a/packages/bpk-docs/src/layouts/links.js
+++ b/packages/bpk-docs/src/layouts/links.js
@@ -24,7 +24,7 @@ import ComponentsImage from '../static/components_hero.jpg';
 import UsingBackpackImage from '../static/using_backpack_hero.jpg';
 import DesignTokensImage from '../static/design_hero.jpg';
 
-export default [
+const componentsLinks = [
   {
     id: 'COMPONENTS',
     category: 'Web components',
@@ -207,6 +207,163 @@ export default [
       { id: 'THEMING', route: routes.THEMING, children: 'Theming' },
     ],
   },
+];
+
+const neoComponentsLinks = [
+  {
+    id: 'COMPONENTS',
+    category: 'Components',
+    sort: true,
+    hero: {
+      url: `/${ComponentsImage}`,
+    },
+    links: [
+      { id: 'TEXT', route: routes.NEO_TEXT, children: 'Text' },
+      { id: 'LINK', route: routes.NEO_LINK, children: 'Link' },
+      { id: 'LIST', route: routes.NEO_LIST, children: 'List' },
+      {
+        id: 'DESCRIPTION_LIST',
+        route: routes.NEO_DESCRIPTION_LIST,
+        children: 'Description List',
+      },
+      { id: 'TABLE', route: routes.NEO_TABLE, children: 'Table' },
+      {
+        id: 'BLOCKQUOTE',
+        route: routes.NEO_BLOCKQUOTE,
+        children: 'Blockquote',
+      },
+      { id: 'CODE', route: routes.NEO_CODE, children: 'Code' },
+      { id: 'BUTTON', route: routes.NEO_BUTTON, children: 'Button' },
+      { id: 'ICON', route: routes.NEO_ICON, children: 'Icon' },
+      { id: 'SPINNER', route: routes.NEO_SPINNER, children: 'Spinner' },
+      { id: 'FORM', route: routes.NEO_FORM, children: 'Form' },
+      { id: 'CARD', route: routes.NEO_CARD, children: 'Card' },
+      { id: 'CHIP', route: routes.NEO_CHIP, children: 'Chip' },
+      { id: 'BADGE', route: routes.NEO_BADGE, children: 'Badge' },
+      { id: 'PANEL', route: routes.NEO_PANEL, children: 'Panel' },
+      { id: 'IMAGE', route: routes.NEO_IMAGE, children: 'Image' },
+      {
+        id: 'BANNER_ALERT',
+        route: routes.NEO_BANNER_ALERT,
+        children: 'Banner alert',
+      },
+      {
+        id: 'MOBILE_SCROLL_CONTAINER',
+        route: routes.NEO_MOBILE_SCROLL_CONTAINER,
+        children: 'Mobile scroll container',
+      },
+      { id: 'MODALS', route: routes.NEO_MODAL, children: 'Modal' },
+      {
+        id: 'AUTOSUGGEST',
+        route: routes.NEO_AUTOSUGGEST,
+        children: 'Autosuggest',
+      },
+      { id: 'POPOVER', route: routes.NEO_POPOVER, children: 'Popover' },
+      { id: 'CALENDAR', route: routes.NEO_CALENDAR, children: 'Calendar' },
+      {
+        id: 'DATEPICKER',
+        route: routes.NEO_DATEPICKER,
+        children: 'Datepicker',
+      },
+      { id: 'TOOLTIP', route: routes.NEO_TOOLTIP, children: 'Tooltip' },
+      {
+        id: 'ACCORDION',
+        route: routes.NEO_ACCORDION,
+        children: 'Accordion',
+      },
+      { id: 'NUDGER', route: routes.NEO_NUDGER, children: 'Nudger' },
+      { id: 'PROGRESS', route: routes.NEO_PROGRESS, children: 'Progress bar' },
+      { id: 'TICKET', route: routes.NEO_TICKET, children: 'Ticket' },
+      {
+        id: 'HORIZONTAL_NAV',
+        route: routes.NEO_HORIZONTAL_NAV,
+        children: 'Horizontal navigation',
+      },
+      { id: 'FIELDSET', route: routes.NEO_FIELDSET, children: 'Fieldset' },
+      {
+        id: 'STAR_RATING',
+        route: routes.NEO_STAR_RATING,
+        children: 'Star rating',
+      },
+      { id: 'BAR_CHART', route: routes.NEO_BARCHART, children: 'Bar chart' },
+      { id: 'SLIDER', route: routes.NEO_SLIDER, children: 'Slider' },
+      { id: 'DRAWER', route: routes.NEO_DRAWER, children: 'Drawer' },
+      {
+        id: 'PAGINATION',
+        route: routes.NEO_PAGINATION,
+        children: 'Pagination',
+      },
+      { id: 'DIALOG', route: routes.NEO_DIALOG, children: 'Dialog' },
+      { id: 'CAROUSEL', route: null, children: 'Carousel' },
+      { id: 'TOAST', route: null, children: 'Toast' },
+      { id: 'VERTICAL_NAV', route: null, children: 'Vertical navigation' },
+      { id: 'OVERFLOW_NAV', route: null, children: 'Overflow navigation' },
+      { id: 'BREADCRUMB', route: null, children: 'Breadcrumb' },
+      { id: 'NUMERICAL_RATING', route: null, children: 'Numerical rating' },
+      { id: 'FLIGHT_ITINERARIES', route: null, children: 'Flight itinerary' },
+      {
+        id: 'BREAKPOINT',
+        route: routes.NEO_BREAKPOINT,
+        children: 'Breakpoint',
+      },
+      {
+        id: 'HORIZONTAL_GRID',
+        route: routes.NEO_HORIZONTAL_GRID,
+        children: 'Horizontal grid',
+      },
+
+      // Native components.
+      {
+        id: 'NATIVE_INPUT',
+        route: routes.NEO_NATIVE_INPUT,
+        children: 'Text input',
+      },
+      {
+        id: 'NATIVE_NAVIGATION_BAR',
+        route: routes.NEO_NATIVE_NAVIGATION_BAR,
+        children: 'Navigation Bar',
+      },
+      // TODO: Uncomment later.
+      // {
+      //   id: 'NATIVE_PAGINATION_DOT',
+      //   route: routes.NEO_NATIVE_PAGINATION_DOT,
+      //   children: 'Pagination Dot',
+      // },
+      {
+        id: 'NATIVE_PHONE_INPUT',
+        route: routes.NEO_NATIVE_PHONE_INPUT,
+        children: 'Phone number input',
+      },
+      {
+        id: 'NATIVE_PICKER',
+        route: routes.NEO_NATIVE_PICKER,
+        children: 'Picker',
+      },
+      {
+        id: 'NATIVE_SWITCH',
+        route: routes.NEO_NATIVE_SWITCH,
+        children: 'Switche',
+      },
+      {
+        id: 'NATIVE_TOUCHABLE_OVERLAY',
+        route: routes.NEO_NATIVE_TOUCHABLE_OVERLAY,
+        children: 'Touchable Overlay',
+      },
+      {
+        id: 'NATIVE_TOUCHABLE_NATIVE_FEEDBACK',
+        route: routes.NEO_NATIVE_TOUCHABLE_NATIVE_FEEDBACK,
+        children: 'Touchable Native Feedback',
+      },
+
+      // Utilities.
+      { id: 'ALIGNMENT', route: routes.NEO_ALIGNMENT, children: 'Alignment' },
+      { id: 'THEMING', route: routes.NEO_THEMING, children: 'Theming' },
+    ],
+  },
+];
+
+export default [
+  ...(process.env.BPK_NEO ? neoComponentsLinks : componentsLinks),
   {
     id: 'TOKENS',
     category: 'Tokens',

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -135,11 +135,11 @@ import {
 // eslint-disable-next-line import/no-webpack-loader-syntax
 const iconsSvgs = require('!!file-loader?name=[name].[hash].zip!zip-it-loader!./../../../bpk-svgs/src/icons/icons');
 
-const isNeo = !!process.env.BPK_NEO;
-
 const Routes = (
   <Route path={ROUTES.HOME} component={DefaultLayout}>
-    <IndexRoute component={withRouter(isNeo ? NeoHomePage : HomePage)} />
+    <IndexRoute
+      component={withRouter(process.env.BPK_NEO ? NeoHomePage : HomePage)}
+    />
 
     <Route path={ROUTES.USING_BACKPACK} component={UsingLayout}>
       <IndexRedirect to={ROUTES.GETTING_STARTED} />
@@ -169,11 +169,8 @@ const Routes = (
       <IndexRedirect to={ROUTES.WEB_COMPONENTS} />
       <Route path={ROUTES.WEB_COMPONENTS}>
         <IndexRedirect to={ROUTES.ACCORDIONS} />
-        <Route path={ROUTES.TEXT} component={isNeo ? NeoTextPage : TextPage} />
-        <Route
-          path={ROUTES.LINKS}
-          component={isNeo ? NeoLinkPage : LinksPage}
-        />
+        <Route path={ROUTES.TEXT} component={TextPage} />
+        <Route path={ROUTES.LINKS} component={LinksPage} />
         <Route path={ROUTES.LISTS} component={ListsPage} />
         <Route
           path={ROUTES.DESCRIPTION_LISTS}
@@ -182,37 +179,16 @@ const Routes = (
         <Route path={ROUTES.TABLES} component={TablesPage} />
         <Route path={ROUTES.BLOCKQUOTES} component={BlockquotesPage} />
         <Route path={ROUTES.CODE} component={CodePage} />
-        <Route
-          path={ROUTES.BUTTONS}
-          component={isNeo ? NeoButtonPage : ButtonsPage}
-        />
-        <Route
-          path={ROUTES.ICONS}
-          component={isNeo ? NeoIconPage : IconsPage}
-        />
-        <Route
-          path={ROUTES.SPINNERS}
-          component={isNeo ? NeoSpinnerPage : SpinnersPage}
-        />
+        <Route path={ROUTES.BUTTONS} component={ButtonsPage} />
+        <Route path={ROUTES.ICONS} component={IconsPage} />
+        <Route path={ROUTES.SPINNERS} component={SpinnersPage} />
         <Route path={ROUTES.FORMS} component={FormsPage} />
-        <Route
-          path={ROUTES.CARDS}
-          component={isNeo ? NeoCardPage : CardsPage}
-        />
+        <Route path={ROUTES.CARDS} component={CardsPage} />
         <Route path={ROUTES.CHIPS} component={ChipsPage} />
-        <Route
-          path={ROUTES.BADGE}
-          component={isNeo ? NeoBadgePage : BadgePage}
-        />
-        <Route
-          path={ROUTES.PANELS}
-          component={isNeo ? NeoPanelPage : PanelsPage}
-        />
+        <Route path={ROUTES.BADGE} component={BadgePage} />
+        <Route path={ROUTES.PANELS} component={PanelsPage} />
         <Route path={ROUTES.IMAGES} component={ImagesPage} />
-        <Route
-          path={ROUTES.BANNER_ALERTS}
-          component={isNeo ? NeoBannerAlertPage : BannerAlertsPage}
-        />
+        <Route path={ROUTES.BANNER_ALERTS} component={BannerAlertsPage} />
         <Route
           path={ROUTES.MOBILE_SCROLL_CONTAINER}
           component={MobileScrollContainerPage}
@@ -224,29 +200,98 @@ const Routes = (
         <Route path={ROUTES.DATEPICKER} component={DatepickerPage} />
         <Route path={ROUTES.TOOLTIPS} component={TooltipsPage} />
         <Route path={ROUTES.ACCORDIONS} component={AccordionsPage} />
-        <Route
-          path={ROUTES.NUDGERS}
-          component={isNeo ? NeoNudgerPage : NudgersPage}
-        />
+        <Route path={ROUTES.NUDGERS} component={NudgersPage} />
         <Route path={ROUTES.PROGRESS} component={ProgressPage} />
         <Route path={ROUTES.PAGINATION} component={PaginationPage} />
         <Route path={ROUTES.TICKETS} component={TicketsPage} />
-        <Route
-          path={ROUTES.HORIZONTAL_NAV}
-          component={isNeo ? NeoHorizontalNavPage : HorizontalNavPage}
-        />
+        <Route path={ROUTES.HORIZONTAL_NAV} component={HorizontalNavPage} />
         <Route path={ROUTES.FIELDSETS} component={FieldsetsPage} />
         <Route path={ROUTES.BARCHARTS} component={BarchartsPage} />
-        <Route
-          path={ROUTES.STAR_RATING}
-          component={isNeo ? NeoStarRatingPage : StarRatingPage}
-        />
+        <Route path={ROUTES.STAR_RATING} component={StarRatingPage} />
         <Route path={ROUTES.BREAKPOINTS} component={BreakpointsPage} />
         <Route path={ROUTES.HORIZONTAL_GRID} component={HorizontalGridPage} />
         <Route path={ROUTES.SLIDERS} component={SlidersPage} />
         <Route path={ROUTES.DRAWER} component={DrawerPage} />
         <Route path={ROUTES.DIALOGS} component={DialogsPage} />
+
+        {/* Neo routes. */}
+        <Route path={ROUTES.NEO_TEXT} component={NeoTextPage} />
+        <Route path={ROUTES.NEO_LINK} component={NeoLinkPage} />
+        <Route path={ROUTES.NEO_LIST} component={ListsPage} />
+        <Route
+          path={ROUTES.NEO_DESCRIPTION_LIST}
+          component={DescriptionListsPage}
+        />
+        <Route path={ROUTES.NEO_TABLE} component={TablesPage} />
+        <Route path={ROUTES.NEO_BLOCKQUOTE} component={BlockquotesPage} />
+        <Route path={ROUTES.NEO_CODE} component={CodePage} />
+        <Route path={ROUTES.NEO_BUTTON} component={NeoButtonPage} />
+        <Route path={ROUTES.NEO_ICON} component={NeoIconPage} />
+        <Route path={ROUTES.NEO_SPINNER} component={NeoSpinnerPage} />
+        <Route path={ROUTES.NEO_FORM} component={FormsPage} />
+        <Route path={ROUTES.NEO_CARD} component={NeoCardPage} />
+        <Route path={ROUTES.NEO_CHIP} component={ChipsPage} />
+        <Route path={ROUTES.NEO_BADGE} component={NeoBadgePage} />
+        <Route path={ROUTES.NEO_PANEL} component={NeoPanelPage} />
+        <Route path={ROUTES.NEO_IMAGE} component={ImagesPage} />
+        <Route path={ROUTES.NEO_BANNER_ALERT} component={NeoBannerAlertPage} />
+        <Route
+          path={ROUTES.NEO_MOBILE_SCROLL_CONTAINER}
+          component={MobileScrollContainerPage}
+        />
+        <Route path={ROUTES.NEO_MODAL} component={ModalsPage} />
+        <Route path={ROUTES.NEO_AUTOSUGGEST} component={AutosuggestPage} />
+        <Route path={ROUTES.NEO_POPOVER} component={PopoversPage} />
+        <Route path={ROUTES.NEO_CALENDAR} component={CalendarPage} />
+        <Route path={ROUTES.NEO_DATEPICKER} component={DatepickerPage} />
+        <Route path={ROUTES.NEO_TOOLTIP} component={TooltipsPage} />
+        <Route path={ROUTES.NEO_ACCORDION} component={AccordionsPage} />
+        <Route path={ROUTES.NEO_NUDGER} component={NeoNudgerPage} />
+        <Route path={ROUTES.NEO_PROGRESS} component={ProgressPage} />
+        <Route path={ROUTES.NEO_TICKET} component={TicketsPage} />
+        <Route
+          path={ROUTES.NEO_HORIZONTAL_NAV}
+          component={NeoHorizontalNavPage}
+        />
+        <Route path={ROUTES.NEO_FIELDSET} component={FieldsetsPage} />
+        <Route path={ROUTES.NEO_BARCHART} component={BarchartsPage} />
+        <Route path={ROUTES.NEO_PAGINATION} component={PaginationPage} />
+        <Route path={ROUTES.NEO_STAR_RATING} component={NeoStarRatingPage} />
+        <Route path={ROUTES.NEO_BREAKPOINT} component={BreakpointsPage} />
+        <Route
+          path={ROUTES.NEO_HORIZONTAL_GRID}
+          component={HorizontalGridPage}
+        />
+        <Route path={ROUTES.NEO_SLIDER} component={SlidersPage} />
+        <Route path={ROUTES.NEO_DRAWER} component={DrawerPage} />
+        <Route path={ROUTES.NEO_DIALOG} component={DialogsPage} />
+        <Route path={ROUTES.NEO_NATIVE_INPUT} component={NativeInputPage} />
+        <Route
+          path={ROUTES.NEO_NATIVE_NAVIGATION_BAR}
+          component={NativeNavigationBarPage}
+        />
+        <Route
+          path={ROUTES.NEO_NATIVE_PAGINATION_DOT}
+          component={NativePaginationDotsPage}
+        />
+        <Route
+          path={ROUTES.NEO_NATIVE_PHONE_INPUT}
+          component={NativePhoneInputPage}
+        />
+        <Route path={ROUTES.NEO_NATIVE_PICKER} component={NativePickerPage} />
+        <Route path={ROUTES.NEO_NATIVE_SWITCH} component={NativeSwitchPage} />
+        <Route
+          path={ROUTES.NEO_NATIVE_TOUCHABLE_OVERLAY}
+          component={NativeTouchableOverlayPage}
+        />
+        <Route
+          path={ROUTES.NEO_NATIVE_TOUCHABLE_NATIVE_FEEDBACK}
+          component={NativeTouchableNativeFeedbackPage}
+        />
+        <Route path={ROUTES.NEO_ALIGNMENT} component={AlignmentPage} />
+        <Route path={ROUTES.NEO_THEMING} component={ThemingPage} />
       </Route>
+
       <Route path={ROUTES.NATIVE_COMPONENTS}>
         <IndexRedirect to={ROUTES.NATIVE_TEXT} />
         <Route


### PR DESCRIPTION
* Sidebar is no longer split into web/native/utilities, it's just an alphabetical list.
* Routes in the sidebar are now `/components/whatever` instead of `/components/web/whatever`. (Except utilities, wasn't sure if we wanted to do those too so I've left them out initially).