### PR TITLE
[BPK-1699] Update react-slider version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5630,6 +5630,7 @@
         "require-from-string": "2.0.1",
         "rfc6902": "2.2.2",
         "supports-hyperlinks": "1.0.1",
+        "vm2": "github:patriksimek/vm2#468bc1e54e75e766b842830ea775669992a979e0",
         "voca": "1.4.0"
       },
       "dependencies": {
@@ -26368,6 +26369,10 @@
       "requires": {
         "indexof": "0.0.1"
       }
+    },
+    "vm2": {
+      "version": "github:patriksimek/vm2#468bc1e54e75e766b842830ea775669992a979e0",
+      "dev": true
     },
     "voca": {
       "version": "1.4.0",

--- a/packages/bpk-component-slider/package-lock.json
+++ b/packages/bpk-component-slider/package-lock.json
@@ -1,16 +1,153 @@
 {
-	"requires": true,
+	"name": "bpk-component-slider",
+	"version": "1.1.34",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
+		"bpk-component-link": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.4.tgz",
+			"integrity": "sha512-NR3MUreQfEMdG49WoECsa6Nms0x7urDGpLiKNRQNWJ6xtviojswTAMH0pzCG5yfmsgFCDbMlmsAtezHKcHIuvQ==",
+			"dev": true,
+			"requires": {
+				"bpk-mixins": "17.11.0",
+				"bpk-react-utils": "2.6.1",
+				"prop-types": "15.6.0"
+			}
+		},
+		"bpk-component-rtl-toggle": {
+			"version": "1.1.23",
+			"resolved": "https://registry.npmjs.org/bpk-component-rtl-toggle/-/bpk-component-rtl-toggle-1.1.23.tgz",
+			"integrity": "sha512-tdeLqUQOJpbP4FK9YH845dDwMu7NxvV08HLiuCvb3e6JHokcH28hqma1emD55OOaj+vBzN/nrbdk1wN063BC0A==",
+			"dev": true,
+			"requires": {
+				"bpk-component-link": "1.2.4",
+				"bpk-react-utils": "2.6.1",
+				"prop-types": "15.6.0"
+			}
+		},
+		"bpk-mixins": {
+			"version": "17.11.0",
+			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.11.0.tgz",
+			"integrity": "sha512-c9nZmkbPzmvPo4vGBO7U2G1GyIEfwJm7WJWlipxygs8tA079RvItzGnFcYIlHRjg05i21cgEu/S/S85FYESoMQ==",
+			"requires": {
+				"bpk-svgs": "5.18.0",
+				"bpk-tokens": "27.0.4"
+			},
+			"dependencies": {
+				"bpk-svgs": {
+					"version": "5.18.0",
+					"resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-5.18.0.tgz",
+					"integrity": "sha512-Y68nA1qm+39PDgUjDiGDukowmSHWusmDx3CSmTF7MCOXLuzOdhQnJtSMxwT5GXd6sw23zWLws/1Up7RwNzk91A=="
+				}
+			}
+		},
+		"bpk-react-utils": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.6.1.tgz",
+			"integrity": "sha512-+Au3nKsS4JXC7paNxtYiiG5GN2kXwwoG9YKWbsvGLOb5173iyOSWvtN5y3RX2uQceLIt6ZpMFNClOtYFtFWqqQ==",
+			"requires": {
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.0",
+				"react-transition-group": "2.4.0",
+				"recompose": "0.26.0"
+			},
+			"dependencies": {
+				"react-transition-group": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
+					"integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
+					"requires": {
+						"dom-helpers": "3.3.1",
+						"loose-envify": "1.3.1",
+						"prop-types": "15.6.2",
+						"react-lifecycles-compat": "3.0.4"
+					},
+					"dependencies": {
+						"prop-types": {
+							"version": "15.6.2",
+							"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+							"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+							"requires": {
+								"loose-envify": "1.3.1",
+								"object-assign": "4.1.1"
+							}
+						}
+					}
+				},
+				"recompose": {
+					"version": "0.26.0",
+					"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+					"integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+					"requires": {
+						"change-emitter": "0.1.6",
+						"fbjs": "0.8.16",
+						"hoist-non-react-statics": "2.5.5",
+						"symbol-observable": "1.2.0"
+					}
+				}
+			}
+		},
+		"bpk-tokens": {
+			"version": "27.0.4",
+			"resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.0.4.tgz",
+			"integrity": "sha512-4RNnBshSH/GrY6ET1VB28p8YeimBfSUNyj8RZ/KFV205Qy1ytwcdbAeHOuYCVOrKUsv3BAcCKcuJ9AyY+3oP1A==",
+			"requires": {
+				"color": "2.0.1"
+			},
+			"dependencies": {
+				"color": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+					"integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+					"requires": {
+						"color-convert": "1.9.2",
+						"color-string": "1.5.2"
+					}
+				}
+			}
+		},
+		"change-emitter": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+		},
+		"color-convert": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"requires": {
+				"color-name": "1.1.1"
+			}
+		},
+		"color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+		},
+		"color-string": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+			"integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+			"requires": {
+				"color-name": "1.1.1",
+				"simple-swizzle": "0.2.2"
+			}
+		},
 		"core-js": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"dom-helpers": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -34,10 +171,20 @@
 				"ua-parser-js": "0.7.17"
 			}
 		},
