### PR TITLE
Added "onDataFetchFailed" prop to "withInfiniteScroll" HOC

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,6 @@
 # Unreleased
 
-_Nothing Yet!___
+**Added:**
+
+- bpk-component-infinite-scroll
+  - Added `onDataFetchFailed` prop to `withInfiniteScroll` HOC.

--- a/packages/bpk-component-infinite-scroll/README.md
+++ b/packages/bpk-component-infinite-scroll/README.md
@@ -167,6 +167,7 @@ Updates the internal array and triggers all listeners.
 | dataSource              | instanceOf(DataSource) | true     | -             |
 | elementsPerScroll       | number                 | false    | 5             |
 | initiallyLoadedElements | number                 | false    | 5             |
+| onDataFetchFailed       | func                   | false    | null          |
 | onScroll                | func                   | false    | null          |
 | onScrollFinished        | func                   | false    | null          |
 | renderLoadingComponent  | func                   | false    | null          |

--- a/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
+++ b/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
@@ -29,6 +29,7 @@ exports[`withInfiniteScroll renders correctly with different initial and onScrol
   }
   elementsPerScroll={2}
   initiallyLoadedElements={3}
+  onDataFetchFailed={null}
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -68,6 +69,7 @@ exports[`withInfiniteScroll renders items after the first render 1`] = `
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  onDataFetchFailed={null}
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -142,6 +144,7 @@ exports[`withInfiniteScroll should pass extra props to the decorated component 1
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  onDataFetchFailed={null}
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -183,6 +186,7 @@ exports[`withInfiniteScroll should refresh data when data changes 1`] = `
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  onDataFetchFailed={null}
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -221,6 +225,7 @@ exports[`withInfiniteScroll should refresh data when data changes 2`] = `
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  onDataFetchFailed={null}
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -260,6 +265,7 @@ exports[`withInfiniteScroll should render correctly when no more elements 1`] = 
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  onDataFetchFailed={null}
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -330,6 +336,7 @@ exports[`withInfiniteScroll should render correctly with a "renderLoadingCompone
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  onDataFetchFailed={null}
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={[Function]}
@@ -373,6 +380,7 @@ exports[`withInfiniteScroll should render correctly with a "renderSeeMoreCompone
   }
   elementsPerScroll={1}
   initiallyLoadedElements={5}
+  onDataFetchFailed={null}
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -425,6 +433,7 @@ exports[`withInfiniteScroll should render correctly with an "elementsPerScroll" 
   }
   elementsPerScroll={1}
   initiallyLoadedElements={5}
+  onDataFetchFailed={null}
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}


### PR DESCRIPTION
We want to show a "Refresh results" button at the bottom of infinite scroll (like the "see more" one) when the request to fetch more items fails.

For this reason, we have added the `onDataFetchFailed` prop, to be able to render on our side this new button.