### PR TITLE
[No JIRA] Add CLI for creating components

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -73,8 +73,8 @@ configure(() => {
   require('./../packages/bpk-component-drawer/stories');
   require('./../packages/bpk-component-fieldset/stories');
   require('./../packages/bpk-component-form-validation/stories');
-  require('./../packages/bpk-component-grid/stories');
   require('./../packages/bpk-component-grid-toggle/stories');
+  require('./../packages/bpk-component-grid/stories');
   require('./../packages/bpk-component-heading/stories');
   require('./../packages/bpk-component-horizontal-nav/stories');
   require('./../packages/bpk-component-icon/stories');

--- a/contributing.md
+++ b/contributing.md
@@ -203,7 +203,6 @@ If you want to add a new component, we will need the following:
 - Tests
 - Documentation (Including main `readme.md`)
 
-
 ### Design
 
 Sketch is the preferred format for non-technical folks. We’d appreciate if you could provide an exact match of your component in Sketch format together with folders for each state e.g. disabled, expanded etc.
@@ -224,21 +223,9 @@ If you add a new file of mixins, for example for a new *atom*, make sure you add
 
 ### React component
 
-Each React component has its own subdirectory `packages/bpk-component-<component-name>`, where the npm module is stored. For it to be properly published, create a `package.json` starting at version `0.0.0` and take inspiration from existing packages in terms of structure. We use [CSS Modules](https://github.com/css-modules/css-modules) along with [BEM](http://getbem.com/) to prevent collisions and accidental overwrites in CSS.
+Use `npm run create-component` to create a new skeleton React component. Once this is created, use existing components for code style inspiration.
 
-#### Storybook
-
-Create a `stories.js` file and use it to list all the different possible states of your component. Check out Storybook's documentation for more details, and also check out the `stories.js` files of existing components.
-
-> Make sure you import your new component's stories into Storybook by adding it to `.storybook/config.js`.
-
-#### Testing
-
-React components need to be properly unit tested. We use [jest](https://facebook.github.io/jest/)'s snapshot testing, but depending on the complexity of your component, you may want to add additional tests.
-
-#### Readme
-
-Create a `readme.md` file that shows how to install and use your component. It should also include a table of the component's props, PropTypes and their default values. Take inspiration from existing components.
+We use [CSS Modules](https://github.com/css-modules/css-modules) along with [BEM](http://getbem.com/) to prevent collisions and accidental overwrites in CSS.
 
 ### Documentation
 

--- a/native/storybook/storybook.js
+++ b/native/storybook/storybook.js
@@ -53,8 +53,8 @@ const hideWarnings = () => {
 configure(() => {
   require('../packages/react-native-bpk-component-alert/stories');
   require('../packages/react-native-bpk-component-animate-height/stories');
-  require('../packages/react-native-bpk-component-banner-alert/stories');
   require('../packages/react-native-bpk-component-badge/stories');
+  require('../packages/react-native-bpk-component-banner-alert/stories');
   require('../packages/react-native-bpk-component-button-link/stories');
   require('../packages/react-native-bpk-component-button/stories');
   require('../packages/react-native-bpk-component-card/stories');
@@ -65,8 +65,8 @@ configure(() => {
   require('../packages/react-native-bpk-component-horizontal-nav/stories');
   require('../packages/react-native-bpk-component-icon/stories');
   require('../packages/react-native-bpk-component-image/stories');
-  require('../packages/react-native-bpk-component-navigation-bar/stories');
   require('../packages/react-native-bpk-component-map/stories');
+  require('../packages/react-native-bpk-component-navigation-bar/stories');
   require('../packages/react-native-bpk-component-nudger/stories');
   require('../packages/react-native-bpk-component-panel/stories');
   require('../packages/react-native-bpk-component-phone-input/stories');
@@ -77,12 +77,12 @@ configure(() => {
   require('../packages/react-native-bpk-component-spinner/stories');
   require('../packages/react-native-bpk-component-star-rating/stories');
   require('../packages/react-native-bpk-component-switch/stories');
-  require('../packages/react-native-bpk-component-text/stories');
   require('../packages/react-native-bpk-component-text-input/stories');
-  require('../packages/react-native-bpk-component-touchable-overlay/stories');
+  require('../packages/react-native-bpk-component-text/stories');
   require('../packages/react-native-bpk-component-touchable-native-feedback/stories');
-  require('../packages/react-native-bpk-theming/stories');
+  require('../packages/react-native-bpk-component-touchable-overlay/stories');
   require('../packages/react-native-bpk-styles/stories');
+  require('../packages/react-native-bpk-theming/stories');
 }, module);
 /* eslint-enable global-require */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4313,9 +4313,9 @@
       }
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
       "dev": true
     },
     "columnify": {
@@ -4401,7 +4401,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
@@ -5571,6 +5571,12 @@
       "requires": {
         "array-find-index": "1.0.2"
       }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
     },
     "cyclist": {
       "version": "0.2.2",
@@ -7990,6 +7996,12 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
+    },
     "falsey": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/falsey/-/falsey-0.3.2.tgz",
@@ -8938,7 +8950,7 @@
       "dev": true,
       "requires": {
         "babel-polyfill": "6.26.0",
-        "colors": "1.1.2",
+        "colors": "1.3.0",
         "fs-extra": "5.0.0",
         "github": "0.2.4",
         "glob": "7.1.2",
@@ -11975,6 +11987,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
       "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=",
+      "dev": true
+    },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
       "dev": true
     },
     "iconv-lite": {
@@ -15044,7 +15062,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -15746,7 +15764,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -16888,6 +16906,12 @@
         "xml-char-classes": "1.0.0"
       }
     },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
+      "dev": true
+    },
     "nearley": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.1.tgz",
@@ -17954,7 +17978,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -18455,6 +18479,12 @@
       "requires": {
         "find-up": "2.1.0"
       }
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "dev": true
     },
     "please-upgrade-node": {
       "version": "3.0.1",
@@ -20817,6 +20847,20 @@
         "function-bind": "1.1.1"
       }
     },
+    "prompt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+      "dev": true,
+      "requires": {
+        "colors": "1.3.0",
+        "pkginfo": "0.4.1",
+        "read": "1.0.7",
+        "revalidator": "0.1.8",
+        "utile": "0.3.0",
+        "winston": "2.1.1"
+      }
+    },
     "prop-types": {
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
@@ -21430,6 +21474,15 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.5"
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "0.0.7"
       }
     },
     "read-cmd-shim": {
@@ -22047,6 +22100,12 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
       "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+      "dev": true
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
       "dev": true
     },
     "rfc6902": {
@@ -24845,6 +24904,12 @@
         "whet.extend": "0.9.9"
       },
       "dependencies": {
+        "colors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "dev": true
+        },
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -26313,6 +26378,34 @@
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "dev": true,
+      "requires": {
+        "async": "0.9.2",
+        "deep-equal": "0.2.2",
+        "i": "0.3.6",
+        "mkdirp": "0.5.1",
+        "ncp": "1.0.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "deep-equal": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+          "dev": true
+        }
+      }
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -27516,6 +27609,41 @@
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true
+    },
+    "winston": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "dev": true,
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "pkginfo": "0.3.1",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+          "dev": true
+        }
+      }
     },
     "wordwrap": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "check-owners": "npm whoami && ( node scripts/npm/get-owners.js | grep -E $(npm whoami) ) && node scripts/npm/check-owners.js",
     "publish": "npm run check-owners && npm run build && git pull --rebase && npm run flow stop && npm run test && lerna publish",
     "danger": "danger ci",
