### PR TITLE
[NoJira] add storybook as part of the deployment process

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,19 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-actions/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -17,6 +17,7 @@
  */
 import React from 'react';
 import { configure, addDecorator } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
 
 import '../packages/bpk-stylesheets';
 import TOKENS from './../packages/bpk-tokens/tokens/base.common';
@@ -30,6 +31,7 @@ import themeableAttributes from './themeableAttributes';
 
 const EnhancedThemeProvider = updateOnThemeChange(BpkThemeProvider);
 
+addDecorator(withKnobs);
 addDecorator(story => (
   <div style={{ padding: TOKENS.spacingBase }}>
     <EnhancedThemeProvider themeAttributes={themeableAttributes}>

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - npm run danger
   - npm test
   - npm run docs:neo:dist
+  - if [ "$TRAVIS_BRANCH" == 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then npm run storybook:dist; fi
   - test -e dist/index.html
   - test -e dist/sassdoc/index.html
 cache:
@@ -26,6 +27,7 @@ branches:
   only:
     - master
     - /^greenkeeper/.*$/
+
 deploy:
   provider: pages
   skip_cleanup: true
@@ -38,6 +40,7 @@ deploy:
   repo: backpack/backpack.github.io
   target-branch: master
   verbose: true
+
 notifications:
   slack:
     rooms:

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,81 @@
         "uuid": "3.2.1"
       }
     },
+    "@storybook/addon-knobs": {
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-3.4.6.tgz",
+      "integrity": "sha512-rEaLM9LyU80UqSp2TkonCAxLlvYTIg3Q6+1fWgZ+b2CGT7YOPjchMcPn7oyDz0OgWbJvzBFNTH/WIAE95mHCew==",
+      "dev": true,
+      "requires": {
+        "@storybook/components": "3.4.6",
+        "babel-runtime": "6.26.0",
+        "deep-equal": "1.0.1",
+        "global": "4.3.2",
+        "insert-css": "2.0.0",
+        "lodash.debounce": "4.0.8",
+        "moment": "2.22.1",
+        "prop-types": "15.6.1",
+        "react-color": "2.14.1",
+        "react-datetime": "2.14.0",
+        "react-textarea-autosize": "5.2.1",
+        "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "@storybook/components": {
+          "version": "3.4.6",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.4.6.tgz",
+          "integrity": "sha512-mpOxTSYS0WE1om2GscxCO4pLMQOcoMZwE0k7nPXzP9wcFdEUj3GxFNYOnRZeWKl+lbT0htiRsY55Wkz4DpOKNw==",
+          "dev": true,
+          "requires": {
+            "glamor": "2.20.40",
+            "glamorous": "4.13.0",
+            "prop-types": "15.6.1"
+          }
+        },
+        "glamorous": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.13.0.tgz",
+          "integrity": "sha512-lJ+ET2Cz5+ZIsxrFNruN7Ye30PSe+jSN8jbma2+AAmNoJZOozqtjfjB5EVi16J9G3CjjXQtENsv4shwR1YYtaQ==",
+          "dev": true,
+          "requires": {
+            "brcast": "3.0.1",
+            "csstype": "2.5.3",
+            "fast-memoize": "2.3.0",
+            "html-tag-names": "1.1.2",
+            "is-function": "1.0.1",
+            "is-plain-object": "2.0.4",
+            "react-html-attributes": "1.4.2",
+            "svg-tag-names": "1.1.1"
+          }
+        },
+        "moment": {
+          "version": "2.22.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+          "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "react-html-attributes": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.2.tgz",
+          "integrity": "sha1-DSzPE0/Hmy01Q4N9wVkdMre5A/k=",
+          "dev": true,
+          "requires": {
+            "html-element-attributes": "1.3.0"
+          }
+        }
+      }
+    },
     "@storybook/addon-links": {
       "version": "3.3.14",
       "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.3.14.tgz",
@@ -5351,6 +5426,12 @@
       "requires": {
         "cssom": "0.3.2"
       }
+    },
+    "csstype": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.3.tgz",
+      "integrity": "sha512-G5HnoK8nOiAq3DXIEoY2n/8Vb7Lgrms+jGJl8E4EJpQEeVONEnPFJSl8IK505wPBoxxtrtHhrRm4WX2GgdqarA==",
+      "dev": true
     },
     "cubic2quad": {
       "version": "1.1.1",
@@ -12082,6 +12163,12 @@
         }
       }
     },
+    "insert-css": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/insert-css/-/insert-css-2.0.0.tgz",
+      "integrity": "sha1-610Ql7dUL0x56jBg067gfQU4gPQ=",
+      "dev": true
+    },
     "internal-ip": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
@@ -16232,6 +16319,12 @@
           }
         }
       }
+    },
+    "material-colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.5.tgz",
+      "integrity": "sha1-UpJZPmdUyxvMK5gDDk4Najr8nqE=",
+      "dev": true
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -20825,6 +20918,39 @@
       "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY=",
       "dev": true
     },
