### PR TITLE
[BPK-2073] Constrain icons used inside badges to 16x16

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -3,3 +3,8 @@
 **Added:**
  - bpk-react-utils:
    - Added `deprecated` function that accepts a prop type and adds a suitable console warning when the prop is used.
+
+**Changed**
+
+- bpk-component-badge:
+  - Badges containing icons are now slightly taller (20px instead of 18px) and the icon inside will be resized and positioned to fit better. See https://backpack.github.io/components/badge?platform=web#with-icons

--- a/packages/bpk-component-badge/BadgeLayout.js
+++ b/packages/bpk-component-badge/BadgeLayout.js
@@ -19,7 +19,7 @@
 /* @flow */
 
 import PropTypes from 'prop-types';
-import React, { type Element, Children } from 'react';
+import React, { type Node, Children } from 'react';
 import { cssModules } from 'bpk-react-utils';
 
 import { BADGE_TYPES } from './index';
@@ -35,7 +35,7 @@ const LIGHT_BADGES = [
 
 export type Props = {
   docked: ?string,
-  children: Element<*>,
+  children: Node,
 };
 
 const BadgeLayout = (props: Props) => {

--- a/packages/bpk-component-badge/package.json
+++ b/packages/bpk-component-badge/package.json
@@ -18,6 +18,7 @@
     "prop-types": "^15.6.2"
   },
   "devDependencies": {
+    "bpk-component-icon": "^3.23.14",
     "bpk-tokens": "^27.3.0"
   }
 }

--- a/packages/bpk-component-badge/src/BpkBadge-test.js
+++ b/packages/bpk-component-badge/src/BpkBadge-test.js
@@ -18,6 +18,7 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
+import BpkSmallFlightIcon from 'bpk-component-icon/sm/flight';
 
 import BpkBadge, { BADGE_TYPES } from './BpkBadge';
 
