### PR TITLE
[BPK-1546] Web section list components

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -94,6 +94,7 @@ configure(() => {
   require('./../packages/bpk-component-radio/stories');
   require('./../packages/bpk-component-router-link/stories');
   require('./../packages/bpk-component-rtl-toggle/stories');
+  require('./../packages/bpk-component-section-list/stories');
   require('./../packages/bpk-component-select/stories');
   require('./../packages/bpk-component-slider/stories');
   require('./../packages/bpk-component-spinner/stories');

--- a/packages/bpk-component-section-list/index.js
+++ b/packages/bpk-component-section-list/index.js
@@ -1,0 +1,26 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import BpkSectionList from './src/BpkSectionList';
+import BpkSectionListSection from './src/BpkSectionListSection';
+import BpkSectionListItem from './src/BpkSectionListItem';
+
+export default BpkSectionList;
+export { BpkSectionListSection, BpkSectionListItem };

--- a/packages/bpk-component-section-list/package-lock.json
+++ b/packages/bpk-component-section-list/package-lock.json
@@ -1,0 +1,125 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.23"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.18"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"requires": {
+				"safer-buffer": "2.1.2"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.4"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"ua-parser-js": {
+			"version": "0.7.18",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+		},
+		"whatwg-fetch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+		}
+	}
+}

--- a/packages/bpk-component-section-list/package.json
+++ b/packages/bpk-component-section-list/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bpk-component-section-list",
+  "version": "0.0.0",
+  "description": "Backpack section list component.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0"
+  },
+  "dependencies": {
+    "bpk-component-icon": "^3.20.2",
+    "bpk-component-text": "^1.0.59",
+    "bpk-mixins": "^17.9.0",
+    "bpk-react-utils": "^2.6.1",
+    "bpk-tokens": "^27.0.0",
+    "prop-types": "^15.5.8"
+  }
+}

--- a/packages/bpk-component-section-list/readme.md
+++ b/packages/bpk-component-section-list/readme.md
@@ -1,0 +1,52 @@
+# bpk-component-section-list
+
+> Backpack section list component.
+
+## Installation
+
+```sh
+npm install bpk-component-section-list --save-dev
+```
+
+## Usage
+
+```js
+import React from 'react';
+import BpkSectionList, { BpkSectionListSection, BpkSectionListItem } from 'bpk-component-section-list';
+
+export default () => (
+  <BpkSectionList>
+    <BpkSectionListSection headerText="Cities">
+      <BpkSectionListItem>Tokyo</BpkSectionListItem>
+      <BpkSectionListItem onClick={() => {}}>Rio de Janeiro</BpkSectionListItem>
+      <BpkSectionListItem href="#">London</BpkSectionListItem>
+    </BpkSectionListSection>
+  </BpkSectionList>
+);
+```
+
+## Props
+
+### BpkSectionList
+
+| Property              | PropType                      | Required | Default Value |
+| --------------------- | ----------------------------- | -------- | ------------- |
+| children              | node                          | true     | -             |
+
+### BpkSectionListSection
+
+| Property              | PropType                      | Required | Default Value |
+| --------------------- | ----------------------------- | -------- | ------------- |
+| children              | node                          | true     | -             |
+| headerText            | string                        | false    | null          |
+
+
+### BpkSectionListItem
+
+| Property              | PropType                      | Required | Default Value |
+| --------------------- | ----------------------------- | -------- | ------------- |
+| children              | node                          | true     | -             |
+| blank                 | bool                          | false    | false         |
+| className             | string                        | false    | null          |
+| href                  | string                        | false    | null          |
+| onClick               | func                          | false    | null          |

