### PR TITLE
Fix backpack-react-scripts changelog.md url in new docs site #trivial

### DIFF
--- a/packages/bpk-docs/src/pages/BackpackReactScriptsPage/BackpackReactScriptsPage.js
+++ b/packages/bpk-docs/src/pages/BackpackReactScriptsPage/BackpackReactScriptsPage.js
@@ -27,7 +27,7 @@ import CodeBlock from '../../components/CodeBlock';
 const createReactAppHref =
   'https://github.com/facebookincubator/create-react-app';
 const backpackReactScriptsChangelogHref =
-  'https://github.com/Skyscanner/backpack-react-scripts/blob/master/packages/react-scripts/CHANGELOG.md';
+  'https://github.com/Skyscanner/backpack-react-scripts/blob/fork/packages/react-scripts/CHANGELOG.md';
 
 const components = [
   {


### PR DESCRIPTION
The link to the changelog.md file of backpack-react-scripts in the new documentation page is broken (https://backpack.github.io/using/backpack-react-scripts)