### PR TITLE
[BPK-1601] Add docs for map component

### DIFF
--- a/packages/bpk-component-map/package.json
+++ b/packages/bpk-component-map/package.json
@@ -1,7 +1,6 @@
 {
   "name": "bpk-component-map",
   "version": "0.0.1",
-  "private": true,
   "description": "Backpack map component.",
   "main": "index.js",
   "repository": {

--- a/packages/bpk-docs/package.json
+++ b/packages/bpk-docs/package.json
@@ -45,6 +45,7 @@
     "bpk-component-link": "^1.1.17",
     "bpk-component-list": "^1.1.38",
     "bpk-component-loading-button": "^2.0.20",
+    "bpk-component-map": "^0.0.1",
     "bpk-component-mobile-scroll-container": "^1.1.1",
     "bpk-component-modal": "^1.7.3",
     "bpk-component-navigation-bar": "^1.2.0",

--- a/packages/bpk-docs/src/constants/routes.js
+++ b/packages/bpk-docs/src/constants/routes.js
@@ -176,6 +176,7 @@ export const NEO_SELECT = '/components/select';
 export const NEO_TOUCHABLE_OVERLAY = '/components/touchable-overlay';
 export const NEO_TOUCHABLE_NATIVE_FEEDBACK =
   '/components/touchable-native-feedback';
+export const NEO_MAP = '/components/map';
 
 export const NEO_ALIGNMENT = '/components/alignment';
 export const NEO_THEMING = '/components/theming';

--- a/packages/bpk-docs/src/layouts/links.js
+++ b/packages/bpk-docs/src/layouts/links.js
@@ -471,6 +471,12 @@ const neoComponentsLinks = [
         children: 'Horizontal grid',
         tags: ['web'],
       },
+      {
+        id: 'MAP',
+        route: routes.NEO_MAP,
+        children: 'Map',
+        tags: ['web'],
+      },
 
       // Native components.
       {

--- a/packages/bpk-docs/src/pages/MapPage/MapPage.js
+++ b/packages/bpk-docs/src/pages/MapPage/MapPage.js
@@ -1,0 +1,79 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import BpkMap, { withScriptjs } from 'bpk-component-map';
+
+import mapReadme from 'bpk-component-map/readme.md';
+
+import DocsPageBuilder from './../../components/DocsPageBuilder';
+import DocsPageWrapper from './../../components/neo/DocsPageWrapper';
+import IntroBlurb from './../../components/neo/IntroBlurb';
+
+const BpkMapWithScript = withScriptjs(BpkMap);
+const MAP_URL =
+  'https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places';
+
+// Shibuya crossing, Tokyo.
+const COORDINATES = {
+  lat: 35.661777,
+  lng: 139.704051,
+};
+
+const components = [
+  {
+    id: 'default',
+    title: 'Default',
+    examples: [
+      <BpkMapWithScript
+        googleMapURL={MAP_URL}
+        loadingElement={<div />}
+        containerElement={<div style={{ height: '400px' }} />}
+        mapElement={<div style={{ height: `100%` }} />}
+        defaultZoom={17}
+        defaultCenter={COORDINATES}
+      />,
+    ],
+  },
+];
+
+const isNeo = process.env.BPK_NEO;
+
+const blurb = [
+  <IntroBlurb>The map component is for embedding maps into pages.</IntroBlurb>,
+];
+
+const MapSubpage = ({ ...rest }) => (
+  <DocsPageBuilder
+    title="Blockquote"
+    components={components}
+    readme={mapReadme}
+    blurb={isNeo ? null : blurb}
+    {...rest}
+  />
+);
+
+const MapPage = () => (
+  <DocsPageWrapper
+    title="Map"
+    blurb={blurb}
+    webSubpage={<MapSubpage wrapped />}
+  />
+);
+
+export default MapPage;

--- a/packages/bpk-docs/src/pages/MapPage/index.js
+++ b/packages/bpk-docs/src/pages/MapPage/index.js
@@ -1,0 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import page from './MapPage';
+
+export default page;

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -70,6 +70,7 @@ import ImagesPage from './../pages/ImagesPage';
 import BreakpointsPage from './../pages/BreakpointsPage';
 import HorizontalGridPage from './../pages/HorizontalGridPage';
 import BannerAlertsPage from './../pages/BannerAlertsPage';
+import MapPage from './../pages/MapPage';
 import MobileScrollContainerPage from './../pages/MobileScrollContainerPage';
 import ModalsPage from './../pages/ModalsPage';
 import AutosuggestPage from './../pages/AutosuggestPage';
@@ -337,6 +338,7 @@ const Routes = (
         <Route path={ROUTES.NEO_SELECT} component={NativeSelectPage} />
         <Route path={ROUTES.NEO_SWITCH} component={NativeSwitchPage} />
         <Route path={ROUTES.NEO_SECTION_LIST} component={NeoSectionListPage} />
+        <Route path={ROUTES.NEO_MAP} component={MapPage} />
         <Route
           path={ROUTES.NEO_TOUCHABLE_OVERLAY}
           component={NativeTouchableOverlayPage}


### PR DESCRIPTION
I've named the route `NEO_MAP` so as not to confuse people, but this is a Neo only thing (seeing as we now only have Neo!).

Right now there's a very minimal example, we can add more later when we add functionality on top of `react-google-maps`.

![0 0 0 0_8080_components_blockquote_platform web](https://user-images.githubusercontent.com/73652/40536945-83897600-6005-11e8-8aaa-716f5340d485.png)