### PR TITLE
[BPK-1640] Improve carousel indicator performance

### DIFF
--- a/native/packages/react-native-bpk-component-carousel-indicator/package-lock.json
+++ b/native/packages/react-native-bpk-component-carousel-indicator/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@skyscanner/react-native-transitiongroup": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@skyscanner/react-native-transitiongroup/-/react-native-transitiongroup-1.1.1.tgz",
-			"integrity": "sha512-avHXo4WYaapPR0Uz73FV7C5sD2iX9bAx+8m2PC2fHNFBU0LdjoTPvxxPcqbi1XQ/jk7IakbAS6/0MNS9ss4JEQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@skyscanner/react-native-transitiongroup/-/react-native-transitiongroup-1.1.3.tgz",
+			"integrity": "sha512-Rb7ufpeeZtiOnqnlKnB9Vnk105d1Jg6B2Z9wAb/+PrGd3vx7HzlmyHhs6+4eHL+vhsk07dS4EWt/cbc3RN5VGQ==",
 			"requires": {
 				"prop-types": "15.6.1"
 			}

--- a/native/packages/react-native-bpk-component-carousel-indicator/package.json
+++ b/native/packages/react-native-bpk-component-carousel-indicator/package.json
@@ -15,7 +15,7 @@
     "react-native": ">= 0.47.0"
   },
   "dependencies": {
-    "@skyscanner/react-native-transitiongroup": "^1.1.1",
+    "@skyscanner/react-native-transitiongroup": "^1.1.3",
     "bpk-tokens": "^27.0.1",
     "prop-types": "^15.5.8"
   },

--- a/native/packages/react-native-bpk-component-carousel-indicator/src/BpkCarouselIndicatorDot.js
+++ b/native/packages/react-native-bpk-component-carousel-indicator/src/BpkCarouselIndicatorDot.js
@@ -62,7 +62,7 @@ type Props = {
   size: $Keys<typeof INDICATOR_SIZES>,
 };
 
-class BpkCarouselIndicatorDot extends React.Component<Props, {}> {
+class BpkCarouselIndicatorDot extends React.PureComponent<Props, {}> {
   size: AnimatedValue;
 
   static propTypes = {

--- a/native/packages/react-native-bpk-component-carousel/src/BpkCarousel.js
+++ b/native/packages/react-native-bpk-component-carousel/src/BpkCarousel.js
@@ -30,7 +30,13 @@ import BpkCarouselIndicator from 'react-native-bpk-component-carousel-indicator'
 import { spacingXl } from 'bpk-tokens/tokens/base.react.native';
 import typeof BpkCarouselItem from './BpkCarouselItem';
 
-const SCROLL_EVENT_THROTTLE = 16; // 1000ms / 60fps = 16ms
+// 16ms would mean 60fps (1000ms / 60fps = 16ms) but that leads to too much
+// calls to setState when the carousel is being scrolled fast.
+// 250 is just a number where the "normal" performance is still very good
+// and also works well when scrolled fast.
+// IF YOU CHANGE THIS, MAKE SURE TO DO AN 0N-DEVICE TEST WITH ~100 IMAGES
+// AND SCROLLING FAST.
+const SCROLL_EVENT_THROTTLE = 250;
 
 const styles = StyleSheet.create({
   carouselIndicator: {

--- a/native/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarousel-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarousel-test.android.js.snap
@@ -55,8 +55,8 @@ exports[`Android BpkCarousel should render correctly 1`] = `
     removeClippedSubviews={false}
     renderAheadOffset={250}
     rowRenderer={[Function]}
-    scrollEventThrottle={16}
-    scrollThrottle={16}
+    scrollEventThrottle={250}
+    scrollThrottle={250}
     showsHorizontalScrollIndicator={false}
   >
     <View>
@@ -169,8 +169,8 @@ exports[`Android BpkCarousel should render correctly with an "accessibilityLabel
     removeClippedSubviews={false}
     renderAheadOffset={250}
     rowRenderer={[Function]}
-    scrollEventThrottle={16}
-    scrollThrottle={16}
+    scrollEventThrottle={250}
+    scrollThrottle={250}
     showsHorizontalScrollIndicator={false}
   >
     <View>
@@ -283,8 +283,8 @@ exports[`Android BpkCarousel should render correctly without indicators 1`] = `
     removeClippedSubviews={false}
     renderAheadOffset={250}
     rowRenderer={[Function]}
-    scrollEventThrottle={16}
-    scrollThrottle={16}
+    scrollEventThrottle={250}
+    scrollThrottle={250}
     showsHorizontalScrollIndicator={false}
   >
     <View>

--- a/native/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarousel-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarousel-test.ios.js.snap
@@ -55,8 +55,8 @@ exports[`IOS BpkCarousel should render correctly 1`] = `
     removeClippedSubviews={false}
     renderAheadOffset={250}
     rowRenderer={[Function]}
-    scrollEventThrottle={16}
-    scrollThrottle={16}
+    scrollEventThrottle={250}
+    scrollThrottle={250}
     showsHorizontalScrollIndicator={false}
   >
     <View>
@@ -169,8 +169,8 @@ exports[`IOS BpkCarousel should render correctly with an "accessibilityLabel" fu
     removeClippedSubviews={false}
     renderAheadOffset={250}
     rowRenderer={[Function]}
-    scrollEventThrottle={16}
-    scrollThrottle={16}
+    scrollEventThrottle={250}
+    scrollThrottle={250}
     showsHorizontalScrollIndicator={false}
   >
     <View>
@@ -283,8 +283,8 @@ exports[`IOS BpkCarousel should render correctly without indicators 1`] = `
     removeClippedSubviews={false}
     renderAheadOffset={250}
     rowRenderer={[Function]}
-    scrollEventThrottle={16}
-    scrollThrottle={16}
+    scrollEventThrottle={250}
+    scrollThrottle={250}
     showsHorizontalScrollIndicator={false}
   >
     <View>


### PR DESCRIPTION
Part of this fix was done in the transitiongroup lib: see https://github.com/Skyscanner/react-native-transitiongroup/commit/da2ef6e710c85f1466cd933bb9cbd774b86a6b67