### PR TITLE
Allow "node" as "children" in BpkBreakpoint

### DIFF
--- a/packages/bpk-component-breakpoint/readme.md
+++ b/packages/bpk-component-breakpoint/readme.md
@@ -18,13 +18,17 @@ export default () => (
   <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
     {isActive => (isActive ? <span>Mobile viewport is active</span> : <span>Mobile viewport is inactive</span>)}
   </BpkBreakpoint>
+
+  <BpkBreakpoint query={BREAKPOINTS.TABLET}>
+    <span>Tablet viewport is active</span>
+  </BpkBreakpoint>
 );
 ```
 
 ## Props
 
-| Property  | PropType           | Required | Default Value |
-| --------- | ------------------ | -------- | ------------- |
-| children  | node               | true     | -             |
-| query     | oneOf(BREAKPOINTS) | true     | -             |
-| legacy    | bool               | false    | false         |
+| Property  | PropType               | Required | Default Value |
+| --------- | ---------------------- | -------- | ------------- |
+| children  | oneOfType(node, func)  | true     | -             |
+| query     | oneOf(BREAKPOINTS)     | true     | -             |
+| legacy    | bool                   | false    | false         |

--- a/packages/bpk-component-breakpoint/src/BpkBreakpoint.js
+++ b/packages/bpk-component-breakpoint/src/BpkBreakpoint.js
@@ -43,7 +43,7 @@ const queryValidator = (props, ...rest) => {
 };
 
 BpkBreakpoint.propTypes = {
-  children: PropTypes.func.isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   query: queryValidator, // eslint-disable-line react/require-default-props
   legacy: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
 };

--- a/unreleased.md
+++ b/unreleased.md
@@ -14,3 +14,6 @@
 
 - bpk-component-link:
   - When `blank` is set, `rel` is automatically set to `rel="noopener noreferrer"`.
+
+- bpk-component-breakpoint:
+  - Change `children` proptype to `oneOfType(node, func)` (added `node`).


### PR DESCRIPTION
About `children` prop in BpkBreakpoint:
* readme.md says it's a `node`: https://github.com/Skyscanner/backpack/blob/master/packages/bpk-component-breakpoint/readme.md
* The code says it’s a `func`: https://github.com/Skyscanner/backpack/blob/master/packages/bpk-component-breakpoint/src/BpkBreakpoint.js#L46
* `react-responsive` code says it any of both: https://github.com/contra/react-responsive/blob/master/src/index.js#L12

The inconsistency between readme.md and the code must be fixed.
Also, I guess there’s no reason in `BpkBreakpoint` for force just one of the two.