### PR TITLE
[TSS-3914] Update react-autosuggest to version 9.4.2 in bpk-component-autosuggest

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,6 @@
 # Unreleased
 
-_Nothing yet..._
+**Fixed:**
+
+- bpk-component-autosuggest:
+  - Updated `react-autosuggest` dependency: `9.4.1` => `9.4.2`

--- a/packages/bpk-component-autosuggest/package-lock.json
+++ b/packages/bpk-component-autosuggest/package-lock.json
@@ -32,9 +32,9 @@
 			}
 		},
 		"react-autosuggest": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-9.4.1.tgz",
-			"integrity": "sha512-k5Uu3LUoe2oXZFh+gJbSKuKe0jWr3SmcQgdF24y7+dMgRgR498+96jjcxqGGz7IldQsBomGLxnxJrEJYgprerg==",
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-9.4.2.tgz",
+			"integrity": "sha512-GkLFnr+79DtDFMNxbjKzTKEwOfItw2mKiCNTD3bE+gZSPf5Y+i+W+8KySmBnDWFPF5cuJeuBhQBgcSdbp45nAg==",
 			"requires": {
 				"prop-types": "^15.5.10",
 				"react-autowhatever": "^10.1.2",

--- a/packages/bpk-component-autosuggest/package.json
+++ b/packages/bpk-component-autosuggest/package.json
@@ -17,7 +17,7 @@
     "bpk-mixins": "^17.11.17",
     "bpk-react-utils": "^2.6.11",
     "prop-types": "^15.6.2",
-    "react-autosuggest": "^9.4.0"
+    "react-autosuggest": "^9.4.2"
   },
   "devDependencies": {
     "bpk-component-icon": "^3.23.6"


### PR DESCRIPTION
Updates react-autosuggest to version 9.4.2 in bpk-component-autosuggest to fix the issue described in https://github.com/moroshko/react-autosuggest/pull/572

Current behaviour: After an autosuggest suggestion is selected, if the user clicks anywhere outside the autosuggest input that was used, it gains focus. If the autosuggest input was configured to lose focus after a suggestion is selected, what the user experiences is that an input that was not focused gains focus automatically.

Expected behaviour after the fix: After an autosuggest suggestion is selected, if the user clicks anywhere outside the autosuggest input that was used, it loses focus if it was focused.