### PR TITLE
[No JIRA] Add boilerplate package

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,10 +7,10 @@
   ],
   "commands": {
     "bootstrap": {
-      "ignore": "bpk-tether"
+      "ignore": ["bpk-tether"]
     },
     "publish": {
-      "ignore": ["bpk-tether"],
+      "ignore": ["bpk-tether", "bpk-component-boilerplate"],
       "allowBranch": "master"
     }
   }

--- a/packages/bpk-component-boilerplate/index.js
+++ b/packages/bpk-component-boilerplate/index.js
@@ -1,0 +1,25 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import BpkBoilerplate, {
+  type Props as BpkBoilerplateProps,
+} from './src/BpkBoilerplate';
+
+export type { BpkBoilerplateProps };
+export default BpkBoilerplate;

--- a/packages/bpk-component-boilerplate/package-lock.json
+++ b/packages/bpk-component-boilerplate/package-lock.json
@@ -1,0 +1,33 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"prop-types": {
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+			"requires": {
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		}
+	}
+}

--- a/packages/bpk-component-boilerplate/package.json
+++ b/packages/bpk-component-boilerplate/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "bpk-component-boilerplate",
+  "version": "0.0.0",
+  "description": "Backpack boilerplate component. For reference only, not intended to be used or published.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0"
+  },
+  "dependencies": {
+    "bpk-mixins": "^17.10.4",
+    "bpk-react-utils": "^2.6.1",
+    "prop-types": "^15.5.8"
+  }
+}

--- a/packages/bpk-component-boilerplate/readme.md
+++ b/packages/bpk-component-boilerplate/readme.md
@@ -1,0 +1,28 @@
+# bpk-component-boilerplate
+
+> Backpack example component.
+
+## Installation
+
+```sh
+npm install bpk-component-boilerplate --save-dev
+```
+
+## Usage
+
+```js
+import React from 'react';
+import BpkBoilerplate from 'bpk-component-code';
+
+export default () => (
+  <div>
+    <BpkBoilerPlate />
+  </div>
+);
+```
+
+## Props
+
+| Property  | PropType | Required | Default Value |
+| --------- | -------- | -------- | ------------- |
+| className | string   | false    | null          |

--- a/packages/bpk-component-boilerplate/src/BpkBoilerplate-test.js
+++ b/packages/bpk-component-boilerplate/src/BpkBoilerplate-test.js
@@ -1,0 +1,41 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BpkBoilerplate from './BpkBoilerplate';
+
+describe('BpkBoilerplate', () => {
+  it('should render correctly', () => {
+    const tree = renderer.create(<BpkBoilerplate />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should support custom class names', () => {
+    const tree = renderer
+      .create(<BpkBoilerplate className="custom-classname" />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should support arbitrary props', () => {
+    const tree = renderer.create(<BpkBoilerplate testID="123" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/bpk-component-boilerplate/src/BpkBoilerplate.js
+++ b/packages/bpk-component-boilerplate/src/BpkBoilerplate.js
@@ -1,0 +1,50 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { cssModules } from 'bpk-react-utils';
+
+import STYLES from './BpkBoilerplate.scss';
+
+const getClassName = cssModules(STYLES);
+
+export type Props = {
+  className: ?string,
+};
+const BpkBoilerplate = (props: Props) => {
+  const { className, ...rest } = props;
+  const classNames = getClassName('bpk-boilerplate', className);
+
+  return (
+    <div className={classNames} {...rest}>
+      I am an example component.
+    </div>
+  );
+};
+
+BpkBoilerplate.propTypes = {
+  className: PropTypes.string,
+};
+
+BpkBoilerplate.defaultProps = {
+  className: null,
+};
+
+export default BpkBoilerplate;

--- a/packages/bpk-component-boilerplate/src/BpkBoilerplate.scss
+++ b/packages/bpk-component-boilerplate/src/BpkBoilerplate.scss
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins/index';
+
+.bpk-boilerplate {
+  display: flex;
+}

--- a/packages/bpk-component-boilerplate/src/__snapshots__/BpkBoilerplate-test.js.snap
+++ b/packages/bpk-component-boilerplate/src/__snapshots__/BpkBoilerplate-test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkBoilerplate should render correctly 1`] = `
+<div
+  className="bpk-boilerplate"
+>
+  I am an example component.
+</div>
+`;
+
+exports[`BpkBoilerplate should support arbitrary props 1`] = `
+<div
+  className="bpk-boilerplate"
+  testID="123"
+>
+  I am an example component.
+</div>
+`;
+
+exports[`BpkBoilerplate should support custom class names 1`] = `
+<div
+  className="bpk-boilerplate custom-classname"
+>
+  I am an example component.
+</div>
+`;

--- a/packages/bpk-component-boilerplate/stories.js
+++ b/packages/bpk-component-boilerplate/stories.js
@@ -1,0 +1,27 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import BpkBoilerplate from './index';
+
+storiesOf('bpk-component-boilerplate', module).add('Default', () => (
+  <BpkBoilerplate />
+));


### PR DESCRIPTION
The idea here is that we can point users to this package from `contributing.md` and then it's a bit more self documenting. We can also use this ourselves.

We'll have to keep this in line with our conventions etc, but we don't change things that often, and we already have to keep the written-down guide in `contributing.md` up to date. Keeping some code up to date should be easier than keeping documentation up to date, too.

My plan is to do two more PRs after this:

1. The same as this but for React Native.
2. Refactor `contributing.md` a little more to point to these packages.