### PR TITLE
[BPK-1630] Enhance map component

### DIFF
--- a/packages/bpk-component-map/index.js
+++ b/packages/bpk-component-map/index.js
@@ -21,22 +21,4 @@
 import BpkMap from './src/BpkMap';
 
 export default BpkMap;
-export {
-  withGoogleMap,
-  withScriptjs,
-  GoogleMap,
-  Circle,
-  Marker,
-  Polyline,
-  Polygon,
-  Rectangle,
-  InfoWindow,
-  OverlayView,
-  GroundOverlay,
-  DirectionsRenderer,
-  FusionTablesLayer,
-  KmlLayer,
-  TrafficLayer,
-  StreetViewPanorama,
-  BicyclingLayer,
-} from 'react-google-maps';
+export { withScriptjs, Marker } from 'react-google-maps';

--- a/packages/bpk-component-map/package-lock.json
+++ b/packages/bpk-component-map/package-lock.json
@@ -12,15 +12,8 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "2.5.6",
+				"core-js": "2.5.7",
 				"regenerator-runtime": "0.11.1"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.5.6",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-					"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
-				}
 			}
 		},
 		"can-use-dom": {
@@ -34,9 +27,9 @@
 			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
 		},
 		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -47,9 +40,9 @@
 			}
 		},
 		"fbjs": {
-			"version": "0.8.16",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
 			"requires": {
 				"core-js": "1.2.7",
 				"isomorphic-fetch": "2.2.1",
@@ -58,6 +51,13 @@
 				"promise": "7.3.1",
 				"setimmediate": "1.0.5",
 				"ua-parser-js": "0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
 			}
 		},
 		"google-maps-infobox": {
@@ -66,9 +66,9 @@
 			"integrity": "sha512-hTuWmWZZSOxf5D/z7l3/hTF1grgRvLG53BEKMdjiKOG+FcK/kH7vqseUeyIU9Zj2ZIqKTOaro0nknxpAuRq4Vw=="
 		},
 		"hoist-non-react-statics": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
-			"integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
 		},
 		"iconv-lite": {
 			"version": "0.4.23",
@@ -151,11 +151,10 @@
 			}
 		},
 		"prop-types": {
-			"version": "15.6.1",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
 			"requires": {
-				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
 				"object-assign": "4.1.1"
 			}
@@ -172,7 +171,7 @@
 				"lodash": "4.17.10",
 				"marker-clusterer-plus": "2.1.4",
 				"markerwithlabel": "2.0.1",
-				"prop-types": "15.6.1",
+				"prop-types": "15.6.2",
 				"recompose": "0.26.0",
 				"scriptjs": "2.5.8",
 				"warning": "3.0.0"
@@ -184,8 +183,8 @@
 			"integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
 			"requires": {
 				"change-emitter": "0.1.6",
-				"fbjs": "0.8.16",
-				"hoist-non-react-statics": "2.5.0",
+				"fbjs": "0.8.17",
+				"hoist-non-react-statics": "2.5.5",
 				"symbol-observable": "1.2.0"
 			}
 		},

--- a/packages/bpk-component-map/package.json
+++ b/packages/bpk-component-map/package.json
@@ -13,11 +13,14 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "bpk-component-spinner": "^2.2.34",
+    "bpk-mixins": "^17.10.4",
+    "bpk-react-utils": "^2.6.1",
+    "prop-types": "^15.5.8",
     "react-google-maps": "^9.4.5"
   },
   "devDependencies": {
-    "bpk-component-icon": "^3.21.4",
-    "bpk-component-tooltip": "^3.1.18",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "bpk-component-text": "^1.0.64"
   }
 }

--- a/packages/bpk-component-map/readme.md
+++ b/packages/bpk-component-map/readme.md
@@ -12,56 +12,52 @@ npm install bpk-component-map --save-dev
 
 ```js
 import React from 'react';
-import BpkMap from 'bpk-component-map';
+import BpkText from 'bpk-component-text';
+import BpkMap, { BpkOverlayView } from 'bpk-component-map';
 
 export default () => (
   <BpkMap
-    containerElement={<div style={{ height: '400px' }} />}
-    mapElement={<div style={{ height: `100%` }} />}
-    defaultZoom={15}
-    defaultCenter={{
-      lat: 27.9881,
-      lng: 86.925,
+    zoom={15}
+    showControls={false}
+    panEnabled={false}
+    center={{
+      latitude: 27.9881,
+      longitude: 86.925,
     }}
-    options={{
-      zoomControl: false,
-      dragEnabled: false,
-    }}
-  />
+  >
+    <BpkOverlayView position={{ latitude: 27.9881, longitude: 86.925 }}>
+      <BpkText>Shibuya Crossing</BpkText>
+    </BpkOverlayView>
+  <BpkMap>
 );
 ```
 
 ## Accompanying HOCs
 
