### PR TITLE
[BPK-1692] Debugging

### DIFF
--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -41,12 +41,17 @@ class BpkDatepicker extends Component {
   }
 
   onOpen = () => {
-    this.setState({
-      isOpen: true,
-    });
+    setTimeout(() => {
+      console.log();
+      console.log('open');
+      this.setState({
+        isOpen: true,
+      });
+    }, 50);
   };
 
   onClose = () => {
+    console.log('close');
     this.setState({
       isOpen: false,
     });

--- a/packages/bpk-react-utils/src/Portal.js
+++ b/packages/bpk-react-utils/src/Portal.js
@@ -81,6 +81,7 @@ class Portal extends Component {
   }
 
   onDocumentMouseDown(event) {
+    console.log('portal mouse down');
     const clickEventProperties = this.getClickEventProperties(event);
     if (
       clickEventProperties.isNotLeftClick ||
@@ -91,10 +92,12 @@ class Portal extends Component {
       return;
     }
 
+    console.log('portal is starting a close');
     this.shouldClose = true;
   }
 
   onDocumentMouseUp(event) {
+    console.log('portal mouse up');
     const clickEventProperties = this.getClickEventProperties(event);
 
     if (
@@ -107,6 +110,7 @@ class Portal extends Component {
     }
 
     if (this.shouldClose) {
+      console.log('portal is finishing a close');
       this.props.onClose(event, { source: 'DOCUMENT_CLICK' });
     }
   }


### PR DESCRIPTION
The issue seems to be that, in Safari, the Portal element is handling the click events that have already happened after opening the Popover.

In other words the chronological order of events is:
 - mouseDown on date field
 - mouseUp on date filed -> results in Popover opening
 - portal is rendered, adding event listeners for mouse events
 - portal handles mouseDown and mouseUp events from above -> results in Popover closing 

There seem to be three sensible ways forward in fixing this:
1. Add a delay between the date field click and rendering the Calendar. This will prevent the Portal handing the same mouse/touch events
2. Add a delay between rendering a portal and adding the mouse/touch event listeners. Similar idea to (1), but hopefully solves the issue for other popup components too.
3. Decide that this doesn't happen that often, and that it only affects mobile safari, and therefore don't fix 