### PR TITLE
Fixed dependencies and changed name for Scrollable Calendar

### DIFF
--- a/packages/bpk-component-scrollable-calendar/index.js
+++ b/packages/bpk-component-scrollable-calendar/index.js
@@ -1,0 +1,25 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import BpkScrollableCalendar, {
+  type Props as BpkScrollableCalendarProps,
+} from './src/BpkScrollableCalendar';
+
+export type { BpkScrollableCalendarProps };
+export default BpkScrollableCalendar;

--- a/packages/bpk-component-scrollable-calendar/package-lock.json
+++ b/packages/bpk-component-scrollable-calendar/package-lock.json
@@ -1,0 +1,33 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"requires": {
+				"js-tokens": "4.0.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"prop-types": {
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+			"requires": {
+				"loose-envify": "1.4.0",
+				"object-assign": "4.1.1"
+			}
+		}
+	}
+}

--- a/packages/bpk-component-scrollable-calendar/package.json
+++ b/packages/bpk-component-scrollable-calendar/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bpk-component-scrollable-calendar",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Backpack scrollable calendar component.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0"
+  },
+  "dependencies": {
+    "bpk-component-calendar": "^4.2.40",
+    "bpk-mixins": "^17.11.2",
+    "bpk-react-utils": "^2.6.3",
+    "prop-types": "^15.5.8"
+  }
+}

--- a/packages/bpk-component-scrollable-calendar/readme.md
+++ b/packages/bpk-component-scrollable-calendar/readme.md
@@ -1,0 +1,24 @@
+# bpk-component-scrollable-calendar
+
+> Backpack scrollable calendar component.
+
+## Installation
+
+```sh
+npm install bpk-component-scrollable-calendar --save-dev
+```
+
+## Usage
+
+```js
+import React from 'react';
+import BpkScrollableCalendar from 'bpk-component-code';
+
+export default () => <BpkScrollableCalendar />;
+```
+
+## Props
+
+| Property  | PropType | Required | Default Value |
+| --------- | -------- | -------- | ------------- |
+| className | string   | false    | null          |

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar-test.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar-test.js
@@ -1,0 +1,43 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BpkScrollableCalendar from './BpkScrollableCalendar';
+
+describe('BpkScrollableCalendar', () => {
+  it('should render correctly', () => {
+    const tree = renderer.create(<BpkScrollableCalendar />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should support custom class names', () => {
+    const tree = renderer
+      .create(<BpkScrollableCalendar className="custom-classname" />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should support arbitrary props', () => {
+    const tree = renderer
+      .create(<BpkScrollableCalendar testID="123" />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.js
@@ -1,0 +1,50 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { cssModules } from '../../bpk-react-utils';
+
+import STYLES from './BpkScrollableCalendar.scss';
+
+const getClassName = cssModules(STYLES);
+
+export type Props = {
+  className: ?string,
+};
+const BpkScrollableCalendar = (props: Props) => {
+  const { className, ...rest } = props;
+  const classNames = getClassName('bpk-scrollable-calendar', className);
+
+  return (
+    <div className={classNames} {...rest}>
+      I am an example component.
+    </div>
+  );
+};
+
+BpkScrollableCalendar.propTypes = {
+  className: PropTypes.string,
+};
+
+BpkScrollableCalendar.defaultProps = {
+  className: null,
+};
+
+export default BpkScrollableCalendar;

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.scss
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.scss
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins/index';
+
+.bpk-scrollable-calendar {
+  display: flex;
+}

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkScrollableCalendar should render correctly 1`] = `
+<div
+  className="bpk-scrollable-calendar"
+>
+  I am an example component.
+</div>
+`;
+
+exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
+<div
+  className="bpk-scrollable-calendar"
+  testID="123"
+>
+  I am an example component.
+</div>
+`;
+
+exports[`BpkScrollableCalendar should support custom class names 1`] = `
+<div
+  className="bpk-scrollable-calendar custom-classname"
+>
+  I am an example component.
+</div>
+`;

--- a/packages/bpk-component-scrollable-calendar/stories.js
+++ b/packages/bpk-component-scrollable-calendar/stories.js
@@ -1,0 +1,27 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import BpkScrollableCalendar from '.';
+
+storiesOf('bpk-component-scrollable-calendar', module).add('Default', () => (
+  <BpkScrollableCalendar />
+));


### PR DESCRIPTION
- made the component private,

- removed dependencies on bpk components from package-lock

- renamed comoponent to bpk-scrollable-calendar

- added "private": true to package.json