### PR TITLE
TER-140 Adding `tabIndex` property to bpk-popover component.

### DIFF
--- a/packages/bpk-component-popover/README.md
+++ b/packages/bpk-component-popover/README.md
@@ -53,6 +53,7 @@ class App extends Component {
           renderTarget={() =>
             document.getElementById('popover-container')
           }
+          tabIndex="0"
         >
           <BpkText>My popover content</BpkText>
         </BpkPopover>
@@ -84,6 +85,7 @@ class App extends Component {
 | portalClassName       | string                                    | false    | null          |
 | renderTarget          | func                                      | false    | null          |
 | popperModifiers       | object                                    | false    | null          |
+| tabIndex              | string                                    | false    | "1"           |
 
 In order to attach the popover to a regular DOM element, provide a function which returns it to `target`:
 

--- a/packages/bpk-component-popover/src/BpkPopover-test.js
+++ b/packages/bpk-component-popover/src/BpkPopover-test.js
@@ -41,6 +41,21 @@ describe('BpkPopover', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should render correctly with "tabIndex" attribute being set', () => {
+    const tree = renderer
+      .create(
+        <BpkPopover
+          id="my-popover"
+          onClose={() => null}
+          label="My popover"
+          closeButtonText="Close"
+          tabIndex="0"
+        />,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should render correctly with "padded" attribute equal to false', () => {
     const tree = renderer
       .create(

--- a/packages/bpk-component-popover/src/BpkPopover.js
+++ b/packages/bpk-component-popover/src/BpkPopover.js
@@ -58,6 +58,7 @@ export type Props = {
   labelAsTitle: boolean,
   closeButtonIcon: boolean,
   className: ?string,
+  tabIndex: string,
 };
 
 const BpkPopover = (props: Props) => {
@@ -71,6 +72,7 @@ const BpkPopover = (props: Props) => {
     padded,
     labelAsTitle,
     closeButtonIcon,
+    tabIndex,
     ...rest
   } = props;
 
@@ -125,6 +127,7 @@ const BpkPopover = (props: Props) => {
               />
             ) : (
               <BpkButtonLink
+                tabIndex={props.tabIndex}
                 onClick={bindEventSource(
                   EVENT_SOURCES.CLOSE_LINK,
                   props.onClose,
@@ -143,6 +146,7 @@ const BpkPopover = (props: Props) => {
         {!labelAsTitle && (
           <footer className={getClassName('bpk-popover__footer')}>
             <BpkButtonLink
+              tabIndex={props.tabIndex}
               onClick={bindEventSource(EVENT_SOURCES.CLOSE_LINK, props.onClose)}
             >
               {closeButtonText}
@@ -164,6 +168,7 @@ export const propTypes = {
   labelAsTitle: PropTypes.bool,
   closeButtonIcon: PropTypes.bool,
   className: PropTypes.string,
+  tabIndex: PropTypes.string,
 };
 
 export const defaultProps = {
@@ -171,6 +176,7 @@ export const defaultProps = {
   labelAsTitle: false,
   closeButtonIcon: true,
   className: null,
+  tabIndex: '1',
 };
 
 BpkPopover.propTypes = { ...propTypes };

--- a/packages/bpk-component-popover/src/__snapshots__/BpkPopover-test.js.snap
+++ b/packages/bpk-component-popover/src/__snapshots__/BpkPopover-test.js.snap
@@ -170,3 +170,40 @@ exports[`BpkPopover should render correctly with "padded" attribute equal to fal
   </footer>
 </section>
 `;
+
+exports[`BpkPopover should render correctly with "tabIndex" attribute being set 1`] = `
+<section
+  aria-labelledby="bpk-popover-label-my-popover"
+  className="bpk-popover"
+  id="my-popover"
+  role="dialog"
+  tabIndex="-1"
+>
+  <span
+    className="bpk-popover__arrow"
+    id="js-bpk-popover-arrow"
+    role="presentation"
+  />
+  <span
+    className="bpk-popover__label"
+    id="bpk-popover-label-my-popover"
+  >
+    My popover
+  </span>
+  <div
+    className="bpk-popover__body--padded"
+  />
+  <footer
+    className="bpk-popover__footer"
+  >
+    <button
+      className="bpk-link"
+      onClick={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      Close
+    </button>
+  </footer>
+</section>
+`;


### PR DESCRIPTION
Our squad noticed a small bug where the `Close` button was not being focused by default once a popover was opened if other links existed within the container body. After investigating and communicating with the backpack team, they advised me to just make the change and add a contribution. I have followed the contribution guides, updated the docs and added a test (also played around with the stories to see if it actually works). 

The change itself allows users to set the tabIndex (as a prop to the `<BpkPopover>` React component) if they need to, or by default it will be set to "1" and is not a mandatory prop.