### PR TITLE
[BPK-1612] select with image

### DIFF
--- a/packages/bpk-component-select/index.js
+++ b/packages/bpk-component-select/index.js
@@ -15,7 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* @flow */
 
-import BpkSelect from './src/BpkSelect';
+import BpkSelect, { type Props } from './src/BpkSelect';
+
+export type BpkSelectProps = Props;
 
 export default BpkSelect;

--- a/packages/bpk-component-select/readme.md
+++ b/packages/bpk-component-select/readme.md
@@ -30,14 +30,18 @@ export default () => (
 
 ## Props
 
-| Property     | PropType | Required | Default Value |
-| ------------ | -------- | -------- | ------------- |
-| id           | string   | true     | -             |
-| name         | string   | true     | -             |
-| value        | string   | true     | -             |
-| onChange     | func     | true     | -             |
-| valid        | bool     | false    | null          |
-| large        | bool     | false    | false         |
-| dockedFirst  | bool     | false    | false         |
-| dockedMiddle | bool     | false    | false         |
-| dockedLast   | bool     | false    | false         |
+| Property                  | PropType   | Required | Default Value |
+| ------------              | --------   | -------- | ------------- |
+| id                        | string     | true     | -             |
+| name                      | string     | true     | -             |
+| value                     | string     | true     | -             |
+| onChange                  | func       | true     | -             |
+| valid                     | bool       | false    | null          |
+| large                     | bool       | false    | false         |
+| docked                    | bool       | false    | false         |
+| dockedFirst               | bool       | false    | false         |
+| dockedMiddle              | bool       | false    | false         |
+| dockedLast                | bool       | false    | false         |
+| image                     | node       | false    | null          |
+| wrapperClassName          | string     | false    | null          |
+| imageWrapperClassName     | string     | false    | null          |

--- a/packages/bpk-component-select/src/BpkSelect-test.js
+++ b/packages/bpk-component-select/src/BpkSelect-test.js
@@ -20,6 +20,9 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import BpkSelect from './BpkSelect';
 
+const svgPlaceholder = `data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 200 150'%2F%3E`;
+const selectImage = <img alt="placeholder" src={svgPlaceholder} />;
+
 describe('BpkSelect', () => {
   it('should render correctly', () => {
     const tree = renderer
@@ -33,8 +36,54 @@ describe('BpkSelect', () => {
           <option value="apples">Apples</option>
           <option value="oranges">Oranges</option>
           <option value="pears">Pears</option>
-          <option value="tomatos" disabled>
-            Tomatos
+          <option value="tomatoes" disabled>
+            Tomatoes
+          </option>
+        </BpkSelect>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with image', () => {
+    const tree = renderer
+      .create(
+        <BpkSelect
+          id="fruits"
+          name="fruits"
+          value="oranges"
+          image={selectImage}
+          onChange={() => null}
+        >
+          <option value="apples">Apples</option>
+          <option value="oranges">Oranges</option>
+          <option value="pears">Pears</option>
+          <option value="tomatoes" disabled>
+            Tomatoes
+          </option>
+        </BpkSelect>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with image and custom classes', () => {
+    const tree = renderer
+      .create(
+        <BpkSelect
+          id="fruits"
+          name="fruits"
+          value="oranges"
+          imageWrapperClassName="imageWrapperClass--test"
+          wrapperClassName="wrapperClass--test"
+          image={selectImage}
+          onChange={() => null}
+        >
+          <option value="apples">Apples</option>
+          <option value="oranges">Oranges</option>
+          <option value="pears">Pears</option>
+          <option value="tomatoes" disabled>
+            Tomatoes
           </option>
         </BpkSelect>,
       )
@@ -55,8 +104,8 @@ describe('BpkSelect', () => {
           <option value="apples">Apples</option>
           <option value="oranges">Oranges</option>
           <option value="pears">Pears</option>
-          <option value="tomatos" disabled>
-            Tomatos
+          <option value="tomatoes" disabled>
+            Tomatoes
           </option>
         </BpkSelect>,
       )
@@ -77,8 +126,8 @@ describe('BpkSelect', () => {
           <option value="apples">Apples</option>
           <option value="oranges">Oranges</option>
           <option value="pears">Pears</option>
-          <option value="tomatos" disabled>
-            Tomatos
+          <option value="tomatoes" disabled>
+            Tomatoes
           </option>
         </BpkSelect>,
       )
@@ -99,8 +148,8 @@ describe('BpkSelect', () => {
           <option value="apples">Apples</option>
           <option value="oranges">Oranges</option>
           <option value="pears">Pears</option>
-          <option value="tomatos" disabled>
-            Tomatos
+          <option value="tomatoes" disabled>
+            Tomatoes
           </option>
         </BpkSelect>,
       )
@@ -121,8 +170,8 @@ describe('BpkSelect', () => {
           <option value="apples">Apples</option>
           <option value="oranges">Oranges</option>
           <option value="pears">Pears</option>
-          <option value="tomatos" disabled>
-            Tomatos
+          <option value="tomatoes" disabled>
+            Tomatoes
           </option>
         </BpkSelect>,
       )
@@ -143,8 +192,8 @@ describe('BpkSelect', () => {
           <option value="apples">Apples</option>
           <option value="oranges">Oranges</option>
           <option value="pears">Pears</option>
-          <option value="tomatos" disabled>
-            Tomatos
+          <option value="tomatoes" disabled>
+            tomatos
           </option>
         </BpkSelect>,
       )
@@ -165,8 +214,8 @@ describe('BpkSelect', () => {
           <option value="apples">Apples</option>
           <option value="oranges">Oranges</option>
           <option value="pears">Pears</option>
-          <option value="tomatos" disabled>
-            Tomatos
+          <option value="tomatoes" disabled>
+            Tomatoes
           </option>
         </BpkSelect>,
       )
@@ -187,8 +236,8 @@ describe('BpkSelect', () => {
           <option value="apples">Apples</option>
           <option value="oranges">Oranges</option>
           <option value="pears">Pears</option>
-          <option value="tomatos" disabled>
-            Tomatos
+          <option value="tomatoes" disabled>
+            Tomatoes
           </option>
         </BpkSelect>,
       )

--- a/packages/bpk-component-select/src/BpkSelect.js
+++ b/packages/bpk-component-select/src/BpkSelect.js
@@ -15,8 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* @flow */
 
-import PropTypes from 'prop-types';
+import PropTypes, { type Node } from 'prop-types';
 import React from 'react';
 import { cssModules } from 'bpk-react-utils';
 
@@ -24,16 +25,34 @@ import STYLES from './bpk-select.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkSelect = props => {
-  const classNames = [getClassName('bpk-select')];
+export type Props = {
+  id: string,
+  name: string,
+  value: string,
+  className: ?string,
+  docked: boolean,
+  dockedFirst: boolean,
+  dockedLast: boolean,
+  dockedMiddle: boolean,
+  image: ?Node,
+  imageWrapperClassName: ?string,
+  large: boolean,
+  valid: ?boolean,
+  wrapperClassName: ?string,
+};
+
+const BpkSelect = (props: Props) => {
   const {
-    valid,
-    large,
+    className,
     docked,
     dockedFirst,
-    dockedMiddle,
     dockedLast,
-    className,
+    dockedMiddle,
+    image,
+    imageWrapperClassName,
+    large,
+    valid,
+    wrapperClassName,
     ...rest
   } = props;
 
@@ -41,32 +60,50 @@ const BpkSelect = props => {
   // treated as neither valid nor invalid
   const isInvalid = valid === false;
 
-  if (large) {
-    classNames.push(getClassName('bpk-select--large'));
-  }
-  if (docked) {
-    classNames.push(getClassName('bpk-select--docked'));
-  }
-  if (dockedFirst) {
-    classNames.push(getClassName('bpk-select--docked-first'));
-  }
-  if (dockedMiddle) {
-    classNames.push(getClassName('bpk-select--docked-middle'));
-  }
-  if (dockedLast) {
-    classNames.push(getClassName('bpk-select--docked-last'));
-  }
-  if (className) {
-    classNames.push(className);
-  }
-
-  return (
+  const select = (
     <select
-      className={classNames.join(' ')}
+      className={getClassName(
+        'bpk-select',
+        large && 'bpk-select--large',
+        docked && 'bpk-select--docked',
+        dockedFirst && 'bpk-select--docked-first',
+        dockedMiddle && 'bpk-select--docked-middle',
+        dockedLast && 'bpk-select--docked-last',
+        image && 'bpk-select--borderless',
+        className,
+      )}
       aria-invalid={isInvalid}
       {...rest}
     />
   );
+
+  if (image) {
+    return (
+      <div
+        className={getClassName(
+          'bpk-select-wrapper',
+          large && 'bpk-select-wrapper--large',
+          docked && 'bpk-select-wrapper--docked',
+          dockedFirst && 'bpk-select-wrapper--docked-first',
+          dockedMiddle && 'bpk-select-wrapper--docked-middle',
+          dockedLast && 'bpk-select-wrapper--docked-last',
+          wrapperClassName,
+        )}
+      >
+        <div
+          className={getClassName(
+            'bpk-select-wrapper__image',
+            large && 'bpk-select-wrapper__image--large',
+            imageWrapperClassName,
+          )}
+        >
+          {image}
+        </div>
+        {select}
+      </div>
+    );
+  }
+  return select;
 };
 
 BpkSelect.propTypes = {
@@ -74,22 +111,28 @@ BpkSelect.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   className: PropTypes.string,
-  valid: PropTypes.bool,
-  large: PropTypes.bool,
   docked: PropTypes.bool,
   dockedFirst: PropTypes.bool,
-  dockedMiddle: PropTypes.bool,
   dockedLast: PropTypes.bool,
+  dockedMiddle: PropTypes.bool,
+  image: PropTypes.node,
+  imageWrapperClassName: PropTypes.string,
+  large: PropTypes.bool,
+  valid: PropTypes.bool,
+  wrapperClassName: PropTypes.string,
 };
 
 BpkSelect.defaultProps = {
   className: null,
-  valid: null,
-  large: false,
   docked: false,
   dockedFirst: false,
-  dockedMiddle: false,
   dockedLast: false,
+  dockedMiddle: false,
+  image: null,
+  imageWrapperClassName: null,
+  large: false,
+  valid: null,
+  wrapperClassName: null,
 };
 
 export default BpkSelect;

--- a/packages/bpk-component-select/src/__snapshots__/BpkSelect-test.js.snap
+++ b/packages/bpk-component-select/src/__snapshots__/BpkSelect-test.js.snap
@@ -26,9 +26,9 @@ exports[`BpkSelect should render correctly 1`] = `
   </option>
   <option
     disabled={true}
-    value="tomatos"
+    value="tomatoes"
   >
-    Tomatos
+    Tomatoes
   </option>
 </select>
 `;
@@ -59,9 +59,9 @@ exports[`BpkSelect should render correctly with "className" attribute 1`] = `
   </option>
   <option
     disabled={true}
-    value="tomatos"
+    value="tomatoes"
   >
-    Tomatos
+    Tomatoes
   </option>
 </select>
 `;
@@ -92,9 +92,9 @@ exports[`BpkSelect should render correctly with "docked" attribute 1`] = `
   </option>
   <option
     disabled={true}
-    value="tomatos"
+    value="tomatoes"
   >
-    Tomatos
+    Tomatoes
   </option>
 </select>
 `;
@@ -125,9 +125,9 @@ exports[`BpkSelect should render correctly with "dockedFirst" attribute 1`] = `
   </option>
   <option
     disabled={true}
-    value="tomatos"
+    value="tomatoes"
   >
-    Tomatos
+    tomatos
   </option>
 </select>
 `;
@@ -158,9 +158,9 @@ exports[`BpkSelect should render correctly with "dockedLast" attribute 1`] = `
   </option>
   <option
     disabled={true}
-    value="tomatos"
+    value="tomatoes"
   >
-    Tomatos
+    Tomatoes
   </option>
 </select>
 `;
@@ -191,9 +191,9 @@ exports[`BpkSelect should render correctly with "dockedMiddle" attribute 1`] = `
   </option>
   <option
     disabled={true}
-    value="tomatos"
+    value="tomatoes"
   >
-    Tomatos
+    Tomatoes
   </option>
 </select>
 `;
@@ -224,9 +224,9 @@ exports[`BpkSelect should render correctly with "large" attribute 1`] = `
   </option>
   <option
     disabled={true}
-    value="tomatos"
+    value="tomatoes"
   >
-    Tomatos
+    Tomatoes
   </option>
 </select>
 `;
@@ -257,9 +257,99 @@ exports[`BpkSelect should render correctly with a "valid" attribute equal to fal
   </option>
   <option
     disabled={true}
-    value="tomatos"
+    value="tomatoes"
   >
-    Tomatos
+    Tomatoes
   </option>
 </select>
+`;
+
+exports[`BpkSelect should render correctly with image 1`] = `
+<div
+  className="bpk-select-wrapper"
+>
+  <div
+    className="bpk-select-wrapper__image"
+  >
+    <img
+      alt="placeholder"
+      src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 200 150'%2F%3E"
+    />
+  </div>
+  <select
+    aria-invalid={false}
+    className="bpk-select bpk-select--borderless"
+    id="fruits"
+    name="fruits"
+    onChange={[Function]}
+    value="oranges"
+  >
+    <option
+      value="apples"
+    >
+      Apples
+    </option>
+    <option
+      value="oranges"
+    >
+      Oranges
+    </option>
+    <option
+      value="pears"
+    >
+      Pears
+    </option>
+    <option
+      disabled={true}
+      value="tomatoes"
+    >
+      Tomatoes
+    </option>
+  </select>
+</div>
+`;
+
+exports[`BpkSelect should render correctly with image and custom classes 1`] = `
+<div
+  className="bpk-select-wrapper wrapperClass--test"
+>
+  <div
+    className="bpk-select-wrapper__image imageWrapperClass--test"
+  >
+    <img
+      alt="placeholder"
+      src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 200 150'%2F%3E"
+    />
+  </div>
+  <select
+    aria-invalid={false}
+    className="bpk-select bpk-select--borderless"
+    id="fruits"
+    name="fruits"
+    onChange={[Function]}
+    value="oranges"
+  >
+    <option
+      value="apples"
+    >
+      Apples
+    </option>
+    <option
+      value="oranges"
+    >
+      Oranges
+    </option>
+    <option
+      value="pears"
+    >
+      Pears
+    </option>
+    <option
+      disabled={true}
+      value="tomatoes"
+    >
+      Tomatoes
+    </option>
+  </select>
+</div>
 `;

--- a/packages/bpk-component-select/src/bpk-select.scss
+++ b/packages/bpk-component-select/src/bpk-select.scss
@@ -40,4 +40,60 @@
       @include bpk-select--docked-last-child;
     }
   }
+
+  &--borderless {
+    height: auto;
+    padding: 0;
+    border: transparent;
+  }
+}
+
+$select-image-width: 18 * $bpk-one-pixel-rem;
+$select-image-height: 14 * $bpk-one-pixel-rem;
+$select-image-large-width: 28 * $bpk-one-pixel-rem;
+$select-image-large-height: 22 * $bpk-one-pixel-rem;
+
+@mixin bpk-select-wrapper {
+  display: flex;
+  padding-right: 0;
+  flex-direction: row;
+  align-items: center;
+  background: none;
+}
+
+.bpk-select-wrapper {
+  @include bpk-select;
+  @include bpk-select-wrapper;
+
+  &--large {
+    @include bpk-select--large;
+  }
+
+  &--docked {
+    @include bpk-select--docked;
+
+    &-first {
+      @include bpk-select--docked-first-child;
+    }
+
+    &-middle {
+      @include bpk-select--docked-middle-child;
+    }
+
+    &-last {
+      @include bpk-select--docked-last-child;
+    }
+  }
+
+  &__image {
+    display: flex;
+    width: $select-image-width;
+    height: $select-image-height;
+    margin-right: $bpk-spacing-xs;
+
+    &--large {
+      width: $select-image-large-width;
+      height: $select-image-large-height;
+    }
+  }
 }

--- a/packages/bpk-component-select/stories.js
+++ b/packages/bpk-component-select/stories.js
@@ -17,10 +17,83 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import BpkSelect from './index';
+
+const getFlagUriFromCountryCode = countryCode =>
+  `https://images.skyscnr.com/images/country/flag/header/${countryCode.toLowerCase()}.png`;
+
+const countries = [
+  { key: 0, id: 'AT', name: 'Austria', disabled: false },
+  { key: 1, id: 'BR', name: 'Brazil', disabled: false },
+  { key: 2, id: 'CN', name: 'China', disabled: false },
+  { key: 3, id: 'DJ', name: 'Djibouti', disabled: false },
+  { key: 4, id: 'EC', name: 'Ecuador', disabled: false },
+  { key: 5, id: 'GD', name: 'Grenada', disabled: false },
+  { key: 6, id: 'HT', name: 'Haiti', disabled: false },
+  { key: 7, id: 'IT', name: 'Italy', disabled: false },
+  { key: 8, id: 'US', name: 'USA', disabled: true },
+];
+class SelectWithImage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selected: 'IT',
+    };
+  }
+
+  getItemByValue = () => {
+    const { options } = this.props;
+    return val => {
+      const items = options.filter(o => o.id === val);
+      if (!items.length) throw new Error('Item does not exists');
+      return items[0];
+    };
+  };
+
+  getItem = this.getItemByValue();
+
+  handleChange = e => {
+    const item = this.getItem(e.target.value);
+
+    this.setState({
+      selected: item.id,
+    });
+  };
+
+  image = id => (
+    <img
+      alt="Flag"
+      style={{ width: '100%' }}
+      src={getFlagUriFromCountryCode(id)}
+    />
+  );
+
+  render() {
+    const { options, ...rest } = this.props;
+    return (
+      <BpkSelect
+        value={this.getItem(this.state.selected).id}
+        {...rest}
+        image={this.image(this.getItem(this.state.selected).id)}
+        onChange={this.handleChange}
+      >
+        {options.map(o => (
+          <option key={o.id} disabled={o.disabled && 'disabled'} value={o.id}>
+            {o.name}
+          </option>
+        ))}
+      </BpkSelect>
+    );
+  }
+}
+
+SelectWithImage.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
 
 storiesOf('bpk-component-select', module)
   .add('Example', () => (
@@ -154,6 +227,38 @@ storiesOf('bpk-component-select', module)
       </BpkSelect>
     </div>
   ))
+  .add('Docked with images', () => (
+    <div style={{ display: 'flex' }}>
+      <SelectWithImage
+        large
+        dockedFirst
+        id="countries"
+        name="countries"
+        options={countries}
+      />
+      <SelectWithImage
+        large
+        dockedMiddle
+        id="countries"
+        name="countries"
+        options={countries}
+      />
+      <SelectWithImage
+        large
+        dockedMiddle
+        id="countries"
+        name="countries"
+        options={countries}
+      />
+      <SelectWithImage
+        large
+        dockedLast
+        id="countries"
+        name="countries"
+        options={countries}
+      />
+    </div>
+  ))
   .add('Manually docked', () => (
     <div style={{ display: 'flex' }}>
       <div style={{ width: '100%' }}>
@@ -226,4 +331,55 @@ storiesOf('bpk-component-select', module)
         </BpkSelect>
       </div>
     </div>
+  ))
+  .add('Manually docked with images', () => (
+    <div style={{ display: 'flex' }}>
+      <div style={{ width: '100%' }}>
+        <SelectWithImage
+          large
+          dockedFirst
+          id="countries"
+          name="countries"
+          options={countries}
+        />
+      </div>
+      <div style={{ width: '100%' }}>
+        <SelectWithImage
+          large
+          dockedMiddle
+          id="countries"
+          name="countries"
+          options={countries}
+        />
+      </div>
+      <div style={{ width: '100%' }}>
+        <SelectWithImage
+          large
+          dockedMiddle
+          id="countries"
+          name="countries"
+          options={countries}
+        />
+      </div>
+      <div style={{ width: '100%' }}>
+        <SelectWithImage
+          large
+          dockedLast
+          id="countries"
+          name="countries"
+          options={countries}
+        />
+      </div>
+    </div>
+  ))
+  .add('With Image', () => (
+    <SelectWithImage id="countries" name="countries" options={countries} />
+  ))
+  .add('With Image Large', () => (
+    <SelectWithImage
+      large
+      id="countries"
+      name="countries"
+      options={countries}
+    />
   ));

--- a/unreleased.md
+++ b/unreleased.md
@@ -17,6 +17,9 @@
 
 - bpk-component-breakpoint:
   - Change `children` proptype to `oneOfType(node, func)` (added `node`).
-  
+
 - bpk-component-phone-input:
   - Introducing the web phone input component.
+
+- bpk-component-select:
+  - Add ability to display an image in the select component.


### PR DESCRIPTION
- [x] Update unrelased.md
- [x] Update Readme

Docs will follow as separate PR

This adds an image render prop to the select box, if the image is set the select box will look like this
```
+------------------------+
|+----+ +--------------+ |
||    | |              | |
|+----+ +--------------+ |
+------------------------+
ASCII art By Matt
```

if no image is provided, it'll render the selecbox as it currently is (fully backward compatible)

In the storybook there is an example of usage

Note: The docked config has not been modified as we need design input for that