### PR TITLE
round the corners of the progress bar value, only for non stepped options

### DIFF
--- a/packages/bpk-component-progress/src/BpkProgress.js
+++ b/packages/bpk-component-progress/src/BpkProgress.js
@@ -84,6 +84,11 @@ class BpkProgress extends Component {
       classNames.push(getClassName('bpk-progress--small'));
     }
 
+    const steppedClassNames = [getClassName('bpk-progress__value')];
+    if (stepped) {
+      steppedClassNames.push(getClassName('bpk-progress__value--stepped'));
+    }
+
     const adjustedValue = clamp(value, min, max);
     const percentage = 100 * (adjustedValue / (max - min));
     const numberOfSteps = stepped ? max - min - 1 : 0;
@@ -103,7 +108,7 @@ class BpkProgress extends Component {
         {...rest}
       >
         <div
-          className={getClassName('bpk-progress__value')}
+          className={steppedClassNames.join(' ')}
           style={{ width: `${percentage}%` }}
           onTransitionEnd={this.handleCompleteTransitionEnd}
         />

--- a/packages/bpk-component-progress/src/__snapshots__/BpkProgress-test.js.snap
+++ b/packages/bpk-component-progress/src/__snapshots__/BpkProgress-test.js.snap
@@ -33,7 +33,7 @@ exports[`BpkProgress should render correctly with "small" and "stepped" attribut
   tabIndex="0"
 >
   <div
-    className="bpk-progress__value"
+    className="bpk-progress__value bpk-progress__value--stepped"
     onTransitionEnd={[Function]}
     style={
       Object {
@@ -171,7 +171,7 @@ exports[`BpkProgress should render correctly with a "stepColor" attribute 1`] = 
   tabIndex="0"
 >
   <div
-    className="bpk-progress__value"
+    className="bpk-progress__value bpk-progress__value--stepped"
     onTransitionEnd={[Function]}
     style={
       Object {
@@ -265,7 +265,7 @@ exports[`BpkProgress should render correctly with a "stepped" attribute 1`] = `
   tabIndex="0"
 >
   <div
-    className="bpk-progress__value"
+    className="bpk-progress__value bpk-progress__value--stepped"
     onTransitionEnd={[Function]}
     style={
       Object {

--- a/packages/bpk-component-progress/src/bpk-progress.scss
+++ b/packages/bpk-component-progress/src/bpk-progress.scss
@@ -39,8 +39,13 @@
     content: ' ';
     width: 0%;
     transition: width $bpk-duration-base ease-in-out;
+    border-radius: $bpk-border-radius-sm;
 
     @include bpk-themeable-property(background-color, --bpk-progress-bar-fill-color, $bpk-color-green-500);
+
+    &--stepped {
+      border-radius: 0;
+    }
   }
 
   &__step {


### PR DESCRIPTION
For consistency with RN, the inner value bar of the progress component should have rounded corners. Except for the stepped version that must keep them not rounded.