### PR TITLE
Add "overflow: hidden" to "bpk-border-radius" mixins

### DIFF
--- a/packages/bpk-mixins/src/mixins/_radii.scss
+++ b/packages/bpk-mixins/src/mixins/_radii.scss
@@ -31,6 +31,7 @@
 
 @mixin bpk-border-radius-xs {
   border-radius: $bpk-border-radius-xs;
+  overflow: hidden;
 }
 
 /// Small border radius.
@@ -42,6 +43,7 @@
 
 @mixin bpk-border-radius-sm {
   border-radius: $bpk-border-radius-sm;
+  overflow: hidden;
 }
 
 /// Pill shaped border radius.
@@ -53,4 +55,5 @@
 
 @mixin bpk-border-radius-pill {
   border-radius: $bpk-border-radius-pill;
+  overflow: hidden;
 }

--- a/unreleased.md
+++ b/unreleased.md
@@ -6,3 +6,6 @@
 
 - react-native-bpk-component-carousel:
   - Introducing the React Native carousel component.
+
+- bpk-mixins
+  - When using any `bpk-border-radius` mixin, `overflow: hidden` is set.


### PR DESCRIPTION
We're using `bpk-border-radius` mixins sometimes to show rounded corners in images, and this requires adding `overflow: hidden` also.

It would be good if this is done automatically by the mixins. Do you see any possible side effect with this change?