### PR TITLE
[BPK-1724] Fix image loading behaviour in mobile safari

### DIFF
--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -145,6 +145,23 @@ class BpkImage extends Component<BpkImageProps> {
           style={{ height: 0, paddingBottom: aspectRatioPc }}
           className={classNames.join(' ')}
         >
+          {/* 
+            Image needs to come before the spinner to avoid a problem where
+            some images would not fully render in mobile Safari when running
+            on a slow network. 
+            
+            The closest to an explanation that I can come up is that putting 
+            the image first means it is rendered first so it has priority, 
+            which seems to be enough to fix it.
+          */}
+          {inView && (
+            <Image // eslint-disable-line backpack/use-components
+              hidden={loading}
+              altText={altText}
+              onImageLoad={this.onImageLoad}
+              {...rest}
+            />
+          )}
           {loading && (
             <CSSTransition
               classNames={{
@@ -157,14 +174,6 @@ class BpkImage extends Component<BpkImageProps> {
                 <BpkSpinner />
               </div>
             </CSSTransition>
-          )}
-          {inView && (
-            <Image // eslint-disable-line backpack/use-components
-              hidden={loading}
-              altText={altText}
-              onImageLoad={this.onImageLoad}
-              {...rest}
-            />
           )}
           {typeof window === 'undefined' &&
             (!inView || loading) && (

--- a/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
+++ b/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
@@ -96,6 +96,12 @@ exports[`BpkImage should have loading behavior 1`] = `
       }
     }
   >
+    <img
+      alt="image description"
+      className="bpk-image__img bpk-image__img--hidden"
+      onLoad={[Function]}
+      src="./path/to/image.jpg"
+    />
     <div
       className="bpk-image__spinner"
     >
@@ -183,12 +189,6 @@ exports[`BpkImage should have loading behavior 1`] = `
         />
       </svg>
     </div>
-    <img
-      alt="image description"
-      className="bpk-image__img bpk-image__img--hidden"
-      onLoad={[Function]}
-      src="./path/to/image.jpg"
-    />
   </div>
 </div>
 `;

--- a/packages/bpk-component-image/src/withLazyLoading.js
+++ b/packages/bpk-component-image/src/withLazyLoading.js
@@ -20,6 +20,7 @@
 import React, { type Node, type ComponentType } from 'react';
 import PropTypes from 'prop-types';
 import { wrapDisplayName } from 'bpk-react-utils';
+import throttle from 'lodash/throttle';
 
 type WithLazyLoadingProps = {
   className: ?string,
@@ -82,11 +83,9 @@ export default function withLazyLoading(
     }
 
     setInView = (): void => {
-      this.setState(
-        (): {} => ({
-          inView: true,
-        }),
-      );
+      this.setState(() => ({
+        inView: true,
+      }));
       this.removeEventListeners();
     };
 
@@ -104,11 +103,11 @@ export default function withLazyLoading(
       documentRef.removeEventListener('fullscreenchange', this.checkInView);
     };
 
-    checkInView = (): void => {
+    checkInView = throttle(() => {
       if (this.isInViewPort()) {
         this.setInView();
       }
-    };
+    }, 250);
 
     // This function is taken from modernizr
     // See https://github.com/modernizr/modernizr

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,11 +1,10 @@
 # Unreleased
 
-+**Added:**
+**Added:**
 - react-native-bpk-component-text-input:
   - Added `tinymask` support via mask property
 
 **Fixed:**
-
 - bpk-component-barchart:
   - Upgraded `d3-scale` from `^1.0.5` -> `^2.1.0`.
 
@@ -31,3 +30,6 @@
 - bpk-component-ticket:
   - Fixed an issue where the hover state would sometimes not apply.
   - When tickets have `padded={false}`, content overflowing the ticket borders will be hidden.
+
+- bpk-component-image:
+  - Fixed loading behaviour in mobile Safari on slow networks.


### PR DESCRIPTION
I have a video comparing before and after if you want check the difference 🙂 