### PR TITLE
TSS-4044, use react lazyload for scrollable calendar instead of infin…

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,4 @@
 # Unreleased
+
+- bpk-component-scrollable-calendar:
+  - Use react-lazyload instead of bpk-component-infinite-scroll

--- a/packages/bpk-component-scrollable-calendar/package-lock.json
+++ b/packages/bpk-component-scrollable-calendar/package-lock.json
@@ -31,28 +31,10 @@
 				"object-assign": "^4.1.1"
 			}
 		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha1-TxonOv38jzSIqMUWv9p4+HI1I2I="
-		},
-		"react-virtualized": {
-			"version": "9.20.1",
-			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-virtualized/-/react-virtualized-9.20.1.tgz",
-			"integrity": "sha1-AtwI/pBwOGuMSOKsVrznrwII0i0=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"classnames": "^2.2.3",
-				"dom-helpers": "^2.4.0 || ^3.0.0",
-				"loose-envify": "^1.3.0",
-				"prop-types": "^15.6.0",
-				"react-lifecycles-compat": "^3.0.4"
-			}
-		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
+		"react-lazyload": {
+			"version": "2.3.0",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-lazyload/-/react-lazyload-2.3.0.tgz",
+			"integrity": "sha1-zLE0IjASRHB0qWVDlU9EsFXcYYU="
 		}
 	}
 }

--- a/packages/bpk-component-scrollable-calendar/package.json
+++ b/packages/bpk-component-scrollable-calendar/package.json
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "bpk-component-calendar": "^4.3.21",
-    "bpk-component-infinite-scroll": "^2.1.4",
     "bpk-component-text": "^1.0.90",
     "bpk-mixins": "^17.11.25",
     "bpk-react-utils": "^2.6.13",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "react-lazyload": "^2.3.0"
   }
 }

--- a/packages/bpk-component-scrollable-calendar/src/MonthPlaceholder.js
+++ b/packages/bpk-component-scrollable-calendar/src/MonthPlaceholder.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { cssModules } from 'bpk-react-utils';
+
+import STYLES from './MonthPlaceholder.scss';
+
+const getClassName = cssModules(STYLES);
+
+const MonthPlaceholder = () => (
+  <div className={getClassName('bpk-scrollable-calendar-placeholder')}>
+    <div
+      className={getClassName('bpk-scrollable-calendar-placeholder__title')}
+    />
+    <div
+      className={getClassName('bpk-scrollable-calendar-placeholder__item')}
+    />
+  </div>
+);
+
+export default MonthPlaceholder;

--- a/packages/bpk-component-scrollable-calendar/src/MonthPlaceholder.js
+++ b/packages/bpk-component-scrollable-calendar/src/MonthPlaceholder.js
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-component-scrollable-calendar/src/MonthPlaceholder.scss
+++ b/packages/bpk-component-scrollable-calendar/src/MonthPlaceholder.scss
@@ -1,0 +1,35 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins/index';
+
+.bpk-scrollable-calendar-placeholder {
+  width: 100%;
+
+  &__title {
+    height: $bpk-line-height-lg;
+    margin: $bpk-spacing-md $bpk-spacing-sm $bpk-spacing-sm $bpk-spacing-sm;
+    background-color: $bpk-color-gray-50;
+  }
+
+  &__item {
+    height: ($bpk-calendar-day-size + $bpk-calendar-day-spacing) * 5;
+    margin: 0 $bpk-spacing-sm 0 $bpk-spacing-sm;
+    background-color: $bpk-color-gray-50;
+  }
+}


### PR DESCRIPTION
…ite scroll

***What:***  
use https://github.com/jasonslyvia/react-lazyload instead of infinite scroll for scrollable calendar

***Why:***  
it allows to render a placeholder before calendar is rendered which makes scrolling smoother and not 'jumpy' (with infinite scroll you can scroll up to the last rendered month, then wait for it to load 2 more months, then scroll again, wait etc)

there was also a bug which made it not scroll to the selected date