### PR TITLE
[BPK-1727] Add font weight documentation

### DIFF
--- a/packages/bpk-docs/src/components/DocsPageBuilder/DocsPageBuilder.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/DocsPageBuilder.js
@@ -37,6 +37,7 @@ import TokenTable from './TokenTable';
 import UsageTable from '../UsageTable';
 
 import STYLES from './DocsPageBuilder.scss';
+import PlatformSwitchingContent from './PlatformSwitchingContent';
 
 const getClassName = cssModules(STYLES);
 
@@ -74,7 +75,7 @@ toSassdocLink.propTypes = {
   category: PropTypes.string.isRequired,
 };
 
-const ComponentExample = (component, registerTokenTable) => {
+const ComponentExample = (component, registerPlatformSwitchingContent) => {
   const heading = (
     <Heading id={component.id} level="h2">
       {component.title}
@@ -115,7 +116,17 @@ const ComponentExample = (component, registerTokenTable) => {
     : null;
 
   const tokenMap = component.tokenMap
-    ? registerTokenTable(<TokenTable tokens={component.tokenMap} />)
+    ? registerPlatformSwitchingContent(
+        <TokenTable tokens={component.tokenMap} />,
+      )
+    : null;
+
+  const platformSwitchingContent = component.platformSwitchingContent
+    ? registerPlatformSwitchingContent(
+        <PlatformSwitchingContent
+          content={component.platformSwitchingContent}
+        />,
+      )
     : null;
 
   const sassdocLink = component.sassdocId
@@ -130,6 +141,7 @@ const ComponentExample = (component, registerTokenTable) => {
       {heading}
       {blurb}
       {tokenMap}
+      {platformSwitchingContent}
       {screenshots}
       {videos}
       {examples}
@@ -174,11 +186,11 @@ const DocsPageBuilder = props => {
   let hasTokens = !!props.tokenMap;
   const components = Children.toArray(
     props.components.map(component =>
-      ComponentExample(component, table => {
+      ComponentExample(component, platformSwitching => {
         hasTokens = true;
         return connect(
           tokenSwitcher,
-          table,
+          platformSwitching,
         );
       }),
     ),
@@ -299,6 +311,11 @@ DocsPageBuilder.propTypes = {
       examples: PropTypes.arrayOf(childrenPropType),
       readme: PropTypes.string,
       tokenMap: PropTypes.shape({
+        web: PropTypes.object,
+        ios: PropTypes.object,
+        android: PropTypes.object,
+      }),
+      platformSwitchingContent: PropTypes.shape({
         web: PropTypes.object,
         ios: PropTypes.object,
         android: PropTypes.object,

--- a/packages/bpk-docs/src/components/DocsPageBuilder/PlatformSwitchingContent.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/PlatformSwitchingContent.js
@@ -1,0 +1,37 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import { type Node } from 'react';
+
+type Props = {
+  platform: string,
+  content: {
+    android: Node,
+    ios: Node,
+    web: Node,
+  },
+};
+
+const PlatformSwitchingContent = (props: Props) => {
+  const { platform, content } = props;
+  return content[platform] || content.web;
+};
+
+export default PlatformSwitchingContent;

--- a/packages/bpk-docs/src/pages/TypesettingPage/TypesettingPage.js
+++ b/packages/bpk-docs/src/pages/TypesettingPage/TypesettingPage.js
@@ -21,9 +21,11 @@ import TOKENS from 'bpk-tokens/tokens/base.raw.json';
 import IOS_TOKENS from 'bpk-tokens/tokens/base.raw.ios.json';
 import ANDROID_TOKENS from 'bpk-tokens/tokens/base.raw.android.json';
 import BpkBlockquote from 'bpk-component-blockquote';
+import { BpkList, BpkListItem } from 'bpk-component-list';
+import { BpkCode } from 'bpk-component-code';
 
 import IntroBlurb from '../../components/IntroBlurb';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import DocsPageBuilder, { Paragraph } from '../../components/DocsPageBuilder';
 import { getPlatformTokens } from '../../helpers/tokens-helper';
 
 const blurb = [
@@ -44,6 +46,48 @@ const components = [
       ANDROID_TOKENS,
       ({ name }) => name === 'FONT_FAMILY_BASE',
     ),
+  },
+  {
+    id: 'font-weight',
+    title: 'Font weight',
+    platformSwitchingContent: {
+      ios: (
+        <section>
+          <Paragraph>
+            When designing for iOS, use <strong>SF Pro Text</strong>.
+          </Paragraph>
+          <BpkList>
+            <BpkListItem>Regular</BpkListItem>
+            <BpkListItem>Semi-bold (for emphasised text)</BpkListItem>
+            <BpkListItem>
+              Heavy (for <BpkCode>font-size-xxl</BpkCode> only)
+            </BpkListItem>
+          </BpkList>
+        </section>
+      ),
+      android: (
+        <section>
+          <Paragraph>
+            When designing for Android, use <strong>Roboto</strong>.
+          </Paragraph>
+          <BpkList>
+            <BpkListItem>Regular</BpkListItem>
+            <BpkListItem>Medium (for emphasised text)</BpkListItem>
+          </BpkList>
+        </section>
+      ),
+      web: (
+        <section>
+          <Paragraph>
+            When designing for web, use <strong>SF UI Text</strong>.
+          </Paragraph>
+          <BpkList>
+            <BpkListItem>Regular</BpkListItem>
+            <BpkListItem>Bold (for emphasised text)</BpkListItem>
+          </BpkList>
+        </section>
+      ),
+    },
   },
   {
     id: 'font-size',


### PR DESCRIPTION
This adds a 'font weight' section to the _Typesetting_ page. It's already been approved by Will in person.

In order to make the copy change when the platform does, I piggybacked off of the `tokenSwitcher` logic to add a `platformSwitchingContent` prop to `DocsPageBuilder.components`. It functions exactly like `tokenMap`, except it can take any arbitrary content. It's a bit messy feeling but, y'know..it's `DocsPageBuilder.js`...

![screen shot 2018-07-11 at 14 42 33](https://user-images.githubusercontent.com/73652/42575706-085599d0-8519-11e8-8887-0da096a41576.png)

**Note:** We could do a refactor to make `tokenMap` use this new `PlatformSwitchingContent` component, but it would be a relatively large refactor, so I think it best if we handle that another time.