### PR TITLE
[BPK-1596] Fix badge docs page overflowing

### DIFF
--- a/packages/bpk-docs/src/pages/BadgePage/BadgePage.js
+++ b/packages/bpk-docs/src/pages/BadgePage/BadgePage.js
@@ -18,7 +18,6 @@
 
 import React from 'react';
 import BpkBadge, { BADGE_TYPES } from 'bpk-component-badge';
-import BadgeLayout from 'bpk-component-badge/BadgeLayout';
 
 import { cssModules } from 'bpk-react-utils';
 
@@ -136,42 +135,40 @@ const components = [
     blurb: [
       <Paragraph>The light badge is a gray color as shown below.</Paragraph>,
     ],
+    dark: true,
     examples: [
-      <BadgeLayout>
-        <BpkBadge type={BADGE_TYPES.light} className={badgeClassName}>
-          Apples
-        </BpkBadge>
-        <BpkBadge type={BADGE_TYPES.light} className={badgeClassName}>
-          Bananas
-        </BpkBadge>
-        <BpkBadge type={BADGE_TYPES.light} className={badgeClassName}>
-          Strawberries
-        </BpkBadge>
-        <BpkBadge type={BADGE_TYPES.light} className={badgeClassName}>
-          Pears
-        </BpkBadge>
-      </BadgeLayout>,
+      <BpkBadge type={BADGE_TYPES.light} className={badgeClassName}>
+        Apples
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.light} className={badgeClassName}>
+        Bananas
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.light} className={badgeClassName}>
+        Strawberries
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.light} className={badgeClassName}>
+        Pears
+      </BpkBadge>,
     ],
   },
   {
     id: 'inverse',
     title: 'Inverse',
     blurb: [<Paragraph>The inverse badge is white as shown below.</Paragraph>],
+    dark: true,
     examples: [
-      <BadgeLayout>
-        <BpkBadge type={BADGE_TYPES.inverse} className={badgeClassName}>
-          Apples
-        </BpkBadge>
-        <BpkBadge type={BADGE_TYPES.inverse} className={badgeClassName}>
-          Bananas
-        </BpkBadge>
-        <BpkBadge type={BADGE_TYPES.inverse} className={badgeClassName}>
-          Strawberries
-        </BpkBadge>
-        <BpkBadge type={BADGE_TYPES.inverse} className={badgeClassName}>
-          Pears
-        </BpkBadge>
-      </BadgeLayout>,
+      <BpkBadge type={BADGE_TYPES.inverse} className={badgeClassName}>
+        Apples
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.inverse} className={badgeClassName}>
+        Bananas
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.inverse} className={badgeClassName}>
+        Strawberries
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.inverse} className={badgeClassName}>
+        Pears
+      </BpkBadge>,
     ],
   },
   {
@@ -182,21 +179,20 @@ const components = [
         The outline badge has a somewhat transparent background as shown below.
       </Paragraph>,
     ],
+    dark: true,
     examples: [
-      <BadgeLayout>
-        <BpkBadge type={BADGE_TYPES.outline} className={badgeClassName}>
-          Apples
-        </BpkBadge>
-        <BpkBadge type={BADGE_TYPES.outline} className={badgeClassName}>
-          Bananas
-        </BpkBadge>
-        <BpkBadge type={BADGE_TYPES.outline} className={badgeClassName}>
-          Strawberries
-        </BpkBadge>
-        <BpkBadge type={BADGE_TYPES.outline} className={badgeClassName}>
-          Pears
-        </BpkBadge>
-      </BadgeLayout>,
+      <BpkBadge type={BADGE_TYPES.outline} className={badgeClassName}>
+        Apples
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.outline} className={badgeClassName}>
+        Bananas
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.outline} className={badgeClassName}>
+        Strawberries
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.outline} className={badgeClassName}>
+        Pears
+      </BpkBadge>,
     ],
   },
 ];


### PR DESCRIPTION
latest badge page:
![screenshot_2018-06-01 badge backpack 3](https://user-images.githubusercontent.com/30267516/40845295-2dcacc9c-65ae-11e8-8fe1-745681b4dc88.png)

![screenshot_2018-06-01 badge backpack 4](https://user-images.githubusercontent.com/30267516/40845314-3cf05e08-65ae-11e8-90f0-1c755c0ea2c9.png)
