### PR TITLE
[NO-JIRA] Fix Data table sorting

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,5 +1,8 @@
 # Unreleased
 
 **Fixed:**
+- bpk-component-data-table
+  - Fixed an issue where sorting columns would cause an exception.
+
 - bpk-component-barchart
   - Removes `onBarTouch` prop as it ultimately had no effect

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -113,11 +113,14 @@ class BpkDataTable extends Component {
       return;
     }
 
+    // TODO This hack has been introduced as event.target directly below was evaluating to `undefined` when used directly below.
+    // There is a follow-up JIRA ticket (https://gojira.skyscanner.net/browse/BPK-1883) to investigate the cause of this further.
+    const eventTarget = event.target;
     this.setState(prevState => {
       const sortDirection = getSortDirection(
         prevState,
         sortBy,
-        getSortIconDirection(event.target),
+        getSortIconDirection(eventTarget),
         column.props.defaultSortDirection || SortDirection.ASC,
       );
 


### PR DESCRIPTION
To see this issue, open [any DataTable in Storybook](https://backpack.github.io/storybook/?knob-Copy=Lorem%20ipsum%20dolor%20sit%20amet%2C%20consectetuer%20adipiscing%20elit.%20Aenean%20commodo%0Aligula%20eget%20dolor.%20Aenean%20massa.%20Cum%20sociis%20natoque%20penatibus%20et%20magnis%20dis%0Aparturient%20montes%2C%20nascetur%20ridiculus%20mus.&knob-Button%20copy=Toggle%20height%21&selectedKind=bpk-component-datatable&selectedStory=Autowidth%20Example&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs) and click on any of the headers

Before:
![2018-08-31 15 00 00](https://user-images.githubusercontent.com/30267516/44916861-a8639700-ad2e-11e8-816b-c02b8b2e25d7.gif)

After:
![2018-08-31 15 00 24](https://user-images.githubusercontent.com/30267516/44916868-abf71e00-ad2e-11e8-9f26-5b6d91020c18.gif)
