### PR TITLE
Lint scss files on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
   "lint-staged": {
     "*.js": [
       "eslint"
+    ],
+    "*.scss": [
+      "stylelint --syntax scss"
     ]
   },
   "repository": {


### PR DESCRIPTION
I just noticed that lint-staged is used to lint only js files. I think it would be very useful (at least for contributors) to lint also scss files.