### PR TITLE
[BPK-1624] Use onScroll for carousel

### DIFF
--- a/native/packages/react-native-bpk-component-carousel-indicator/stories.js
+++ b/native/packages/react-native-bpk-component-carousel-indicator/stories.js
@@ -19,7 +19,7 @@
 /* @flow */
 
 import React from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import {
   borderRadiusSm,
@@ -95,10 +95,6 @@ class StatefulBpkCarouselIndicatorExample extends React.Component<
     };
   }
 
-  getPageColor = index => pageColors[index % pageColors.length];
-
-  scrollViewRef: ScrollView = null;
-
   handlePageCountChange = pageCount => {
     let { selectedIndex } = this.state;
     if (selectedIndex >= pageCount) {
@@ -109,15 +105,6 @@ class StatefulBpkCarouselIndicatorExample extends React.Component<
 
   handleSelectedIndexChange = selectedIndex => {
     this.setState({ selectedIndex });
-    this.scrollViewRef.scrollTo({
-      x: PAGE_WIDTH * selectedIndex,
-    });
-  };
-
-  handleScroll = event => {
-    const { contentOffset } = event.nativeEvent;
-    const selectedIndex = contentOffset.x / PAGE_WIDTH;
-    this.setState({ selectedIndex });
   };
 
   render() {
@@ -125,28 +112,6 @@ class StatefulBpkCarouselIndicatorExample extends React.Component<
     return (
       <View>
         <View style={styles.overlay}>
-          <ScrollView
-            horizontal
-            pagingEnabled
-            onMomentumScrollEnd={this.handleScroll}
-            ref={ref => {
-              this.scrollViewRef = ref;
-            }}
-            showsHorizontalScrollIndicator={false}
-            style={styles.pager}
-          >
-            {new Array(pageCount)
-              .fill()
-              .map((_, index) => (
-                <View
-                  key={index.toString()}
-                  style={[
-                    styles.page,
-                    { backgroundColor: this.getPageColor(index) },
-                  ]}
-                />
-              ))}
-          </ScrollView>
           <BpkCarouselIndicator
             pageCount={pageCount}
             selectedIndex={selectedIndex}

--- a/native/packages/react-native-bpk-component-carousel/src/BpkCarousel.js
+++ b/native/packages/react-native-bpk-component-carousel/src/BpkCarousel.js
@@ -30,6 +30,8 @@ import BpkCarouselIndicator from 'react-native-bpk-component-carousel-indicator'
 import { spacingXl } from 'bpk-tokens/tokens/base.react.native';
 import typeof BpkCarouselItem from './BpkCarouselItem';
 
+const SCROLL_EVENT_THROTTLE = 16; // 1000ms / 60fps = 16ms
+
 const styles = StyleSheet.create({
   carouselIndicator: {
     alignSelf: 'center',
@@ -90,9 +92,11 @@ class BpkCarousel extends React.Component<Props, State> {
   handleScroll = (event: any) => {
     const { contentOffset } = event.nativeEvent;
     const currentIndex = this.state.width
-      ? contentOffset.x / this.state.width
+      ? Math.round(contentOffset.x / this.state.width)
       : 0;
-    this.setState({ currentIndex });
+    if (currentIndex !== this.state.currentIndex) {
+      this.setState({ currentIndex });
+    }
   };
 
   render() {
@@ -107,7 +111,8 @@ class BpkCarousel extends React.Component<Props, State> {
         <ScrollView
           accessible
           accessibilityLabel={this.getAccessibilityLabel()}
-          onMomentumScrollEnd={this.handleScroll}
+          onScroll={this.handleScroll}
+          scrollEventThrottle={SCROLL_EVENT_THROTTLE}
           onLayout={this.onLayout}
           horizontal
           pagingEnabled

--- a/native/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarousel-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarousel-test.android.js.snap
@@ -7,8 +7,9 @@ Array [
     accessible={true}
     horizontal={true}
     onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
     pagingEnabled={true}
+    scrollEventThrottle={16}
     showsHorizontalScrollIndicator={false}
     style={
       Object {
@@ -98,8 +99,9 @@ Array [
     accessible={true}
     horizontal={true}
     onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
     pagingEnabled={true}
+    scrollEventThrottle={16}
     showsHorizontalScrollIndicator={false}
     style={null}
   >
@@ -184,8 +186,9 @@ exports[`Android BpkCarousel should render correctly without indicators 1`] = `
   accessible={true}
   horizontal={true}
   onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
   pagingEnabled={true}
+  scrollEventThrottle={16}
   showsHorizontalScrollIndicator={false}
   style={null}
 >

--- a/native/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarousel-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarousel-test.ios.js.snap
@@ -7,8 +7,9 @@ Array [
     accessible={true}
     horizontal={true}
     onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
     pagingEnabled={true}
+    scrollEventThrottle={16}
     showsHorizontalScrollIndicator={false}
     style={
       Object {
@@ -98,8 +99,9 @@ Array [
     accessible={true}
     horizontal={true}
     onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
     pagingEnabled={true}
+    scrollEventThrottle={16}
     showsHorizontalScrollIndicator={false}
     style={null}
   >
@@ -184,8 +186,9 @@ exports[`IOS BpkCarousel should render correctly without indicators 1`] = `
   accessible={true}
   horizontal={true}
   onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
   pagingEnabled={true}
+  scrollEventThrottle={16}
   showsHorizontalScrollIndicator={false}
   style={null}
 >

--- a/native/storybook/storybook.js
+++ b/native/storybook/storybook.js
@@ -58,6 +58,7 @@ configure(() => {
   require('../packages/react-native-bpk-component-button-link/stories');
   require('../packages/react-native-bpk-component-button/stories');
   require('../packages/react-native-bpk-component-card/stories');
+  require('../packages/react-native-bpk-component-carousel-indicator/stories');
   require('../packages/react-native-bpk-component-carousel/stories');
   require('../packages/react-native-bpk-component-flat-list/stories');
   require('../packages/react-native-bpk-component-horizontal-nav/stories');
@@ -65,7 +66,6 @@ configure(() => {
   require('../packages/react-native-bpk-component-navigation-bar/stories');
   require('../packages/react-native-bpk-component-map/stories');
   require('../packages/react-native-bpk-component-nudger/stories');
-  require('../packages/react-native-bpk-component-carousel-indicator/stories');
   require('../packages/react-native-bpk-component-panel/stories');
   require('../packages/react-native-bpk-component-phone-input/stories');
   require('../packages/react-native-bpk-component-picker/stories');


### PR DESCRIPTION
* Instead of `onMomentumScrollEnd`, we now use `onScroll`.
* `scrollEventThrottle` is how often `onScroll` fires. I couldn't find much conventional wisdom here on what's a good value for this that blends scroll performance with speed. It seems to perform well with the current value (tested on iOS and Android sims and we maintain 60fps), but this can be looked at further in the upcoming performance card.

![kapture 2018-06-06 at 9 10 43](https://user-images.githubusercontent.com/73652/41025403-a83be4fc-6969-11e8-977c-171aa5091b23.gif)