+		"hoist-non-react-statics": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+		},
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
 			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"is-arrayish": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -98,15 +245,33 @@
 				"object-assign": "4.1.1"
 			}
 		},
+		"react-lifecycles-compat": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+		},
 		"react-slider": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/react-slider/-/react-slider-0.9.0.tgz",
-			"integrity": "sha512-xAcW33uW82317OcJw0vcpT2N949MqwNSy53CiuPwXOEx/g4BdFbOgfemlsueEd+3q7DvAAP/Kj8fiy+1rekfiA=="
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/react-slider/-/react-slider-0.11.2.tgz",
+			"integrity": "sha512-y49ZwJJ7OcPdihgt71xYI8GRdAzpFuSLQR8b+cKotutxqf8MAEPEtqvWKlg+3ZQRe5PMN6oWbIb7wEYDF8XhNQ=="
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"requires": {
+				"is-arrayish": "0.3.2"
+			}
+		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
 		},
 		"ua-parser-js": {
 			"version": "0.7.17",

--- a/packages/bpk-component-slider/package.json
+++ b/packages/bpk-component-slider/package.json
@@ -17,7 +17,7 @@
     "bpk-react-utils": "^2.6.1",
     "bpk-tokens": "^27.0.4",
     "prop-types": "^15.5.8",
-    "react-slider": "^0.9.0"
+    "react-slider": "^0.11.1"
   },
   "devDependencies": {
     "bpk-component-rtl-toggle": "^1.1.23"

--- a/packages/bpk-component-slider/src/BpkSlider-test.js
+++ b/packages/bpk-component-slider/src/BpkSlider-test.js
@@ -20,6 +20,8 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import BpkSlider from './BpkSlider';
 
+jest.mock('react-slider', () => 'react-slider');
+
 describe('BpkSlider', () => {
   it('should render correctly', () => {
     const tree = renderer

--- a/packages/bpk-component-slider/src/__snapshots__/BpkSlider-test.js.snap
+++ b/packages/bpk-component-slider/src/__snapshots__/BpkSlider-test.js.snap
@@ -1,391 +1,97 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BpkSlider should render correctly 1`] = `
-<div
+<react-slider
+  barClassName="bpk-slider__bar"
   className="bpk-slider"
-  onClick={[Function]}
-  onMouseDown={[Function]}
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
->
-  <div
-    className="bpk-slider__bar bpk-slider__bar-0"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    className="bpk-slider__bar bpk-slider__bar-1"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    aria-valuemax={100}
-    aria-valuemin={0}
-    aria-valuenow={25}
-    className="bpk-slider__handle bpk-slider__handle-0 "
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-    role="slider"
-    style={
-      Object {
-        "left": "0px",
-        "position": "absolute",
-        "willChange": "",
-        "zIndex": 1,
-      }
-    }
-    tabIndex={0}
-  />
-</div>
+  handleActiveClassName="bpk-slider__handle--active"
+  handleClassName="bpk-slider__handle"
+  invert={false}
+  max={100}
+  min={0}
+  value={25}
+  withBars={true}
+/>
 `;
 
 exports[`BpkSlider should render correctly with a "className" attribute 1`] = `
-<div
+<react-slider
+  barClassName="bpk-slider__bar"
   className="bpk-slider my-slider"
-  onClick={[Function]}
-  onMouseDown={[Function]}
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
->
-  <div
-    className="bpk-slider__bar bpk-slider__bar-0"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    className="bpk-slider__bar bpk-slider__bar-1"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    aria-valuemax={100}
-    aria-valuemin={0}
-    aria-valuenow={25}
-    className="bpk-slider__handle bpk-slider__handle-0 "
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-    role="slider"
-    style={
-      Object {
-        "left": "0px",
-        "position": "absolute",
-        "willChange": "",
-        "zIndex": 1,
-      }
-    }
-    tabIndex={0}
-  />
-</div>
+  handleActiveClassName="bpk-slider__handle--active"
+  handleClassName="bpk-slider__handle"
+  invert={false}
+  max={100}
+  min={0}
+  value={25}
+  withBars={true}
+/>
 `;
 
 exports[`BpkSlider should render correctly with a "large" attribute 1`] = `
-<div
+<react-slider
+  barClassName="bpk-slider__bar"
   className="bpk-slider bpk-slider--large"
-  onClick={[Function]}
-  onMouseDown={[Function]}
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
->
-  <div
-    className="bpk-slider__bar bpk-slider__bar-0"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    className="bpk-slider__bar bpk-slider__bar-1"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    aria-valuemax={9}
-    aria-valuemin={0}
-    aria-valuenow={2}
-    className="bpk-slider__handle bpk-slider__handle--large bpk-slider__handle bpk-slider__handle--large-0 "
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-    role="slider"
-    style={
-      Object {
-        "left": "0px",
-        "position": "absolute",
-        "willChange": "",
-        "zIndex": 1,
-      }
-    }
-    tabIndex={0}
-  />
-</div>
+  handleActiveClassName="bpk-slider__handle--active"
+  handleClassName="bpk-slider__handle bpk-slider__handle--large"
+  invert={false}
+  max={9}
+  min={0}
+  value={2}
+  withBars={true}
+/>
 `;
 
 exports[`BpkSlider should render correctly with a "step" attribute 1`] = `
-<div
+<react-slider
+  barClassName="bpk-slider__bar"
   className="bpk-slider"
-  onClick={[Function]}
-  onMouseDown={[Function]}
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
->
-  <div
-    className="bpk-slider__bar bpk-slider__bar-0"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    className="bpk-slider__bar bpk-slider__bar-1"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    aria-valuemax={100}
-    aria-valuemin={0}
-    aria-valuenow={0}
-    className="bpk-slider__handle bpk-slider__handle-0 "
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-    role="slider"
-    style={
-      Object {
-        "left": "0px",
-        "position": "absolute",
-        "willChange": "",
-        "zIndex": 1,
-      }
-    }
-    tabIndex={0}
-  />
-</div>
+  handleActiveClassName="bpk-slider__handle--active"
+  handleClassName="bpk-slider__handle"
+  invert={false}
+  max={100}
+  min={0}
+  step={10}
+  value={2}
+  withBars={true}
+/>
 `;
 
 exports[`BpkSlider should render correctly with a minimum distance between controls 1`] = `
-<div
+<react-slider
+  barClassName="bpk-slider__bar"
   className="bpk-slider bpk-slider--range"
-  onClick={[Function]}
-  onMouseDown={[Function]}
-  style={
-    Object {
-      "position": "relative",
-    }
+  handleActiveClassName="bpk-slider__handle--active"
+  handleClassName="bpk-slider__handle"
+  invert={false}
+  max={100}
+  min={0}
+  minDistance={20}
+  value={
+    Array [
+      10,
+      90,
+    ]
   }
->
-  <div
-    className="bpk-slider__bar bpk-slider__bar-0"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    className="bpk-slider__bar bpk-slider__bar-1"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    className="bpk-slider__bar bpk-slider__bar-2"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    aria-valuemax={100}
-    aria-valuemin={0}
-    aria-valuenow={10}
-    className="bpk-slider__handle bpk-slider__handle-0 "
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-    role="slider"
-    style={
-      Object {
-        "left": "0px",
-        "position": "absolute",
-        "willChange": "",
-        "zIndex": 1,
-      }
-    }
-    tabIndex={0}
-  />
-  <div
-    aria-valuemax={100}
-    aria-valuemin={0}
-    aria-valuenow={90}
-    className="bpk-slider__handle bpk-slider__handle-1 "
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-    role="slider"
-    style={
-      Object {
-        "left": "0px",
-        "position": "absolute",
-        "willChange": "",
-        "zIndex": 2,
-      }
-    }
-    tabIndex={0}
-  />
-</div>
+  withBars={true}
+/>
 `;
 
 exports[`BpkSlider should render correctly with a range of values 1`] = `
-<div
+<react-slider
+  barClassName="bpk-slider__bar"
   className="bpk-slider bpk-slider--range"
-  onClick={[Function]}
-  onMouseDown={[Function]}
-  style={
-    Object {
-      "position": "relative",
-    }
+  handleActiveClassName="bpk-slider__handle--active"
+  handleClassName="bpk-slider__handle"
+  invert={false}
+  max={100}
+  min={0}
+  value={
+    Array [
+      10,
+      90,
+    ]
   }
->
-  <div
-    className="bpk-slider__bar bpk-slider__bar-0"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    className="bpk-slider__bar bpk-slider__bar-1"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    className="bpk-slider__bar bpk-slider__bar-2"
-    style={
-      Object {
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "willChange": "",
-      }
-    }
-  />
-  <div
-    aria-valuemax={100}
-    aria-valuemin={0}
-    aria-valuenow={10}
-    className="bpk-slider__handle bpk-slider__handle-0 "
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-    role="slider"
-    style={
-      Object {
-        "left": "0px",
-        "position": "absolute",
-        "willChange": "",
-        "zIndex": 1,
-      }
-    }
-    tabIndex={0}
-  />
-  <div
-    aria-valuemax={100}
-    aria-valuemin={0}
-    aria-valuenow={90}
-    className="bpk-slider__handle bpk-slider__handle-1 "
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-    role="slider"
-    style={
-      Object {
-        "left": "0px",
-        "position": "absolute",
-        "willChange": "",
-        "zIndex": 2,
-      }
-    }
-    tabIndex={0}
-  />
-</div>
+  withBars={true}
+/>
 `;

--- a/unreleased.md
+++ b/unreleased.md
@@ -9,3 +9,6 @@
 
 - react-native-bpk-horizontal-nav:
   - `BpkHorizontalNav` now displays correctly when using RTL.
+
+- bpk-component-slider:
+  - Fixed a bug where the handle would get stuck at the minimum value by upgrading `react-slider`. See [`react-slider#136`](https://github.com/mpowaga/react-slider/issues/136).


### PR DESCRIPTION
The bug in BPK-1699 is resolved by upgrading to the latest version of `react-slider`. `react-slider` now has a peer dependency on React of `^16.2`, but it still works fine with React 15 in my tests