### PR TITLE
[BPK-1750] Add new alignment props to BpkButton

### DIFF
--- a/native/packages/react-native-bpk-component-button/index.js
+++ b/native/packages/react-native-bpk-component-button/index.js
@@ -18,7 +18,12 @@
 
 /* @flow */
 
-import BpkButton, { type Props } from './src/BpkButton';
+import BpkButton, {
+  BUTTON_TYPES,
+  ICON_ALIGNMENTS,
+  type Props,
+} from './src/BpkButton';
 
 export type BpkButtonProps = Props;
 export default BpkButton;
+export { BUTTON_TYPES, ICON_ALIGNMENTS };

--- a/native/packages/react-native-bpk-component-button/readme.md
+++ b/native/packages/react-native-bpk-component-button/readme.md
@@ -25,7 +25,7 @@ pod 'BVLinearGradient', :path => '../node_modules/react-native-bpk-component-but
 ```js
 import { StyleSheet, View } from 'react-native';
 import React, { Component } from 'react';
-import BpkButton from 'react-native-bpk-component-button';
+import BpkButton, { BUTTON_TYPES, ICON_ALIGNMENTS } from 'react-native-bpk-component-button';
 import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
 
 const styles = StyleSheet.create({
@@ -41,42 +41,42 @@ export default class App extends Component {
     return (
       <View style={styles.container}>
         <BpkButton
-          type="primary"
+          type={BUTTON_TYPES.primary}
           title="Book flight"
           onPress={() => {}}
         />
         <BpkButton
-          type="featured"
+          type={BUTTON_TYPES.featured}
           title="Book flight"
           onPress={() => {}}
         />
         <BpkButton
           disabled
-          type="destructive"
+          type={BUTTON_TYPES.destructive}
           title="Book flight"
           onPress={() => {}}
         />
         <BpkButton
           large
-          type="primary"
+          type={BUTTON_TYPES.primary}
           title="Book flight"
           onPress={() => {}}
         />
         <BpkButton
-          type="featured"
-          title="Book flight"
-          icon="baggage"
-          onPress={() => {}}
-        />
-        <BpkButton
-          type="primary"
+          type={BUTTON_TYPES.featured}
           title="Book flight"
           icon="baggage"
-          iconAlignment="leading"
           onPress={() => {}}
         />
         <BpkButton
-          type="featured"
+          type={BUTTON_TYPES.primary}
+          title="Book flight"
+          icon="baggage"
+          iconAlignment={ICON_ALIGNMENTS.leading}
+          onPress={() => {}}
+        />
+        <BpkButton
+          type={BUTTON_TYPES.featured}
           title="Book flight"
           icon="baggage"
           iconOnly
@@ -97,7 +97,7 @@ export default class App extends Component {
 | accessibilityLabel    | string                                                                    | false    | props.title   |
 | disabled              | bool                                                                      | false    | false         |
 | icon                  | oneOf(string, element) Strings must be a [BpkIcon](/components/web/icons) | false    | null          |
-| iconAlignment         | oneOf('leading', 'trailing')                                              | false    | trailing      |
+| iconAlignment         | oneOf('leading', 'trailing', 'centerLeading', 'centerTrailing')           | false    | trailing      |
 | iconOnly (iOS only)   | bool                                                                      | false    | false         |
 | large (iOS only)      | bool                                                                      | false    | false         |
 | theme                 | See [Theme Props](#theme-props) below                                     | false    | null          |

--- a/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
@@ -22,8 +22,7 @@ import BpkThemeProvider from 'react-native-bpk-theming';
 import { spacingSm } from 'bpk-tokens/tokens/base.react.native';
 import BpkText from 'react-native-bpk-component-text';
 
-import BpkButton from './BpkButton';
-import { BUTTON_TYPES, ICON_ALIGNMENTS } from './common-types';
+import BpkButton, { BUTTON_TYPES, ICON_ALIGNMENTS } from './BpkButton';
 
 const onPressFn = jest.fn();
 

--- a/native/packages/react-native-bpk-component-button/src/BpkButton.android.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton.android.js
@@ -39,6 +39,7 @@ import {
   commonPropTypes,
   commonDefaultProps,
   BUTTON_TYPES,
+  ICON_ALIGNMENTS,
 } from './common-types';
 
 export type Props = {
@@ -124,3 +125,4 @@ BpkButton.defaultProps = {
 };
 
 export default withTheme(BpkButton);
+export { BUTTON_TYPES, ICON_ALIGNMENTS };

--- a/native/packages/react-native-bpk-component-button/src/BpkButton.ios.js
+++ b/native/packages/react-native-bpk-component-button/src/BpkButton.ios.js
@@ -41,6 +41,7 @@ import {
   commonPropTypes,
   commonDefaultProps,
   BUTTON_TYPES,
+  ICON_ALIGNMENTS,
 } from './common-types';
 
 export type Props = {
@@ -133,3 +134,4 @@ BpkButton.defaultProps = {
 };
 
 export default withTheme(BpkButton);
+export { BUTTON_TYPES, ICON_ALIGNMENTS };

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
@@ -285,6 +285,279 @@ exports[`Android BpkButton should render correctly 1`] = `
 </View>
 `;
 
+exports[`Android BpkButton should render correctly with iconAlignment="centerLeading" 1`] = `
+<View
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 40,
+          "height": 36,
+        },
+        undefined,
+      ],
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeBackgroundAndroid={
+      Object {
+        "attribute": "selectableItemBackgroundBorderless",
+        "type": "ThemeAttrAndroid",
+      }
+    }
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 36,
+            "paddingHorizontal": 12,
+            "paddingVertical": 8,
+          },
+          undefined,
+        ],
+        Object {
+          "backgroundColor": "rgb(0, 215, 117)",
+        },
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "flexDirection": "row-reverse",
+          },
+        ],
+      ]
+    }
+    testID={undefined}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "sans-serif",
+            "fontSize": 14,
+            "fontWeight": "400",
+          },
+          Object {
+            "fontFamily": "sans-serif-medium",
+          },
+          Array [
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+              undefined,
+            ],
+            Object {},
+          ],
+        ]
+      }
+    >
+      LOREM IPSUM
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+              undefined,
+            ],
+            Object {},
+            Array [
+              Object {
+                "marginLeft": 4,
+              },
+              Object {
+                "marginLeft": 0,
+                "marginRight": 4,
+              },
+            ],
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`Android BpkButton should render correctly with iconAlignment="centerTrailing" 1`] = `
+<View
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 40,
+          "height": 36,
+        },
+      ],
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeBackgroundAndroid={
+      Object {
+        "attribute": "selectableItemBackgroundBorderless",
+        "type": "ThemeAttrAndroid",
+      }
+    }
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 36,
+            "paddingHorizontal": 12,
+            "paddingVertical": 8,
+          },
+        ],
+        Object {
+          "backgroundColor": "rgb(0, 215, 117)",
+        },
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+        ],
+      ]
+    }
+    testID={undefined}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "sans-serif",
+            "fontSize": 14,
+            "fontWeight": "400",
+          },
+          Object {
+            "fontFamily": "sans-serif-medium",
+          },
+          Array [
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+            ],
+            Object {},
+          ],
+        ]
+      }
+    >
+      LOREM IPSUM
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+            ],
+            Object {},
+            Array [
+              Object {
+                "marginLeft": 4,
+              },
+            ],
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`Android BpkButton should render correctly with iconAlignment="leading" 1`] = `
 <View
   style={
@@ -416,10 +689,10 @@ exports[`Android BpkButton should render correctly with iconAlignment="leading" 
             ],
             Object {},
             Array [
-              null,
               Object {
                 "marginLeft": 4,
               },
+              undefined,
               Object {
                 "marginLeft": 0,
                 "marginRight": 4,
@@ -559,10 +832,10 @@ exports[`Android BpkButton should render correctly with iconAlignment="trailing"
             ],
             Object {},
             Array [
-              null,
               Object {
                 "marginLeft": 4,
               },
+              undefined,
             ],
           ],
         ]
