### PR TITLE
[NO-JIRA] Fix modal scrim animation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,5 +1,7 @@
 # Unreleased
 
 **Fixed:**
-- bpk-component-calendar:
-  - Fixed issue with DST transition during midnight in Safari.
+- bpk-component-modal:
+- bpk-component-dialog:
+- bpk-component-datepicker:
+  - Scrim fade animation wasn't rendering properly before, giving a janky feel. This has now been fixed so that it fades in nicely.

--- a/packages/bpk-scrim-utils/src/bpk-scrim.scss
+++ b/packages/bpk-scrim-utils/src/bpk-scrim.scss
@@ -25,7 +25,7 @@
   bottom: 0;
   left: 0;
   z-index: $bpk-zindex-scrim;
-  transition: opacity $bpk-duration-xs ease-in-out;
+  transition: opacity $bpk-duration-sm ease-in-out;
   background-color: $bpk-scrim-background-color;
   opacity: $bpk-scrim-opacity;
   overflow: hidden;


### PR DESCRIPTION
The animation for BpkScrim behind modals is not visible as the animation duration is so short. Increasing it makes the scrim fade instead of just appearing, making it less visually jarring (especially for mobile modals)

I've attached some videos below with the scrim turned red for clarity. Thoughts?

Before:
https://www.dropbox.com/s/utwkq6w5hn2fdj2/before.mov?dl=0

With no scrim:
﻿https://www.dropbox.com/s/vpopfkmb6d8a1eh/after.mov?dl=0

With a fading scrim:
﻿https://www.dropbox.com/s/n5iana9bh8xxs6m/after_2.mov?dl=0