-### withScriptjs
+### withGoogleMapsScript
 
-`withScriptjs` is a HOC that loads the Google Maps Javascript, then loads the map. This is useful for when you don't already have the Google Maps Javascript loaded.
+`withGoogleMapsScript` is a HOC that loads the Google Maps Javascript, then loads the map. This is useful for when you don't already have the Google Maps Javascript loaded.
 
 If you intend to include multiple maps on one page, it's better to load the Google Maps Javascript elsewhere and not use this HOC, as it downloads the script every time it's used.
 
 ```js
 import React from 'react';
-import BpkMap, { withScriptjs } from 'bpk-component-map';
+import BpkMap, { withGoogleMapsScript } from 'bpk-component-map';
 
 const MAP_URL = 'https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places';
 
-const BpkMapWithScript = withScriptjs(BpkMap);
+const BpkMapWithScript = withGoogleMapsScript(BpkMap);
 
 export default () => (
   <BpkMapWithScript
     googleMapURL={MAP_URL}
-    loadingElement={<div />}
-    containerElement={<div style={{ height: '400px' }} />}
-    mapElement={<div style={{ height: `100%` }} />}
-    defaultZoom={15}
-    defaultCenter={{
-      lat: 27.9881,
-      lng: 86.925,
+    zoom={15}
+    center={{
+      latitide: 27.9881,
+      longitude: 86.925,
     }}
-    options={{
-      zoomControl: false,
-      dragEnabled: false,
-    }}
+    showControls={false}
+    panEnabled={false}
   />
 );
 ```
