### PR TITLE
[No JIRA] Add inner wrapper to tickets when not padded

### DIFF
--- a/packages/bpk-component-ticket/src/BpkTicket-test.js
+++ b/packages/bpk-component-ticket/src/BpkTicket-test.js
@@ -60,6 +60,19 @@ describe('BpkTicket', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should render correctly with "padded" attribute equal to "false" and a "vertical" attribute', () => {
+    const tree = renderer
+      .create(
+        <BpkTicket stub="Ticket stub" vertical padded={false}>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
+          commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus
+          et magnis dis parturient montes, nascetur ridiculus mus.
+        </BpkTicket>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should render correctly with a "vertical" attribute', () => {
     const tree = renderer
       .create(

--- a/packages/bpk-component-ticket/src/BpkTicket.js
+++ b/packages/bpk-component-ticket/src/BpkTicket.js
@@ -41,13 +41,16 @@ const BpkTicket = props => {
     stubProps,
     ...rest
   } = props;
+
   const classNames = [getClassName('bpk-ticket')];
   const mainClassNames = ['bpk-ticket__paper', 'bpk-ticket__main'].map(
     getClassName,
   );
+  const mainInnerClassNames = [getClassName('bpk-ticket__main-inner')];
   const stubClassNames = ['bpk-ticket__paper', 'bpk-ticket__stub'].map(
     getClassName,
   );
+  const stubInnerClassNames = [getClassName('bpk-ticket__stub-inner')];
   const punchlineClassNames = [getClassName('bpk-ticket__punchline')];
   const startNotchClassNames = [getClassName('bpk-ticket__notch')];
   const endNotchClassNames = [getClassName('bpk-ticket__notch')];
@@ -66,13 +69,21 @@ const BpkTicket = props => {
   if (vertical) {
     classNames.push(getClassName('bpk-ticket--vertical'));
     mainClassNames.push(getClassName('bpk-ticket__main--vertical'));
+    mainInnerClassNames.push(getClassName('bpk-ticket__main-inner--vertical'));
     stubClassNames.push(getClassName('bpk-ticket__stub--vertical'));
+    stubInnerClassNames.push(getClassName('bpk-ticket__stub-inner--vertical'));
     punchlineClassNames.push(getClassName('bpk-ticket__punchline--horizontal'));
     startNotchClassNames.push(getClassName('bpk-ticket__notch--left'));
     endNotchClassNames.push(getClassName('bpk-ticket__notch--right'));
   } else {
     mainClassNames.push(getClassName('bpk-ticket__main--horizontal'));
+    mainInnerClassNames.push(
+      getClassName('bpk-ticket__main-inner--horizontal'),
+    );
     stubClassNames.push(getClassName('bpk-ticket__stub--horizontal'));
+    stubInnerClassNames.push(
+      getClassName('bpk-ticket__stub-inner--horizontal'),
+    );
 
     if (!fallback) {
       punchlineClassNames.push(getClassName('bpk-ticket__punchline--vertical'));
@@ -91,9 +102,21 @@ const BpkTicket = props => {
 
   const classNameFinal = classNames.join(' ');
 
+  const mainContent = padded ? (
+    children
+  ) : (
+    <div className={mainInnerClassNames.join(' ')}>{children}</div>
+  );
+
+  const stubContent = padded ? (
+    stub
+  ) : (
+    <div className={stubInnerClassNames.join(' ')}>{stub}</div>
+  );
+
   const contents = [
     <div key="main" className={mainClassNames.join(' ')}>
-      {children}
+      {mainContent}
     </div>,
     <div
       key="punchline"
@@ -105,7 +128,7 @@ const BpkTicket = props => {
       <div className={endNotchClassNames.join(' ')} />
     </div>,
     <div key="stub" className={stubClassNames.join(' ')} {...stubProps}>
-      {stub}
+      {stubContent}
     </div>,
   ];
 

--- a/packages/bpk-component-ticket/src/__snapshots__/BpkTicket-test.js.snap
+++ b/packages/bpk-component-ticket/src/__snapshots__/BpkTicket-test.js.snap
@@ -38,7 +38,11 @@ exports[`BpkTicket should render correctly with "padded" attribute equal to "fal
   <div
     className="bpk-ticket__paper bpk-ticket__main bpk-ticket__main--horizontal"
   >
-    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    <div
+      className="bpk-ticket__main-inner bpk-ticket__main-inner--horizontal"
+    >
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </div>
   </div>
   <div
     aria-hidden="true"
@@ -55,7 +59,49 @@ exports[`BpkTicket should render correctly with "padded" attribute equal to "fal
   <div
     className="bpk-ticket__paper bpk-ticket__stub bpk-ticket__stub--horizontal"
   >
-    Ticket stub
+    <div
+      className="bpk-ticket__stub-inner bpk-ticket__stub-inner--horizontal"
+    >
+      Ticket stub
+    </div>
+  </div>
+</div>
+`;
+
+exports[`BpkTicket should render correctly with "padded" attribute equal to "false" and a "vertical" attribute 1`] = `
+<div
+  className="bpk-ticket bpk-ticket--vertical"
+  role="button"
+>
+  <div
+    className="bpk-ticket__paper bpk-ticket__main bpk-ticket__main--vertical"
+  >
+    <div
+      className="bpk-ticket__main-inner bpk-ticket__main-inner--vertical"
+    >
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    className="bpk-ticket__punchline bpk-ticket__punchline--horizontal"
+    role="presentation"
+  >
+    <div
+      className="bpk-ticket__notch bpk-ticket__notch--left"
+    />
+    <div
+      className="bpk-ticket__notch bpk-ticket__notch--right"
+    />
+  </div>
+  <div
+    className="bpk-ticket__paper bpk-ticket__stub bpk-ticket__stub--vertical"
+  >
+    <div
+      className="bpk-ticket__stub-inner bpk-ticket__stub-inner--vertical"
+    >
+      Ticket stub
+    </div>
   </div>
 </div>
 `;

--- a/packages/bpk-component-ticket/src/bpk-ticket.scss
+++ b/packages/bpk-component-ticket/src/bpk-ticket.scss
@@ -81,9 +81,7 @@
     }
   }
 
-  &__main {
-    flex: 2 1 auto;
-
+  @mixin main-styles {
     &--horizontal {
       border-radius: $bpk-border-radius-sm 0 0 $bpk-border-radius-sm;
 
@@ -95,15 +93,25 @@
     &--vertical {
       border-radius: $bpk-border-radius-sm $bpk-border-radius-sm 0 0;
     }
+  }
+
+  &__main {
+    flex: 2 1 auto;
+
+    @include main-styles;
 
     &--padded {
       padding: $bpk-card-padding;
     }
   }
 
-  &__stub {
-    flex: 1 1 auto;
+  &__main-inner {
+    overflow: hidden;
 
+    @include main-styles;
+  }
+
+  @mixin stub-styles {
     &--horizontal {
       min-width: 30%;
       border-radius: 0 $bpk-border-radius-sm $bpk-border-radius-sm 0;
@@ -116,6 +124,12 @@
     &--vertical {
       border-radius: 0 0 $bpk-border-radius-sm $bpk-border-radius-sm;
     }
+  }
+
+  &__stub {
+    flex: 1 1 auto;
+
+    @include stub-styles;
 
     &--padded {
       padding: $bpk-card-padding;
@@ -124,6 +138,12 @@
     &--fallback {
       width: 32%;
     }
+  }
+
+  &__stub-inner {
+    overflow: hidden;
+
+    @include stub-styles;
   }
 
   &__punchline {

--- a/packages/bpk-component-ticket/stories.js
+++ b/packages/bpk-component-ticket/stories.js
@@ -117,6 +117,15 @@ storiesOf('bpk-component-ticket', module)
       nascetur ridiculus mus.
     </BpkTicket>
   ))
+  .add('Without padding and with an image ', () => (
+    <BpkTicket stub="Lorem ipsum dolor sit amet." padded={false}>
+      <img
+        src="https://images.unsplash.com/44/MIbCzcvxQdahamZSNQ26_12082014-IMG_3526.jpg?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=22b674fb2c751f77f7d80d22c77da67a&auto=format&fit=crop&w=1650&q=80"
+        alt="Thoughtful bear"
+        width={300}
+      />
+    </BpkTicket>
+  ))
   .add('With a "href" prop', () => (
     <BpkTicket stub="Lorem ipsum dolor sit amet." href="#">
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo

--- a/unreleased.md
+++ b/unreleased.md
@@ -26,3 +26,4 @@
 
 - bpk-component-ticket:
   - Fixed an issue where the hover state would sometimes not apply.
+  - When tickets have `padded={false}`, an inner wrapper is now applied to clip the content.


### PR DESCRIPTION
This is the second attempt at this PR: https://github.com/Skyscanner/backpack/pull/941

The first PR had an issue - adding `overflow: hidden` did clip the inner content like we wanted, but it also meant that the shadow no longer appeared on hover.

To fix this, I've added an inner div to wrap the content, which has `overflow: hidden` and matches the border radius. I've included a screenshot below (note how the shadow appears correctly now).

<img width="684" alt="screen shot 2018-07-20 at 09 09 35" src="https://user-images.githubusercontent.com/73652/42992018-43134b66-8bff-11e8-8da2-209295ba309f.png">

To minimise the surface area of this change, and only apply the extra `div` when it's needed, I've only applied the inner wrapper when `padded={false}`.

I've been trying to think of issues that adding the inner wrapper may bring. The only thing I can think of is that if consumers are targeting styles down in the tree, the structure will change and it'll break that. However as we don't support that use case we should be fine.


**PS:** I have a separate branch that I'm actively working on to clean up `BpkTicket.js` - adding Flow, using the new, nicer `getClassName` logic, removing IE9 fallbacks, so that'll come later.