@@ -1650,10 +1923,10 @@ exports[`Android BpkButton should support having an icon as well as a title 1`] 
             ],
             Object {},
             Array [
-              null,
               Object {
                 "marginLeft": 4,
               },
+              undefined,
             ],
           ],
         ]
@@ -1995,10 +2268,10 @@ exports[`Android BpkButton should support the "icon" property 1`] = `
             ],
             Object {},
             Array [
-              null,
               Object {
                 "marginLeft": 4,
               },
+              undefined,
             ],
           ],
         ]
@@ -2106,8 +2379,13 @@ exports[`Android BpkButton should support the "iconOnly" property 1`] = `
             ],
             Object {},
             Array [
-              null,
-              undefined,
+              Object {
+                "marginLeft": 4,
+              },
+              Object {
+                "marginLeft": 0,
+                "marginRight": 0,
+              },
             ],
           ],
         ]

--- a/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -114,6 +114,313 @@ exports[`iOS BpkButton should render correctly 1`] = `
 </View>
 `;
 
+exports[`iOS BpkButton should render correctly with iconAlignment="centerLeading" 1`] = `
+<View
+  colors={
+    Array [
+      "rgb(0, 215, 117)",
+      "rgb(0, 189, 104)",
+    ]
+  }
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 40,
+          "height": 32,
+        },
+        undefined,
+      ],
+      Object {},
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hitSlop={undefined}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+            "paddingHorizontal": 12,
+            "paddingVertical": 8,
+          },
+          undefined,
+        ],
+        Object {},
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "flexDirection": "row-reverse",
+          },
+        ],
+      ]
+    }
+    testID={undefined}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 13,
+            "fontWeight": "400",
+          },
+          Object {
+            "fontWeight": "600",
+          },
+          Array [
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+              undefined,
+            ],
+            Object {},
+          ],
+        ]
+      }
+    >
+      Lorem ipsum
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+              undefined,
+            ],
+            Object {},
+            Array [
+              Object {
+                "marginLeft": 4,
+              },
+              Object {
+                "marginLeft": 0,
+                "marginRight": 4,
+              },
+            ],
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(37, 32, 51)",
+            "bottom": 0,
+            "flex": 1,
+            "left": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          Object {
+            "borderRadius": 40,
+          },
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`iOS BpkButton should render correctly with iconAlignment="centerTrailing" 1`] = `
+<View
+  colors={
+    Array [
+      "rgb(0, 215, 117)",
+      "rgb(0, 189, 104)",
+    ]
+  }
+  style={
+    Array [
+      Array [
+        Object {
+          "borderRadius": 40,
+          "height": 32,
+        },
+      ],
+      Object {},
+      null,
+    ]
+  }
+>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel="Lorem ipsum"
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hitSlop={undefined}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Array [
+          Object {
+            "borderRadius": 40,
+            "height": 32,
+            "paddingHorizontal": 12,
+            "paddingVertical": 8,
+          },
+        ],
+        Object {},
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+        ],
+      ]
+    }
+    testID={undefined}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "System",
+            "fontSize": 13,
+            "fontWeight": "400",
+          },
+          Object {
+            "fontWeight": "600",
+          },
+          Array [
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+            ],
+            Object {},
+          ],
+        ]
+      }
+    >
+      Lorem ipsum
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgb(255, 255, 255)",
+              },
+            ],
+            Object {},
+            Array [
+              Object {
+                "marginLeft": 4,
+              },
+            ],
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(37, 32, 51)",
+            "bottom": 0,
+            "flex": 1,
+            "left": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          Object {
+            "borderRadius": 40,
+          },
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
 exports[`iOS BpkButton should render correctly with iconAlignment="leading" 1`] = `
 <View
   colors={
@@ -243,10 +550,10 @@ exports[`iOS BpkButton should render correctly with iconAlignment="leading" 1`] 
             ],
             Object {},
             Array [
-              null,
               Object {
                 "marginLeft": 4,
               },
+              undefined,
               Object {
                 "marginLeft": 0,
                 "marginRight": 4,
@@ -403,10 +710,10 @@ exports[`iOS BpkButton should render correctly with iconAlignment="trailing" 1`]
             ],
             Object {},
             Array [
-              null,
               Object {
                 "marginLeft": 4,
               },
+              undefined,
             ],
           ],
         ]
@@ -1664,10 +1971,10 @@ exports[`iOS BpkButton should support having an icon as well as a title 1`] = `
             ],
             Object {},
             Array [
-              null,
               Object {
                 "marginLeft": 4,
               },
+              undefined,
             ],
           ],
         ]
