### PR TITLE
[No JIRA] Improve performance of BpkFlatList and BpkSectionList

### DIFF
--- a/native/packages/react-native-bpk-component-flat-list/readme.md
+++ b/native/packages/react-native-bpk-component-flat-list/readme.md
@@ -37,18 +37,32 @@ const FLAG_IMAGES = {
 };
 
 export default class App extends Component {
+  constructor() {
+    super();
+    this.itemOnPressCallbacks = {};
+  }
+
+  getItemOnPressCallback = countryId => {
+    this.itemOnPressCallbacks[countryId] =
+      this.itemOnPressCallbacks[countryId] ||
+      (() => console.log(countryId));
+    return this.itemOnPressCallbacks[countryId];
+  };
+
+  renderItem = ({ country }) => (
+    <BpkFlatListItem
+      key={country.id}
+      title={country.name}
+      image={<Image source={require(FLAG_IMAGES[country.id])} />}
+      onPress={this.getItemOnPressCallback(country.id)}
+    />
+  );
+
   render() {
     return (
       <BpkFlatList
         data={COUNTRIES}
-        renderItem={({ country }) => (
-          <BpkFlatListItem
-            key={country.id}
-            title={country.name}
-            image={<Image source={require(FLAG_IMAGES[country.id])} />}
-            onPress={() => console.log(country.id)}
-          />
-        )}
+        renderItem={this.renderItem}
         ItemSeparatorComponent={BpkFlatListItemSeparator}
       />
     );
@@ -70,8 +84,6 @@ Inherits all props from React Native's [FlatList](https://facebook.github.io/rea
 | title              | string                                | true     | -             |
 | image              | instanceOf(Image)                     | false    | null          |
 | selected           | bool                                  | false    | false         |
-
-**Note:** To assist with performance, `BpkFlatListItem` overrides `shouldComponentUpdate` and will only update if `title`, `image` or `selected` changes. Therefore, changes to `onPress` will have no effect unless a re-render is forced.
 
 ### BpkFlatListItemSeparator
 

--- a/native/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.android.js
+++ b/native/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.android.js
@@ -63,18 +63,9 @@ const styles = StyleSheet.create({
   },
 });
 
-class BpkFlatListItem extends React.Component<ListItemProps> {
+class BpkFlatListItem extends React.PureComponent<ListItemProps> {
   static propTypes = LIST_ITEM_PROP_TYPES;
   static defaultProps = LIST_ITEM_DEFAULT_PROPS;
-
-  // Compare only primitive props (not onPress) to help performance.
-  shouldComponentUpdate(nextProps: ListItemProps) {
-    return (
-      nextProps.selected !== this.props.selected ||
-      nextProps.title !== this.props.title ||
-      nextProps.image !== this.props.image
-    );
-  }
 
   render() {
     const { image, title, selected, ...rest } = this.props;

--- a/native/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.ios.js
+++ b/native/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.ios.js
@@ -70,18 +70,9 @@ const styles = StyleSheet.create({
   },
 });
 
-class BpkFlatListItem extends React.Component<ListItemProps> {
+class BpkFlatListItem extends React.PureComponent<ListItemProps> {
   static propTypes = LIST_ITEM_PROP_TYPES;
   static defaultProps = LIST_ITEM_DEFAULT_PROPS;
-
-  // Compare only primitive props (not onPress) to help performance.
-  shouldComponentUpdate(nextProps: ListItemProps) {
-    return (
-      nextProps.selected !== this.props.selected ||
-      nextProps.title !== this.props.title ||
-      nextProps.image !== this.props.image
-    );
-  }
 
   render() {
     const { image, title, selected, ...rest } = this.props;

--- a/native/packages/react-native-bpk-component-flat-list/stories.js
+++ b/native/packages/react-native-bpk-component-flat-list/stories.js
@@ -66,8 +66,16 @@ class StatefulBpkFlatList extends React.Component<{
 
   constructor() {
     super();
+    this.itemPressCallbacks = {};
     this.state = { selectedCountry: 'DJ' };
   }
+
+  getOnItemPressCallback = id => {
+    this.itemPressCallbacks[id] =
+      this.itemPressCallbacks[id] ||
+      (() => this.setState({ selectedCountry: id }));
+    return this.itemPressCallbacks[id];
+  };
 
   getData = () => {
     const data = countries.slice();
@@ -93,9 +101,7 @@ class StatefulBpkFlatList extends React.Component<{
           />
         ) : null
       }
-      onPress={() => {
-        this.setState({ selectedCountry: item.id });
-      }}
+      onPress={this.getOnItemPressCallback(item.id)}
     />
   );
 

--- a/native/packages/react-native-bpk-component-section-list/readme.md
+++ b/native/packages/react-native-bpk-component-section-list/readme.md
@@ -64,18 +64,32 @@ const FLAG_IMAGES = {
 };
 
 export default class App extends Component {
+  constructor() {
+    super();
+    this.itemOnPressCallbacks = {};
+  }
+
+  getItemOnPressCallback = airportId => {
+    this.itemOnPressCallbacks[airportId] =
+      this.itemOnPressCallbacks[airportId] ||
+      (() => console.log(airportId));
+    return this.itemOnPressCallbacks[airportId];
+  };
+
+  renderItem = ({ airport, section }) => (
+    <BpkSectionListItem
+      key={airport.id}
+      title={airport.name}
+      image={<Image source={require(FLAG_IMAGES[section.country])} />}
+      onPress={this.getItemOnPressCallback(airportId)}
+    />
+  );
+
   render() {
     return (
       <BpkSectionList
         sections={AIRPORTS}
-        renderItem={({ airport, section }) => (
-          <BpkSectionListItem
-            key={airport.id}
-            title={airport.name}
-            image={<Image source={require(FLAG_IMAGES[section.country])} />}
-            onPress={() => console.log(airport.id)}
-          />
-        )}
+        renderItem={this.renderItem}
         renderSectionHeader={(section) => (
           <BpkSectionListHeader title={section.title} />
         )}
@@ -100,8 +114,6 @@ Inherits all props from React Native's [SectionList](https://facebook.github.io/
 | title              | string                                | true     | -             |
 | image              | instanceOf(Image)                     | false    | null          |
 | selected           | bool                                  | false    | false         |
-
-**Note:** To assist with performance, `BpkSectionListItem` overrides `shouldComponentUpdate` and will only update if `title`, `image` or `selected` changes. Therefore, changes to `onPress` will have no effect unless a re-render is forced.
 
 ### BpkSectionListHeader
 

--- a/native/packages/react-native-bpk-component-section-list/src/BpkSectionListItem.android.js
+++ b/native/packages/react-native-bpk-component-section-list/src/BpkSectionListItem.android.js
@@ -63,18 +63,9 @@ const styles = StyleSheet.create({
   },
 });
 
-class BpkSectionListItem extends React.Component<ListItemProps> {
+class BpkSectionListItem extends React.PureComponent<ListItemProps> {
   static propTypes = LIST_ITEM_PROP_TYPES;
   static defaultProps = LIST_ITEM_DEFAULT_PROPS;
-
-  // Compare only primitive props (not onPress) to help performance.
-  shouldComponentUpdate(nextProps: ListItemProps) {
-    return (
-      nextProps.selected !== this.props.selected ||
-      nextProps.title !== this.props.title ||
-      nextProps.image !== this.props.image
-    );
-  }
 
   render() {
     const { image, title, selected, ...rest } = this.props;

--- a/native/packages/react-native-bpk-component-section-list/src/BpkSectionListItem.ios.js
+++ b/native/packages/react-native-bpk-component-section-list/src/BpkSectionListItem.ios.js
@@ -70,18 +70,9 @@ const styles = StyleSheet.create({
   },
 });
 
-class BpkSectionListItem extends React.Component<ListItemProps> {
+class BpkSectionListItem extends React.PureComponent<ListItemProps> {
   static propTypes = LIST_ITEM_PROP_TYPES;
   static defaultProps = LIST_ITEM_DEFAULT_PROPS;
-
-  // Compare only primitive props (not onPress) to help performance.
-  shouldComponentUpdate(nextProps: ListItemProps) {
-    return (
-      nextProps.selected !== this.props.selected ||
-      nextProps.title !== this.props.title ||
-      nextProps.image !== this.props.image
-    );
-  }
 
   render() {
     const { image, title, selected, onPress } = this.props;

--- a/native/packages/react-native-bpk-component-section-list/stories.js
+++ b/native/packages/react-native-bpk-component-section-list/stories.js
@@ -93,11 +93,15 @@ class StatefulBpkSectionList extends React.Component<{
 
   constructor() {
     super();
+    this.itemPressCallbacks = {};
     this.state = { selectedAirport: 'GLA' };
   }
 
-  onItemPress = item => {
-    this.setState({ selectedAirport: item.id });
+  getOnItemPressCallback = id => {
+    this.itemPressCallbacks[id] =
+      this.itemPressCallbacks[id] ||
+      (() => this.setState({ selectedAirport: id }));
+    return this.itemPressCallbacks[id];
   };
 
   getData = () => {
@@ -126,7 +130,7 @@ class StatefulBpkSectionList extends React.Component<{
           />
         ) : null
       }
-      onPress={() => this.onItemPress(item)}
+      onPress={this.getOnItemPressCallback(item.id)}
     />
   );
 


### PR DESCRIPTION
Updated storybook and readme uses of `BpkFlatList` and `BpkSectionList` so that `PureComponent` can be used for list items, negating the need for our previous overriding of `shouldComponentUpdate`. 

Thanks @tiagoengel! ⭐️ 

![bitmoji](https://render.bitstrips.com/v2/cpanel/84fe956e-bbff-4d6e-8517-fa8a6614910e-d83078a8-f9f5-4da7-a6de-5ac9c1be4181-v1.png?transparent=1&palette=1&width=246)