-    "prettier": "prettier --config .prettierrc --write \"**/*.js\""
+    "prettier": "prettier --config .prettierrc --write \"**/*.js\"",
+    "create-component": "node scripts/npm/create-component.js"
   },
   "lint-staged": {
     "*.js": [
@@ -87,6 +88,7 @@
     "babel-preset-react": "^6.16.0",
     "chalk": "^2.3.2",
     "color": "^3.0.0",
+    "colors": "^1.3.0",
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^0.28.8",
     "danger": "^3.0.4",
@@ -135,6 +137,7 @@
     "postcss-flexbugs-fixes": "^3.2.0",
     "postcss-loader": "^2.0.10",
     "prettier": "^1.13.5",
+    "prompt": "^1.0.0",
     "prop-types": "^15.5.10",
     "punycode": "^2.1.0",
     "puppeteer": "^1.5.0",

--- a/packages/bpk-component-boilerplate/package.json
+++ b/packages/bpk-component-boilerplate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bpk-component-boilerplate",
   "version": "0.0.0",
-  "description": "Backpack boilerplate component. For reference only, not intended to be used or published.",
+  "description": "Backpack boilerplate component.",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/packages/bpk-component-boilerplate/readme.md
+++ b/packages/bpk-component-boilerplate/readme.md
@@ -14,11 +14,7 @@ npm install bpk-component-boilerplate --save-dev
 import React from 'react';
 import BpkBoilerplate from 'bpk-component-code';
 
-export default () => (
-  <div>
-    <BpkBoilerPlate />
-  </div>
-);
+export default () => <BpkBoilerplate />;
 ```
 
 ## Props

--- a/scripts/npm/create-component.js
+++ b/scripts/npm/create-component.js
@@ -1,0 +1,204 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-console */
+
+const { execSync } = require('child_process');
+const prompt = require('prompt');
+const fs = require('fs');
+const colors = require('colors');
+const { Transform } = require('stream');
+const path = require('path');
+const _ = require('lodash');
+const globby = require('globby');
+
+const STORYBOOK_CONFIG_SPLIT_POINT_1 = 'configure(() => {';
+const STORYBOOK_CONFIG_SPLIT_POINT_2 = '}, module);';
+
+const schema = {
+  properties: {
+    platform: {
+      description: 'native or web?',
+      default: 'native',
+      pattern: /^(native|web)$/,
+      message: 'Enter "native" or "web"',
+    },
+    name: {
+      description: "Enter the component name, e.g. 'banner-alert'",
+      pattern: /^[a-z-]+$/,
+      message: 'Use snake case, e.g. "banner-alert".',
+      required: true,
+    },
+  },
+};
+
+_.mixin({
+  pascalCase: _.flow(
+    _.camelCase,
+    _.upperFirst,
+  ),
+});
+
+// Util to recursively make dirs
+const mkdirp = dir =>
+  path
+    .resolve(dir)
+    .split(path.sep)
+    .reduce((acc, cur) => {
+      const currentPath = path.normalize(acc + path.sep + cur);
+      try {
+        fs.statSync(currentPath);
+      } catch (e) {
+        if (e.code === 'ENOENT') {
+          fs.mkdirSync(currentPath);
+        } else {
+          throw e;
+        }
+      }
+      return currentPath;
+    }, '');
+
+const Replacer = (source, destination) =>
+  new Transform({
+    transform(chunk, enc, cb) {
+      const data = chunk.toString();
+      this.push(data.replace(new RegExp(source, 'g'), destination));
+      cb();
+    },
+  });
+
+const sortLines = (lineA, lineB) => {
+  const trimmedA = lineA.trim();
+  const trimmedB = lineB.trim();
+  if (trimmedA < trimmedB) {
+    return -1;
+  }
+  if (trimmedA > trimmedB) {
+    return 1;
+  }
+  return 0;
+};
+
+const createComponent = async (err, { platform, name }) => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  let boilerplateComponentPath = `packages/bpk-component-boilerplate`;
+  let newComponentPath = `packages/bpk-component-${name}`;
+  let storybookConfigFile = `.storybook/config.js`;
+  let storybookImport = `require('./../${newComponentPath}/stories');`;
+
+  if (platform === 'native') {
+    boilerplateComponentPath = `native/packages/react-native-bpk-component-boilerplate`;
+    newComponentPath = `native/packages/react-native-bpk-component-${name}`;
+    storybookConfigFile = `native/storybook/storybook.js`;
+    storybookImport = `require('../packages/react-native-bpk-component-${name}/stories');`;
+  }
+
+  const pascalCaseName = _.pascalCase(name);
+
+  const boilerPlateFilePaths = await globby([
+    `${boilerplateComponentPath}/**`,
+    `!**/node_modules/**`,
+  ]);
+
+  const processBoilerPlateFiles = boilerPlateFilePath => {
+    const newFilePath = boilerPlateFilePath
+      .split('boilerplate')
+      .join(name)
+      .split('Boilerplate')
+      .join(pascalCaseName);
+
+    mkdirp(path.dirname(newFilePath));
+
+    return new Promise((resolve, reject) => {
+      fs.createReadStream(boilerPlateFilePath)
+        .pipe(Replacer('boilerplate', name))
+        .pipe(Replacer('Boilerplate', pascalCaseName))
+        .pipe(fs.createWriteStream(newFilePath))
+        .on('finish', resolve)
+        .on('error', reject);
+    });
+  };
+
+  const componentCreationProcess = async directoryAlreadyExists => {
+    if (directoryAlreadyExists) {
+      console.error(
+        colors.red(
+          `Directory ${newComponentPath} already exists. New components must have a unique name.`,
+        ),
+      );
+      return;
+    }
+
+    console.log(colors.yellow(`Creating ${newComponentPath}…`));
+
+    await Promise.all(
+      boilerPlateFilePaths.map(_.unary(processBoilerPlateFiles)),
+    );
+
+    // Add the new component to storybook config:
+    const storybookConfigContent = fs
+      .readFileSync(storybookConfigFile)
+      .toString();
+
+    const storybookConfigContentImports = storybookConfigContent
+      .split(STORYBOOK_CONFIG_SPLIT_POINT_1)[1]
+      .split(STORYBOOK_CONFIG_SPLIT_POINT_2)[0]
+      .split('\n')
+      .filter(s => !_.isEmpty(s));
+
+    storybookConfigContentImports.push(storybookImport);
+
+    const newStorybookConfigContent = `${
+      storybookConfigContent.split(STORYBOOK_CONFIG_SPLIT_POINT_1)[0]
+    }${STORYBOOK_CONFIG_SPLIT_POINT_1}\n${storybookConfigContentImports
+      .sort(sortLines)
+      .join('\n')}\n${STORYBOOK_CONFIG_SPLIT_POINT_2}${
+      storybookConfigContent.split(STORYBOOK_CONFIG_SPLIT_POINT_2)[1]
+    }`;
+
+    fs.writeFileSync(storybookConfigFile, newStorybookConfigContent, 'utf8');
+
+    // Fix eslint errors and run Prettier.
+    execSync(`npx eslint --fix ${newComponentPath} ${storybookConfigFile}`);
+
+    console.log(colors.green(`${newComponentPath} has been created! 👍\n`));
+
+    if (platform === 'web') {
+      console.log(`Run tests with ${colors.cyan(`npm test`)}`);
+      console.log(`Run Storybook with ${colors.cyan(`npm start`)}`);
+    } else {
+      console.log(`Run tests with ${colors.cyan(`npm run test:native`)}`);
+      console.log(
+        `Run Storybook with ${colors.cyan(
+          `npm run native`,
+        )}, then in another terminal run ${colors.cyan(
+          `npm run ios`,
+        )} and ${colors.cyan(`npm run android`)}`,
+      );
+    }
+  };
+
+  fs.exists(newComponentPath, componentCreationProcess);
+};
+
+prompt.start();
+prompt.get(schema, createComponent);


### PR DESCRIPTION
Now we have the boilerplate component, here's a basic CLI for creating new components.

It does the following:
* Makes a copy of `bpk-component-boilerplate` or `react-native-bpk-component-boilerplate` with the new component name.
* Renames the files within appropriately.
* Replaces instances of `boilerplate` within files.
* Adds it to the storybook config.
* Lints the new folder and the storybook config with `--fix` to fix any formatting errors and run Prettier.
* Tells the user how to run tests and storybook.

You run it like this:

<img width="554" alt="screen shot 2018-07-03 at 20 27 15" src="https://user-images.githubusercontent.com/73652/42240526-82f8d2ee-7eff-11e8-81a3-baf889844efc.png">

The cool thing about this is that not only is it useful for us, it also means we can remove some of `contributing.md` because it's self evident by using this CLI (for example, the part where we tell them how to add to the storybook config).

My Bash skillz aren't that great so if you see anywhere this can be improved, please feel free.