### PR TITLE
[No JIRA] Improve performance for BpkFlatListItem and BpkSectionListItem

### DIFF
--- a/native/packages/react-native-bpk-component-flat-list/readme.md
+++ b/native/packages/react-native-bpk-component-flat-list/readme.md
@@ -71,6 +71,8 @@ Inherits all props from React Native's [FlatList](https://facebook.github.io/rea
 | image              | instanceOf(Image)                     | false    | null          |
 | selected           | bool                                  | false    | false         |
 
+**Note:** To assist with performance, `BpkFlatListItem` overrides `shouldComponentUpdate` and will only update if `title`, `image` or `selected` changes. Therefore, changes to `onPress` will have no effect unless a re-render is forced.
+
 ### BpkFlatListItemSeparator
 
 None.

--- a/native/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.android.js
+++ b/native/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.android.js
@@ -63,40 +63,51 @@ const styles = StyleSheet.create({
   },
 });
 
-const BpkFlatListItem = (props: ListItemProps) => {
-  const { image, title, selected, ...rest } = props;
+class BpkFlatListItem extends React.Component<ListItemProps> {
+  static propTypes = LIST_ITEM_PROP_TYPES;
+  static defaultProps = LIST_ITEM_DEFAULT_PROPS;
 
-  const styledImage = image
-    ? React.cloneElement(image, {
-        style: [image.props.style, styles.image],
-      })
-    : null;
+  // Compare only primitive props (not onPress) to help performance.
+  shouldComponentUpdate(nextProps: ListItemProps) {
+    return (
+      nextProps.selected !== this.props.selected ||
+      nextProps.title !== this.props.title ||
+      nextProps.image !== this.props.image
+    );
+  }
 
-  return (
-    <BpkTouchableNativeFeedback
-      borderlessBackground={false}
-      accessibilityComponentType="button"
-      accessibilityLabel={title}
-      accessibilityTraits={['button']}
-      {...rest}
-    >
-      <View style={styles.outer}>
-        <View style={styles.content}>
-          {styledImage}
-          <BpkText
-            textStyle="base"
-            style={[styles.text, selected ? styles.textSelected : null]}
-          >
-            {title}
-          </BpkText>
+  render() {
+    const { image, title, selected, ...rest } = this.props;
+
+    const styledImage = image
+      ? React.cloneElement(image, {
+          style: [image.props.style, styles.image],
+        })
+      : null;
+
+    return (
+      <BpkTouchableNativeFeedback
+        borderlessBackground={false}
+        accessibilityComponentType="button"
+        accessibilityLabel={title}
+        accessibilityTraits={['button']}
+        {...rest}
+      >
+        <View style={styles.outer}>
+          <View style={styles.content}>
+            {styledImage}
+            <BpkText
+              textStyle="base"
+              style={[styles.text, selected ? styles.textSelected : null]}
+            >
+              {title}
+            </BpkText>
+          </View>
+          <BpkRadioIcon selected={selected} />
         </View>
-        <BpkRadioIcon selected={selected} />
-      </View>
-    </BpkTouchableNativeFeedback>
-  );
-};
-
-BpkFlatListItem.propTypes = LIST_ITEM_PROP_TYPES;
-BpkFlatListItem.defaultProps = LIST_ITEM_DEFAULT_PROPS;
+      </BpkTouchableNativeFeedback>
+    );
+  }
+}
 
 export default BpkFlatListItem;

--- a/native/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.ios.js
+++ b/native/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.ios.js
@@ -70,42 +70,55 @@ const styles = StyleSheet.create({
   },
 });
 
