### PR TITLE
Added scrollable calendar date component

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -100,6 +100,7 @@ configure(() => {
   require('./../packages/bpk-component-radio/stories');
   require('./../packages/bpk-component-router-link/stories');
   require('./../packages/bpk-component-rtl-toggle/stories');
+  require('./../packages/bpk-component-scrollable-calendar/stories');
   require('./../packages/bpk-component-section-list/stories');
   require('./../packages/bpk-component-select/stories');
   require('./../packages/bpk-component-slider/stories');

--- a/packages/bpk-component-calendar/index.js
+++ b/packages/bpk-component-calendar/index.js
@@ -22,7 +22,9 @@ import BpkCalendarContainer, {
 import BpkCalendarGrid from './src/BpkCalendarGrid';
 import BpkCalendarGridHeader from './src/BpkCalendarGridHeader';
 import BpkCalendarNav from './src/BpkCalendarNav';
-import BpkCalendarDate from './src/BpkCalendarDate';
+import BpkCalendarDate, {
+  BpkCalendarDatePropTypes,
+} from './src/BpkCalendarDate';
 import composeCalendar from './src/composeCalendar';
 import CustomPropTypes from './src/custom-proptypes';
 import * as DateUtils from './src/date-utils';
@@ -40,4 +42,5 @@ export {
   composeCalendar,
   withCalendarState,
   themeAttributes,
+  BpkCalendarDatePropTypes,
 };

--- a/packages/bpk-component-calendar/index.js
+++ b/packages/bpk-component-calendar/index.js
@@ -23,7 +23,7 @@ import BpkCalendarGrid from './src/BpkCalendarGrid';
 import BpkCalendarGridHeader from './src/BpkCalendarGridHeader';
 import BpkCalendarNav from './src/BpkCalendarNav';
 import BpkCalendarDate, {
-  BpkCalendarDatePropTypes,
+  propTypes as BpkCalendarDatePropTypes,
 } from './src/BpkCalendarDate';
 import composeCalendar from './src/composeCalendar';
 import CustomPropTypes from './src/custom-proptypes';

--- a/packages/bpk-component-calendar/src/BpkCalendarDate.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate.js
@@ -139,7 +139,7 @@ class BpkCalendarDate extends PureComponent {
   }
 }
 
-BpkCalendarDate.propTypes = {
+export const BpkCalendarDatePropTypes = {
   // Required
   date: PropTypes.instanceOf(Date).isRequired,
   // Optional
@@ -155,7 +155,7 @@ BpkCalendarDate.propTypes = {
   preventKeyboardFocus: PropTypes.bool,
 };
 
-export const BpkCalendarDatePropTypes = BpkCalendarDate.propTypes;
+BpkCalendarDate.propTypes = BpkCalendarDatePropTypes;
 
 BpkCalendarDate.defaultProps = {
   isBlocked: false,

--- a/packages/bpk-component-calendar/src/BpkCalendarDate.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate.js
@@ -155,6 +155,8 @@ BpkCalendarDate.propTypes = {
   preventKeyboardFocus: PropTypes.bool,
 };
 
+export const BpkCalendarDatePropTypes = BpkCalendarDate.propTypes;
+
 BpkCalendarDate.defaultProps = {
   isBlocked: false,
   isFocused: false,

--- a/packages/bpk-component-calendar/src/BpkCalendarDate.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate.js
@@ -139,7 +139,7 @@ class BpkCalendarDate extends PureComponent {
   }
 }
 
-export const BpkCalendarDatePropTypes = {
+export const propTypes = {
   // Required
   date: PropTypes.instanceOf(Date).isRequired,
   // Optional
@@ -155,7 +155,7 @@ export const BpkCalendarDatePropTypes = {
   preventKeyboardFocus: PropTypes.bool,
 };
 
-BpkCalendarDate.propTypes = BpkCalendarDatePropTypes;
+BpkCalendarDate.propTypes = propTypes;
 
 BpkCalendarDate.defaultProps = {
   isBlocked: false,

--- a/packages/bpk-component-scrollable-calendar/index.js
+++ b/packages/bpk-component-scrollable-calendar/index.js
@@ -17,9 +17,9 @@
  */
 /* @flow */
 
-import BpkScrollableCalendar, {
-  type Props as BpkScrollableCalendarProps,
-} from './src/BpkScrollableCalendar';
+import BpkScrollableCalendar from './src/BpkScrollableCalendar';
+import BpkScrollableCalendarDate from './src/BpkScrollableCalendarDate';
 
-export type { BpkScrollableCalendarProps };
 export default BpkScrollableCalendar;
+
+export { BpkScrollableCalendarDate };

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarDate.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarDate.js
@@ -18,7 +18,10 @@
 
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { BpkCalendarDate, CustomPropTypes } from 'bpk-component-calendar';
+import {
+  BpkCalendarDate,
+  BpkCalendarDatePropTypes,
+} from 'bpk-component-calendar';
 
 class BpkScrollableCalendarDate extends PureComponent {
   render() {
@@ -30,30 +33,12 @@ class BpkScrollableCalendarDate extends PureComponent {
 }
 
 BpkScrollableCalendarDate.propTypes = {
-  // Required
-  date: PropTypes.instanceOf(Date).isRequired,
-  // Optional
-  isBlocked: PropTypes.bool,
-  isFocused: PropTypes.bool,
+  ...BpkCalendarDatePropTypes,
   isOutside: PropTypes.bool,
-  isSelected: PropTypes.bool,
-  isToday: PropTypes.bool,
-  modifiers: CustomPropTypes.DateModifiers,
-  onClick: PropTypes.func,
-  onDateKeyDown: PropTypes.func,
-  preventKeyboardFocus: PropTypes.bool,
 };
 
 BpkScrollableCalendarDate.defaultProps = {
-  isBlocked: false,
-  isFocused: false,
   isOutside: false,
-  isSelected: false,
-  isToday: false,
-  modifiers: {},
-  onClick: null,
-  onDateKeyDown: null,
-  preventKeyboardFocus: true,
 };
 
 export default BpkScrollableCalendarDate;

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarDate.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarDate.js
@@ -1,0 +1,59 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { BpkCalendarDate, CustomPropTypes } from 'bpk-component-calendar';
+
+class BpkScrollableCalendarDate extends PureComponent {
+  render() {
+    const { date, isOutside, ...rest } = this.props;
+
+    // Returning empty span when isOutside is true ensures only focused month displays in grid
+    return !isOutside ? <BpkCalendarDate date={date} {...rest} /> : <span />;
+  }
+}
+
+BpkScrollableCalendarDate.propTypes = {
+  // Required
+  date: PropTypes.instanceOf(Date).isRequired,
+  // Optional
+  isBlocked: PropTypes.bool,
+  isFocused: PropTypes.bool,
+  isOutside: PropTypes.bool,
+  isSelected: PropTypes.bool,
+  isToday: PropTypes.bool,
+  modifiers: CustomPropTypes.DateModifiers,
+  onClick: PropTypes.func,
+  onDateKeyDown: PropTypes.func,
+  preventKeyboardFocus: PropTypes.bool,
+};
+
+BpkScrollableCalendarDate.defaultProps = {
+  isBlocked: false,
+  isFocused: false,
+  isOutside: false,
+  isSelected: false,
+  isToday: false,
+  modifiers: {},
+  onClick: null,
+  onDateKeyDown: null,
+  preventKeyboardFocus: true,
+};
+
+export default BpkScrollableCalendarDate;

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarDate.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarDate.js
@@ -24,8 +24,8 @@ class BpkScrollableCalendarDate extends PureComponent {
   render() {
     const { date, isOutside, ...rest } = this.props;
 
-    // Returning empty span when isOutside is true ensures only focused month displays in grid
-    return !isOutside ? <BpkCalendarDate date={date} {...rest} /> : <span />;
+    // Returning null when isOutside is true ensures only focused month displays in grid
+    return !isOutside ? <BpkCalendarDate date={date} {...rest} /> : null;
   }
 }
 

--- a/packages/bpk-component-scrollable-calendar/stories.js
+++ b/packages/bpk-component-scrollable-calendar/stories.js
@@ -20,8 +20,16 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import BpkScrollableCalendar from '.';
+import { BpkScrollableCalendarDate } from './index';
 
-storiesOf('bpk-component-scrollable-calendar', module).add('Default', () => (
-  <BpkScrollableCalendar />
-));
+storiesOf('bpk-component-scrollable-calendar', module).add(
+  'BpkScrollableCalendarDate',
+  () => (
+    <div>
+      <h3> Middle date is an empty span - outside of current month </h3>
+      <BpkScrollableCalendarDate date={new Date()} />
+      <BpkScrollableCalendarDate date={new Date()} isOutside />
+      <BpkScrollableCalendarDate date={new Date()} />
+    </div>
+  ),
+);

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,8 @@
 # Unreleased
+
+### BpkScrollableCalendar
+- Scrollable calendar component building on top of BpkCalendar
+- So far, BpkScrollableCalendarDate
+### BpkCalendar
+- Exposed `BpkCalendarDate.propTypes` as `BpkCalendarDatePropTypes` for reuse in BpkScrollableCalendarDate
+ 


### PR DESCRIPTION
Implemented a scrollable calendar date component building on top of BpkCalendarDate

the component uses all the same props, but when isOutside is passed, it only returns an empty span tag in order to only display dates within a specific grid's month.