@@ -30,6 +31,17 @@ describe('BpkBadge', () => {
   it('should render correctly with a "centered"', () => {
     const tree = renderer
       .create(<BpkBadge centered>Promociando</BpkBadge>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with an icon', () => {
+    const tree = renderer
+      .create(
+        <BpkBadge>
+          <BpkSmallFlightIcon />Promociando
+        </BpkBadge>,
+      )
       .toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/bpk-component-badge/src/__snapshots__/BpkBadge-test.js.snap
+++ b/packages/bpk-component-badge/src/__snapshots__/BpkBadge-test.js.snap
@@ -32,6 +32,30 @@ exports[`BpkBadge should render correctly with a "docked" attribute value equal 
 </span>
 `;
 
+exports[`BpkBadge should render correctly with an icon 1`] = `
+<span
+  className="bpk-badge "
+>
+  <svg
+    height="18"
+    style={
+      Object {
+        "height": "1.125rem",
+        "width": "1.125rem",
+      }
+    }
+    viewBox="0 0 24 24"
+    width="18"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M17.8 20.1l.6-.6c.2-.2.3-.5.2-.8l-2.2-9.3 4.1-4.2c.5-.5.5-1.3 0-1.9-.5-.5-1.4-.5-1.9 0l-4.2 4.1-9.1-2c-.3-.1-.6 0-.8.2l-.6.6c-.4.4-.3 1.1.2 1.4l7.2 3.2-3.7 3.7-2.3-.8c-.3-.1-.6 0-.8.2L3 15.2l4.2 1.6L8.8 21l1.3-1.5c.2-.2.3-.6.2-.8l-.8-2.3 3.7-3.7 3.2 7.2c.3.5 1 .6 1.4.2z"
+    />
+  </svg>
+  Promociando
+</span>
+`;
+
 exports[`BpkBadge should render correctly with type="destructive" 1`] = `
 <span
   className="bpk-badge bpk-badge--destructive"

--- a/packages/bpk-component-badge/stories.js
+++ b/packages/bpk-component-badge/stories.js
@@ -20,6 +20,9 @@
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import BpkSmallBeerIcon from 'bpk-component-icon/sm/beer';
+import BpkSmallFlightIcon from 'bpk-component-icon/sm/flight';
+import BpkSmallWeatherIcon from 'bpk-component-icon/sm/weather';
 
 import BpkBadge, { BADGE_TYPES } from './index';
 import BadgeLayout from './BadgeLayout';
@@ -29,6 +32,24 @@ storiesOf('bpk-component-badge', module)
     <BadgeLayout>
       <div>
         This is a badge <BpkBadge>Promocionado</BpkBadge>
+      </div>
+    </BadgeLayout>
+  ))
+  .add('With icons', () => (
+    <BadgeLayout>
+      <div>
+        With one icon{' '}
+        <BpkBadge>
+          <BpkSmallFlightIcon />
+          Promocionado
+        </BpkBadge>
+      </div>
+      <div>
+        With multiple icons{' '}
+        <BpkBadge>
+          <BpkSmallWeatherIcon /> + <BpkSmallBeerIcon />
+          Promocionado
+        </BpkBadge>
       </div>
     </BadgeLayout>
   ))

--- a/packages/bpk-docs/src/pages/WebBadgePage/BadgePage.js
+++ b/packages/bpk-docs/src/pages/WebBadgePage/BadgePage.js
@@ -18,6 +18,9 @@
 
 import React from 'react';
 import BpkBadge, { BADGE_TYPES } from 'bpk-component-badge';
+import BpkSmallFlightIcon from 'bpk-component-icon/sm/flight';
+import BpkSmallCarIcon from 'bpk-component-icon/sm/cars';
+import BpkSmallHotelIcon from 'bpk-component-icon/sm/hotels';
 
 import { cssModules } from 'bpk-react-utils';
 
@@ -191,6 +194,24 @@ const components = [
       </BpkBadge>,
       <BpkBadge type={BADGE_TYPES.outline} className={badgeClassName}>
         Pears
+      </BpkBadge>,
+    ],
+  },
+  {
+    id: 'with-icons',
+    title: 'With icons',
+    blurb: [
+      <Paragraph>
+        When badges contain icons, the icons are resized to fit and have some
+        margin applied. The badge&apos;s height also increases slightly.
+      </Paragraph>,
+    ],
+    examples: [
+      <BpkBadge type={BADGE_TYPES.success} className={badgeClassName}>
+        <BpkSmallFlightIcon /> Flights
+      </BpkBadge>,
+      <BpkBadge type={BADGE_TYPES.warning} className={badgeClassName}>
+        <BpkSmallHotelIcon /> + <BpkSmallCarIcon /> Multiple
       </BpkBadge>,
     ],
   },

--- a/packages/bpk-mixins/src/mixins/_badges.scss
+++ b/packages/bpk-mixins/src/mixins/_badges.scss
@@ -31,13 +31,29 @@
 ///   }
 
 @mixin bpk-badge {
-  display: inline-block;
+  display: inline-flex;
   padding: $bpk-badge-padding-y $bpk-badge-padding-x;
+  align-items: center;
   background-color: $bpk-badge-background-color;
 
   @include bpk-border-radius-xs;
   @include bpk-text;
   @include bpk-text--sm;
+
+  // // HACK: Icons have an inline style attribute setting the height and width.
+  // // so the only way to override this in CSS is to use !important.
+  > svg {
+    /* stylelint-disable declaration-no-important */
+    width: 16 * $bpk-one-pixel-rem !important;
+    height: 16 * $bpk-one-pixel-rem !important;
+    /* stylelint-enable declaration-no-important */
+    margin-top: $bpk-one-pixel-rem * 2;
+    margin-bottom: $bpk-one-pixel-rem * 2;
+
+    &:last-of-type {
+      @include bpk-margin-trailing($bpk-badge-padding-x);
+    }
+  }
 }
 /// Centered badge. Modifies the bpk-badge mixin.
 ///


### PR DESCRIPTION

![screen shot 2018-11-22 at 11 42 58](https://user-images.githubusercontent.com/73652/48900975-d64b0a00-ee4b-11e8-9c8d-ce99ca43b061.png)


**Summary**
When a badge contains an icon, we constrain it to 16x16, add some margin to separate it from the text and increase the badge height to 20px.

**Details**
As our icons don't have a class name and use an inline style attribute, I've had to write some horrible CSS to target all SVGs and adds width and height using `!important`.

The only other way I can think of doing this is to add logic inside the badge component to find all children that are SVGs and then manually add a style prop to override the existing one. But it feels a bit complex when CSS can do the job.

Sidenote: Should we add a data attribute to our icon SVGs so that they can be targeted easier in the future?