### PR TITLE
[BPK-1581] Fix docs title issue

### DIFF
--- a/packages/bpk-docs/src/components/DocsPageBuilder/NeoDocsPageBuilder.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/NeoDocsPageBuilder.js
@@ -17,6 +17,7 @@
 */
 
 import marked from 'marked';
+import Helmet from 'react-helmet';
 import isString from 'lodash/isString';
 import PropTypes from 'prop-types';
 import React, { Children } from 'react';
@@ -199,12 +200,14 @@ const NeoDocsPageBuilder = props => {
     <BpkContentContainer
       className={getClassName(
         `bpkdocs-content-page--${
-          sections.length % 2 === 0 ? 'even' : 'odd'
+          sections.length % 2 === (props.wrapped ? 1 : 0) ? 'even' : 'odd'
         }-sections`,
       )}
     >
+      <Helmet title={props.title} />
       {showPageHead && (
         <PageHead
+          title={props.wrapped ? null : props.title}
           blurb={props.blurb}
           menu={menu.map(({ id, title }) => ({
             href: `#${id}`,
@@ -213,7 +216,7 @@ const NeoDocsPageBuilder = props => {
           wrapped={props.wrapped}
         />
       )}
-      <AlternatingPageContent sections={sections} />
+      <AlternatingPageContent sections={sections} invert={props.wrapped} />
     </BpkContentContainer>
   );
 };

--- a/packages/bpk-docs/src/components/DocsPageBuilder/NeoDocsPageBuilder.scss
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/NeoDocsPageBuilder.scss
@@ -19,10 +19,10 @@
 
 .bpkdocs-content-page {
   &--even-sections {
-    background-color: $bpk-color-gray-50;
+    background-color: $bpk-color-gray-100;
   }
 
   &--odd-sections {
-    background-color: $bpk-color-gray-100;
+    background-color: $bpk-color-gray-50;
   }
 }

--- a/packages/bpk-docs/src/components/neo/AlternatingPageContent/AlternatingPageContent.js
+++ b/packages/bpk-docs/src/components/neo/AlternatingPageContent/AlternatingPageContent.js
@@ -25,6 +25,7 @@ import STYLES from './AlternatingPageContent.scss';
 const getClassName = cssModules(STYLES);
 
 type Props = {
+  invert: boolean,
   sections: Array<?Node>,
 };
 
@@ -32,7 +33,7 @@ const AlternatingPageContent = (props: Props) => (
   <section className={getClassName('bpkdocs-alternating-content')}>
     {React.Children.toArray(
       props.sections.filter(x => x).map((section, i) => {
-        const useAlternateStyle = i % 2 !== 0;
+        const useAlternateStyle = i % 2 === (props.invert ? 1 : 0);
         const classNames = [
           getClassName('bpkdocs-alternating-content__section'),
         ];

--- a/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.js
+++ b/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.js
@@ -18,7 +18,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Helmet from 'react-helmet';
 import BpkContentContainer from 'bpk-component-content-container';
 import BpkHorizontalNav, {
   BpkHorizontalNavItem,
@@ -68,7 +67,6 @@ class DocsPageWrapper extends React.Component {
 
     return (
       <BpkContentContainer className={getClassName('bpkdocs-page-wrapper')}>
-        <Helmet title={title} />
         <div className={getClassName('bpkdocs-page-wrapper__inner')}>
           <Heading level="h1">{title}</Heading>
           {blurb && <Blurb content={blurb} />}

--- a/packages/bpk-docs/src/components/neo/PageHead/PageHead.js
+++ b/packages/bpk-docs/src/components/neo/PageHead/PageHead.js
@@ -24,6 +24,7 @@ import BpkText from 'bpk-component-text';
 import { BpkList, BpkListItem } from 'bpk-component-list';
 import isString from 'lodash/isString';
 
+import Heading from '../Heading';
 import Paragraph from '../Paragraph';
 
 import STYLES from './PageHead.scss';
@@ -44,15 +45,21 @@ type MenuItem = {
 };
 
 type Props = {
+  title: string,
   blurb: string | Node,
+  wrapped: boolean,
   menu: ?Array<MenuItem>,
 };
 const PageHead = (props: Props) => {
-  const contentClassNames = [getClassName('bpkdocs-page-head__content')];
+  const contentClassNames = getClassName(
+    'bpkdocs-page-head__content',
+    props.wrapped && 'bpkdocs-page-head__content--wrapped',
+  );
   const showMenu = props.menu && props.menu.length > 0;
   return (
     <section className={getClassName('bpkdocs-page-head')}>
-      <div className={contentClassNames.join(' ')}>
+      <div className={contentClassNames}>
+        {props.title && <Heading level="h1">{props.title}</Heading>}
         {props.blurb && toNodes(props.blurb)}
         {showMenu && (
           <div>

--- a/packages/bpk-docs/src/components/neo/PageHead/PageHead.scss
+++ b/packages/bpk-docs/src/components/neo/PageHead/PageHead.scss
@@ -21,10 +21,14 @@
 .bpkdocs-page-head {
   &__content {
     padding: $bpk-spacing-xs * 10;
-    background-color: $bpk-color-gray-50;
+    background-color: $bpk-color-white;
 
     @include bpk-breakpoint-mobile {
       padding: $bpk-spacing-lg;
+    }
+
+    &--wrapped {
+      background-color: $bpk-color-gray-50;
     }
   }
 


### PR DESCRIPTION
In #704 I removed some things from `NeoDocsPageBuilder` because I thought *all* pages were now 'wrapped' (inside an instance of `DocsPageWrapper`). Turns out this was wrong, because while all _component_ pages are wrapped, tokens and other pages are not.

This PR reverts lots of the previous PR to reinstate the correct appearance. It also fixes the issue where `window.title` wasn't always updated as users moved between pages.

**Before this PR**
![screen shot 2018-05-11 at 14 06 13](https://user-images.githubusercontent.com/73652/39925690-84e8be34-5524-11e8-96a9-e24f3cc16254.png)

**After this PR**
![screen shot 2018-05-11 at 14 05 58](https://user-images.githubusercontent.com/73652/39925696-889f4fca-5524-11e8-84c2-2c54ae069788.png)
