### PR TITLE
[BPK-1580] Add missing themes for the neo sidebar

### DIFF
--- a/packages/bpk-component-theme-toggle/src/theming.js
+++ b/packages/bpk-component-theme-toggle/src/theming.js
@@ -36,6 +36,7 @@ const generateTheme = ({
   docsSidebarBackground,
   docsSidebarLink,
   docsSidebarLinkBorder,
+  docsSidebarSelectedArrowColor,
   themeName,
 }) => ({
   themeName,
@@ -124,6 +125,7 @@ const generateTheme = ({
   docsSidebarBackground,
   docsSidebarLink,
   docsSidebarLinkBorder,
+  docsSidebarSelectedArrowColor,
 });
 
 const londonTheme = {
@@ -138,6 +140,7 @@ const londonTheme = {
   docsSidebarBackground: '#013A76',
   docsSidebarLink: '#6889AB',
   docsSidebarLinkBorder: '#6889AB',
+  docsSidebarSelectedArrowColor: '#ED1B28',
   themeName: 'London',
 };
 
@@ -153,6 +156,7 @@ const hongKongTheme = {
   docsSidebarBackground: '#4C4C4C',
   docsSidebarLink: '#686868',
   docsSidebarLinkBorder: '#686868',
+  docsSidebarSelectedArrowColor: '#108685',
   themeName: 'HongKong',
 };
 
@@ -168,6 +172,7 @@ const dohaTheme = {
   docsSidebarBackground: '#5E072C',
   docsSidebarLink: '#BF3671',
   docsSidebarLinkBorder: '#BF3671',
+  docsSidebarSelectedArrowColor: '#BF3671',
   themeName: 'Doha',
 };
 

--- a/packages/bpk-docs/src/layouts/NeoSideNavLayout/NavList.js
+++ b/packages/bpk-docs/src/layouts/NeoSideNavLayout/NavList.js
@@ -20,7 +20,8 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
 import { cssModules } from 'bpk-react-utils';
-
+import ArrowIcon from 'bpk-component-icon/sm/arrow-right';
+import { withRtlSupport } from 'bpk-component-icon';
 import NavListFilter, { type Option as FilterOption } from './NavListFilter';
 import STYLES from './NavList.scss';
 import sortLinks from './links-sorter';
@@ -31,6 +32,8 @@ import {
 } from './common-types';
 
 const getClassName = cssModules(STYLES);
+
+const ArrowIconWithRtl = withRtlSupport(ArrowIcon);
 
 const NavLink = (props: LinkPropType) => {
   const { children, route, tags, ...rest } = props;
@@ -43,6 +46,9 @@ const NavLink = (props: LinkPropType) => {
         to={route}
         {...rest}
       >
+        <ArrowIconWithRtl
+          className={getClassName('bpkdocs-side-nav-list__link-active-icon')}
+        />
         {children}
       </Link>
     );

--- a/packages/bpk-docs/src/layouts/NeoSideNavLayout/NavList.scss
+++ b/packages/bpk-docs/src/layouts/NeoSideNavLayout/NavList.scss
@@ -81,34 +81,36 @@
   }
 
   &__link {
+    position: relative;
+
     @include nav-link;
     @include nav-link--enabled;
   }
 
   &__link--active {
-    position: relative;
-
     @include nav-link--active;
+  }
 
-    &::before {
-      position: absolute;
-      top: 50%;
-      // HACK: Move sligthly further to the left to account for icon bounding box so
+  &__link-active-icon {
+    position: absolute;
+    top: calc(50% - (#{$bpk-icon-size-sm} / 2));
+    // HACK: Move sligthly further to the left to account for icon bounding box so
+    // that the actual icon lines up with other content.
+    left: calc(-#{$bpk-first-column-size} - #{$bpk-one-pixel-rem * 5});
+    display: none;
+
+    @include bpk-themeable-property(fill, --bpk-docs-sidebar-selected-arrow-color, $bpk-color-red-500);
+
+    @include bpk-rtl {
+      // HACK: Move sligthly further to the right to account for icon bounding box so
       // that the actual icon lines up with other content.
-      left: calc(-#{$bpk-first-column-size} - #{$bpk-one-pixel-rem * 5});
-      content: ' ';
-      transform: translateY(-50%);
-
-      @include bpk-icon(arrow-right, $bpk-color-red-500, small);
-
-      @include bpk-rtl {
-        // HACK: Move sligthly further to the right to account for icon bounding box so
-        // that the actual icon lines up with other content.
-        right: calc(-#{$bpk-first-column-size} - #{$bpk-one-pixel-rem * 5});
-        left: 0;
-        transform: scaleX(-1);
-      }
+      right: calc(-#{$bpk-first-column-size} - #{$bpk-one-pixel-rem * 5});
+      left: 0;
     }
+  }
+
+  &__link--active &__link-active-icon {
+    display: inline;
   }
 
   &__pending-link {

--- a/packages/bpk-docs/src/layouts/NeoSideNavLayout/SectionsList.scss
+++ b/packages/bpk-docs/src/layouts/NeoSideNavLayout/SectionsList.scss
@@ -41,6 +41,7 @@ $bpk-heading-button-padding: $bpk-spacing-md;
     @include bpk-text;
     @include bpk-text-xl;
     @include bpk-border-bottom-sm($bpk-color-gray-700);
+    @include bpk-border-bottom-sm(var(--bpk-docs-sidebar-link-border, $bpk-color-gray-700));
 
     @include bpk-rtl {
       text-align: right;
@@ -94,6 +95,7 @@ $bpk-heading-button-padding: $bpk-spacing-md;
     text-align: left;
 
     @include bpk-border-bottom-sm($bpk-color-gray-700);
+    @include bpk-border-bottom-sm(var(--bpk-docs-sidebar-link-border, $bpk-color-gray-700));
     @include nav-link;
     @include nav-link--enabled;
     @include nav-link--lg;

--- a/packages/bpk-docs/src/themeableAttributes.js
+++ b/packages/bpk-docs/src/themeableAttributes.js
@@ -46,6 +46,7 @@ const docsThemeAttributes = [
   'docsSidebarBackground',
   'docsSidebarLink',
   'docsSidebarLinkBorder',
+  'docsSidebarSelectedArrowColor',
   'themeName',
   'logoFillColor',
 ];


### PR DESCRIPTION
<img width="1497" alt="screen shot 2018-05-11 at 14 04 37" src="https://user-images.githubusercontent.com/1457263/39925631-4ab50a92-5524-11e8-9238-758148e68213.png">
<img width="1483" alt="screen shot 2018-05-11 at 14 04 22" src="https://user-images.githubusercontent.com/1457263/39925632-4aca0528-5524-11e8-8abd-714f7ee7d814.png">
<img width="903" alt="screen shot 2018-05-11 at 14 58 31" src="https://user-images.githubusercontent.com/1457263/39927962-debfce28-552b-11e8-8c06-87b59d3b6a81.png">
<img width="1439" alt="screen shot 2018-05-11 at 14 04 01" src="https://user-images.githubusercontent.com/1457263/39925634-4b01dc50-5524-11e8-8779-d9b43ab87079.png">