@@ -2060,10 +2367,10 @@ exports[`iOS BpkButton should support the "icon" property 1`] = `
             ],
             Object {},
             Array [
-              null,
               Object {
                 "marginLeft": 4,
               },
+              undefined,
             ],
           ],
         ]
@@ -2188,8 +2495,13 @@ exports[`iOS BpkButton should support the "iconOnly" property 1`] = `
             ],
             Object {},
             Array [
-              null,
-              undefined,
+              Object {
+                "marginLeft": 4,
+              },
+              Object {
+                "marginLeft": 0,
+                "marginRight": 0,
+              },
             ],
           ],
         ]
@@ -2590,11 +2902,11 @@ exports[`iOS should support the "icon" and "large" property 1`] = `
             ],
             Object {},
             Array [
-              null,
-              undefined,
               Object {
                 "marginLeft": 4,
               },
+              undefined,
+              undefined,
             ],
           ],
         ]
@@ -2725,9 +3037,14 @@ exports[`iOS should support the "iconOnly" and "large" property 1`] = `
             ],
             Object {},
             Array [
-              null,
+              Object {
+                "marginLeft": 4,
+              },
               undefined,
-              undefined,
+              Object {
+                "marginLeft": 0,
+                "marginRight": 0,
+              },
             ],
           ],
         ]

