### PR TITLE
[BPK-1725] update eslint skyscanner config with prettier

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,6 @@
     }
   },
   "rules": {
-    "react/destructuring-assignment": 0,
     "prettier/prettier": "error",
     "react/jsx-filename-extension": 0,
     "import/no-extraneous-dependencies": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7058,15 +7058,15 @@
       }
     },
     "eslint-config-skyscanner": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-skyscanner/-/eslint-config-skyscanner-4.0.0-beta.4.tgz",
-      "integrity": "sha512-oAM5ZfMx1VLyWjSTUZukpW8RYonskxDBU+hlUtMugFWdgDDZuAtCqSM+eVrFNaycb5VtuGy3mkY8PcbS7bRfoQ==",
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-skyscanner/-/eslint-config-skyscanner-4.0.0-beta.5.tgz",
+      "integrity": "sha512-cpZ4PeSscQI/Nrt1CzQEUn2UbpPbz7y4d46/t72ugmAM/1GPTZ3Niz+XQ//9ATMuk7pEp32McVhmOu5Gpxk9fQ==",
       "dev": true
     },
     "eslint-config-skyscanner-with-prettier": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-skyscanner-with-prettier/-/eslint-config-skyscanner-with-prettier-0.1.0.tgz",
-      "integrity": "sha512-oGzAMakcEWQkmD1OBT5zMyYrGcyBndGHg1f5a9C2qz82LoeU9xkwOwVMbLmRDADaKJai1P+SBR0aTLNIFbCStw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-skyscanner-with-prettier/-/eslint-config-skyscanner-with-prettier-0.1.1.tgz",
+      "integrity": "sha512-07CCt+fJH7S5co5RTvwQi8UGOa58AfNgx2/+XbA8gLtGmBGQAxtZQm6N6DALazeXR6cZGcrC9HQsHRSOYUfNjA==",
       "dev": true,
       "requires": {
         "babel-eslint": "8.2.6",
@@ -7074,7 +7074,7 @@
         "eslint": "4.19.1",
         "eslint-config-airbnb": "17.0.0",
         "eslint-config-prettier": "2.9.0",
-        "eslint-config-skyscanner": "4.0.0-beta.4",
+        "eslint-config-skyscanner": "4.0.0-beta.5",
         "eslint-plugin-backpack": "0.1.1",
         "eslint-plugin-import": "2.13.0",
         "eslint-plugin-jsx-a11y": "6.1.0",
@@ -7410,6 +7410,15 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "eval": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.2.tgz",
+      "integrity": "sha1-n3EDKEwQWmbfQDCysycxZYNwE9o=",
+      "dev": true,
+      "requires": {
+        "require-like": "0.1.2"
+      }
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -15065,6 +15074,12 @@
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+      "dev": true
+    },
     "lodash.bind": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
@@ -15146,16 +15161,34 @@
         "lodash._root": "3.0.1"
       }
     },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
+      "dev": true
+    },
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
       "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
       "dev": true
     },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
       "dev": true
     },
     "lodash.identity": {
@@ -15223,10 +15256,22 @@
         "lodash.isarray": "3.0.4"
       }
     },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
       "dev": true
     },
     "lodash.mergewith": {
@@ -15245,6 +15290,18 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
+      "dev": true
+    },
+    "lodash.reject": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
       "dev": true
     },
     "lodash.restparam": {
@@ -21621,6 +21678,12 @@
       "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
       "dev": true
     },
+    "require-like": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
+      "integrity": "sha1-rW8wwTvs15cBDEaK+ndcDAprR/o=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -23227,6 +23290,78 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "static-site-generator-webpack-plugin": {
+      "version": "github:skyscanner/static-site-generator-webpack-plugin#7bac616348e472759c107caca11f281323f8238d",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "cheerio": "0.22.0",
+        "eval": "0.1.2",
+        "url": "0.11.0",
+        "webpack-sources": "1.1.0"
+      },
+      "dependencies": {
+        "cheerio": {
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+          "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+          "dev": true,
+          "requires": {
+            "css-select": "1.2.0",
+            "dom-serializer": "0.1.0",
+            "entities": "1.1.1",
+            "htmlparser2": "3.9.2",
+            "lodash.assignin": "4.2.0",
+            "lodash.bind": "4.2.1",
+            "lodash.defaults": "4.2.0",
+            "lodash.filter": "4.6.0",
+            "lodash.flatten": "4.4.0",
+            "lodash.foreach": "4.5.0",
+            "lodash.map": "4.6.0",
+            "lodash.merge": "4.6.1",
+            "lodash.pick": "4.4.0",
+            "lodash.reduce": "4.6.0",
+            "lodash.reject": "4.6.0",
+            "lodash.some": "4.6.0"
+          }
+        },
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.4"
+          }
+        },
+        "lodash.bind": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+          "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
+          "dev": true
+        },
+        "lodash.defaults": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+          "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-15": "^1.0.5",
     "enzyme-to-json": "^3.3.0",
-    "eslint-config-skyscanner-with-prettier": "^0.1.0",
+    "eslint-config-skyscanner-with-prettier": "^0.1.1",
     "eslint-plugin-flowtype": "^2.41.0",
     "eslint_d": "^5.3.1",
     "extract-text-webpack-plugin": "^3.0.2",


### PR DESCRIPTION
This removes `react/destructuring-assignment` and updates `eslint-config-skyscanner-with-prettier` to the latest and greatest 

A reminder, the removed rule is not a default in `eslint-config-skyscanner-with-prettier` dependency of `eslint-config-skyscanner`