### PR TITLE
[NoJira] update prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20538,9 +20538,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
-      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz",
+      "integrity": "sha512-4M90mfvLz6yRf2Dhzd+xPIE6b4xkI8nHMJhsSm9IlfG17g6wujrrm7+H1X8x52tC4cSNm6HmuhCUSNe6Hd5wfw==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "node-sass": "^4.7.2",
     "postcss-flexbugs-fixes": "^3.2.0",
     "postcss-loader": "^2.0.10",
-    "prettier": "^1.10.2",
+    "prettier": "^1.13.5",
     "prop-types": "^15.5.10",
     "punycode": "^2.1.0",
     "raw-loader": "^0.5.1",

--- a/packages/bpk-component-image/src/withLazyLoading.js
+++ b/packages/bpk-component-image/src/withLazyLoading.js
@@ -75,9 +75,11 @@ export default function withLazyLoading(
     }
 
     setInView = (): void => {
-      this.setState((): {} => ({
-        inView: true,
-      }));
+      this.setState(
+        (): {} => ({
+          inView: true,
+        }),
+      );
       this.removeEventListeners();
     };
 

--- a/scripts/release-process/upcoming-changes.js
+++ b/scripts/release-process/upcoming-changes.js
@@ -36,7 +36,9 @@ const {
   const data = zip(changelogs, parsedChangelogs);
   const upcomingChanges = (await Promise.all(
     data.map(async ([changelogPath, parsedChangelog]) => {
-      const { upcoming: { changes } } = parsedChangelog;
+      const {
+        upcoming: { changes },
+      } = parsedChangelog;
       if (!changes) {
         return null;
       }


### PR DESCRIPTION
This updates prettier to the latest version (and fixes a couple of formatting errors because of the version change)

the reason for this update is not only regular housekeeping but better markdown support (https://github.com/prettier/prettier/blob/master/CHANGELOG.md#1135)