### PR TITLE
[No JIRA] Remove large PR check from Danger

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -131,18 +131,6 @@ if (unlicensedFiles.length > 0) {
   );
 }
 
-// Encourage smaller PRs.
-const bigPRThreshold = 8;
-if (fileChanges.length > bigPRThreshold) {
-  warn(
-    `This PR contains ${fileChanges.length} files (${
-      createdFiles.length
-    } new, ${
-      modifiedFiles.length
-    } modified). Consider splitting it into multiple PRs.`,
-  ); // eslint-disable-line max-len
-}
-
 // iOS tokens should not appear in Android snapshot files
 const androidSnapshotsWithIosTokens = fileChanges.filter(filePath => {
   if (!filePath.match(/\.android\.js\.snap$/)) {


### PR DESCRIPTION
<img width="689" alt="screen shot 2018-07-12 at 08 06 20" src="https://user-images.githubusercontent.com/73652/42617696-7c736662-85aa-11e8-8ef7-a027a0ea26c7.png">

I think we all feel that the above message is just visual noise at this point. We've tried a few different thresholds for it appearing and can't seem to get it right. The reality is that a lot of things we do require a lot of files to be changed! 

For example, a new component tends to involve 20-30 changes, adding docs can be ~15 now we have the native/web wrappers plus screenshots, and updating eslint involves at least 9,000,000 changes.

So, I think we should remove this check. Benefits of this:

* We do a good job of tracking PR size ourselves, so we should keep Danger for things that humans are less good at spotting (e.g. 'have you updated `unreleased.md`).
* Reducing noise from Danger means that the times it does have something to say are more powerful.

![bitmoji](https://render.bitstrips.com/v2/cpanel/fb4ca132-6b26-438d-9b9a-9885f9837627-234ddedb-d769-46c1-a553-117bf8ce1b1c-v1.png?transparent=1&palette=1&width=246)