### PR TITLE
Revert "[BPK-1733] Ticket images"

### DIFF
--- a/packages/bpk-component-ticket/src/bpk-ticket.scss
+++ b/packages/bpk-component-ticket/src/bpk-ticket.scss
@@ -83,7 +83,6 @@
 
   &__main {
     flex: 2 1 auto;
-    overflow: hidden;
 
     &--horizontal {
       border-radius: $bpk-border-radius-sm 0 0 $bpk-border-radius-sm;

--- a/unreleased.md
+++ b/unreleased.md
@@ -26,4 +26,3 @@
 
 - bpk-component-ticket:
   - Fixed an issue where the hover state would sometimes not apply.
-  - Added `overflow: hidden` to `BpkTicket` to prevent clipped images.


### PR DESCRIPTION
Reverts Skyscanner/backpack#941

This is breaking the hover shadow.