### PR TITLE
Fixed css (gridClassName) for scrollable calendar

### DIFF
--- a/packages/bpk-component-scrollable-calendar/src/bpk-scrollable-calendar-grid-list.scss
+++ b/packages/bpk-component-scrollable-calendar/src/bpk-scrollable-calendar-grid-list.scss
@@ -31,7 +31,8 @@ $calendar-height: 7 * ($bpk-calendar-day-size + $bpk-calendar-day-spacing);
 
   &__strip {
     z-index: 0;
-    height: $calendar-height;
+    height: 100%;
+    min-height: $calendar-height;
     flex-direction: column;
   }
 


### PR DESCRIPTION
What: Fix the way height is handled for scrollable calendar grid

Why: AutoSizer did not work with original way of overriding grid's height. Now gridClassName works again.