### PR TITLE
Add "blank" prop to BpkButton

### DIFF
--- a/packages/bpk-component-button/readme.md
+++ b/packages/bpk-component-button/readme.md
@@ -48,6 +48,8 @@ export default () => (
 | featured    | bool     | false    | false         |
 | iconOnly    | bool     | false    | false         |
 | onClick     | func     | false    | null          |
+| blank       | bool     | false    | false         |
+| rel         | string   | false    | null          |
 
 ## Theme Props
 

--- a/packages/bpk-component-button/src/BpkButton-test.js
+++ b/packages/bpk-component-button/src/BpkButton-test.js
@@ -107,4 +107,37 @@ describe('BpkButton', () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with "blank" attribute', () => {
+    const tree = renderer
+      .create(
+        <BpkButton href="#" blank>
+          My button
+        </BpkButton>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with "rel" attribute', () => {
+    const tree = renderer
+      .create(
+        <BpkButton href="#" rel="rel-attr">
+          My button
+        </BpkButton>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with "blank" and "rel" attributes', () => {
+    const tree = renderer
+      .create(
+        <BpkButton href="#" blank rel="rel-overwrite">
+          My button
+        </BpkButton>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-button/src/BpkButton.js
+++ b/packages/bpk-component-button/src/BpkButton.js
@@ -45,6 +45,8 @@ type Props = {
   link: boolean,
   iconOnly: boolean,
   featured: boolean,
+  blank: boolean,
+  rel: ?string,
 };
 
 const BpkButton = (props: Props) => {
@@ -61,6 +63,8 @@ const BpkButton = (props: Props) => {
     large,
     link,
     iconOnly,
+    blank,
+    rel: propRel,
     ...rest
   } = props;
 
@@ -94,9 +98,19 @@ const BpkButton = (props: Props) => {
 
   const classNameFinal = classNames.join(' ');
 
+  const target = blank ? '_blank' : null;
+  const rel = blank ? propRel || 'noopener noreferrer' : propRel;
+
   if (href) {
     return (
-      <a href={href} className={classNameFinal} onClick={onClick} {...rest}>
+      <a
+        href={href}
+        className={classNameFinal}
+        onClick={onClick}
+        target={target}
+        rel={rel}
+        {...rest}
+      >
         {children}
       </a>
     );
@@ -140,6 +154,8 @@ BpkButton.propTypes = {
   link: PropTypes.bool,
   iconOnly: PropTypes.bool,
   featured: PropTypes.bool,
+  blank: PropTypes.bool,
+  rel: PropTypes.string,
 };
 
 BpkButton.defaultProps = {
@@ -154,6 +170,8 @@ BpkButton.defaultProps = {
   link: false,
   iconOnly: false,
   featured: false,
+  blank: false,
+  rel: null,
 };
 
 export default BpkButton;

--- a/packages/bpk-component-button/src/__snapshots__/BpkButton-test.js.snap
+++ b/packages/bpk-component-button/src/__snapshots__/BpkButton-test.js.snap
@@ -22,6 +22,30 @@ exports[`BpkButton should render correctly 1`] = `
 </button>
 `;
 
+exports[`BpkButton should render correctly with "blank" and "rel" attributes 1`] = `
+<a
+  className="bpk-button"
+  href="#"
+  onClick={null}
+  rel="rel-overwrite"
+  target="_blank"
+>
+  My button
+</a>
+`;
+
+exports[`BpkButton should render correctly with "blank" attribute 1`] = `
+<a
+  className="bpk-button"
+  href="#"
+  onClick={null}
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  My button
+</a>
+`;
+
 exports[`BpkButton should render correctly with "large" and "secondary" attributes 1`] = `
 <button
   className="bpk-button bpk-button--secondary bpk-button--large"
@@ -31,6 +55,18 @@ exports[`BpkButton should render correctly with "large" and "secondary" attribut
 >
   My button
 </button>
+`;
+
+exports[`BpkButton should render correctly with "rel" attribute 1`] = `
+<a
+  className="bpk-button"
+  href="#"
+  onClick={null}
+  rel="rel-attr"
+  target={null}
+>
+  My button
+</a>
 `;
 
 exports[`BpkButton should render correctly with a "destructive" attribute 1`] = `
@@ -60,6 +96,8 @@ exports[`BpkButton should render correctly with a "href" attribute 1`] = `
   className="bpk-button"
   href="#"
   onClick={null}
+  rel={null}
+  target={null}
 >
   My button
 </a>

--- a/packages/bpk-component-link/readme.md
+++ b/packages/bpk-component-link/readme.md
@@ -32,6 +32,7 @@ export default () => (
 | href      | string   | true     | -             |
 | onClick   | func     | false    | null          |
 | blank     | bool     | false    | false         |
+| rel       | string   | false    | null          |
 | alternate | bool     | false    | false         |
 
 ### BpkButtonLink

--- a/packages/bpk-component-link/src/BpkLink-test.js
+++ b/packages/bpk-component-link/src/BpkLink-test.js
@@ -48,6 +48,28 @@ describe('BpkLink', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should render correctly with a "rel" attribute', () => {
+    const tree = renderer
+      .create(
+        <BpkLink href="#" blank rel="rel-attr">
+          Link (new window)
+        </BpkLink>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with "blank" and "rel" attributes', () => {
+    const tree = renderer
+      .create(
+        <BpkLink href="#" blank rel="rel-overwrite">
+          Link (new window)
+        </BpkLink>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should render correctly with a "white" attribute', () => {
     const tree = renderer
       .create(

--- a/packages/bpk-component-link/src/BpkLink.js
+++ b/packages/bpk-component-link/src/BpkLink.js
@@ -34,13 +34,16 @@ const BpkLink = props => {
     href,
     onClick,
     blank,
+    rel: propRel,
     white,
     alternate,
     ...rest
   } = props;
 
   const classNames = [getClassName('bpk-link')];
+
   const target = blank ? '_blank' : null;
+  const rel = blank ? propRel || 'noopener noreferrer' : propRel;
 
   if (white || alternate) {
     classNames.push(getClassName('bpk-link--alternate'));
@@ -55,6 +58,7 @@ const BpkLink = props => {
       href={href}
       onClick={onClick}
       target={target}
+      rel={rel}
       {...rest}
     >
       {children}
@@ -71,6 +75,7 @@ BpkLink.propTypes = {
   className: PropTypes.string,
   onClick: PropTypes.func,
   blank: PropTypes.bool,
+  rel: PropTypes.string,
   alternate: PropTypes.bool,
   // DEPRECATED
   white: PropTypes.bool,
@@ -80,6 +85,7 @@ BpkLink.defaultProps = {
   className: null,
   onClick: null,
   blank: false,
+  rel: null,
   alternate: false,
   // DEPRECATED
   white: false,

--- a/packages/bpk-component-link/src/__snapshots__/BpkLink-test.js.snap
+++ b/packages/bpk-component-link/src/__snapshots__/BpkLink-test.js.snap
@@ -1,10 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BpkLink should render correctly with "blank" and "rel" attributes 1`] = `
+<a
+  className="bpk-link"
+  href="#"
+  onClick={null}
+  rel="rel-overwrite"
+  target="_blank"
+>
+  Link (new window)
+</a>
+`;
+
 exports[`BpkLink should render correctly with a "alternate" attribute 1`] = `
 <a
   className="bpk-link bpk-link--alternate"
   href="#"
   onClick={null}
+  rel={null}
   target={null}
 >
   Link
@@ -16,6 +29,7 @@ exports[`BpkLink should render correctly with a "blank" attribute 1`] = `
   className="bpk-link"
   href="#"
   onClick={null}
+  rel="noopener noreferrer"
   target="_blank"
 >
   Link (new window)
@@ -27,6 +41,7 @@ exports[`BpkLink should render correctly with a "className" attribute 1`] = `
   className="bpk-link test-class"
   href="#"
   onClick={null}
+  rel={null}
   target={null}
 >
   Link
@@ -38,9 +53,22 @@ exports[`BpkLink should render correctly with a "href" attribute 1`] = `
   className="bpk-link"
   href="#"
   onClick={null}
+  rel={null}
   target={null}
 >
   Link
+</a>
+`;
+
+exports[`BpkLink should render correctly with a "rel" attribute 1`] = `
+<a
+  className="bpk-link"
+  href="#"
+  onClick={null}
+  rel="rel-attr"
+  target="_blank"
+>
+  Link (new window)
 </a>
 `;
 
@@ -49,6 +77,7 @@ exports[`BpkLink should render correctly with a "white" attribute 1`] = `
   className="bpk-link bpk-link--alternate"
   href="#"
   onClick={null}
+  rel={null}
   target={null}
 >
   Link
@@ -61,6 +90,7 @@ exports[`BpkLink should render correctly with arbitrary attributes 1`] = `
   href="#"
   id="test-id"
   onClick={null}
+  rel={null}
   target={null}
 >
   Link

--- a/packages/bpk-component-loading-button/src/__snapshots__/BpkLoadingButton-test.js.snap
+++ b/packages/bpk-component-loading-button/src/__snapshots__/BpkLoadingButton-test.js.snap
@@ -544,6 +544,8 @@ exports[`BpkLoadingButton should render correctly with a "href" attribute 1`] = 
   className="bpk-button"
   href="#"
   onClick={null}
+  rel={null}
+  target={null}
 >
   My button
    

--- a/unreleased.md
+++ b/unreleased.md
@@ -7,3 +7,10 @@
 
 - react-native-bpk-component-carousel:
   - Introducing the React Native carousel component.
+
+- bpk-component-button:
+  - Added `blank` and `rel` props.
+  - When `blank` is set, `rel` is automatically set to `rel="noopener noreferrer"`.
+
+- bpk-component-link:
+  - When `blank` is set, `rel` is automatically set to `rel="noopener noreferrer"`.


### PR DESCRIPTION
* Add `blank` prop to BpkButton so `rel="noopener noreferrer"` is set automatically.
* Automatically set `rel="noopener noreferrer"` also in BpkLink.

This was initiated from this Slack conversation: https://skyscanner.slack.com/archives/C0JHPDSSU/p1527687947000202