### PR TITLE
[BPK-1855] fix prop type spreading

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,5 @@
 # Unreleased
 
-_Nothing yet!_
+** Fixed **
+- react-native-bpk-component-phone-input:
+  - fix spread operation in PropTypes

--- a/native/packages/react-native-bpk-component-phone-input/src/BpkPhoneNumberInput.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/BpkPhoneNumberInput.js
@@ -89,7 +89,7 @@ const {
 
 export const propTypes = {
   ...newTextInputPropTypes,
-  dialingCode: PropTypes.shape(...CODE_PROP_TYPES).isRequired,
+  dialingCode: PropTypes.shape(CODE_PROP_TYPES).isRequired,
   renderFlag: PropTypes.func.isRequired,
   onDialingCodePress: PropTypes.func.isRequired,
 };

--- a/native/packages/react-native-bpk-component-phone-input/src/common-types.js
+++ b/native/packages/react-native-bpk-component-phone-input/src/common-types.js
@@ -61,8 +61,7 @@ export const LIST_ITEM_PROP_TYPES = {
 };
 
 export const LIST_COMMON_PROP_TYPES = {
-  dialingCodes: PropTypes.arrayOf(PropTypes.shape(...CODE_PROP_TYPES))
-    .isRequired,
+  dialingCodes: PropTypes.arrayOf(PropTypes.shape(CODE_PROP_TYPES)).isRequired,
   onItemPress: PropTypes.func.isRequired,
   renderFlag: PropTypes.func.isRequired,
   selectedId: PropTypes.string,


### PR DESCRIPTION
`PropType.shape` expect an object in (https://reactjs.org/docs/typechecking-with-proptypes.html) in the phone input we were spreading an object and somehow was working but with babel 7 that's not the case anymore so here's a fix

I've done some due diligence of checking the whole codebase for similar error  and I didn't find any