### PR TITLE
[No JIRA] Improve invalid BpkText prop combo

### DIFF
--- a/native/packages/react-native-bpk-component-text/src/BpkText-test.ios.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText-test.ios.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import React from 'react';
+import renderer from 'react-test-renderer';
 import BpkText from './BpkText';
 import commonTests from './BpkText-test.common';
 
@@ -37,5 +39,18 @@ describe('iOS', () => {
     ).toEqual(
       'Error: Invalid prop `emphasize` of value `true` supplied to `BpkText`. `textStyle` value of `xxl` cannot be emphasized.',
     ); // eslint-disable-line max-len
+  });
+
+  it('should not apply `emphasize` for textStyle="xxl"', () => {
+    const tree = renderer
+      .create(
+        <BpkText emphasize textStyle="xxl">
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
+          commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus
+          et magnis dis parturient montes, nascetur ridiculus mus.
+        </BpkText>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/native/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/native/packages/react-native-bpk-component-text/src/BpkText.js
@@ -98,8 +98,12 @@ const BpkText = props => {
   const { children, textStyle, style, emphasize, ...rest } = props;
 
   const finalStyle = [styles[textStyle]];
+  // Emphasize on iOS is not supported for the XXL size. This is also checked with
+  // the `emphasizePropType` prop.
+  const shouldEmpasize =
+    emphasize && !(Platform.OS === 'ios' && textStyle === 'xxl');
 
-  if (emphasize) {
+  if (shouldEmpasize) {
     finalStyle.push(getEmphasizeProperties(props));
   }
 

--- a/native/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.ios.js.snap
@@ -193,3 +193,24 @@ exports[`iOS BpkText should support overwriting styles 1`] = `
   Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
 </Text>
 `;
+
+exports[`iOS should not apply \`emphasize\` for textStyle="xxl" 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Array [
+      Object {
+        "color": "rgb(82, 76, 97)",
+        "fontFamily": "System",
+        "fontSize": 34,
+        "fontWeight": "700",
+      },
+      Object {},
+    ]
+  }
+>
+  Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+</Text>
+`;

--- a/unreleased.md
+++ b/unreleased.md
@@ -9,3 +9,7 @@
 
 - react-native-bpk-component-carousel:
   - Introducing the React Native carousel component.
+
+**Fixed:**
+- react-bpk-component-infinite-scroll:
+  - In addition to issuing a prop warning when using emphasize in combination with xxl on iOS now nothing actually happens.


### PR DESCRIPTION
On iOS emphasize is not supported when supplying xxl for the `textStyle`
with this change we no longer incorrectly apply a lower font weight
style in this configuration.