+    "react-color": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.14.1.tgz",
+      "integrity": "sha512-ssv2ArSZdhTbIs29hyfw8JW+s3G4BCx/ILkwCajWZzrcx/2ZQfRpsaLVt38LAPbxe50LLszlmGtRerA14JzzRw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.5",
+        "material-colors": "1.2.5",
+        "prop-types": "15.6.0",
+        "reactcss": "1.2.3",
+        "tinycolor2": "1.4.1"
+      }
+    },
+    "react-datetime": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/react-datetime/-/react-datetime-2.14.0.tgz",
+      "integrity": "sha512-BUWIzMLRGzWQSYyJf0mivLyDgw4KCTFYn8zW50UTl2qB3xd/BH/TgPzfgDvAScNbiXwWpXei/GCoc6nI2J3GgA==",
+      "dev": true,
+      "requires": {
+        "create-react-class": "15.6.3",
+        "object-assign": "3.0.0",
+        "prop-types": "15.6.0",
+        "react-onclickoutside": "6.7.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
+        }
+      }
+    },
     "react-docgen": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.20.1.tgz",
@@ -20921,6 +21047,12 @@
         "warning": "3.0.0"
       }
     },
+    "react-onclickoutside": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
+      "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==",
+      "dev": true
+    },
     "react-router": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.8.1.tgz",
@@ -21007,6 +21139,15 @@
         "object-assign": "4.1.1"
       }
     },
+    "react-textarea-autosize": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz",
+      "integrity": "sha512-bx6z2I35aapr71ggw2yZIA4qhmqeTa4ZVsSaTeFvtf9kfcZppDBh2PbMt8lvbdmzEk7qbSFhAxR9vxEVm6oiMg==",
+      "dev": true,
+      "requires": {
+        "prop-types": "15.6.0"
+      }
+    },
     "react-transition-group": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
@@ -21032,6 +21173,15 @@
         "radium": "0.19.6",
         "shallowequal": "0.2.2",
         "velocity-react": "1.3.3"
+      }
+    },
+    "reactcss": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.5"
       }
     },
     "read-cmd-shim": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:tokens": "lerna run tokens --scope bpk-tokens",
     "build:svgs": "lerna run svgs --scope bpk-svgs",
     "build": "npm run build:tokens && npm run build:svgs && lerna run build && (cd ./native && npm run link)",
+    "storybook:dist": "build-storybook -c .storybook -o dist/storybook",
     "storybook": "start-storybook -p 9001",
     "sassdoc": "sassdoc {packages/bpk-mixins/src/**/*,packages/bpk-svgs/dist/*,packages/bpk-tokens/tokens/base.default}.scss -d dist/sassdoc -v --strict",
     "docs": "webpack-dev-server --open",
@@ -66,6 +67,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@storybook/addon-actions": "^3.3.9",
+    "@storybook/addon-knobs": "^3.4.6",
     "@storybook/addon-links": "^3.3.9",
     "@storybook/react": "^3.3.9",
     "autoprefixer": "^8.0.0",

--- a/packages/bpk-animate-height/stories.js
+++ b/packages/bpk-animate-height/stories.js
@@ -20,6 +20,7 @@ import BpkButton from 'bpk-component-button';
 import { storiesOf } from '@storybook/react';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { text } from '@storybook/addon-knobs';
 
 import AnimateHeight from './index';
 
@@ -49,7 +50,9 @@ class AnimateHeightContainer extends Component {
       <div>
         <AnimateHeight {...rest} height={this.state.height} />
         <br />
-        <BpkButton onClick={this.onClick}>Toggle height!</BpkButton>
+        <BpkButton onClick={this.onClick}>
+          {text('Button copy', 'Toggle height!')}
+        </BpkButton>
       </div>
     );
   }
@@ -64,8 +67,11 @@ AnimateHeightContainer.propTypes = {
 
 storiesOf('bpk-animate-height', module).add('Example', () => (
   <AnimateHeightContainer fromHeight="auto" toHeight={0} duration={300}>
-    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
-    ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis
-    parturient montes, nascetur ridiculus mus.
+    {text(
+      'Copy',
+      `Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis
+parturient montes, nascetur ridiculus mus.`,
+    )}
   </AnimateHeightContainer>
 ));


### PR DESCRIPTION
This adds the built version of the storybook as part of the build process and will get deployed as part of the doc site under the `/playground` endpoint, it's a static app so it's just a folder name that can be changed.

To test it locally:
- check out this branch
- `npm i`
- `npm run docs:neo:dist`
- ☕️
- once the build is done use an http server to serve the content of the dist folder (if you don't have one installed run `npx http-server ./dist`
- go to http://127.0.0.1:8081/playground/?knob-Copy=Yes%2C%20he%20is%21&knob-Button%20copy=Is%20Matteo%20Awesome%3F&selectedKind=bpk-animate-height&selectedStory=Example&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs and you'll see the truth 
