### PR TITLE
 Added Scrollable calendar grid item

### DIFF
--- a/packages/bpk-component-calendar/index.js
+++ b/packages/bpk-component-calendar/index.js
@@ -19,7 +19,9 @@
 import BpkCalendarContainer, {
   withCalendarState,
 } from './src/BpkCalendarContainer';
-import BpkCalendarGrid from './src/BpkCalendarGrid';
+import BpkCalendarGrid, {
+  propTypes as BpkCalendarGridPropTypes,
+} from './src/BpkCalendarGrid';
 import BpkCalendarGridHeader from './src/BpkCalendarGridHeader';
 import BpkCalendarNav from './src/BpkCalendarNav';
 import BpkCalendarDate, {
@@ -43,4 +45,5 @@ export {
   withCalendarState,
   themeAttributes,
   BpkCalendarDatePropTypes,
+  BpkCalendarGridPropTypes,
 };

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -144,7 +144,7 @@ class BpkCalendarGrid extends Component {
   }
 }
 
-BpkCalendarGrid.propTypes = {
+export const propTypes = {
   // Required
   DateComponent: PropTypes.func.isRequired,
   daysOfWeek: CustomPropTypes.DaysOfWeek.isRequired,
@@ -167,6 +167,8 @@ BpkCalendarGrid.propTypes = {
   showWeekendSeparator: PropTypes.bool,
   weekStartsOn: PropTypes.number,
 };
+
+BpkCalendarGrid.propTypes = propTypes;
 
 BpkCalendarGrid.defaultProps = {
   className: null,

--- a/packages/bpk-component-scrollable-calendar/src/_variables.scss
+++ b/packages/bpk-component-scrollable-calendar/src/_variables.scss
@@ -1,0 +1,25 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins/index';
+
+$shadow-bottom: 0 1px 0 0 $bpk-color-gray-100; /* stylelint-disable-line unit-blacklist */
+$shadow-left: -1px 0 0 0 $bpk-color-gray-100; /* stylelint-disable-line unit-blacklist */
+$shadow-right: 1px 0 0 0 $bpk-color-gray-100; /* stylelint-disable-line unit-blacklist */
+$calendar-width: 7 * ($bpk-calendar-day-size + $bpk-calendar-day-spacing);
+$calendar-height: 6 * ($bpk-calendar-day-size + $bpk-calendar-day-spacing);


### PR DESCRIPTION
Added the month component for scrollable calendar component. The idea is to display the month's name above every grid element in `BpkScrollableCalendar` for clarity.

The month name is a `BpkText` component. The missing days in comparison with `BpkCalendarGrid` are `null` instead

As with `BpkScrollableCalendarDate`, the props are the same as `BpkCalendarGrid`'s 

BpkScrollableCalendarGrid:
![screen shot 2018-08-06 at 11 36 27](https://user-images.githubusercontent.com/26122575/43709462-373e207e-996d-11e8-8953-aa987acb3311.png)

BpkCalendarGrid: 
![screen shot 2018-08-06 at 11 36 19](https://user-images.githubusercontent.com/26122575/43709449-31c117dc-996d-11e8-9a36-808641b4d572.png)