@@ -70,12 +66,33 @@ export default () => (
 
 ### BpkMap
 
-| Property	      | PropType	| Required                	| Default Value |
-| --------------- | --------- | ------------------------- | ------------- |
-| mapRef          | func      | false                     | null          |
+| Property	       | PropType                                                          | Required                 | Default Value                    |
+| ---------------- | ----------------------------------------------------------------- | ------------------------ | -------------------------------- |
+| bounds           | shape({north: number, east: number, south: number, west: number}) | false                    | null                             |
+| center           | shape({latitude: number, longitude: number})                      | false                    | null                             |
+| containerElement | node                                                              | false                    | <div style={{height: '100%'}} /> |
+| mapElement       | node                                                              | false                    | <div style={{height: '100%'}} /> |
+| mapRef           | func                                                              | false                    | null                             |
+| onRegionChange   | func                                                              | false                    | null                             |
+| onZoom           | func                                                              | false                    | null                             |
+| panEnabled       | bool                                                              | false                    | true                             |
+| showControls     | bool                                                              | false                    | true                             |
+| zoom             | number                                                            | false                    | 15                               |
 
-When using `withScriptjs`, some additional props are required. Refer to [`withScriptjs` from `react-google-maps`](https://tomchentw.github.io/react-google-maps/#withscriptjs).
+Note: One of `bounds` and `center` must be provided.
 
-Refer to [`GoogleMap` from `react-google-maps`](https://tomchentw.github.io/react-google-maps/#withgooglemap) for all other props.
+#### withGoogleMapsScript
 
-> Note: `bpk-component-map` also exports everything that `react-google-maps` does, such as `InfoBox` and `OverlayView`.
+When using `withGoogleMapsScript`, some additional props are available:
+
+| Property	       | PropType                                     | Required                  | Default Value  |
+| ---------------- | -------------------------------------------- | ------------------------- | -------------- |
+| googleMapURL     | string                                       | true                      | -              |
+| loadingElement   | node                                         | false                     | BpkSpinner     |
+
+### BpkOverlayView
+
+| Property	       | PropType                                     | Required                 | Default Value      |
+| ---------------- | -------------------------------------------- | ------------------------ | ------------------ |
+| children         | node                                         | true                     | -                  |
+| position         | shape({latitude: number, longitude: number}) | true                     | -                  |

--- a/packages/bpk-component-map/src/BpkMap.js
+++ b/packages/bpk-component-map/src/BpkMap.js
@@ -18,11 +18,137 @@
 
 /* @flow */
 
-import React from 'react';
+import React, { type Node } from 'react';
+import PropTypes from 'prop-types';
 import { withGoogleMap, GoogleMap } from 'react-google-maps';
+import { LatLongPropType, type LatLong } from './common-types';
 
-const BpkMap = withGoogleMap(({ mapRef, ...rest }) => (
-  <GoogleMap ref={mapRef} {...rest} />
-));
+export type Bounds = {
+  south: number,
+  west: number,
+  north: number,
+  east: number,
+};
+
+export type MapRef = ?{
+  getBounds: () => Bounds,
+  getCenter: () => LatLong,
+  getZoom: () => number,
+  fitBounds: Bounds => void,
+};
+
+type Props = {
+  panEnabled: boolean,
+  showControls: boolean,
+  zoom: number,
+  bounds: ?Bounds,
+  center: ?LatLong,
+  children: ?Node,
+  containerElement: ?Node,
+  mapElement: ?Node,
+  mapRef: ?(MapRef) => mixed,
+  onRegionChange: ?(Bounds, LatLong) => mixed,
+  onZoom: ?(number) => mixed,
+};
+
+const BpkMap = withGoogleMap((props: Props) => {
+  const {
+    bounds,
+    children,
+    mapRef,
+    onRegionChange,
+    onZoom,
+    center,
+    panEnabled,
+    showControls,
+    zoom,
+  } = props;
+  let ref: MapRef = null;
+
+  if (!bounds && !center) {
+    throw new Error('BpkMap: Provide either `bounds` or `center` props.');
+  }
+
+  return (
+    <GoogleMap
+      ref={(map: MapRef) => {
+        ref = map;
+        if (map && bounds) {
+          map.fitBounds({
+            south: bounds.south,
+            west: bounds.west,
+            north: bounds.north,
+            east: bounds.east,
+          });
+        }
+        if (mapRef) {
+          mapRef(map);
+        }
+      }}
+      defaultCenter={
+        center
+          ? {
+              lat: center.latitude,
+              lng: center.longitude,
+            }
+          : null
+      }
+      defaultZoom={zoom}
+      options={{
+        gestureHandling: panEnabled ? 'auto' : 'none',
+        disableDefaultUI: !showControls,
+        mapTypeControl: false,
+        streetViewControl: false,
+        fullscreenControl: false,
+        rotateControl: false,
+      }}
+      onDragEnd={() => {
+        if (ref && onRegionChange) {
+          onRegionChange(ref.getBounds(), ref.getCenter());
+        }
+      }}
+      onZoomChanged={() => {
+        if (ref && onZoom) {
+          onZoom(ref.getZoom());
+        }
+      }}
+    >
+      {children}
+    </GoogleMap>
+  );
+});
+
+BpkMap.propTypes = {
+  bounds: PropTypes.shape({
+    south: PropTypes.number.isRequired,
+    west: PropTypes.number.isRequired,
+    north: PropTypes.number.isRequired,
+    east: PropTypes.number.isRequired,
+  }),
+  center: LatLongPropType,
+  children: PropTypes.node,
+  containerElement: PropTypes.node,
+  mapElement: PropTypes.node,
+  mapRef: PropTypes.func,
+  onRegionChange: PropTypes.func,
+  onZoom: PropTypes.func,
+  panEnabled: PropTypes.bool,
+  showControls: PropTypes.bool,
+  zoom: PropTypes.number,
+};
+
+BpkMap.defaultProps = {
+  bounds: null,
+  center: null,
+  children: null,
+  containerElement: <div style={{ height: '100%' }} />,
+  mapElement: <div style={{ height: '100%' }} />,
+  mapRef: null,
+  onRegionChange: null,
+  onZoom: null,
+  panEnabled: true,
+  showControls: true,
+  zoom: 15,
+};
 
 export default BpkMap;

--- a/packages/bpk-component-map/src/BpkOverlayView.js
+++ b/packages/bpk-component-map/src/BpkOverlayView.js
@@ -1,0 +1,48 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React, { type Node } from 'react';
+import PropTypes from 'prop-types';
+import { OverlayView } from 'react-google-maps';
+import { LatLongPropType, type LatLong } from './common-types';
+
+type Props = {
+  children: Node,
+  position: LatLong,
+};
+
+const BpkOverlayView = (props: Props) => {
+  const { children, position, ...rest } = props;
+  return (
+    <OverlayView
+      mapPaneName="overlayMouseTarget"
+      position={{ lat: position.latitude, lng: position.longitude }}
+      {...rest}
+    >
+      {children}
+    </OverlayView>
+  );
+};
+BpkOverlayView.propTypes = {
+  children: PropTypes.node.isRequired,
+  position: LatLongPropType.isRequired,
+};
+
+export default BpkOverlayView;

--- a/packages/bpk-component-map/src/DefaultLoadingElement.js
+++ b/packages/bpk-component-map/src/DefaultLoadingElement.js
@@ -15,14 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /* @flow */
 
-import BpkMap from './src/BpkMap';
-import BpkOverlayView from './src/BpkOverlayView';
-import withGoogleMapsScript from './src/withGoogleMapsScript';
-import { type LatLong } from './src/common-types';
+import React from 'react';
+import { BpkLargeSpinner, SPINNER_TYPES } from 'bpk-component-spinner';
+import { cssModules } from 'bpk-react-utils';
 
-export default BpkMap;
-export type BpkMapLatLong = LatLong;
-export { BpkOverlayView, withGoogleMapsScript };
+import STYLES from './DefaultLoadingElement.scss';
+
+const getClassName = cssModules(STYLES);
+
+const DefaultLoadingElement = () => (
+  <div className={getClassName('bpk-map-default-loading-element')}>
+    <BpkLargeSpinner type={SPINNER_TYPES.primary} />
+  </div>
+);
+
+export default DefaultLoadingElement;

--- a/packages/bpk-component-map/src/DefaultLoadingElement.scss
+++ b/packages/bpk-component-map/src/DefaultLoadingElement.scss
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-/* @flow */
+@import '~bpk-mixins/index';
 
-import BpkMap from './src/BpkMap';
-import BpkOverlayView from './src/BpkOverlayView';
-import withGoogleMapsScript from './src/withGoogleMapsScript';
-import { type LatLong } from './src/common-types';
-
-export default BpkMap;
-export type BpkMapLatLong = LatLong;
-export { BpkOverlayView, withGoogleMapsScript };
+.bpk-map-default-loading-element {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+  background-color: $bpk-color-gray-100;
+}

--- a/packages/bpk-component-map/src/common-types.js
+++ b/packages/bpk-component-map/src/common-types.js
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018 Skyscanner Ltd
+ * Copyright 2017 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,15 @@
 
 /* @flow */
 
-import BpkMap from './src/BpkMap';
-import BpkOverlayView from './src/BpkOverlayView';
-import withGoogleMapsScript from './src/withGoogleMapsScript';
-import { type LatLong } from './src/common-types';
+import PropTypes from 'prop-types';
 
-export default BpkMap;
-export type BpkMapLatLong = LatLong;
-export { BpkOverlayView, withGoogleMapsScript };
+export type LatLong = {
+  latitude: number,
+  longitude: number,
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const LatLongPropType = PropTypes.shape({
+  latitude: PropTypes.number.isRequired,
+  longitude: PropTypes.number.isRequired,
+});

--- a/packages/bpk-component-map/src/withGoogleMapsScript.js
+++ b/packages/bpk-component-map/src/withGoogleMapsScript.js
@@ -1,0 +1,43 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import React, { type ComponentType } from 'react';
+import PropTypes from 'prop-types';
+import { withScriptjs } from 'react-google-maps';
+import DefaultLoadingElement from './DefaultLoadingElement';
+
+function withGoogleMapsScript(Component: ComponentType<any>) {
+  const ScriptedComponent = withScriptjs(Component);
+
+  const WithGoogleMapsScript = ({ ...rest }: { [string]: any }) => (
+    <ScriptedComponent {...rest} />
+  );
+
+  WithGoogleMapsScript.propTypes = {
+    loadingElement: PropTypes.node,
+  };
+
+  WithGoogleMapsScript.defaultProps = {
+    loadingElement: <DefaultLoadingElement />,
+  };
+
+  return WithGoogleMapsScript;
+}
+
+export default withGoogleMapsScript;

--- a/packages/bpk-component-map/stories.js
+++ b/packages/bpk-component-map/stories.js
@@ -21,106 +21,80 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import BpkMap, { withScriptjs } from './index';
+import BpkText from 'bpk-component-text';
+import BpkMap, { BpkOverlayView, withGoogleMapsScript } from './index';
 
-const BpkMapWithLoading = withScriptjs(BpkMap);
+const BpkMapWithLoading = withGoogleMapsScript(BpkMap);
 
 const StoryMap = props => {
-  const { language, ...rest } = props;
+  const { children, language, ...rest } = props;
   return (
-    <BpkMapWithLoading
-      containerElement={<div style={{ height: '400px' }} />}
-      mapElement={<div style={{ height: `100%` }} />}
-      googleMapURL={`https://maps.googleapis.com/maps/api/js?v=3.exp&language=${language}&libraries=geometry,drawing,places`}
-      loadingElement={<div />}
-      {...rest}
-    />
+    <div style={{ height: '400px' }}>
+      <BpkMapWithLoading
+        googleMapURL="https://maps.googleapis.com/maps/api/js?v=3.exp&language=en&libraries=geometry,drawing,places"
+        {...rest}
+      >
+        {children}
+      </BpkMapWithLoading>
+    </div>
   );
 };
 
 StoryMap.propTypes = {
+  children: PropTypes.node,
   language: PropTypes.string,
 };
 
 StoryMap.defaultProps = {
+  children: null,
   language: '',
 };
 
-const zoom = level => {
+const onZoom = level => {
   action(`Zoom changed to ${level}`);
 };
 
-const drag = (bounds, center) => {
+const onRegionChange = (bounds, center) => {
   action(
     `Dragged to bounds: ${bounds.toString()}, center: ${center.toString()}`,
   );
 };
 
-type MapRef = ?{
-  getBounds: () => Object,
-  getCenter: () => Object,
-  getZoom: () => number,
-  fitBounds: ({
-    south: number,
-    west: number,
-    north: number,
-    east: number,
-  }) => void,
-};
-
 storiesOf('bpk-component-map', module)
   .add('Simple', () => (
     <StoryMap
-      defaultZoom={15}
-      defaultCenter={{ lat: 55.944357, lng: -3.1967116 }}
-      language="en"
+      zoom={15}
+      center={{ latitude: 55.944357, longitude: -3.1967116 }}
     />
   ))
-  .add('Zoom and drag disabled', () => (
+  .add('Drag disabled and controls hidden', () => (
     <StoryMap
-      defaultZoom={15}
-      defaultCenter={{ lat: 55.944357, lng: -3.1967116 }}
-      language="zh"
-      options={{
-        zoomControl: false,
-        dragEnabled: false,
-      }}
+      center={{ latitude: 55.944357, longitude: -3.1967116 }}
+      panEnabled={false}
+      showControls={false}
     />
   ))
-  .add('With onZoomChanged and onDragEnd callbacks', () => {
-    let ref: MapRef = null;
-
-    return (
-      <StoryMap
-        mapRef={map => {
-          ref = map;
-        }}
-        defaultZoom={15}
-        defaultCenter={{ lat: 55.944357, lng: -3.1967116 }}
-        onZoomChanged={() => {
-          if (ref) {
-            zoom(ref.getZoom());
-          }
-        }}
-        onDragEnd={() => {
-          if (ref) {
-            drag(ref.getBounds(), ref.getCenter());
-          }
-        }}
-      />
-    );
-  })
+  .add('With onZoom and onRegionChange callbacks', () => (
+    <StoryMap
+      center={{ latitude: 55.944357, longitude: -3.1967116 }}
+      onZoom={onZoom}
+      onRegionChange={onRegionChange}
+    />
+  ))
   .add('With a bounding box', () => (
     <StoryMap
-      mapRef={(map: MapRef) => {
-        if (map) {
-          map.fitBounds({
-            south: 55.94129273544452,
-            west: -3.2285547854247625,
-            north: 55.952707392208396,
-            east: -3.159632742578083,
-          });
-        }
+      bounds={{
+        south: 25.94129273544452,
+        west: -3.2285547854247625,
+        north: 20.952707392208396,
+        east: -2.159632742578083,
       }}
     />
+  ))
+  .add('With a marker', () => (
+    <StoryMap center={{ latitude: 55.944357, longitude: -3.1967116 }}>
+      <BpkOverlayView position={{ latitude: 55.944, longitude: -3.1967116 }}>
+        <BpkText>Backpack</BpkText>
+      </BpkOverlayView>
+    </StoryMap>
   ));

--- a/packages/bpk-docs/src/pages/MapPage/MapPage.js
+++ b/packages/bpk-docs/src/pages/MapPage/MapPage.js
@@ -16,26 +16,36 @@
  * limitations under the License.
  */
 
+/* @flow */
+
 import React from 'react';
-import BpkMap, { withScriptjs } from 'bpk-component-map';
+import BpkMap, {
+  withGoogleMapsScript,
+  type BpkMapLatLong,
+} from 'bpk-component-map';
+import { cssModules } from 'bpk-react-utils';
 
 import iosScreenshot from 'react-native-bpk-component-map/screenshots/ios/default.png';
 import androidScreenshot from 'react-native-bpk-component-map/screenshots/android/default.png';
 import nativeMapReadme from 'react-native-bpk-component-map/readme.md';
 import mapReadme from 'bpk-component-map/readme.md';
 
+import STYLES from './MapPage.scss';
+
 import DocsPageBuilder from './../../components/DocsPageBuilder';
 import DocsPageWrapper from './../../components/DocsPageWrapper';
 import IntroBlurb from './../../components/IntroBlurb';
 
-const BpkMapWithScript = withScriptjs(BpkMap);
+const BpkMapWithScript = withGoogleMapsScript(BpkMap);
 const API_KEY = process.env.GOOGLE_MAPS_API_KEY || '';
 const MAP_URL = `https://maps.googleapis.com/maps/api/js?v=3.exp&key=${API_KEY}&libraries=geometry,drawing,places`;
 
+const getClassName = cssModules(STYLES);
+
 // Shibuya crossing, Tokyo.
-const COORDINATES = {
-  lat: 35.661777,
-  lng: 139.704051,
+const COORDINATES: BpkMapLatLong = {
+  latitude: 35.661777,
+  longitude: 139.704051,
 };
 
 const components = [
@@ -43,14 +53,13 @@ const components = [
     id: 'default',
     title: 'Default',
     examples: [
-      <BpkMapWithScript
-        googleMapURL={MAP_URL}
-        loadingElement={<div />}
-        containerElement={<div style={{ height: '400px' }} />}
-        mapElement={<div style={{ height: `100%` }} />}
-        defaultZoom={17}
-        defaultCenter={COORDINATES}
-      />,
+      <div className={getClassName('bpkdocs-map-page__map')}>
+        <BpkMapWithScript
+          googleMapURL={MAP_URL}
+          zoom={17}
+          center={COORDINATES}
+        />
+      </div>,
     ],
   },
 ];

--- a/packages/bpk-docs/src/pages/MapPage/MapPage.scss
+++ b/packages/bpk-docs/src/pages/MapPage/MapPage.scss
@@ -16,13 +16,10 @@
  * limitations under the License.
  */
 
-/* @flow */
+@import '~bpk-mixins/index';
 
-import BpkMap from './src/BpkMap';
-import BpkOverlayView from './src/BpkOverlayView';
-import withGoogleMapsScript from './src/withGoogleMapsScript';
-import { type LatLong } from './src/common-types';
-
-export default BpkMap;
-export type BpkMapLatLong = LatLong;
-export { BpkOverlayView, withGoogleMapsScript };
+.bpkdocs-map-page {
+  &__map {
+    height: $bpk-spacing-xl * 15;
+  }
+}

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,8 @@
 # Unreleased
+
+**Breaking:**
+- bpk-component-map:
+  - Removed all exports except for `BpkMap`, `BpkOverlayView` and `withGoogleMapsScript`.
+  - Introduced `BpkOverlayView` component to replace `OverlayView`.
+  - Introduced `withGoogleMapsScript` HOC to replace `withScriptjs`.
+  - Simplified `BpkMap`'s props by removing unused ones and renaming others.


### PR DESCRIPTION
Previously, `BpkMap` was a thin layer around `GoogleMap`. Now, I've whitelisted props on it to make the API closer to the map we use in React Native. For example, `onZoomChanged()` from `GoogleMap` is now `onZoom(newZoomLevel)`.

I've also removed all the exports from `react-google-map` that we were re-exporting previously. Because one of these exports, `OverlayView`, was already in use by consumers, I've created `BpkOverlayView` to serve this use case. The code for it is based on the code that Blue Dolphin did in their app.

I've deliberately called the component `BpkOverlayView` and **not** `BpkMapMarker` to leave scope for adding a simpler marker component in future.

The readme, storybook and docs have been updated to suit this new way of doing things.

**Other things**
* Added a default loading spinner.
* Added defaults for `mapElement` and `containerElement`.
* Added the ability to achieve functionality that previously required usage of `refs` using props (e.g. `fitBounds()`.
* Added new types for `LatLong` and `Bounds`. `LatLong` is abstracted into `common-types` and exported.
* Added a `showControls` prop which is passed down to `disableDefaultUI`.
* Hard coded some options to false, based on how consumers currently use the component (we can amend this later if necessary).