### PR TITLE
[BPK-1598] Contribution guide improvements

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,34 +1,26 @@
 # Contributing to Backpack
 
-So you want to help us enable Skyscanner to create beautiful, coherent products at scale? That's awesome! ♥
+You want to help us enable Skyscanner to create beautiful, coherent products at scale? That's awesome! :heart:
 
-This document describes how to go about it.
+## Table of contents
 
-<!-- TOC depthFrom:2 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
+* [Prerequisites](#prerequisites)
+* [Getting started](#getting-started)
+* [Adding a new component](#adding-a-new-component)
+* [How to](#how-to)
 
-- [License](#license)
-- [Before you jump in](#before-you-jump-in)
-- [Getting started](#getting-started)
-- [Development tasks](#development-tasks)
-- [Decisions](#decisions)
-- [Adding a new component](#adding-a-new-component)
-- [Design](#design)
-- [Tokens](#tokens)
-- [Sass mixins](#sass-mixins)
-- [React component](#react-component)
-- [Documentation](#documentation)
-- [React Native](#react-native)
-- [Publishing packages (Backpack squad members only)](#publishing-packages-backpack-squad-members-only)
+## Prerequisites
 
-<!-- /TOC -->
-
-## License
+### Licence
 
 By contributing your code, you agree to license your contribution under the terms of the [APLv2](./LICENSE).
 
-All files are released with the Apache 2.0 license.
+All files are released with the Apache 2.0 licence.
 
-If you are adding a new file it should have a header comment like this:
+If you are adding a new file it should have a header comment containing licence information:
+
+<details>
+<summary>Show/hide licence header</summary>
 
 ```
 Backpack - Skyscanner's Design System
@@ -48,228 +40,48 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## Before you jump in
+</details>
 
-Is there something that you think should be in Backpack, but currently isn't? Before you dive in, please note that not everything that is a UI component belongs in Backpack.
+### Decisions
 
-> Is this really going to be used by multiple products?
+Conventions and squad decisions are kept in the [decisions folder](/decisions). We recommend familiarising yourself with these.
 
-If you use it multiple times yourself, it might as well be a component, but maybe Backpack is the wrong place for it and it should instead stay in your own codebase. If in doubt, don’t hesitate to get in touch with us!
+### Installing Node
 
-> I’m sure this should be in Backpack!
+Backpack is developed using Node, using the following versions:
 
-Awesome! The rest of this file should give you a good picture of the process.
+* `LTS` (Node)
+* `^5.6.0` (npm)
 
-* * *
+This is enforced using a pre-install hook that calls out to [ensure-node-env](https://github.com/Skyscanner/ensure-node-env).
 
-Backpack development takes places on Github. If you don't have a Github account, you can create one
-on [github.com](https://github.com).
+If you use [nvm](https://github.com/creationix/nvm) or [nave](https://github.com/isaacs/nave) to manage your Node environment, Backpack has built-in support for these. Just run `nvm use` or `nave auto` to install the correct Node version.
 
-When you are ready to jump into code, use the following workflow to add new components or change any existing ones:
+To install npm, use `npm install --global npm@^5.6.0`.
 
-1. [Fork the repository](https://github.com/Skyscanner/backpack)
-2. Create a new branch
-3. Make your changes
-4. Commit and push your new branch
-5. Submit a [pull request](https://github.com/Skyscanner/backpack/pulls)
-6. Notify someone in the Backpack Design System squad or drop a note in #backpack
+### React Native 
 
-## Getting started
+> Skip this section if you don't intend to develop React Native components.
 
-> Backpack development requires Node LTS and npm `^5.6.0`. [Nvm](https://github.com/creationix/nvm) users can run
-`nvm use` to switch to `lts/carbon`. [Nave](https://github.com/isaacs/nave) users can use `nave auto`. You can also
-download Node LTS using [their website](https://nodejs.org/en/). To install npm `^5.6.0`,
-run `npm install --global npm@^5.6.0`. Backpack uses prettier via ESLint to format code, you should set up your editor to run eslint fix on save or if you don't whish to do that run `npm run prettier` before committing.
-A pre-commit hook exists to verify code style and will fail if prettier is not being used.
+<details>
+<summary>iOS</summary>
 
-To get started run:
+Install XCode from the [App Store](https://itunes.apple.com/gb/app/xcode/id497799835?mt=12). Once installed, open it and accept the licence agreement. You're free to close it after that.
 
-```sh
-npm install
-```
+We use [Cocoapods](https://cocoapods.org) to install some iOS-specific dependencies. Cocoapods uses Ruby, so you'll need to install that too. [rbenv](https://github.com/rbenv/rbenv) and [rvm](https://rvm.io/) are both good ways to get Ruby. The version of Ruby you'll need is specified in `native/ios/.ruby-version`.
 
-The Backpack repository is a **multi-package repository**. This means that, instead of having one code repository for each npm module, we manage all of Backpack’s npm modules in a single code repository.
+Once you have Ruby, install [Bundler](https://bundler.io) with `gem install bundler`.
 
-The tool we use for managing this multi-repo is [Lerna](https://lernajs.io).
+</details>
 
-> Because we use Lerna to manage multiple packages in one repository,
-> you'll also need to run `npm run bootstrap` anytime that you have changed the dependencies
-> within a package. This is the equivalent to running `npm install` inside each of the package
-> folders.
+<details>
+<summary>Android</summary>
 
-You can find the individual modules / packages inside the `packages/` folder.
+Get [Homebrew](https://brew.sh/) if you don't already have it.
 
-## Development tasks
+Install Watchman with `brew install watchman`, then install Java 8 with `brew tap caskroom/versions && brew cask install java8`.
 
-```sh
-ENABLE_CSS_MODULES=true npm start # Start development test harness complete with hot module reloading [HMR]
-npm test                          # Lints .js & .scss files and runs unit tests
-npm run build                     # Runs the build process for all packages
-```
-
-## Decisions
-
-See the [decisions directory](/decisions) for an organised list of cultural and code decisions
-made concerning this monorepo.
-
-## Adding a new component
-
-If you want to add a new component, we will need the following:
-
-- Design (Sketch file)
-- Associated tokens
-- Sass mixin(s)
-- React component
-- Stories
-- Tests
-- Documentation (Including main `readme.md`)
-
-
-### Design
-
-Sketch is the preferred format for non-technical folks. We’d appreciate if you could provide an exact match of your component in Sketch format together with folders for each state e.g. disabled, expanded etc.
-
-### Tokens
-
-Any visual CSS parameters of the component, such as *color, margins, paddings* etc. should not live as magic numbers in the component code, but as **tokens** in the `bpk-tokens` package.
-
-Tokens are defined in the `src/base` directory (with the exception of product-specific tokens, which are in other subdirectories). Tokens come in two layers: In `aliases.json`, all base tokens are defined with concrete values, such as colors, numbers and sizes. The other files then map those aliases to tokens for specific elements.
-
-> You should probably not touch `aliases.json`, as our color palette or grid rarely changes.
-
-Be aware that changing tokens will update *all* packages in the repository, as they all depend on `bpk-tokens`. Changing an existing token is almost always worth a "major" release, whereas adding a new token is usually a "minor" release.
-
-#### Building
-
-To build the tokens, run
-
-```sh
-npm run build:tokens
-```
-
-This will output different formats from the source JSON, for example Sass variables, a JavaScript module, Android and iOS resources.
-
-### Sass mixins
-
-All Sass mixins are defined in the `bpk-mixins` package. The package also exposes the Sass variables from the `bpk-tokens` package.
-
-If you add a new file of mixins, for example for a new *atom*, make sure you add the file to the imports in `_index.scss`.
-
-#### Linting
-
-To lint the Sass, run
-
-```sh
-npm run lint:scss
-```
-
-### React component
-
-Each React component has its own subdirectory `packages/bpk-component-<component-name>`, where the npm module is stored. For it to be properly published, create a `package.json` starting at version `0.0.0` and take inspiration from existing packages in terms of structure. We use [CSS Modules](https://github.com/css-modules/css-modules) along with [BEM](http://getbem.com/) to prevent collisions and accidental overwrites in CSS.
-
-#### Storybook
-
-We use [Storybook](https://getstorybook.io/) to drive the development of Backpack's UI components. Start it using `npm start`.
-
-Create a `stories.js` file and use it to list all the different possible states of your component. Check out Storybook's documentation for more details, and also check out the `stories.js` files of existing components.
-
-> Make sure you import your new component's stories into Storybook by adding it to `.storybook/config.js`.
-
-#### Testing
-
-React components need to be properly unit tested. We use [jest](https://facebook.github.io/jest/)'s snapshot testing, but depending on the complexity of your component, you may want to add additional tests.
-
-#### README
-
-Create a `readme.md` file that shows how to install and use your component. It should also include a table of the component's props, PropTypes and their default values. Take inspiration from existing components.
-
-### Documentation
-
-Our documentation consists of two parts: [Sassdoc](https://backpack.github.io/sassdoc/), which is automatically generated from the `bpk-mixin` sources, and the main [documentation](https://backpack.github.io).
-
-#### Sassdoc
-
-As mentioned, the Sassdoc are automatically generated from source and comments. If you want to double check, you can generate them using `npm run sassdoc` and start a static server to browse the docs, but usually this is not necessary.
-
-Take a look at some of the mixin source files to see how to annotate your Sass to generate proper Sassdoc.
-
-#### Backpack documentation
-
-The Backpack documentation is a standalone client-side app. Each package has its own “page”, which you can find and edit in the `bpk-docs` package under `src/pages`.
-
-The “page” modules themselves contain introductory blurbs and examples for the respective component. They also import the component’s README, which you should have created according to the section further up in this document.
-
-You can run the docs app locally using:
-
-```sh
-npm run build
-npm run docs
-```
-
-And loading [http://localhost:8080/](http://localhost:8080/)
-
-If you need any help writing documentation, get in touch!
-
-When adding documentation for a new component:
- * add the new dependency in `packages/bpk-docs/package.json` and run `npm run bootstrap` to install it.
- * add routes for your new component in `packages/bpk-docs/src/constants/Routes.js` and `packages/bpk-docs/src/constants/redirect-routes.js`
- * add new link in `packages/bpk-docs/src/layouts/links.js`
-
-The web Map component page requires an environment variable named `GOOGLE_MAPS_API_KEY`. During builds, this is set by Travis.
-
-## React Native
-
-Backpack comes in two flavours: web and React Native. React Native (RN) components
-live inside `/native/packages`. The root of `/native` contains things to assist
-with running and testing RN components locally.
-
-### Prerequisites
-
-Before running RN components locally, you'll need a few things in place.
-
-#### iOS
-
-##### XCode
-
-Available from the [Mac App Store](https://itunes.apple.com/gb/app/xcode/id497799835?mt=12). Once installed,
-open it and accept the licence agreement. You're free to close it after that.
-
-##### Ruby via rbenv or rvm
-
-We use Ruby to manage CocoaPods and recommend you use [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/) to get the correct Ruby version. The ruby version is specified in `native/ios/.ruby-version`. With the correct ruby version and bundler installed run `bundler install` followed by `bundle exec pod install` inside `native/ios`.
-
-#### Android
-
-The following instructions heavily make use of [Homebrew](https://brew.sh/),
-which is available for macOS. Windows and Linux installation for these packages is also well-supported, but isn't currently documented here.
-
-In future, we intend to automate more of this to reduce the number of steps required. To ensure that maps powered by Google work set the `google_maps_api_key` in `native/android/local.properties` and make sure you are using the backpack.keystore.
-
-##### APK signing
-
-For members of Backpack we have a keystore tied to our Google Maps API key in LastPass. Retrieve this key and place it in `native/android/backpack.keystore`. For contributors who are not members of Backpack nothing needs to be done, but Google Maps will not work. If you need Google Maps to work you'll need to supply your own Google Maps Api Key and possible keystore.
-
-##### Watchman (if not already installed)
-
-```
-brew install watchman
-```
-
-## Java 8
-Java 8 is required. Other versions may not work!
-
-```
-brew tap caskroom/versions
-brew cask install java8
-```
-
-##### Android Studio and SDK
-
-```
-brew cask install android-studio
-```
-
-Open it once installed, and a setup wizard will guide you through installing lots of extra things like the Android SDK (choose *Standard* installation). You may be asked for your password during this. Once that's done, you're free to close Android Studio.
+Get Android Studio with `brew cask install android-studio`. Once installed, open it and a setup wizard will guide you through installing lots of extra things like the Android SDK (choose *Standard* installation). You may be asked for your password during this. You're free to close Android Studio once this is done.
 
 Add an environment variable pointing to the SDK location to your `~/.bash_profile`
 (or similarly used file):
@@ -298,34 +110,231 @@ Create Android Virtual Devices (AVDs):
 $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --name "bpk-avd" --package "system-images;android-27;google_apis;x86" --device "pixel" && cp native/android/bpk-avd.ini ~/.android/avd/bpk-avd.avd/config.ini
 $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --name "bpk-avd-min" --package "system-images;android-21;google_apis;x86" --device "Nexus 5"
 ```
+</details>
 
-You should now have a functioning Android development environment, including
-virtual devices to run things on. You can run the AVD manually with `$ANDROID_SDK_ROOT/emulator/emulator -avd bpk-avd`,
-but `npm run android` will handle this for you, so it's not required.
+### Code style
 
-To test on the minimum supported API level , run the `bpk-avd-min` with `$ANDROID_SDK_ROOT/emulator/emulator -avd bpk-avd-min`. Make sure each component is rendered correctly and functions properly on all versions above `minSdkVersion` of Android.
+Backpack uses a combination of [ESLint](https://eslint.org) and [Prettier](https://prettier.io) to enforce coding styles. ESLint runs as a pre-commit hook, so it isn't possible to commit code that causes ESLint to fail.
 
-### Storybook
+We recommend that you install [a plugin to your editor](https://eslint.org/docs/user-guide/integrations#editors) to run ESLint automatically, which will then show you any errors inline. You can even enable an option to fix ESLint errors automatically upon saving.
 
-Just like with the web, [Storybook](https://github.com/storybooks/storybook/tree/master/app/react-native) is used to test RN components. Start it with `npm run native`.
+## Getting started
 
-Once Storybook is running, use `npm run ios` or `npm run android` to run storybook
-on a device.
+### Install dependencies
 
-## Publishing packages (Backpack squad members only)
+Run `npm install` to install dependencies from npm.
+
+<details>
+<summary>A note on dependencies</summary>
+
+Backpack is a multi-package repository, also known as a monorepo. This means that instead of having one code repository for each npm package, we manage them all inside this single repository.
+
+We use [Lerna](https://lernajs.io) to achieve this. Lerna links packages together inside this repo by 'bootstrapping'. 
+
+When you run `npm install`, Lerna is bootstrapped automatically as a post-install hook. However, if you change dependencies within a package, you will need to run Lerna manually with `npm run bootstrap`.
+
+</details>
+
+#### React Native
+
+> Skip this section if you don't intend to develop React Native components.
+
+<details>
+<summary>iOS</summary>
+
+From inside `native/ios`, run `bundler install` followed by `bundle exec pod install`.
+</details>
+
+<details>
+<summary>Android</summary>
+
+To ensure that maps powered by Google work set the `google_maps_api_key` in `native/android/local.properties` and make sure you are using the backpack.keystore.
+
+##### APK signing
+
+For members of Backpack we have a keystore tied to our Google Maps API key in LastPass. Retrieve this key and place it in `native/android/backpack.keystore`. For contributors who are not members of Backpack nothing needs to be done, but Google Maps will not work. If you need Google Maps to work you'll need to supply your own Google Maps Api Key and possible keystore.
+
+</details>
+
+### Build the code
+
+Backpack's code depends on some things that must be built first, such as icon fonts, SVGs and tokens.
+
+Use `npm run build` to do this.
+
+### Run the development environment
+
+We use [Storybook](https://getstorybook.io) for our development environment. The instructions for running it are different, depending on whether you're running the web or React Native storybook.
+
+#### Web
+
+Run `npm start` to start the storybook server, then go to [http://localhost:9001](http://localhost:9001) in a web browser to view it.
+
+#### React Native
+
+1. Run `npm run native` to start the storybook server.
+2. Open another terminal tab/window.
+3. Run `npm run ios` to run the Backpack app on an iPhone simulator.
+4. Run `npm run android` to run the Backpack app on an Android emulator.
+5. Go to [http://localhost:7007](http://localhost:7007) in a web browser.
+
+At this point, you should have a functioning development environment running on your local machine.
+
+## Adding a new component
+
+If you want to add a new component, we will need the following:
+
+- Design (Sketch file)
+- Associated tokens
+- Sass mixin(s)
+- React component
+- Stories
+- Tests
+- Documentation (Including main `readme.md`)
+
+
+### Design
+
+Sketch is the preferred format for non-technical folks. We’d appreciate if you could provide an exact match of your component in Sketch format together with folders for each state e.g. disabled, expanded etc.
+
+### Tokens
+
+Any visual CSS parameters of the component, such as *color, margins, paddings* etc. should not live as magic numbers in the component code, but as **tokens** in the `bpk-tokens` package.
+
+Tokens are defined in the `src/base` directory (with the exception of product-specific tokens, which are in other subdirectories). Tokens come in two layers: In `aliases.json`, all base tokens are defined with concrete values, such as colors, numbers and sizes. The other files then map those aliases to tokens for specific elements.
+
+> You should probably not touch `aliases.json`, as our color palette or grid rarely changes.
+
+### Sass mixins
+
+All Sass mixins are defined in the `bpk-mixins` package. The package also exposes the Sass variables from the `bpk-tokens` package.
+
+If you add a new file of mixins, for example for a new *atom*, make sure you add the file to the imports in `_index.scss`.
+
+### React component
+
+Each React component has its own subdirectory `packages/bpk-component-<component-name>`, where the npm module is stored. For it to be properly published, create a `package.json` starting at version `0.0.0` and take inspiration from existing packages in terms of structure. We use [CSS Modules](https://github.com/css-modules/css-modules) along with [BEM](http://getbem.com/) to prevent collisions and accidental overwrites in CSS.
+
+#### Storybook
+
+Create a `stories.js` file and use it to list all the different possible states of your component. Check out Storybook's documentation for more details, and also check out the `stories.js` files of existing components.
+
+> Make sure you import your new component's stories into Storybook by adding it to `.storybook/config.js`.
+
+#### Testing
+
+React components need to be properly unit tested. We use [jest](https://facebook.github.io/jest/)'s snapshot testing, but depending on the complexity of your component, you may want to add additional tests.
+
+#### Readme
+
+Create a `readme.md` file that shows how to install and use your component. It should also include a table of the component's props, PropTypes and their default values. Take inspiration from existing components.
+
+### Documentation
+
+Our documentation consists of two parts: [Sassdoc](https://backpack.github.io/sassdoc/), which is automatically generated from the `bpk-mixin` sources, and the main [documentation](https://backpack.github.io).
+
+#### Sassdoc
+
+As mentioned, the Sassdoc are automatically generated from source and comments. If you want to double check, you can generate them using `npm run sassdoc` and start a static server to browse the docs, but usually this is not necessary.
+
+Take a look at some of the mixin source files to see how to annotate your Sass to generate proper Sassdoc.
+
+#### Backpack documentation
+
+When adding documentation for a new component:
+
+ * Add the new dependency in `packages/bpk-docs/package.json` and run `npm run bootstrap` to install it.
+ * Add routes for your new component in `packages/bpk-docs/src/constants/Routes.js` and `packages/bpk-docs/src/constants/redirect-routes.js`.
+ * Add new link in `packages/bpk-docs/src/layouts/links.js`.
+
+ For help writing documentation, see Skyscanner's [copywriting guide](https://backpack.github.io/style-guide/copywriting) and Backpack's [guide for writing docs](/decisions/writing-docs.md).
+
+## How to
+
+<details>
+<summary>Create a pull request to Backpack</summary>
+
+For anything non-trivial, we strongly recommend speaking to somebody from Backpack squad before starting work on a PR. This lets us pass on any advice or knowledge we already have about the work you're proposing. It might even be something we're already working on. After this, follow the steps below.
+
+1. [Fork the repository](https://github.com/Skyscanner/backpack/fork).
+2. Create a new branch.
+3. Make your changes.
+4. Commit and push your new branch.
+5. Submit a [pull request](https://github.com/Skyscanner/backpack/pulls).
+6. Notify someone in Backpack squad or drop a note in #backpack.
+
+Bear in mind that small, incremental pull requests are likely to be reviewed faster.
+
+</details>
+
+<details>
+<summary>Run tests</summary>
+
+`npm test` will run all tests for both web and React Native. It will pick up any files that end in `-test.js`, so you don't need to do anything to make Jest pick them up. You can also use `npm run test:native` to only run React Native tests.
+
+You can also run the tests in 'watch mode', which means the process will continually run and run tests every time files change. Use `npm run jest:watch` to do this, or `npm run jest:native:watch` to only run them for React Native.
+
+</details>
+
+<details>
+<summary>Run the documentation site</summary>
+
+The Backpack documentation is a standalone client-side app. Each package has its own page, which you can find and edit in the `bpk-docs` package under `src/pages`.
+
+The “page” modules themselves contain introductory blurbs and examples for the respective component. They also import the component’s README, which you should have created as part of your component.
+
+You can run the docs app locally using:
+
+```sh
+npm run build
+npm run docs
+```
+
+And loading [http://localhost:8080](http://localhost:8080).
+
+The web Map component page requires an environment variable named `GOOGLE_MAPS_API_KEY`. During builds, this is set by Travis.
+
+</details>
+
+<details>
+<summary>Run linters manually</summary>
+
+* `npm run lint` to lint both JS and SCSS.
+* `npm run lint:js` to lint JS.
+* `npm run lint:js:fix` to lint and try to automatically fix any errors. 
+* `npm run lint:scss` to lint SCSS.
+
+</details>
+
+<details>
+<summary>Run Android emulators manually</summary>
+
+The setup process detailed in *[Prerequisites](#prerequisites)* created two Android emulators. One with API version 27 and another with 21.
+
+To run these manually, from inside the `/native` folder, run `npm run android:emulator` or `npm run android:emulator:min` to run API versions 27 and 21 respectively.
+
+</details>
+
+<details>
+<summary>Publish packages (Backpack squad members only)</summary>
 
 - Update the [unreleased changelog](/unreleased.md) with every package that has changed, separating out breaking changes (*major*), additions (*minor*) and fixes (*patch*) changes (you should see examples of this in previous entries of the [changelog](/changelog.md)).
   - Some useful commands for determining "what's changed?":
     - `npm run lerna updated`
     - `npm run lerna diff <package-name>`
-- Make sure you are an owner of the npm packages (speak to a member of the Backpack squad)
+- Make sure you are an owner of the npm packages (speak to a member of the Backpack squad).
 - **Do not run `npm publish`. Instead, run `npm run publish`** (this will run `lerna publish`).
 - You’ll be asked to specify a new version for every package that has changed. Options are *patch*, *minor* or *major*. These should directly align to the entries you put in the [unreleased changelog](/unreleased.md) in step 1.
 - You’ll be asked at the end to confirm. Note you can still exit without making these changes.
 - Move entries from [unreleased.md](/unreleased.md) to the [changelog](/changelog.md). Update the package versions for the new changes, and group them under a title with today’s date and a brief summary of what has changed.
 - Commit and push to master.
 
-## Publishing new components
-Whenever a new component is added make sure the version is 0.0.1 until it gets published.
+Be aware that if `bpk-tokens` has changed, *all* packages in the repository will be updated as they all depend on `bpk-tokens`. Changing an existing token is almost always worth a "major" release, whereas adding a new token is usually a "minor" release.
 
-When a component is released for the first time on NPM remember to add the component to the Skyscanner org through the [NPM UI](https://www.npmjs.com/settings/skyscanner/teams/team/backpack/access), be careful to add only Backpack components to the organisation.
+When a component is released for the first time on npm, remember to add the component to the Skyscanner organisation through the [npm UI](https://www.npmjs.com/settings/skyscanner/teams/team/backpack/access).
+
+</details>
+
+## And finally..
+
+If you have any questions at all, don't hesitate to get in touch. We love to talk all things Backpack and we look forward to seeing your contribution!

--- a/native/package.json
+++ b/native/package.json
@@ -7,6 +7,7 @@
     "start": "react-native start",
     "ios": "react-native run-ios --simulator=\"iPhone 8\"",
     "android:emulator": "$ANDROID_SDK_ROOT/emulator/emulator -avd bpk-avd",
+    "android:emulator:min": "$ANDROID_SDK_ROOT/emulator/emulator -avd bpk-avd-min",
     "android:build": "react-native run-android",
     "android": "npm run android:emulator & npm run android:build",
     "test": "jest --coverage",

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,10 @@ https://backpack.github.io/
 npm install [package-name] --save-dev
 ```
 
+## Contributing
+
+To contribute please see [contributing.md](contributing.md).
+
 ## List of packages
 
 | Component | Version |
@@ -112,10 +116,6 @@ npm install [package-name] --save-dev
 | [`react-native-bpk-component-touchable-native-feedback`](/native/packages/react-native-bpk-component-touchable-native-feedback) | [![npm version](https://badge.fury.io/js/react-native-bpk-component-touchable-native-feedback.svg)](http://badge.fury.io/js/react-native-bpk-component-touchable-native-feedback) |
 | [`react-native-bpk-component-touchable-overlay`](/native/packages/react-native-bpk-component-touchable-overlay) | [![npm version](https://badge.fury.io/js/react-native-bpk-component-touchable-overlay.svg)](http://badge.fury.io/js/react-native-bpk-component-touchable-overlay) |
 | [`react-native-bpk-theming`](/native/packages/react-native-bpk-theming) | [![npm version](https://badge.fury.io/js/react-native-bpk-theming.svg)](http://badge.fury.io/js/react-native-bpk-theming) |
-
-## Contributing
-
-To contribute please see [contributing.md](contributing.md).
 
 ## Contact
 - backpack@skyscanner.net


### PR DESCRIPTION
Diff is going to be quite hard to read, so I recommend just looking at the file directly: https://github.com/Skyscanner/backpack/blob/BPK-1598-contribution-guide/contributing.md

It's been separated into more of a flow. Previously it was very web heavy, with a React Native bit in its own section. With this PR, RN is integrated into the setup instructions throughout.

I'm liberally using `details` elements. May be controversial.

I've also tried to make this a lot more focused on the code side of things. I've removed a lot of the philosophical side (e.g. should `x` be in Backpack) because I feel that's covered well by our internal FAQ. 

The 'adding a new component' part has been largely left alone, as I think it's quite good already, and I'd also like to implement @k0nserv's in a future PR and make a sample/template package for users to copy and reference. I think having that will make a lot of the process around creating a new component self-documenting, so we may be able to remove more of this section then.