### PR TITLE
[NO-JIRA] Support touchable overlay with lg border radius

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,4 @@
 # Unreleased
+
+ - react-native-bpk-component-touchable-overlay:
+   - Added support for 'lg' border radius.

--- a/native/packages/react-native-bpk-component-touchable-overlay/README.md
+++ b/native/packages/react-native-bpk-component-touchable-overlay/README.md
@@ -47,8 +47,8 @@ export default class App extends Component {
 
 ## Props
 
-| Property     | PropType            | Required | Default Value |
-| ------------ | ------------------- | -------- | ------------- |
-| children     | node                | true     | -             |
-| borderRadius | oneOf('sm', 'pill') | false    | null          |
-| overlayStyle | object              | false    | null          |
+| Property     | PropType                  | Required | Default Value |
+| ------------ | ------------------------- | -------- | ------------- |
+| children     | node                      | true     | -             |
+| borderRadius | oneOf('sm', 'lg', 'pill') | false    | null          |
+| overlayStyle | object                    | false    | null          |

--- a/native/packages/react-native-bpk-component-touchable-overlay/src/BpkTouchableOverlay.js
+++ b/native/packages/react-native-bpk-component-touchable-overlay/src/BpkTouchableOverlay.js
@@ -20,6 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   borderRadiusSm,
+  borderRadiusLg,
   borderRadiusPill,
   touchableOverlayColor,
   touchableOverlayOpacity,
@@ -45,6 +46,9 @@ const styles = StyleSheet.create({
   overlayBorderRadiusSm: {
     borderRadius: borderRadiusSm,
   },
+  overlayBorderRadiusLg: {
+    borderRadius: borderRadiusLg,
+  },
   overlayBorderRadiusPill: {
     borderRadius: borderRadiusPill,
   },
@@ -69,6 +73,9 @@ const BpkTouchableOverlay = props => {
   const overlayStyles = [styles.overlay];
   if (borderRadius === 'sm') {
     overlayStyles.push(styles.overlayBorderRadiusSm);
+  }
+  if (borderRadius === 'lg') {
+    overlayStyles.push(styles.overlayBorderRadiusLg);
   }
   if (borderRadius === 'pill') {
     overlayStyles.push(styles.overlayBorderRadiusPill);
@@ -110,7 +117,7 @@ const BpkTouchableOverlay = props => {
 
 BpkTouchableOverlay.propTypes = {
   children: PropTypes.node.isRequired,
-  borderRadius: PropTypes.oneOf(['sm', 'pill']),
+  borderRadius: PropTypes.oneOf(['sm', 'lg', 'pill']),
   style: ViewPropTypes.style,
   overlayStyle: ViewPropTypes.style,
   onPressIn: PropTypes.func,


### PR DESCRIPTION
We need touchable overlay to support `lg` border radius in order to achieve [BPK-2058](https://gojira.skyscanner.net/browse/BPK-2058)