### PR TITLE
[No JIRA] Disable font scaling for native icons

### DIFF
--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
@@ -51,7 +51,7 @@ exports[`Android BpkBannerAlert should accept userland styling 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -132,7 +132,7 @@ exports[`Android BpkBannerAlert should accept userland styling 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -234,7 +234,7 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -315,7 +315,7 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -417,7 +417,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnEnter 1`] 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -498,7 +498,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnEnter 1`] 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -600,7 +600,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -681,7 +681,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -804,7 +804,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -852,7 +852,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1005,7 +1005,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1053,7 +1053,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1206,7 +1206,7 @@ exports[`Android BpkBannerAlert should render correctly with dismissable 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1357,7 +1357,7 @@ exports[`Android BpkBannerAlert should render correctly with dismissable 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1550,7 +1550,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1598,7 +1598,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1751,7 +1751,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1799,7 +1799,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1952,7 +1952,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to error
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2033,7 +2033,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to error
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2135,7 +2135,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to neutr
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2216,7 +2216,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to neutr
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2318,7 +2318,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to succe
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2399,7 +2399,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to succe
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2501,7 +2501,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to warn 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2582,7 +2582,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to warn 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [

--- a/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
@@ -53,7 +53,7 @@ exports[`iOS BpkBannerAlert should accept userland styling 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -136,7 +136,7 @@ exports[`iOS BpkBannerAlert should accept userland styling 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -240,7 +240,7 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -323,7 +323,7 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -427,7 +427,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnEnter 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -510,7 +510,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnEnter 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -614,7 +614,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -697,7 +697,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -815,7 +815,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -863,7 +863,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1027,7 +1027,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1075,7 +1075,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1249,7 +1249,7 @@ exports[`iOS BpkBannerAlert should render correctly with dismissable 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1322,7 +1322,7 @@ exports[`iOS BpkBannerAlert should render correctly with dismissable 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1396,7 +1396,7 @@ exports[`iOS BpkBannerAlert should render correctly with dismissable 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1469,7 +1469,7 @@ exports[`iOS BpkBannerAlert should render correctly with dismissable 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1575,7 +1575,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1623,7 +1623,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1787,7 +1787,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1835,7 +1835,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2006,7 +2006,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to error 1`]
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2089,7 +2089,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to error 1`]
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2193,7 +2193,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to neutral 1
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2276,7 +2276,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to neutral 1
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2380,7 +2380,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to success 1
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2463,7 +2463,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to success 1
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2567,7 +2567,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to warn 1`] 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -2650,7 +2650,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to warn 1`] 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [

--- a/native/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.android.js.snap
@@ -143,7 +143,7 @@ exports[`Android BpkButtonLink should render correctly with iconAlignment="leadi
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -244,7 +244,7 @@ exports[`Android BpkButtonLink should render correctly with iconAlignment="trail
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -653,7 +653,7 @@ exports[`Android BpkButtonLink should support the "icon" property 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [

--- a/native/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.ios.js.snap
@@ -145,7 +145,7 @@ exports[`iOS BpkButtonLink should render correctly with iconAlignment="leading" 
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -247,7 +247,7 @@ exports[`iOS BpkButtonLink should render correctly with iconAlignment="trailing"
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -658,7 +658,7 @@ exports[`iOS BpkButtonLink should support the "icon" property 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -759,7 +759,7 @@ exports[`iOS should support the "icon" and "large" property 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
@@ -392,7 +392,7 @@ exports[`Android BpkButton should render correctly with iconAlignment="leading" 
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -536,7 +536,7 @@ exports[`Android BpkButton should render correctly with iconAlignment="trailing"
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -1617,7 +1617,7 @@ exports[`Android BpkButton should support having an icon as well as a title 1`] 
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -1962,7 +1962,7 @@ exports[`Android BpkButton should support the "icon" property 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -2073,7 +2073,7 @@ exports[`Android BpkButton should support the "iconOnly" property 1`] = `
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -219,7 +219,7 @@ exports[`iOS BpkButton should render correctly with iconAlignment="leading" 1`] 
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -380,7 +380,7 @@ exports[`iOS BpkButton should render correctly with iconAlignment="trailing" 1`]
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -1631,7 +1631,7 @@ exports[`iOS BpkButton should support having an icon as well as a title 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -2027,7 +2027,7 @@ exports[`iOS BpkButton should support the "icon" property 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -2155,7 +2155,7 @@ exports[`iOS BpkButton should support the "iconOnly" property 1`] = `
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -2559,7 +2559,7 @@ exports[`iOS should support the "icon" and "large" property 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -2694,7 +2694,7 @@ exports[`iOS should support the "iconOnly" and "large" property 1`] = `
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [

--- a/native/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.ios.js.snap
@@ -67,7 +67,7 @@ exports[`iOS BpkFlatListItem should render correctly 1`] = `
   </View>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -187,7 +187,7 @@ exports[`iOS BpkFlatListItem should support the "image" property 1`] = `
   </View>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -299,7 +299,7 @@ exports[`iOS BpkFlatListItem should support the "selected" property 1`] = `
   </View>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [

--- a/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
+++ b/native/packages/react-native-bpk-component-icon/src/BpkIcon.js
@@ -65,7 +65,7 @@ const BpkIcon = (props: Props) => {
   }
 
   return (
-    <Text style={textStyleFinal} {...rest}>
+    <Text style={textStyleFinal} {...rest} allowFontScaling={false}>
       {mapCharacterCode(characterCode)}
     </Text>
   );

--- a/native/packages/react-native-bpk-component-icon/src/__snapshots__/BpkIcon-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-icon/src/__snapshots__/BpkIcon-test.android.js.snap
@@ -3,7 +3,7 @@
 exports[`Android BpkIcon should apply user props 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [
@@ -26,7 +26,7 @@ exports[`Android BpkIcon should apply user props 1`] = `
 exports[`Android BpkIcon should render correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [
@@ -46,7 +46,7 @@ exports[`Android BpkIcon should render correctly 1`] = `
 exports[`Android BpkIcon should render small icon correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [

--- a/native/packages/react-native-bpk-component-icon/src/__snapshots__/BpkIcon-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-icon/src/__snapshots__/BpkIcon-test.ios.js.snap
@@ -3,7 +3,7 @@
 exports[`iOS BpkIcon should apply user props 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [
@@ -26,7 +26,7 @@ exports[`iOS BpkIcon should apply user props 1`] = `
 exports[`iOS BpkIcon should render correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [
@@ -46,7 +46,7 @@ exports[`iOS BpkIcon should render correctly 1`] = `
 exports[`iOS BpkIcon should render small icon correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [

--- a/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.android.js.snap
@@ -63,7 +63,7 @@ exports[`android BpkNavigationBar should render correctly 1`] = `
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -201,7 +201,7 @@ exports[`android BpkNavigationBar should render correctly with a subtitle view 1
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -347,7 +347,7 @@ exports[`android BpkNavigationBar should render correctly with a title view 1`] 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -464,7 +464,7 @@ exports[`android BpkNavigationBar should render correctly with an icon in the ti
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -506,7 +506,7 @@ exports[`android BpkNavigationBar should render correctly with an icon in the ti
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -632,7 +632,7 @@ exports[`android BpkNavigationBar should render correctly with custom style 1`] 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -767,7 +767,7 @@ exports[`android BpkNavigationBar should render correctly with trailing button 1
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -872,7 +872,7 @@ exports[`android BpkNavigationBar should render correctly with trailing button 1
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [

--- a/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.ios.js.snap
@@ -621,7 +621,7 @@ exports[`ios BpkNavigationBar should render correctly with an icon in the title 
       >
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [

--- a/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarButtonAndroid-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarButtonAndroid-test.android.js.snap
@@ -38,7 +38,7 @@ exports[`android BpkNavigationBarButton should render correctly back icon 1`] = 
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -104,7 +104,7 @@ exports[`android BpkNavigationBarButton should render correctly disabled 1`] = `
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -169,7 +169,7 @@ exports[`android BpkNavigationBarButton should render correctly with close icon 
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -234,7 +234,7 @@ exports[`android BpkNavigationBarButton should render correctly with tick icon 1
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -300,7 +300,7 @@ exports[`android BpkNavigationBarButton should respect "disabledTintColor" 1`] =
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -365,7 +365,7 @@ exports[`android BpkNavigationBarButton should respect "tintColor" 1`] = `
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -430,7 +430,7 @@ exports[`android BpkNavigationBarButton should respect "touchableColor" 1`] = `
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [

--- a/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarIconButtonIOS-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarIconButtonIOS-test.ios.js.snap
@@ -34,7 +34,7 @@ exports[`iOS BpkNavigationBarIconButtonIOS should render correctly 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -96,7 +96,7 @@ exports[`iOS BpkNavigationBarIconButtonIOS should render correctly disabled 1`] 
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -157,7 +157,7 @@ exports[`iOS BpkNavigationBarIconButtonIOS should render correctly leading confi
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -219,7 +219,7 @@ exports[`iOS BpkNavigationBarIconButtonIOS should resepect "disabledTintColor" 1
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -280,7 +280,7 @@ exports[`iOS BpkNavigationBarIconButtonIOS should resepect "tintColor" 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [

--- a/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/TitleView-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/TitleView-test.android.js.snap
@@ -14,7 +14,7 @@ exports[`android TitleView should render correctly with leading icon 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -157,7 +157,7 @@ exports[`android TitleView should render correctly with trailing icon 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [

--- a/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/TitleView-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/TitleView-test.ios.js.snap
@@ -14,7 +14,7 @@ exports[`ios TitleView should render correctly with leading icon 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -157,7 +157,7 @@ exports[`ios TitleView should render correctly with trailing icon 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [

--- a/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
@@ -94,7 +94,7 @@ exports[`Android BpkNudger should disable theming if the required attribute is o
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -240,7 +240,7 @@ exports[`Android BpkNudger should disable theming if the required attribute is o
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -377,7 +377,7 @@ exports[`Android BpkNudger should render correctly 1`] = `
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -523,7 +523,7 @@ exports[`Android BpkNudger should render correctly 1`] = `
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -667,7 +667,7 @@ exports[`Android BpkNudger should render correctly when value is a not an intege
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -817,7 +817,7 @@ exports[`Android BpkNudger should render correctly when value is a not an intege
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -954,7 +954,7 @@ exports[`Android BpkNudger should render correctly when value is greater than ma
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1107,7 +1107,7 @@ exports[`Android BpkNudger should render correctly when value is greater than ma
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1255,7 +1255,7 @@ exports[`Android BpkNudger should render correctly when value is less than min 1
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1405,7 +1405,7 @@ exports[`Android BpkNudger should render correctly when value is less than min 1
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1542,7 +1542,7 @@ exports[`Android BpkNudger should support theming 1`] = `
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1690,7 +1690,7 @@ exports[`Android BpkNudger should support theming 1`] = `
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [

--- a/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
@@ -95,7 +95,7 @@ exports[`iOS BpkNudger should disable theming if the required attribute is omitt
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -258,7 +258,7 @@ exports[`iOS BpkNudger should disable theming if the required attribute is omitt
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -412,7 +412,7 @@ exports[`iOS BpkNudger should render correctly 1`] = `
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -575,7 +575,7 @@ exports[`iOS BpkNudger should render correctly 1`] = `
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -736,7 +736,7 @@ exports[`iOS BpkNudger should render correctly when value is a not an integer 1`
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -903,7 +903,7 @@ exports[`iOS BpkNudger should render correctly when value is a not an integer 1`
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1057,7 +1057,7 @@ exports[`iOS BpkNudger should render correctly when value is greater than max 1`
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1227,7 +1227,7 @@ exports[`iOS BpkNudger should render correctly when value is greater than max 1`
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1392,7 +1392,7 @@ exports[`iOS BpkNudger should render correctly when value is less than min 1`] =
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1559,7 +1559,7 @@ exports[`iOS BpkNudger should render correctly when value is less than min 1`] =
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1715,7 +1715,7 @@ exports[`iOS BpkNudger should support theming 1`] = `
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1882,7 +1882,7 @@ exports[`iOS BpkNudger should support theming 1`] = `
     >
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.android.js.snap
@@ -138,7 +138,7 @@ exports[`Android BpkDialingCodeList should render correctly 1`] = `
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -281,7 +281,7 @@ exports[`Android BpkDialingCodeList should render correctly 1`] = `
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -424,7 +424,7 @@ exports[`Android BpkDialingCodeList should render correctly 1`] = `
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -610,7 +610,7 @@ exports[`Android BpkDialingCodeList should render correctly with "selectedId" se
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -756,7 +756,7 @@ exports[`Android BpkDialingCodeList should render correctly with "selectedId" se
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -899,7 +899,7 @@ exports[`Android BpkDialingCodeList should render correctly with "selectedId" se
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.ios.js.snap
@@ -231,7 +231,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -406,7 +406,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -581,7 +581,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -864,7 +864,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1042,7 +1042,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -1217,7 +1217,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
         </View>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.android.js.snap
@@ -112,7 +112,7 @@ exports[`Android BpkPhoneNumberInput should render correctly 1`] = `
       </Text>
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -292,7 +292,7 @@ exports[`Android BpkPhoneNumberInput should render correctly with \`editable\` f
       </Text>
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [

--- a/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.ios.js.snap
@@ -112,7 +112,7 @@ exports[`iOS BpkPhoneNumberInput should render correctly 1`] = `
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [
@@ -309,7 +309,7 @@ exports[`iOS BpkPhoneNumberInput should render correctly with \`editable\` false
         </Text>
         <Text
           accessible={true}
-          allowFontScaling={true}
+          allowFontScaling={false}
           ellipsizeMode="tail"
           style={
             Array [

--- a/native/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListItem-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListItem-test.ios.js.snap
@@ -67,7 +67,7 @@ exports[`iOS BpkListItem should render correctly 1`] = `
   </View>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -187,7 +187,7 @@ exports[`iOS BpkListItem should support the "image" property 1`] = `
   </View>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -299,7 +299,7 @@ exports[`iOS BpkListItem should support the "selected" property 1`] = `
   </View>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [

--- a/native/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.android.js.snap
@@ -40,7 +40,7 @@ exports[`Android BpkSelect should render correctly 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -117,7 +117,7 @@ exports[`Android BpkSelect should render correctly with "showImage" and image 1`
   />
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -191,7 +191,7 @@ exports[`Android BpkSelect should render correctly with "showImage" and no image
   />
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -278,7 +278,7 @@ exports[`Android BpkSelect should render correctly with a text label 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -343,7 +343,7 @@ exports[`Android BpkSelect should render correctly with an element label 1`] = `
   <View />
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -430,7 +430,7 @@ exports[`Android BpkSelect should render correctly with custom styles 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -520,7 +520,7 @@ exports[`Android BpkSelect should render correctly with the disabled prop 1`] = 
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [

--- a/native/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.ios.js.snap
@@ -36,7 +36,7 @@ exports[`iOS BpkSelect should render correctly 1`] = `
   >
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -126,7 +126,7 @@ exports[`iOS BpkSelect should render correctly with "showImage" and image 1`] = 
     />
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -213,7 +213,7 @@ exports[`iOS BpkSelect should render correctly with "showImage" and no image 1`]
     />
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -313,7 +313,7 @@ exports[`iOS BpkSelect should render correctly with a text label 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -391,7 +391,7 @@ exports[`iOS BpkSelect should render correctly with an element label 1`] = `
     <View />
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -495,7 +495,7 @@ exports[`iOS BpkSelect should render correctly with custom styles 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [
@@ -598,7 +598,7 @@ exports[`iOS BpkSelect should render correctly with the disabled prop 1`] = `
     </Text>
     <Text
       accessible={true}
-      allowFontScaling={true}
+      allowFontScaling={false}
       ellipsizeMode="tail"
       style={
         Array [

--- a/native/packages/react-native-bpk-component-star-rating/src/__snapshots__/BpkStar-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-star-rating/src/__snapshots__/BpkStar-test.ios.js.snap
@@ -12,7 +12,7 @@ exports[`iOS BpkStar should render correctly when empty 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -55,7 +55,7 @@ exports[`iOS BpkStar should render correctly when full 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -85,7 +85,7 @@ exports[`iOS BpkStar should render correctly when full 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -134,7 +134,7 @@ exports[`iOS BpkStar should render correctly when half 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -164,7 +164,7 @@ exports[`iOS BpkStar should render correctly when half 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [

--- a/native/packages/react-native-bpk-component-star-rating/src/__snapshots__/BpkStarRating-RTL-test.js.snap
+++ b/native/packages/react-native-bpk-component-star-rating/src/__snapshots__/BpkStarRating-RTL-test.js.snap
@@ -12,7 +12,7 @@ exports[`RTL BpkStar should render correctly when empty 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -55,7 +55,7 @@ exports[`RTL BpkStar should render correctly when full 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -85,7 +85,7 @@ exports[`RTL BpkStar should render correctly when full 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -134,7 +134,7 @@ exports[`RTL BpkStar should render correctly when half 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -164,7 +164,7 @@ exports[`RTL BpkStar should render correctly when half 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [

--- a/native/packages/react-native-bpk-component-star-rating/src/__snapshots__/BpkStarRating-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-star-rating/src/__snapshots__/BpkStarRating-test.android.js.snap
@@ -12,7 +12,7 @@ exports[`Android BpkStar should render correctly when empty 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -55,7 +55,7 @@ exports[`Android BpkStar should render correctly when full 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -85,7 +85,7 @@ exports[`Android BpkStar should render correctly when full 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -134,7 +134,7 @@ exports[`Android BpkStar should render correctly when half 1`] = `
 >
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [
@@ -164,7 +164,7 @@ exports[`Android BpkStar should render correctly when half 1`] = `
   </Text>
   <Text
     accessible={true}
-    allowFontScaling={true}
+    allowFontScaling={false}
     ellipsizeMode="tail"
     style={
       Array [

--- a/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -562,7 +562,7 @@ exports[`RTL BpkTextInput should render correctly with description, valid=false 
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -843,7 +843,7 @@ exports[`RTL BpkTextInput should render correctly with valid 1`] = `
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -949,7 +949,7 @@ exports[`RTL BpkTextInput should render correctly with valid false 1`] = `
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1055,7 +1055,7 @@ exports[`RTL BpkTextInput should render correctly with valid false and a validat
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [

--- a/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -562,7 +562,7 @@ exports[`Android BpkTextInput should render correctly with description, valid=fa
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -843,7 +843,7 @@ exports[`Android BpkTextInput should render correctly with valid 1`] = `
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -949,7 +949,7 @@ exports[`Android BpkTextInput should render correctly with valid false 1`] = `
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1055,7 +1055,7 @@ exports[`Android BpkTextInput should render correctly with valid false and a val
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [

--- a/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -562,7 +562,7 @@ exports[`iOS BpkTextInput should render correctly with description, valid=false 
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -843,7 +843,7 @@ exports[`iOS BpkTextInput should render correctly with valid 1`] = `
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -949,7 +949,7 @@ exports[`iOS BpkTextInput should render correctly with valid false 1`] = `
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [
@@ -1055,7 +1055,7 @@ exports[`iOS BpkTextInput should render correctly with valid false and a validat
       />
       <Text
         accessible={true}
-        allowFontScaling={true}
+        allowFontScaling={false}
         ellipsizeMode="tail"
         style={
           Array [

--- a/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInputIcons-RTL-test.js.snap
+++ b/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInputIcons-RTL-test.js.snap
@@ -3,7 +3,7 @@
 exports[`RTL InvalidIcon should render correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [
@@ -35,7 +35,7 @@ exports[`RTL InvalidIcon should render correctly 1`] = `
 exports[`RTL ValidIcon should render correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [

--- a/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInputIcons-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInputIcons-test.android.js.snap
@@ -3,7 +3,7 @@
 exports[`Android InvalidIcon should render correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [
@@ -35,7 +35,7 @@ exports[`Android InvalidIcon should render correctly 1`] = `
 exports[`Android ValidIcon should render correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [

--- a/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInputIcons-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInputIcons-test.ios.js.snap
@@ -3,7 +3,7 @@
 exports[`iOS InvalidIcon should render correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [
@@ -35,7 +35,7 @@ exports[`iOS InvalidIcon should render correctly 1`] = `
 exports[`iOS ValidIcon should render correctly 1`] = `
 <Text
   accessible={true}
-  allowFontScaling={true}
+  allowFontScaling={false}
   ellipsizeMode="tail"
   style={
     Array [

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,6 @@
 # Unreleased
+
+**Fixed:**
+
+- react-native-bpk-component-icon:
+  - Font scaling was incorrectly being applied to icons. This has now been remedied and icons will stay the size you intended.


### PR DESCRIPTION
When font scaling is enabled for `BpkIcon` it breaks icons by increasing their size when accessibility text sizes are used. Arguably this is a good thing for most text, but icons probably shouldn't scale 