-const BpkFlatListItem = (props: ListItemProps) => {
-  const { image, title, selected, ...rest } = props;
-  const iconStyles = [styles.tick];
-  if (selected) {
-    iconStyles.push(styles.tickVisible);
+class BpkFlatListItem extends React.Component<ListItemProps> {
+  static propTypes = LIST_ITEM_PROP_TYPES;
+  static defaultProps = LIST_ITEM_DEFAULT_PROPS;
+
+  // Compare only primitive props (not onPress) to help performance.
+  shouldComponentUpdate(nextProps: ListItemProps) {
+    return (
+      nextProps.selected !== this.props.selected ||
+      nextProps.title !== this.props.title ||
+      nextProps.image !== this.props.image
+    );
   }
 
-  const styledImage = image
-    ? React.cloneElement(image, {
-        style: [image.props.style, styles.image],
-      })
-    : null;
+  render() {
+    const { image, title, selected, ...rest } = this.props;
+    const iconStyles = [styles.tick];
+    if (selected) {
+      iconStyles.push(styles.tickVisible);
+    }
 
-  return (
-    <BpkTouchableOverlay
-      accessibilityComponentType="button"
-      accessibilityLabel={title}
-      accessibilityTraits={['button']}
-      style={styles.outer}
-      {...rest}
-    >
-      <View style={styles.content}>
-        {styledImage}
-        <BpkText
-          textStyle="lg"
-          style={[styles.text, selected ? styles.textSelected : null]}
-        >
-          {title}
-        </BpkText>
-      </View>
-      <BpkIcon small icon={icons.tick} style={iconStyles} />
-    </BpkTouchableOverlay>
-  );
-};
+    const styledImage = image
+      ? React.cloneElement(image, {
+          style: [image.props.style, styles.image],
+        })
+      : null;
 
-BpkFlatListItem.propTypes = LIST_ITEM_PROP_TYPES;
+    return (
+      <BpkTouchableOverlay
+        accessibilityComponentType="button"
+        accessibilityLabel={title}
+        accessibilityTraits={['button']}
+        style={styles.outer}
+        {...rest}
+      >
+        <View style={styles.content}>
+          {styledImage}
+          <BpkText
+            textStyle="lg"
+            style={[styles.text, selected ? styles.textSelected : null]}
+          >
+            {title}
+          </BpkText>
+        </View>
+        <BpkIcon small icon={icons.tick} style={iconStyles} />
+      </BpkTouchableOverlay>
+    );
+  }
+}
+
 BpkFlatListItem.defaultProps = LIST_ITEM_DEFAULT_PROPS;
 
 export default BpkFlatListItem;

--- a/native/packages/react-native-bpk-component-flat-list/stories.js
+++ b/native/packages/react-native-bpk-component-flat-list/stories.js
@@ -51,13 +51,16 @@ const countries = [
 ];
 
 class StatefulBpkFlatList extends React.Component<{
+  extraEntries: number,
   showImages: boolean,
 }> {
   static propTypes = {
+    extraEntries: PropTypes.number,
     showImages: PropTypes.bool,
   };
 
   static defaultProps = {
+    extraEntries: 0,
     showImages: false,
   };
 
@@ -65,27 +68,42 @@ class StatefulBpkFlatList extends React.Component<{
     super();
     this.state = { selectedCountry: 'DJ' };
   }
+
+  getData = () => {
+    const data = countries.slice();
+    if (this.props.extraEntries > 0) {
+      data.push(
+        ...new Array(this.props.extraEntries)
+          .fill()
+          .map((_, i) => ({ id: i.toString(), name: `Country ${i}` })),
+      );
+    }
+    return data;
+  };
+
+  renderItem = ({ item }) => (
+    <BpkFlatListItem
+      title={item.name}
+      selected={this.state.selectedCountry === item.id}
+      image={
+        this.props.showImages ? (
+          <Image
+            source={{ uri: getFlagUriFromCountryCode(item.id) }}
+            style={styles.image}
+          />
+        ) : null
+      }
+      onPress={() => {
+        this.setState({ selectedCountry: item.id });
+      }}
+    />
+  );
+
   render() {
     return (
       <BpkFlatList
-        data={countries}
-        renderItem={({ item }) => (
-          <BpkFlatListItem
-            title={item.name}
-            selected={this.state.selectedCountry === item.id}
-            image={
-              this.props.showImages ? (
-                <Image
-                  source={{ uri: getFlagUriFromCountryCode(item.id) }}
-                  style={styles.image}
-                />
-              ) : null
-            }
-            onPress={() => {
-              this.setState({ selectedCountry: item.id });
-            }}
-          />
-        )}
+        data={this.getData()}
+        renderItem={this.renderItem}
         ItemSeparatorComponent={
           Platform.OS === 'ios' ? BpkFlatListItemSeparator : null
         }
@@ -99,4 +117,5 @@ class StatefulBpkFlatList extends React.Component<{
 storiesOf('react-native-bpk-component-flat-list', module)
   .addDecorator(getStory => <View style={styles.topMargin}>{getStory()}</View>)
   .add('docs:default', () => <StatefulBpkFlatList />)
-  .add('docs:with-images', () => <StatefulBpkFlatList showImages />);
+  .add('docs:with-images', () => <StatefulBpkFlatList showImages />)
+  .add('Perf (Long list)', () => <StatefulBpkFlatList extraEntries={200} />);

--- a/native/packages/react-native-bpk-component-section-list/readme.md
+++ b/native/packages/react-native-bpk-component-section-list/readme.md
@@ -101,6 +101,8 @@ Inherits all props from React Native's [SectionList](https://facebook.github.io/
 | image              | instanceOf(Image)                     | false    | null          |
 | selected           | bool                                  | false    | false         |
 
+**Note:** To assist with performance, `BpkSectionListItem` overrides `shouldComponentUpdate` and will only update if `title`, `image` or `selected` changes. Therefore, changes to `onPress` will have no effect unless a re-render is forced.
+
 ### BpkSectionListHeader
 
 | Property           | PropType                              | Required | Default Value |

--- a/native/packages/react-native-bpk-component-section-list/src/BpkSectionListItem.android.js
+++ b/native/packages/react-native-bpk-component-section-list/src/BpkSectionListItem.android.js
@@ -63,38 +63,49 @@ const styles = StyleSheet.create({
   },
 });
 
-const BpkSectionListItem = (props: ListItemProps) => {
-  const { image, title, selected, ...rest } = props;
+class BpkSectionListItem extends React.Component<ListItemProps> {
+  static propTypes = LIST_ITEM_PROP_TYPES;
+  static defaultProps = LIST_ITEM_DEFAULT_PROPS;
 
-  const styledImage = image
-    ? React.cloneElement(image, { style: [image.props.style, styles.image] })
-    : null;
+  // Compare only primitive props (not onPress) to help performance.
+  shouldComponentUpdate(nextProps: ListItemProps) {
+    return (
+      nextProps.selected !== this.props.selected ||
+      nextProps.title !== this.props.title ||
+      nextProps.image !== this.props.image
+    );
+  }
 
-  return (
-    <BpkTouchableNativeFeedback
-      borderlessBackground={false}
-      accessibilityComponentType="button"
-      accessibilityLabel={title}
-      accessibilityTraits={['button']}
-      {...rest}
-    >
-      <View style={styles.outer}>
-        <View style={styles.content}>
-          {styledImage}
-          <BpkText
-            textStyle="base"
-            style={[styles.text, selected ? styles.textSelected : null]}
-          >
-            {title}
-          </BpkText>
+  render() {
+    const { image, title, selected, ...rest } = this.props;
+
+    const styledImage = image
+      ? React.cloneElement(image, { style: [image.props.style, styles.image] })
+      : null;
+
+    return (
+      <BpkTouchableNativeFeedback
+        borderlessBackground={false}
+        accessibilityComponentType="button"
+        accessibilityLabel={title}
+        accessibilityTraits={['button']}
+        {...rest}
+      >
+        <View style={styles.outer}>
+          <View style={styles.content}>
+            {styledImage}
+            <BpkText
+              textStyle="base"
+              style={[styles.text, selected ? styles.textSelected : null]}
+            >
+              {title}
+            </BpkText>
+          </View>
+          <BpkRadioIcon selected={selected} />
         </View>
-        <BpkRadioIcon selected={selected} />
-      </View>
-    </BpkTouchableNativeFeedback>
-  );
-};
-
-BpkSectionListItem.propTypes = LIST_ITEM_PROP_TYPES;
-BpkSectionListItem.defaultProps = LIST_ITEM_DEFAULT_PROPS;
+      </BpkTouchableNativeFeedback>
+    );
+  }
+}
 
 export default BpkSectionListItem;

--- a/native/packages/react-native-bpk-component-section-list/src/BpkSectionListItem.ios.js
+++ b/native/packages/react-native-bpk-component-section-list/src/BpkSectionListItem.ios.js
@@ -70,40 +70,51 @@ const styles = StyleSheet.create({
   },
 });
 
-const BpkSectionListItem = (props: ListItemProps) => {
-  const { image, title, selected, ...rest } = props;
-  const iconStyles = [styles.tick];
-  if (selected) {
-    iconStyles.push(styles.tickVisible);
+class BpkSectionListItem extends React.Component<ListItemProps> {
+  static propTypes = LIST_ITEM_PROP_TYPES;
+  static defaultProps = LIST_ITEM_DEFAULT_PROPS;
+
+  // Compare only primitive props (not onPress) to help performance.
+  shouldComponentUpdate(nextProps: ListItemProps) {
+    return (
+      nextProps.selected !== this.props.selected ||
+      nextProps.title !== this.props.title ||
+      nextProps.image !== this.props.image
+    );
   }
 
-  const styledImage = image
-    ? React.cloneElement(image, { style: [image.props.style, styles.image] })
-    : null;
+  render() {
+    const { image, title, selected, onPress } = this.props;
+    const iconStyles = [styles.tick];
+    if (selected) {
+      iconStyles.push(styles.tickVisible);
+    }
 
-  return (
-    <BpkTouchableOverlay
-      accessibilityComponentType="button"
-      accessibilityLabel={title}
-      accessibilityTraits={['button']}
-      style={styles.outer}
-      {...rest}
-    >
-      <View style={styles.content}>
-        {styledImage}
-        <BpkText
-          textStyle="lg"
-          style={[styles.text, selected ? styles.textSelected : null]}
-        >
-          {title}
-        </BpkText>
-      </View>
-      <BpkIcon small icon={icons.tick} style={iconStyles} />
-    </BpkTouchableOverlay>
-  );
-};
+    const styledImage = image
+      ? React.cloneElement(image, { style: [image.props.style, styles.image] })
+      : null;
 
-BpkSectionListItem.propTypes = LIST_ITEM_PROP_TYPES;
-BpkSectionListItem.defaultProps = LIST_ITEM_DEFAULT_PROPS;
+    return (
+      <BpkTouchableOverlay
+        accessibilityComponentType="button"
+        accessibilityLabel={title}
+        accessibilityTraits={['button']}
+        onPress={onPress}
+        style={styles.outer}
+      >
+        <View style={styles.content}>
+          {styledImage}
+          <BpkText
+            textStyle="lg"
+            style={[styles.text, selected ? styles.textSelected : null]}
+          >
+            {title}
+          </BpkText>
+        </View>
+        <BpkIcon small icon={icons.tick} style={iconStyles} />
+      </BpkTouchableOverlay>
+    );
+  }
+}
 
 export default BpkSectionListItem;

--- a/native/packages/react-native-bpk-component-section-list/stories.js
+++ b/native/packages/react-native-bpk-component-section-list/stories.js
@@ -78,13 +78,16 @@ const getFlagUriFromCountryCode = countryCode =>
 
 // eslint-disable-next-line react/no-multi-comp
 class StatefulBpkSectionList extends React.Component<{
+  extraEntries: number,
   showImages: boolean,
 }> {
   static propTypes = {
+    extraEntries: PropTypes.number,
     showImages: PropTypes.bool,
   };
 
   static defaultProps = {
+    extraEntries: 0,
     showImages: false,
   };
 
@@ -92,27 +95,46 @@ class StatefulBpkSectionList extends React.Component<{
     super();
     this.state = { selectedAirport: 'GLA' };
   }
+
+  onItemPress = item => {
+    this.setState({ selectedAirport: item.id });
+  };
+
+  getData = () => {
+    const data = airportCities.slice();
+    if (this.props.extraEntries > 0) {
+      data.push({
+        title: 'Unassigned',
+        country: 'None',
+        data: new Array(this.props.extraEntries)
+          .fill()
+          .map((_, i) => ({ id: i.toString(), name: `Airport ${i}` })),
+      });
+    }
+    return data;
+  };
+
+  renderItem = ({ item, section }) => (
+    <BpkSectionListItem
+      title={item.name}
+      selected={this.state.selectedAirport === item.id}
+      image={
+        this.props.showImages ? (
+          <Image
+            source={{ uri: getFlagUriFromCountryCode(section.country) }}
+            style={styles.image}
+          />
+        ) : null
+      }
+      onPress={() => this.onItemPress(item)}
+    />
+  );
+
   render() {
     return (
       <BpkSectionList
-        sections={airportCities}
-        renderItem={({ item, section }) => (
-          <BpkSectionListItem
-            title={item.name}
-            selected={this.state.selectedAirport === item.id}
-            image={
-              this.props.showImages ? (
-                <Image
-                  source={{ uri: getFlagUriFromCountryCode(section.country) }}
-                  style={styles.image}
-                />
-              ) : null
-            }
-            onPress={() => {
-              this.setState({ selectedAirport: item.id });
-            }}
-          />
-        )}
+        sections={this.getData()}
+        renderItem={this.renderItem}
         renderSectionHeader={({ section: { title } }) => (
           <BpkSectionListHeader title={title} />
         )}
@@ -120,6 +142,7 @@ class StatefulBpkSectionList extends React.Component<{
           Platform.OS === 'ios' ? BpkSectionListItemSeparator : null
         }
         keyExtractor={item => item.id}
+        removeClippedSubviews
       />
     );
   }
@@ -128,4 +151,5 @@ class StatefulBpkSectionList extends React.Component<{
 storiesOf('react-native-bpk-component-section-list', module)
   .addDecorator(getStory => <View style={styles.topMargin}>{getStory()}</View>)
   .add('docs:default', () => <StatefulBpkSectionList />)
-  .add('docs:with-images', () => <StatefulBpkSectionList showImages />);
+  .add('docs:with-images', () => <StatefulBpkSectionList showImages />)
+  .add('Perf (Long list)', () => <StatefulBpkSectionList extraEntries={200} />);


### PR DESCRIPTION
* Override `shouldComponentUpdate` to only compare primitive props, as comparing `onPress` was causing long lists to be very slow.
* Add a storybook example for long lists for future performance testing.