### PR TITLE
[BPK-1583] Apply max-width to neo screenshots

### DIFF
--- a/packages/bpk-docs/src/components/DocsPageBuilder/ComponentScreenshots.scss
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/ComponentScreenshots.scss
@@ -31,6 +31,7 @@
 
     @include bpk-breakpoint-above-mobile {
       width: calc(50% - #{$bpk-spacing-base});
+      max-width: $bpk-one-pixel-rem * 540; // 1080 (width of Android screenshot) / 2 (pixel density)
       margin-right: $bpk-spacing-base;
 
       @include bpk-rtl {


### PR DESCRIPTION
See attached low-res af gif
![kapture 2018-05-11 at 11 04 46](https://user-images.githubusercontent.com/73652/39919438-87ee2eb6-550b-11e8-94b9-66c043f53048.gif)
