### PR TITLE
[BPK-1597] Fix issue with nav bars in IE with RTL enabled

### DIFF
--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.scss
@@ -44,7 +44,7 @@
 
     @include bpk-rtl {
       right: $bpk-spacing-sm;
-      left: unset;
+      left: auto;
     }
   }
 
@@ -52,7 +52,7 @@
     right: $bpk-spacing-sm;
 
     @include bpk-rtl {
-      right: unset;
+      right: auto;
       left: $bpk-spacing-sm;
     }
   }

--- a/unreleased.md
+++ b/unreleased.md
@@ -5,3 +5,8 @@
   - Introducing the React Native pagination dots component.
 - bpk-component-map:
   - Introducing the map component.
+
+
+**Fixed:**
+- bpk-component-navigation-bar:
+  - Fixed issue in IE where buttons were misplaced for RTL languages.


### PR DESCRIPTION
`unset` used in the RTL selector wasn't being applied properly in IE 11. Changing to `auto` resolves this.

Screenshot before:
![screen shot 2018-05-25 at 14 21 14](https://user-images.githubusercontent.com/30267516/40546325-e9fc731c-6026-11e8-95f2-c61a502bd897.png)
