### PR TITLE
[No JIRA] Loosen react native peer depedency

### DIFF
--- a/native/packages/react-native-bpk-component-button-link/package.json
+++ b/native/packages/react-native-bpk-component-button-link/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "react": "^16.2.0",
-    "react-native": "^0.52.0"
+    "react-native": ">= 0.52.0"
   },
   "dependencies": {
     "bpk-tokens": "^27.0.3",

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,3 +1,5 @@
 # Unreleased
 
-_Nothing yet..._
+**Fixed:**
+- react-native-bpk-component-button-link:
+  - Loosened React Native peer depedency.


### PR DESCRIPTION
A peer of 0.52.0 is overly strict because it doesn't match 0.53.0 etc
due to the stricter caret behaviour for pre-1.0.0 versions.