### PR TITLE
[BPK-1584] Add sticky footer to docs layout

### DIFF
--- a/packages/bpk-docs/src/layouts/DefaultLayout/DefaultLayout.js
+++ b/packages/bpk-docs/src/layouts/DefaultLayout/DefaultLayout.js
@@ -75,13 +75,15 @@ class DefaultLayout extends Component {
       <EnhancedThemeProvider
         themeAttributes={themeAttributes}
         id="portal-target"
-        className={
-          process.env.BPK_NEO
-            ? getClassName('bpkdocs-default-layout__container')
-            : null
-        }
       >
-        <div id="application-container">
+        <div
+          id="application-container"
+          className={
+            process.env.BPK_NEO
+              ? getClassName('bpkdocs-default-layout__container')
+              : null
+          }
+        >
           <Helmet titleTemplate="%s | Backpack" />
           {!process.env.BPK_NEO && (
             <Header
@@ -90,7 +92,13 @@ class DefaultLayout extends Component {
             />
           )}
 
-          <main>{children}</main>
+          <main
+            className={getClassName(
+              'bpkdocs-default-layout__content-container',
+            )}
+          >
+            {children}
+          </main>
 
           {process.env.BPK_NEO ? (
             <Footer />

--- a/packages/bpk-docs/src/layouts/DefaultLayout/default-layout.scss
+++ b/packages/bpk-docs/src/layouts/DefaultLayout/default-layout.scss
@@ -20,7 +20,21 @@
 
 .bpkdocs-default-layout {
   &__container {
-    background-color: $bpk-color-gray-100;
+    position: absolute;
+    display: flex;
+    width: 100%;
+    min-height: 100%;
+    flex-direction: column;
+  }
+
+  &__content-container {
+    display: flex;
+    flex-direction: column;
+    flex: 1 0 auto;
+
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      min-height: calc(100vh - 5.25rem); /* Hack for Internet Explorer: */
+    }
   }
 
   &__footer-container {

--- a/packages/bpk-docs/src/layouts/NeoSideNavLayout/SideNavLayout.scss
+++ b/packages/bpk-docs/src/layouts/NeoSideNavLayout/SideNavLayout.scss
@@ -20,6 +20,7 @@
 
 .bpkdocs-side-nav-layout {
   display: flex;
+  flex: 1 0 auto;
 
   &__sidebar-destop-wrapper {
     display: flex;
@@ -36,6 +37,6 @@
 
   &__main {
     min-width: 0;
-    flex: 1;
+    flex: 1 1 auto;
   }
 }


### PR DESCRIPTION
**UPDATE 12/05/2018** (Yes, that's a saturday 😆)

When I first implemented this, the solution did not cater for Safari versions < 11.1 or IE 11.

I fixed IE 11 with a [small hack](https://github.com/Skyscanner/backpack/pull/747/files#diff-4e104caa9fb361ea77529d88c900d991R35) that is applied to IE only.

I fixed the Safari issues with blood, sweat and anger.

Now for screenshots:

Chrome:
![chrome](https://user-images.githubusercontent.com/30267516/39957485-bf3d5622-55eb-11e8-9718-78229d09d615.png)

Edge:
![edge](https://user-images.githubusercontent.com/30267516/39957486-bf534586-55eb-11e8-8fa7-22b73c2cef72.png)

Firefox (Quantum):
![firefox_quantum](https://user-images.githubusercontent.com/30267516/39957487-bf69a146-55eb-11e8-9627-c0f0729b5cf0.png)

IE:
![internet_explorer](https://user-images.githubusercontent.com/30267516/39957488-bf808a64-55eb-11e8-88aa-96c97a232043.png)

IOS:
![ios](https://user-images.githubusercontent.com/30267516/39957489-bf963940-55eb-11e8-927e-0525d0b9dc32.png)

Safari 10.1:
![safari_10 1](https://user-images.githubusercontent.com/30267516/39957490-bfad9f40-55eb-11e8-8dad-54bd81c5647d.png)

Safari 11.1:
![safari_11 1](https://user-images.githubusercontent.com/30267516/39957491-bfc44a60-55eb-11e8-8771-9dfb6e23bf0b.png)
