### PR TITLE
[BPK-1597] Fix navigation bar display issue in IE with RTL

### DIFF
--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.scss
@@ -44,7 +44,7 @@
 
     @include bpk-rtl {
       right: $bpk-spacing-sm;
-      left: unset;
+      left: auto;
     }
   }
 
@@ -52,7 +52,7 @@
     right: $bpk-spacing-sm;
 
     @include bpk-rtl {
-      right: unset;
+      right: auto;
       left: $bpk-spacing-sm;
     }
   }

--- a/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.js
+++ b/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.js
@@ -19,6 +19,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { withRouter } from 'react-router';
+import { find } from 'lodash';
 import BpkContentContainer from 'bpk-component-content-container';
 import BpkHorizontalNav, {
   BpkHorizontalNavItem,
@@ -73,7 +74,7 @@ class DocsPageWrapper extends React.Component {
 
   componentWillMount = () => {
     const { router } = this.props;
-    const activePlatform = this.compatibleFind(['native', 'web'], platform =>
+    const activePlatform = find(['native', 'web'], platform =>
       router.isActive({ query: { platform } }),
     );
     if (activePlatform) {
@@ -95,27 +96,6 @@ class DocsPageWrapper extends React.Component {
   };
 
   getSelectedSubpage = () => (this.props.nativeSubpage ? 'native' : 'web');
-
-  compatibleFind = (arr, val) => {
-    if ('find' in arr) {
-      return arr.find(val);
-    }
-    // MDN Polyfill Code https://tc39.github.io/ecma262/#sec-array.prototype.find
-    const len = arr.length;
-    if (typeof val !== 'function') {
-      throw new TypeError('val must be a function');
-    }
-    const thisArg = arguments[1];
-    let k = 0;
-    while (k < len) {
-      const kValue = arr[k];
-      if (val.call(thisArg, kValue, k, arr)) {
-        return kValue;
-      }
-      k += 1;
-    }
-    return undefined;
-  };
 
   render() {
     const { blurb, nativeSubpage, title, webSubpage } = this.props;

--- a/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.js
+++ b/packages/bpk-docs/src/components/neo/DocsPageWrapper/DocsPageWrapper.js
@@ -73,7 +73,7 @@ class DocsPageWrapper extends React.Component {
 
   componentWillMount = () => {
     const { router } = this.props;
-    const activePlatform = ['native', 'web'].find(platform =>
+    const activePlatform = this.compatibleFind(['native', 'web'], platform =>
       router.isActive({ query: { platform } }),
     );
     if (activePlatform) {
@@ -95,6 +95,27 @@ class DocsPageWrapper extends React.Component {
   };
 
   getSelectedSubpage = () => (this.props.nativeSubpage ? 'native' : 'web');
+
+  compatibleFind = (arr, val) => {
+    if ('find' in arr) {
+      return arr.find(val);
+    }
+    // MDN Polyfill Code https://tc39.github.io/ecma262/#sec-array.prototype.find
+    const len = arr.length;
+    if (typeof val !== 'function') {
+      throw new TypeError('val must be a function');
+    }
+    const thisArg = arguments[1];
+    let k = 0;
+    while (k < len) {
+      const kValue = arr[k];
+      if (val.call(thisArg, kValue, k, arr)) {
+        return kValue;
+      }
+      k += 1;
+    }
+    return undefined;
+  };
 
   render() {
     const { blurb, nativeSubpage, title, webSubpage } = this.props;

--- a/unreleased.md
+++ b/unreleased.md
@@ -5,3 +5,6 @@
   - Introducing the React Native pagination dots component.
 - bpk-component-map:
   - Introducing the map component.
+**Fixed:**
+ - bpk-component-navigation-bar:
+  - Fixed issue in IE where buttons were misplaced for RTL languages.


### PR DESCRIPTION
`unset` used in the RTL selector wasn't being applied properly in IE 11. Changing to `auto` resolves this.

Screenshot before:
![screen shot 2018-05-25 at 14 21 14](https://user-images.githubusercontent.com/30267516/40546325-e9fc731c-6026-11e8-95f2-c61a502bd897.png)
