### PR TITLE
[NoJira] fix drawer page double title

### DIFF
--- a/packages/bpk-docs/src/pages/DrawerPage/DrawerPage.js
+++ b/packages/bpk-docs/src/pages/DrawerPage/DrawerPage.js
@@ -125,12 +125,13 @@ const blurb = [
   </IntroBlurb>,
 ];
 
-const DrawerPage = () => (
+const DrawerPage = ({ ...rest }) => (
   <DocsPageBuilder
     title="Drawer"
     blurb={isNeo ? null : blurb}
     components={components}
     readme={drawerReadme}
+    {...rest}
   />
 );
 


### PR DESCRIPTION
During automatic tests we found the Drawer page had the tittle added twice to the page



![screen shot 2018-05-18 at 12 58 35 pm](https://user-images.githubusercontent.com/3579758/40233649-caae5268-5a9b-11e8-9b70-77d0d885868a.png)

this PR fixes it 🎉

![screen shot 2018-05-18 at 12 58 46 pm](https://user-images.githubusercontent.com/3579758/40233657-d21a7054-5a9b-11e8-8b94-a93cc467d08d.png)

