### PR TITLE
[NO-JIRA]: Change anchor links title

### DIFF
--- a/packages/bpk-docs/src/components/neo/PageHead/PageHead.js
+++ b/packages/bpk-docs/src/components/neo/PageHead/PageHead.js
@@ -56,9 +56,9 @@ const PageHead = (props: Props) => {
         <BpkText
           bold
           tagName="h2"
-          className={getClassName('bpkdocs-page-head__available-configs')}
+          className={getClassName('bpkdocs-page-head__in-section')}
         >
-          Available configurations
+          In this section:
         </BpkText>
         {props.menu && (
           <BpkList>

--- a/packages/bpk-docs/src/components/neo/PageHead/PageHead.js
+++ b/packages/bpk-docs/src/components/neo/PageHead/PageHead.js
@@ -58,7 +58,7 @@ const PageHead = (props: Props) => {
           tagName="h2"
           className={getClassName('bpkdocs-page-head__in-section')}
         >
-          In this section:
+          In this section
         </BpkText>
         {props.menu && (
           <BpkList>

--- a/packages/bpk-docs/src/components/neo/PageHead/PageHead.scss
+++ b/packages/bpk-docs/src/components/neo/PageHead/PageHead.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  &__available-configs {
+  &__in-section {
     margin-bottom: $bpk-spacing-md;
   }
 }


### PR DESCRIPTION
The anchor links title appears on all pages, not just components and therefore does not make sense to name 'Available configurations'. 'In this section' is more generic and can apply to all pages.