--- a/native/packages/react-native-bpk-component-button/src/common-types.js
+++ b/native/packages/react-native-bpk-component-button/src/common-types.js
@@ -18,7 +18,7 @@
 
 /* @flow */
 
-import { ViewPropTypes } from 'react-native';
+import { ViewPropTypes, type StyleObj } from 'react-native';
 import { type Node } from 'react';
 import PropTypes from 'prop-types';
 import { type Theme } from 'react-native-bpk-theming';
@@ -35,6 +35,8 @@ export const BUTTON_TYPES = {
 export const ICON_ALIGNMENTS = {
   leading: 'leading',
   trailing: 'trailing',
+  centerLeading: 'centerLeading',
+  centerTrailing: 'centerTrailing',
 };
 
 export type CommonProps = {
@@ -43,7 +45,7 @@ export type CommonProps = {
   accessibilityLabel: ?string,
   disabled: boolean,
   icon: ?Node,
-  style: ?(Object | Array<Object>),
+  style: ?StyleObj,
   type: $Keys<typeof BUTTON_TYPES>,
   theme: ?Theme,
   iconAlignment: $Keys<typeof ICON_ALIGNMENTS>,

--- a/native/packages/react-native-bpk-component-button/src/styles.js
+++ b/native/packages/react-native-bpk-component-button/src/styles.js
@@ -68,12 +68,15 @@ const base = StyleSheet.create({
       lineHeight: lineHeightXs,
     }),
   })(),
-  icon: Platform.select({
-    ios: () => null,
-    android: () => ({
-      lineHeight: spacingBase,
-    }),
-  })(),
+  icon: {
+    marginLeft: spacingSm,
+    ...Platform.select({
+      ios: () => null,
+      android: () => ({
+        lineHeight: spacingBase,
+      }),
+    })(),
+  },
 });
 
 const outlineButtonStyle = {
@@ -139,6 +142,10 @@ const modifiers = {
     button: {
       paddingHorizontal: 0,
     },
+    icon: {
+      marginLeft: 0,
+      marginRight: 0,
+    },
   }),
   iconOnlyLarge: StyleSheet.create({
     container: {
@@ -147,21 +154,19 @@ const modifiers = {
     button: {
       paddingHorizontal: 0,
     },
+    icon: {
+      marginLeft: 0,
+      marginRight: 0,
+    },
   }),
   textAndIcon: StyleSheet.create({
     view: {
       justifyContent: 'space-between',
     },
-    icon: {
-      marginLeft: spacingSm,
-    },
   }),
   textAndIconLarge: StyleSheet.create({
     view: {
       justifyContent: 'space-between',
-    },
-    icon: {
-      marginLeft: spacingSm,
     },
   }),
   iconLeading: StyleSheet.create({

--- a/native/packages/react-native-bpk-component-button/src/utils.js
+++ b/native/packages/react-native-bpk-component-button/src/utils.js
@@ -72,13 +72,15 @@ export const getStyleForElement = (
         : styles.modifiers.iconOnly[elementType],
     );
   } else if (title && icon) {
-    styleForElement.push(
-      styles.modifiers[isLarge ? 'textAndIconLarge' : 'textAndIcon'][
-        elementType
-      ],
-    );
+    if (iconAlignment === 'leading' || iconAlignment === 'trailing') {
+      styleForElement.push(
+        styles.modifiers[isLarge ? 'textAndIconLarge' : 'textAndIcon'][
+          elementType
+        ],
+      );
+    }
 
-    if (iconAlignment === 'leading') {
+    if (iconAlignment === 'leading' || iconAlignment === 'centerLeading') {
       styleForElement.push(styles.modifiers.iconLeading[elementType]);
     }
   }

--- a/native/packages/react-native-bpk-component-button/stories.js
+++ b/native/packages/react-native-bpk-component-button/stories.js
@@ -27,8 +27,7 @@ import { icons } from 'react-native-bpk-component-icon';
 import { spacingMd } from 'bpk-tokens/tokens/base.react.native';
 import BpkText from 'react-native-bpk-component-text';
 
-import BpkButton from './index';
-import { BUTTON_TYPES } from './src/common-types';
+import BpkButton, { BUTTON_TYPES, ICON_ALIGNMENTS } from './index';
 import themeAttributes from '../../storybook/themeAttributes';
 import { StoryHeading, StorySubheading } from '../../storybook/TextStyles';
 import CenterDecorator from '../../storybook/CenterDecorator';
@@ -42,6 +41,9 @@ const styles = StyleSheet.create({
   buttonStyles: {
     marginBottom: spacingMd,
     marginRight: spacingMd,
+  },
+  bottomMargin: {
+    marginBottom: spacingMd,
   },
 });
 
@@ -159,9 +161,9 @@ const allThemedButtons = (
   <BpkThemeProvider theme={themeAttributes}>
     <View>
       <StoryHeading>Primary</StoryHeading>
-      {generateButtonStoryForType('primary')}
+      {generateButtonStoryForType(BUTTON_TYPES.primary)}
       <StoryHeading>Secondary</StoryHeading>
-      {generateButtonStoryForType('secondary')}
+      {generateButtonStoryForType(BUTTON_TYPES.secondary)}
     </View>
   </BpkThemeProvider>
 );
@@ -181,6 +183,21 @@ storiesOf('react-native-bpk-component-button', module)
     <View>{generateButtonStoryForType('featured')}</View>
   ))
   .add('docs:withTheme', () => allThemedButtons)
+  .add('Icon alignments', () => (
+    <View>
+      {Object.keys(ICON_ALIGNMENTS).map(iconAlignment => (
+        <BpkButton
+          key={iconAlignment}
+          iconAlignment={iconAlignment}
+          title={iconAlignment}
+          icon="star"
+          type={BUTTON_TYPES.primary}
+          onPress={action(`${iconAlignment} button pressed.`)}
+          style={styles.bottomMargin}
+        />
+      ))}
+    </View>
+  ))
   .add('All Button Types', () => (
     <ScrollView>
       <StoryHeading>All Types</StoryHeading>

--- a/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
+++ b/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
@@ -123,8 +123,12 @@ exports[`Android BpkNudger should disable theming if the required attribute is o
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -269,8 +273,12 @@ exports[`Android BpkNudger should disable theming if the required attribute is o
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -406,8 +414,12 @@ exports[`Android BpkNudger should render correctly 1`] = `
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -552,8 +564,12 @@ exports[`Android BpkNudger should render correctly 1`] = `
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -699,9 +715,13 @@ exports[`Android BpkNudger should render correctly when value is a not an intege
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
                 undefined,
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -846,8 +866,12 @@ exports[`Android BpkNudger should render correctly when value is a not an intege
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -983,8 +1007,12 @@ exports[`Android BpkNudger should render correctly when value is greater than ma
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1139,9 +1167,13 @@ exports[`Android BpkNudger should render correctly when value is greater than ma
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
                 undefined,
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1287,9 +1319,13 @@ exports[`Android BpkNudger should render correctly when value is less than min 1
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
                 undefined,
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1434,8 +1470,12 @@ exports[`Android BpkNudger should render correctly when value is less than min 1
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1573,8 +1613,12 @@ exports[`Android BpkNudger should support theming 1`] = `
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1721,8 +1765,12 @@ exports[`Android BpkNudger should support theming 1`] = `
               Array [
                 Object {
                   "lineHeight": 16,
+                  "marginLeft": 4,
                 },
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]

--- a/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
+++ b/native/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
@@ -131,8 +131,13 @@ exports[`iOS BpkNudger should disable theming if the required attribute is omitt
               ],
               Object {},
               Array [
-                null,
-                undefined,
+                Object {
+                  "marginLeft": 4,
+                },
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -304,8 +309,13 @@ exports[`iOS BpkNudger should disable theming if the required attribute is omitt
               ],
               Object {},
               Array [
-                null,
-                undefined,
+                Object {
+                  "marginLeft": 4,
+                },
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -468,8 +478,13 @@ exports[`iOS BpkNudger should render correctly 1`] = `
               ],
               Object {},
               Array [
-                null,
-                undefined,
+                Object {
+                  "marginLeft": 4,
+                },
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -641,8 +656,13 @@ exports[`iOS BpkNudger should render correctly 1`] = `
               ],
               Object {},
               Array [
-                null,
-                undefined,
+                Object {
+                  "marginLeft": 4,
+                },
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -815,9 +835,14 @@ exports[`iOS BpkNudger should render correctly when value is a not an integer 1`
               ],
               Object {},
               Array [
-                null,
+                Object {
+                  "marginLeft": 4,
+                },
                 undefined,
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -989,8 +1014,13 @@ exports[`iOS BpkNudger should render correctly when value is a not an integer 1`
               ],
               Object {},
               Array [
-                null,
-                undefined,
+                Object {
+                  "marginLeft": 4,
+                },
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1153,8 +1183,13 @@ exports[`iOS BpkNudger should render correctly when value is greater than max 1`
               ],
               Object {},
               Array [
-                null,
-                undefined,
+                Object {
+                  "marginLeft": 4,
+                },
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1336,9 +1371,14 @@ exports[`iOS BpkNudger should render correctly when value is greater than max 1`
               ],
               Object {},
               Array [
-                null,
+                Object {
+                  "marginLeft": 4,
+                },
                 undefined,
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1511,9 +1551,14 @@ exports[`iOS BpkNudger should render correctly when value is less than min 1`] =
               ],
               Object {},
               Array [
-                null,
+                Object {
+                  "marginLeft": 4,
+                },
                 undefined,
-                undefined,
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1685,8 +1730,13 @@ exports[`iOS BpkNudger should render correctly when value is less than min 1`] =
               ],
               Object {},
               Array [
-                null,
-                undefined,
+                Object {
+                  "marginLeft": 4,
+                },
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -1853,8 +1903,13 @@ exports[`iOS BpkNudger should support theming 1`] = `
                 "color": "red",
               },
               Array [
-                null,
-                undefined,
+                Object {
+                  "marginLeft": 4,
+                },
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]
@@ -2030,8 +2085,13 @@ exports[`iOS BpkNudger should support theming 1`] = `
                 "color": "red",
               },
               Array [
-                null,
-                undefined,
+                Object {
+                  "marginLeft": 4,
+                },
+                Object {
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                },
               ],
             ],
           ]

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,3 +1,6 @@
 # Unreleased
 
-__Nothing yet...__
+**Added:**
+- react-native-bpk-component-button:
+  - Added `BUTTON_TYPES` and `ICON_ALIGNMENTS` exports.
+  - Added `centerLeading` and `centerTrailing` to the possible values of `iconAlignment`.


### PR DESCRIPTION
* Added `centerLeading` and `centerTrailing` values to the `iconAlignment` prop.
* Added story to show all the icon alignments (screenshot of it is below).
* Added `BUTTON_TYPES` and `ICON_ALIGNMENTS` exports so consumers can make use of them instead of using raw strings (updated readme, tests and stories to reflect this).

Don't look too closely at the code because it's the worst. I'm going to refactor this **soon**. Promise.


![simulator screen shot - iphone 8 - 2018-07-18 at 08 30 48](https://user-images.githubusercontent.com/73652/42866846-ae48cb04-8a65-11e8-8534-01bee2929bbb.png)
![screenshot_1531899049](https://user-images.githubusercontent.com/73652/42866848-ae6dccec-8a65-11e8-89ae-cc13103c8e04.png)
