### PR TITLE
[NO-JIRA] Update native carousel to private

### DIFF
--- a/native/packages/react-native-bpk-component-carousel/package.json
+++ b/native/packages/react-native-bpk-component-carousel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-native-bpk-component-carousel",
   "version": "0.0.0",
+  "private": true,
   "main": "index.js",
   "description": "Backpack React Native carousel component.",
   "repository": {


### PR DESCRIPTION
We need to wait for the new version of the `Pagination Dots` to release the carousel.