### PR TITLE
Allow passing custom properties to calendar components

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,5 @@
 - bpk-tokens:
   - Changed `fontSizeXxl` and `fontSizeXxl` tokens for Android and iOS. They are now `30` and `36` (previously `36` and `42`).
   - Changed `letterSpacingXxl` and `letterSpacingXxxl` tokens for Android. They are now `-0.8` and `-1.0` (previously `-1.0` and `-1.2`).
+- bpk-component-calendar
+  - BpkCalendar accepts navProps, headerProps, gridProps and dateProps and passes them to sub-components

--- a/packages/bpk-component-calendar/README.md
+++ b/packages/bpk-component-calendar/README.md
@@ -169,6 +169,10 @@ withCalendarState(composeCalendar(
 | selectedDate          | Date                 | false               | null             |
 | showWeekendSeparator  | bool                 | false               | true             |
 | weekStartsOn          | number               | false               | 1                |
+| navProps              | object               | false               | {}               |
+| headerProps           | object               | false               | {}               |
+| gridProps             | object               | false               | {}               |
+| dateProps             | object               | false               | {}               |
 
 Some of the more complex props and props for sub-components are detailed below.
 
@@ -321,6 +325,10 @@ const onMonthChange = (event, {
 #### initiallyFocusedDate
 
 Sets the date that is focused initially, this prop has no effect if `selectedDate` or the deprecated `date` prop are specified in which case the date specified in those props is focused. If no selected date is set and `initiallyFocusedDate` is not set the focused date is the `minDate`(defaults to today if it has not been explicitly set).
+
+#### navProps, headerProps, gridProps, dateProps
+
+These are useful if your custom implementation of one of these components requires additional properties. They will be passed, unmodified, to the respective component.
 
 ## Theme Props
 

--- a/packages/bpk-component-calendar/README.md
+++ b/packages/bpk-component-calendar/README.md
@@ -169,10 +169,10 @@ withCalendarState(composeCalendar(
 | selectedDate          | Date                 | false               | null             |
 | showWeekendSeparator  | bool                 | false               | true             |
 | weekStartsOn          | number               | false               | 1                |
-| navProps              | object               | false               | {}               |
-| headerProps           | object               | false               | {}               |
-| gridProps             | object               | false               | {}               |
-| dateProps             | object               | false               | {}               |
+| navProps              | object               | false               | null             |
+| headerProps           | object               | false               | null             |
+| gridProps             | object               | false               | null             |
+| dateProps             | object               | false               | null             |
 
 Some of the more complex props and props for sub-components are detailed below.
 

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -192,7 +192,7 @@ BpkCalendarGrid.defaultProps = {
   showWeekendSeparator: true,
   weekStartsOn: 1,
   ignoreOutsideDate: false,
-  dateProps: {},
+  dateProps: null,
 };
 
 export default BpkCalendarGrid;

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -92,6 +92,7 @@ class BpkCalendarGrid extends Component {
       minDate,
       maxDate,
       ignoreOutsideDate,
+      dateProps,
     } = this.props;
 
     const { calendarMonthWeeks, daysOfWeek } = this.state;
@@ -138,6 +139,7 @@ class BpkCalendarGrid extends Component {
               minDate={minDate}
               maxDate={maxDate}
               ignoreOutsideDate={ignoreOutsideDate}
+              dateProps={dateProps}
             />
           ))}
         </tbody>
@@ -169,6 +171,7 @@ export const propTypes = {
   showWeekendSeparator: PropTypes.bool,
   weekStartsOn: PropTypes.number,
   ignoreOutsideDate: PropTypes.bool,
+  dateProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 BpkCalendarGrid.propTypes = propTypes;
@@ -189,6 +192,7 @@ BpkCalendarGrid.defaultProps = {
   showWeekendSeparator: true,
   weekStartsOn: 1,
   ignoreOutsideDate: false,
+  dateProps: {},
 };
 
 export default BpkCalendarGrid;

--- a/packages/bpk-component-calendar/src/Week.js
+++ b/packages/bpk-component-calendar/src/Week.js
@@ -124,6 +124,7 @@ class Week extends Component {
       selectedDate,
       showWeekendSeparator,
       ignoreOutsideDate,
+      dateProps,
     } = this.props;
 
     const firstDayOfWeekendIndex = getFirstDayOfWeekend(daysOfWeek);
@@ -171,6 +172,7 @@ class Week extends Component {
               }
               isOutside={markOutsideDays && !isSameMonth(date, month)}
               isToday={markToday && isToday(date)}
+              {...dateProps}
             />
           </DateContainer>
         ))}
@@ -199,6 +201,7 @@ Week.propTypes = {
   onDateKeyDown: PropTypes.func,
   selectedDate: PropTypes.instanceOf(Date),
   ignoreOutsideDate: PropTypes.bool,
+  dateProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 Week.defaultProps = {
@@ -209,6 +212,7 @@ Week.defaultProps = {
   onDateKeyDown: null,
   selectedDate: null,
   ignoreOutsideDate: false,
+  dateProps: {},
 };
 
 /*

--- a/packages/bpk-component-calendar/src/Week.js
+++ b/packages/bpk-component-calendar/src/Week.js
@@ -212,7 +212,7 @@ Week.defaultProps = {
   onDateKeyDown: null,
   selectedDate: null,
   ignoreOutsideDate: false,
-  dateProps: {},
+  dateProps: null,
 };
 
 /*

--- a/packages/bpk-component-calendar/src/__snapshots__/composeCalendar-test.js.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/composeCalendar-test.js.snap
@@ -68,6 +68,7 @@ exports[`composeCalendar should compose a nav, header, grid and date component c
     DateComponent="Date"
     className=""
     dateModifiers={Object {}}
+    dateProps={Object {}}
     daysOfWeek={
       Array [
         Object {
@@ -129,6 +130,21 @@ exports[`composeCalendar should compose a nav, header, grid and date component c
     showWeekendSeparator={true}
     weekStartsOn={1}
   />
+</div>
+`;
+
+exports[`composeCalendar should pass props to their respective components 1`] = `
+<div
+  className="bpk-calendar bpk-calendar--fixed"
+>
+  Nav
+  Header
+  <div>
+    <h1>
+      Grid
+    </h1>
+    Date
+  </div>
 </div>
 `;
 
@@ -200,6 +216,7 @@ exports[`composeCalendar should render with "fixedWidth" set to false 1`] = `
     DateComponent="Date"
     className=""
     dateModifiers={Object {}}
+    dateProps={Object {}}
     daysOfWeek={
       Array [
         Object {
@@ -332,6 +349,7 @@ exports[`composeCalendar should render with custom className prop correctly 1`] 
     DateComponent="Date"
     className=""
     dateModifiers={Object {}}
+    dateProps={Object {}}
     daysOfWeek={
       Array [
         Object {
@@ -413,6 +431,7 @@ exports[`composeCalendar should render without a header element 1`] = `
     DateComponent="Date"
     className="bpk-calendar__grid"
     dateModifiers={Object {}}
+    dateProps={Object {}}
     daysOfWeek={
       Array [
         Object {
@@ -485,6 +504,7 @@ exports[`composeCalendar should render without a nav or header element 1`] = `
     DateComponent="Date"
     className=""
     dateModifiers={Object {}}
+    dateProps={Object {}}
     daysOfWeek={
       Array [
         Object {

--- a/packages/bpk-component-calendar/src/__snapshots__/composeCalendar-test.js.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/composeCalendar-test.js.snap
@@ -68,7 +68,7 @@ exports[`composeCalendar should compose a nav, header, grid and date component c
     DateComponent="Date"
     className=""
     dateModifiers={Object {}}
-    dateProps={Object {}}
+    dateProps={null}
     daysOfWeek={
       Array [
         Object {
@@ -216,7 +216,7 @@ exports[`composeCalendar should render with "fixedWidth" set to false 1`] = `
     DateComponent="Date"
     className=""
     dateModifiers={Object {}}
-    dateProps={Object {}}
+    dateProps={null}
     daysOfWeek={
       Array [
         Object {
@@ -349,7 +349,7 @@ exports[`composeCalendar should render with custom className prop correctly 1`] 
     DateComponent="Date"
     className=""
     dateModifiers={Object {}}
-    dateProps={Object {}}
+    dateProps={null}
     daysOfWeek={
       Array [
         Object {
@@ -431,7 +431,7 @@ exports[`composeCalendar should render without a header element 1`] = `
     DateComponent="Date"
     className="bpk-calendar__grid"
     dateModifiers={Object {}}
-    dateProps={Object {}}
+    dateProps={null}
     daysOfWeek={
       Array [
         Object {
@@ -504,7 +504,7 @@ exports[`composeCalendar should render without a nav or header element 1`] = `
     DateComponent="Date"
     className=""
     dateModifiers={Object {}}
-    dateProps={Object {}}
+    dateProps={null}
     daysOfWeek={
       Array [
         Object {

--- a/packages/bpk-component-calendar/src/composeCalendar-test.js
+++ b/packages/bpk-component-calendar/src/composeCalendar-test.js
@@ -128,4 +128,39 @@ describe('composeCalendar', () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should pass props to their respective components', () => {
+    const PropsBasedCalendarComponent = composeCalendar(
+      props => props.name,
+      props => props.name,
+      props => (
+        <div>
+          <h1>{props.name}</h1>
+          <props.DateComponent {...props.dateProps} />
+        </div>
+      ),
+      props => props.name,
+    );
+
+    const tree = renderer
+      .create(
+        <PropsBasedCalendarComponent
+          id="myCalendar"
+          formatMonth={formatMonth}
+          formatDateFull={formatDateFull}
+          daysOfWeek={weekDays}
+          changeMonthLabel="Change month"
+          minDate={new Date(Date.UTC(2010, 1, 15))}
+          maxDate={new Date(Date.UTC(2010, 2, 15))}
+          month={new Date(Date.UTC(2010, 1, 15))}
+          navProps={{ name: 'Nav' }}
+          headerProps={{ name: 'Header' }}
+          gridProps={{ name: 'Grid' }}
+          dateProps={{ name: 'Date' }}
+        />,
+        { createNodeMock },
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-calendar/src/composeCalendar.js
+++ b/packages/bpk-component-calendar/src/composeCalendar.js
@@ -180,10 +180,10 @@ const composeCalendar = (Nav, GridHeader, Grid, CalendarDate) => {
     showWeekendSeparator: true,
     weekStartsOn: 1,
     gridClassName: null,
-    navProps: {},
-    headerProps: {},
-    gridProps: {},
-    dateProps: {},
+    navProps: null,
+    headerProps: null,
+    gridProps: null,
+    dateProps: null,
   };
 
   return BpkCalendar;

--- a/packages/bpk-component-calendar/src/composeCalendar.js
+++ b/packages/bpk-component-calendar/src/composeCalendar.js
@@ -52,6 +52,10 @@ const composeCalendar = (Nav, GridHeader, Grid, CalendarDate) => {
       weekStartsOn,
       fixedWidth,
       gridClassName,
+      navProps,
+      headerProps,
+      gridProps,
+      dateProps,
     } = props;
 
     if (className) {
@@ -89,6 +93,7 @@ const composeCalendar = (Nav, GridHeader, Grid, CalendarDate) => {
             minDate={minDate}
             month={month}
             onMonthChange={onMonthChange}
+            {...navProps}
           />
         )}
         {GridHeader && (
@@ -97,6 +102,7 @@ const composeCalendar = (Nav, GridHeader, Grid, CalendarDate) => {
             showWeekendSeparator={showWeekendSeparator}
             weekStartsOn={weekStartsOn}
             className={headerClasses.join(' ')}
+            {...headerProps}
           />
         )}
         <Grid
@@ -118,6 +124,8 @@ const composeCalendar = (Nav, GridHeader, Grid, CalendarDate) => {
           markOutsideDays={markOutsideDays}
           selectedDate={selectedDate}
           className={gridClasses.join(' ')}
+          dateProps={dateProps}
+          {...gridProps}
         />
       </div>
     );
@@ -148,6 +156,12 @@ const composeCalendar = (Nav, GridHeader, Grid, CalendarDate) => {
     showWeekendSeparator: PropTypes.bool,
     weekStartsOn: PropTypes.number,
     gridClassName: PropTypes.string,
+    /* eslint-disable react/forbid-prop-types */
+    navProps: PropTypes.object,
+    headerProps: PropTypes.object,
+    gridProps: PropTypes.object,
+    dateProps: PropTypes.object,
+    /* eslint-enable */
   };
 
   BpkCalendar.defaultProps = {
@@ -166,6 +180,10 @@ const composeCalendar = (Nav, GridHeader, Grid, CalendarDate) => {
     showWeekendSeparator: true,
     weekStartsOn: 1,
     gridClassName: null,
+    navProps: {},
+    headerProps: {},
+    gridProps: {},
+    dateProps: {},
   };
 
   return BpkCalendar;


### PR DESCRIPTION
At the moment with composeCalendar you can specify custom components for each piece of the calendar but there's no way to efficiently pass custom properties through to them. This provides a mechanism for that.