--- a/packages/bpk-component-section-list/src/BpkSectionList-test.js
+++ b/packages/bpk-component-section-list/src/BpkSectionList-test.js
@@ -1,0 +1,48 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BpkSectionList from './BpkSectionList';
+
+describe('BpkSectionList', () => {
+  it('should render correctly', () => {
+    const tree = renderer
+      .create(<BpkSectionList>Hello world</BpkSectionList>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with a custom className', () => {
+    const tree = renderer
+      .create(
+        <BpkSectionList className="custom-class">Hello world</BpkSectionList>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with arbitrary props', () => {
+    const tree = renderer
+      .create(<BpkSectionList testId="123">Hello world</BpkSectionList>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/bpk-component-section-list/src/BpkSectionList.js
+++ b/packages/bpk-component-section-list/src/BpkSectionList.js
@@ -1,0 +1,38 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import PropTypes from 'prop-types';
+import React, { type Node } from 'react';
+
+type Props = {
+  children: Node,
+};
+
+const BpkSectionList = (props: Props) => {
+  const { children, ...rest } = props;
+
+  return <section {...rest}>{children}</section>;
+};
+
+BpkSectionList.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default BpkSectionList;

--- a/packages/bpk-component-section-list/src/BpkSectionListItem-test.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListItem-test.js
@@ -1,0 +1,68 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BpkSectionListItem from './BpkSectionListItem';
+
+describe('BpkSectionListItem', () => {
+  it('should render correctly', () => {
+    const tree = renderer
+      .create(<BpkSectionListItem>Hello world</BpkSectionListItem>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with a "href" prop', () => {
+    const tree = renderer
+      .create(<BpkSectionListItem href="#">Hello world</BpkSectionListItem>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with an "onClick" prop', () => {
+    const tree = renderer
+      .create(
+        <BpkSectionListItem onClick={jest.fn()}>
+          Hello world
+        </BpkSectionListItem>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with a custom className', () => {
+    const tree = renderer
+      .create(
+        <BpkSectionListItem className="custom-class">
+          Hello world
+        </BpkSectionListItem>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with arbitrary props', () => {
+    const tree = renderer
+      .create(<BpkSectionListItem testId="123">Hello world</BpkSectionListItem>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/bpk-component-section-list/src/BpkSectionListItem.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListItem.js
@@ -1,0 +1,109 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import PropTypes from 'prop-types';
+import React, { type Node } from 'react';
+import { cssModules } from 'bpk-react-utils';
+import BpkLargeChevronRightIcon from 'bpk-component-icon/lg/chevron-right';
+import { withRtlSupport } from 'bpk-component-icon';
+
+import STYLES from './bpk-section-list-item.scss';
+
+const BpkLargeChevronRightIconWithRtlSupport = withRtlSupport(
+  BpkLargeChevronRightIcon,
+);
+
+const getClassName = cssModules(STYLES);
+
+type Props = {
+  blank: boolean,
+  children: Node,
+  className: ?string,
+  href: ?string,
+  onClick: ?(event: SyntheticEvent<>) => void,
+};
+
+const BpkSectionListItem = (props: Props) => {
+  const { blank, children, className, href, onClick, ...rest } = props;
+  const classNames = [
+    getClassName(
+      'bpk-section-list-item',
+      (href || onClick) && 'bpk-section-list-item--interactive',
+      className,
+    ),
+  ];
+
+  if (href) {
+    const target = blank ? '_blank' : null;
+    return (
+      <a
+        href={href}
+        target={target}
+        onClick={onClick}
+        className={classNames.join(' ')}
+        {...rest}
+      >
+        {children}
+        <BpkLargeChevronRightIconWithRtlSupport
+          className={getClassName('bpk-section-list-item__chevron')}
+        />
+      </a>
+    );
+  }
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={classNames.join(' ')}
+        {...rest}
+      >
+        {children}
+        <BpkLargeChevronRightIconWithRtlSupport
+          className={getClassName('bpk-section-list-item__chevron')}
+        />
+      </button>
+    );
+  }
+
+  return (
+    <div className={classNames.join(' ')} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+BpkSectionListItem.propTypes = {
+  children: PropTypes.node.isRequired,
+  blank: PropTypes.bool,
+  className: PropTypes.string,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+BpkSectionListItem.defaultProps = {
+  blank: false,
+  className: null,
+  href: null,
+  onClick: null,
+};
+
+export default BpkSectionListItem;

--- a/packages/bpk-component-section-list/src/BpkSectionListSection-test.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListSection-test.js
@@ -1,0 +1,52 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BpkSectionListSection from './BpkSectionListSection';
+
+describe('BpkSectionListSection', () => {
+  it('should render correctly', () => {
+    const tree = renderer
+      .create(<BpkSectionListSection>Hello world</BpkSectionListSection>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with "headerText" prop', () => {
+    const tree = renderer
+      .create(
+        <BpkSectionListSection headerText="Heading">
+          Hello world
+        </BpkSectionListSection>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with arbitrary props', () => {
+    const tree = renderer
+      .create(
+        <BpkSectionListSection testId="123">Hello world</BpkSectionListSection>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/bpk-component-section-list/src/BpkSectionListSection.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListSection.js
@@ -1,0 +1,62 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import PropTypes from 'prop-types';
+import React, { type Node } from 'react';
+import { cssModules } from 'bpk-react-utils';
+import BpkText from 'bpk-component-text';
+import STYLES from './bpk-section-list-section.scss';
+
+const getClassName = cssModules(STYLES);
+
+type Props = {
+  children: Node,
+  headerText: ?string,
+};
+
+const BpkSectionListSection = (props: Props) => {
+  const { children, headerText, ...rest } = props;
+
+  return (
+    <section {...rest}>
+      {headerText && (
+        <header className={getClassName('bpk-section-list-section__header')}>
+          <BpkText bold textStyle="base">
+            {headerText}
+          </BpkText>
+        </header>
+      )}
+      <ul className={getClassName('bpk-section-list-section')}>
+        {React.Children.map(children, child => <li>{child}</li>)}
+      </ul>
+    </section>
+  );
+};
+
+BpkSectionListSection.propTypes = {
+  children: PropTypes.node.isRequired,
+  headerText: PropTypes.string,
+};
+
+BpkSectionListSection.defaultProps = {
+  headerText: null,
+};
+
+export default BpkSectionListSection;

--- a/packages/bpk-component-section-list/src/__snapshots__/BpkSectionList-test.js.snap
+++ b/packages/bpk-component-section-list/src/__snapshots__/BpkSectionList-test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkSectionList should render correctly 1`] = `
+<section>
+  Hello world
+</section>
+`;
+
+exports[`BpkSectionList should render correctly with a custom className 1`] = `
+<section
+  className="custom-class"
+>
+  Hello world
+</section>
+`;
+
+exports[`BpkSectionList should render correctly with arbitrary props 1`] = `
+<section
+  testId="123"
+>
+  Hello world
+</section>
+`;

--- a/packages/bpk-component-section-list/src/__snapshots__/BpkSectionListItem-test.js.snap
+++ b/packages/bpk-component-section-list/src/__snapshots__/BpkSectionListItem-test.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkSectionListItem should render correctly 1`] = `
+<div
+  className="bpk-section-list-item"
+>
+  Hello world
+</div>
+`;
+
+exports[`BpkSectionListItem should render correctly with a "href" prop 1`] = `
+<a
+  className="bpk-section-list-item bpk-section-list-item--interactive"
+  href="#"
+  onClick={null}
+  target={null}
+>
+  Hello world
+  <svg
+    className="bpk-section-list-item__chevron bpk-icon--rtl-support"
+    height="24"
+    style={
+      Object {
+        "height": "1.5rem",
+        "width": "1.5rem",
+      }
+    }
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M16.5 12l-6.4 7.2c-.6.6-1.5.7-2.1.1-.6-.5-.7-1.5-.1-2.1l4.6-5.2-4.6-5.2c-.6-.6-.5-1.6.1-2.1s1.6-.5 2.1.1l6.4 7.2z"
+    />
+  </svg>
+</a>
+`;
+
+exports[`BpkSectionListItem should render correctly with a custom className 1`] = `
+<div
+  className="bpk-section-list-item custom-class"
+>
+  Hello world
+</div>
+`;
+
+exports[`BpkSectionListItem should render correctly with an "onClick" prop 1`] = `
+<button
+  className="bpk-section-list-item bpk-section-list-item--interactive"
+  onClick={[Function]}
+  type="button"
+>
+  Hello world
+  <svg
+    className="bpk-section-list-item__chevron bpk-icon--rtl-support"
+    height="24"
+    style={
+      Object {
+        "height": "1.5rem",
+        "width": "1.5rem",
+      }
+    }
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M16.5 12l-6.4 7.2c-.6.6-1.5.7-2.1.1-.6-.5-.7-1.5-.1-2.1l4.6-5.2-4.6-5.2c-.6-.6-.5-1.6.1-2.1s1.6-.5 2.1.1l6.4 7.2z"
+    />
+  </svg>
+</button>
+`;
+
+exports[`BpkSectionListItem should render correctly with arbitrary props 1`] = `
+<div
+  className="bpk-section-list-item"
+  testId="123"
+>
+  Hello world
+</div>
+`;

--- a/packages/bpk-component-section-list/src/__snapshots__/BpkSectionListSection-test.js.snap
+++ b/packages/bpk-component-section-list/src/__snapshots__/BpkSectionListSection-test.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkSectionListSection should render correctly 1`] = `
+<section>
+  <ul
+    className="bpk-section-list-section"
+  >
+    <li>
+      Hello world
+    </li>
+  </ul>
+</section>
+`;
+
+exports[`BpkSectionListSection should render correctly with "headerText" prop 1`] = `
+<section>
+  <header
+    className="bpk-section-list-section__header"
+  >
+    <span
+      className="bpk-text bpk-text--base bpk-text--bold"
+    >
+      Heading
+    </span>
+  </header>
+  <ul
+    className="bpk-section-list-section"
+  >
+    <li>
+      Hello world
+    </li>
+  </ul>
+</section>
+`;
+
+exports[`BpkSectionListSection should render correctly with arbitrary props 1`] = `
+<section
+  testId="123"
+>
+  <ul
+    className="bpk-section-list-section"
+  >
+    <li>
+      Hello world
+    </li>
+  </ul>
+</section>
+`;

--- a/packages/bpk-component-section-list/src/bpk-section-list-item.scss
+++ b/packages/bpk-component-section-list/src/bpk-section-list-item.scss
@@ -1,0 +1,52 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins/index';
+
+.bpk-section-list-item {
+  $root: &;
+
+  display: flex;
+  width: 100%;
+  min-height: $bpk-spacing-lg * 2;
+  padding: $bpk-spacing-xs $bpk-spacing-sm;
+  justify-content: space-between;
+  align-items: center;
+  border: none;
+  background-color: $bpk-color-white;
+  color: $bpk-color-gray-700;
+  text-decoration: none;
+
+  @include bpk-border-bottom-sm($bpk-color-gray-100);
+
+  &--interactive {
+    cursor: pointer;
+  }
+
+  &__chevron {
+    fill: $bpk-color-gray-500;
+
+    #{$root}:hover & {
+      fill: $bpk-color-gray-700;
+    }
+
+    #{$root}:active & {
+      fill: $bpk-color-gray-900;
+    }
+  }
+}

--- a/packages/bpk-component-section-list/src/bpk-section-list-section.scss
+++ b/packages/bpk-component-section-list/src/bpk-section-list-section.scss
@@ -1,0 +1,33 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins/index';
+
+.bpk-section-list-section {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  &__header {
+    display: flex;
+    min-height: $bpk-spacing-xl;
+    padding: $bpk-spacing-xs $bpk-spacing-sm;
+    align-items: center;
+    background-color: $bpk-color-gray-100;
+  }
+}

--- a/packages/bpk-component-section-list/stories.js
+++ b/packages/bpk-component-section-list/stories.js
@@ -1,0 +1,54 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import BpkSectionList, {
+  BpkSectionListSection,
+  BpkSectionListItem,
+} from './index';
+
+storiesOf('bpk-component-section-list', module).add('BpkSectionList', () => (
+  <BpkSectionList>
+    <BpkSectionListSection>
+      <BpkSectionListItem>Section list item</BpkSectionListItem>
+      <BpkSectionListItem
+        onClick={action('Clickable BpkSectionListItem clicked')}
+      >
+        With onClick prop
+      </BpkSectionListItem>
+      <BpkSectionListItem
+        href="https://skyscanner.net"
+        blank
+        onClick={action('BpkSectionListItem with href clicked')}
+      >
+        With href
+      </BpkSectionListItem>
+    </BpkSectionListSection>
+    <BpkSectionListSection headerText="Cities">
+      <BpkSectionListItem>Tokyo</BpkSectionListItem>
+      <BpkSectionListItem>Rio de Janeiro</BpkSectionListItem>
+      <BpkSectionListItem>London</BpkSectionListItem>
+      <BpkSectionListItem>Beijing</BpkSectionListItem>
+    </BpkSectionListSection>
+  </BpkSectionList>
+));

--- a/unreleased.md
+++ b/unreleased.md
@@ -5,3 +5,6 @@
   - Introducing the React Native pagination dots component.
 - bpk-component-navigation-stack:
   - Introducing the Navigation Stack component.
+
+- bpk-component-section-list:
+  - Introducing the web section list component.


### PR DESCRIPTION
* Docs to come in a separate PR.
* In future there are going to be more options for this, e.g. title, subtitle, icons. Keeping one eye on that, I think this implementation leaves it loose enough that we can support that in future without making breaking changes.
* I also created three new mixins for adding both a top and bottom border simultaneously. In the end I didn't use them (see below for why) but I figured it's good to have them anyway, now I've already made them.
* One compromise I've made wrt the design is I've only added a bottom border. I originally had a top and bottom one, but then when they stack, you get a double border where the two components touch. I've made the assumption that just a bottom one is ok, because I think there will always be an instance of the header component at the top of the section list (cc @jamesf3rguson to confirm).

<img width="902" alt="screen shot 2018-05-09 at 14 12 54" src="https://user-images.githubusercontent.com/73652/39818174-31df37d2-5398-11e8-90ff-8ac3c880654d.png">
