### PR TITLE
[BPK-1783] Fix test snapshot differences between timezones

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jest:native:watch": "(cd ./native && jest --watch)",
     "jest:update": "jest --updateSnapshot",
     "jest:watch": "jest --watch",
-    "jest": "jest --coverage",
+    "jest": "TZ=Europe/London jest --coverage",
     "flow": "flow",
     "flow-typed": "flow-typed",
     "build:tokens": "lerna run tokens --scope bpk-tokens",


### PR DESCRIPTION
I think an `unreleased.md` entry is overkill as this should not affect consumers.

To test this out, you can run this command which will set the system timezone between test runs:
`npm run jest Calendar && sudo systemsetup -settimezone America/Campo_Grande && sleep 3 && npm run jest Calendar && sudo systemsetup -settimezone Australia/Adelaide && sleep 3 && npm run jest Calendar && sudo systemsetup -settimezone Europe/London`

And to run all tests:
`npm run test && sudo systemsetup -settimezone America/Campo_Grande && sleep 3 && npm run test && sudo systemsetup -settimezone Australia/Adelaide && sleep 3 && npm run test && sudo systemsetup -settimezone Europe/London`