### PR TITLE
[BPK-1596] Fix calendar docs page on narrow devices

### DIFF
--- a/packages/bpk-docs/src/pages/CalendarPage/CalendarPage.js
+++ b/packages/bpk-docs/src/pages/CalendarPage/CalendarPage.js
@@ -24,6 +24,8 @@ import BpkCalendar, {
   BpkCalendarDate,
   BpkCalendarGridHeader,
 } from 'bpk-component-calendar';
+import BpkMobileScrollContainer from 'bpk-component-mobile-scroll-container';
+import { cssModules } from 'bpk-react-utils';
 
 import calendarReadme from 'bpk-component-calendar/readme.md';
 import DocsPageBuilder from './../../components/DocsPageBuilder';
@@ -39,6 +41,10 @@ import {
   formatMonth,
   formatMonthArabic,
 } from '../../../../bpk-component-calendar/test-utils';
+
+import STYLES from './calendar-page.scss';
+
+const getClassName = cssModules(STYLES);
 
 /* eslint-disable react/no-multi-comp */
 class CalendarNavContainer extends Component {
@@ -108,13 +114,15 @@ const components = [
       </Paragraph>,
     ],
     examples: [
-      <CalendarContainer
-        id="calendar-1"
-        formatMonth={formatMonth}
-        formatDateFull={formatDateFull}
-        daysOfWeek={weekDays}
-        changeMonthLabel="Change month"
-      />,
+      <BpkMobileScrollContainer className={getClassName('bpk-calendar-demo')}>
+        <CalendarContainer
+          id="calendar-1"
+          formatMonth={formatMonth}
+          formatDateFull={formatDateFull}
+          daysOfWeek={weekDays}
+          changeMonthLabel="Change month"
+        />
+      </BpkMobileScrollContainer>,
     ],
   },
   {
@@ -127,14 +135,16 @@ const components = [
       </Paragraph>,
     ],
     examples: [
-      <CalendarContainer
-        id="calendar-ar1"
-        formatMonth={formatMonthArabic}
-        formatDateFull={formatDateFullArabic}
-        daysOfWeek={weekDaysArabic}
-        changeMonthLabel="Change month"
-        weekStartsOn={6}
-      />,
+      <BpkMobileScrollContainer className={getClassName('bpk-calendar-demo')}>
+        <CalendarContainer
+          id="calendar-ar1"
+          formatMonth={formatMonthArabic}
+          formatDateFull={formatDateFullArabic}
+          daysOfWeek={weekDaysArabic}
+          changeMonthLabel="Change month"
+          weekStartsOn={6}
+        />
+      </BpkMobileScrollContainer>,
     ],
   },
   {
@@ -159,6 +169,7 @@ const components = [
     ],
     examples: [
       <BpkCalendarGridHeader
+        className={getClassName('bpk-calendar-demo')}
         month={new Date()}
         daysOfWeek={weekDays}
         weekStartsOn={1}
@@ -168,6 +179,7 @@ const components = [
         showWeekendSeparator
       />,
       <BpkCalendarGrid
+        className={getClassName('bpk-calendar-demo')}
         month={new Date()}
         daysOfWeek={weekDays}
         weekStartsOn={1}

--- a/packages/bpk-docs/src/pages/CalendarPage/calendar-page.scss
+++ b/packages/bpk-docs/src/pages/CalendarPage/calendar-page.scss
@@ -1,0 +1,27 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins/index';
+
+.bpk-calendar-demo {
+  @include bpk-breakpoint-mobile {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
[Edit by Matteo]

I've updated the css slightly to center the calendar on mobile view, it also gave me the change to finally understand how flex works:

![](https://media.giphy.com/media/12NUbkX6p4xOO4/giphy.gif)

Screenshot:
![screen shot 2018-06-25 at 10 37 27 am](https://user-images.githubusercontent.com/3579758/41842834-c8fbe3aa-7863-11e8-8798-886ad4a0f6a4.png)
