### PR TITLE
[backpack-love] Add changelog link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 https://backpack.github.io/
 
+## Changelog
+
+The up-to-date changelog can be found [here](./CHANGELOG.md)
+
 ## Usage
 
 ### Installing packages

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://backpack.github.io/
 
 ## Changelog
 
-The up-to-date changelog can be found [here](./CHANGELOG.md)
+[View our up-to-date changelog](./CHANGELOG.md)
 
 ## Usage
 


### PR DESCRIPTION
The main readme is the place where to look for things, using backpack from the other side I notice how annoying is not  to have that link in the readme