### PR TITLE
Revert "Use BpkInfiniteScroll instead of react-virtualized"

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,6 @@
 # Unreleased
 
+**Fixed:**
+   
+ - bpk-component-scrollable-calendar:
+   - Revert to use react-virtualized instead of bpk-component-infinite-scroll

--- a/packages/bpk-component-scrollable-calendar/package-lock.json
+++ b/packages/bpk-component-scrollable-calendar/package-lock.json
@@ -4,6 +4,30 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			}
+		},
+		"classnames": {
+			"version": "2.2.6",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/classnames/-/classnames-2.2.6.tgz",
+			"integrity": "sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4="
+		},
+		"core-js": {
+			"version": "2.5.7",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/core-js/-/core-js-2.5.7.tgz",
+			"integrity": "sha1-+XJgj/DOrWi4QaFqky0LGDeRgU4="
+		},
+		"dom-helpers": {
+			"version": "3.3.1",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-helpers/-/dom-helpers-3.3.1.tgz",
+			"integrity": "sha1-/BpOFf/fYN3eA6SAqcD+zoId1KY="
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/packages/bpk-component-scrollable-calendar/package.json
+++ b/packages/bpk-component-scrollable-calendar/package.json
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "bpk-component-calendar": "^4.4.0",
-    "bpk-component-infinite-scroll": "^2.1.6",
     "bpk-component-text": "^1.0.92",
     "bpk-mixins": "^17.11.27",
     "bpk-react-utils": "^2.7.0",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "react-virtualized": "^9.20.1"
   }
 }

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
@@ -21,10 +21,13 @@ import React from 'react';
 
 import { cssModules } from 'bpk-react-utils';
 import { DateUtils, BpkCalendarGridPropTypes } from 'bpk-component-calendar';
-import withInfiniteScroll, {
-  ArrayDataSource,
-} from 'bpk-component-infinite-scroll';
-import { startOfDay, startOfMonth } from 'date-fns';
+import { startOfDay, startOfMonth, isSameMonth } from 'date-fns';
+import {
+  AutoSizer,
+  List,
+  CellMeasurer,
+  CellMeasurerCache,
+} from 'react-virtualized';
 
 import STYLES from './bpk-scrollable-calendar-grid-list.scss';
 import BpkScrollableCalendarGrid from './BpkScrollableCalendarGrid';
@@ -36,6 +39,9 @@ class BpkScrollableCalendarGridList extends React.Component {
   constructor(props) {
     super(props);
 
+    this.rowRenderer = this.rowRenderer.bind(this);
+    this.renderList = this.renderList.bind(this);
+
     const startDate = startOfDay(startOfMonth(this.props.minDate));
     const endDate = startOfDay(startOfMonth(this.props.maxDate));
     const monthsCount = DateUtils.differenceInCalendarMonths(
@@ -44,52 +50,89 @@ class BpkScrollableCalendarGridList extends React.Component {
     );
     const months = getMonthsArray(startDate, monthsCount);
 
-    this.lastLoaded = 0;
-    this.state = { months };
-
-    this.setLoaded = this.setLoaded.bind(this);
+    const cache = new CellMeasurerCache({
+      fixedWidth: true,
+      defaultHeight: 276, // most common height (in px) of BpkScrollableCalendarGrid
+    });
+    this.state = {
+      months,
+      cache,
+    };
   }
 
   getHtmlElement = () =>
     typeof document !== 'undefined' ? document.querySelector('html') : {};
 
-  setLoaded(month) {
-    this.lastLoaded = Math.max(month, this.lastLoaded);
+  rowRenderer({ index, key, style, parent }) {
+    return (
+      <CellMeasurer
+        key={key}
+        cache={this.state.cache}
+        parent={parent}
+        columnIndex={0}
+        rowIndex={index}
+      >
+        <div style={style}>
+          <BpkScrollableCalendarGrid
+            onDateClick={this.props.onDateClick}
+            {...this.props}
+            key={key}
+            month={this.state.months[index]}
+            focusedDate={this.props.focusedDate}
+            preventKeyboardFocus={this.props.preventKeyboardFocus}
+            aria-hidden={index !== 1}
+            className={getClassName('bpk-scrollable-calendar-grid-list__item')}
+          />
+        </div>
+      </CellMeasurer>
+    );
   }
 
-  render() {
-    const Calendars = ({ elements }) => (
-      <div
-        className={getClassName('bpk-scrollable-calendar-grid-list__strip')}
+  renderList({ width, height }) {
+    return (
+      <List
+        extraData={this.props}
         style={
           this.getHtmlElement().dir === 'rtl' ? { direction: 'rtl' } : null
         }
-      >
-        {elements.map((month, index) => (
-          <div ref={() => this.setLoaded(index)} key={month}>
-            <BpkScrollableCalendarGrid
-              onDateClick={this.props.onDateClick}
-              {...this.props}
-              month={month}
-              focusedDate={this.props.focusedDate}
-              preventKeyboardFocus={this.props.preventKeyboardFocus}
-              aria-hidden={index !== 1}
-              className={getClassName(
-                'bpk-scrollable-calendar-grid-list__item',
-              )}
-            />
-          </div>
-        ))}
-      </div>
-    );
-    const List = withInfiniteScroll(Calendars);
-    const months = new ArrayDataSource(this.state.months);
-    return (
-      <List
-        dataSource={months}
-        elementsPerScroll={2}
-        initiallyLoadedElements={Math.max(2, this.lastLoaded + 1)}
+        width={width}
+        height={height}
+        deferredMeasurementCache={this.state.cache}
+        rowHeight={this.state.cache.rowHeight}
+        rowRenderer={this.rowRenderer}
+        rowCount={this.state.months.length}
+        overscanRowCount={0}
+        scrollToIndex={
+          isSameMonth(this.props.focusedDate, this.props.selectedDate)
+            ? DateUtils.differenceInCalendarMonths(
+                this.props.selectedDate,
+                this.props.minDate,
+              )
+            : DateUtils.differenceInCalendarMonths(
+                this.props.focusedDate,
+                this.props.minDate,
+              )
+        }
       />
+    );
+  }
+
+  render() {
+    return (
+      <div
+        className={getClassName(
+          'bpk-scrollable-calendar-grid-list',
+          this.props.className,
+        )}
+      >
+        <div
+          className={getClassName('bpk-scrollable-calendar-grid-list__strip')}
+        >
+          <AutoSizer>
+            {(width, height) => this.renderList(width, height)}
+          </AutoSizer>{' '}
+        </div>
+      </div>
     );
   }
 }

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
@@ -82,14 +82,47 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
       </li>
     </ol>
   </header>
-  <div>
+  <div
+    className="bpk-scrollable-calendar-grid-list"
+  >
     <div
       className="bpk-scrollable-calendar-grid-list__strip"
-      style={null}
-    />
-    <div
-      className="bpk-sentinel"
-    />
+    >
+      <div
+        className={undefined}
+        style={
+          Object {
+            "height": 0,
+            "overflow": "visible",
+            "width": 0,
+          }
+        }
+      >
+        <div
+          aria-label="grid"
+          aria-readonly={true}
+          className="ReactVirtualized__Grid ReactVirtualized__List"
+          id={undefined}
+          onScroll={[Function]}
+          role="grid"
+          style={
+            Object {
+              "WebkitOverflowScrolling": "touch",
+              "boxSizing": "border-box",
+              "direction": "ltr",
+              "height": 0,
+              "overflowX": "hidden",
+              "overflowY": "auto",
+              "position": "relative",
+              "width": 0,
+              "willChange": "transform",
+            }
+          }
+          tabIndex={0}
+        />
+      </div>
+       
+    </div>
   </div>
 </div>
 `;
@@ -176,14 +209,47 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
       </li>
     </ol>
   </header>
-  <div>
+  <div
+    className="bpk-scrollable-calendar-grid-list"
+  >
     <div
       className="bpk-scrollable-calendar-grid-list__strip"
-      style={null}
-    />
-    <div
-      className="bpk-sentinel"
-    />
+    >
+      <div
+        className={undefined}
+        style={
+          Object {
+            "height": 0,
+            "overflow": "visible",
+            "width": 0,
+          }
+        }
+      >
+        <div
+          aria-label="grid"
+          aria-readonly={true}
+          className="ReactVirtualized__Grid ReactVirtualized__List"
+          id={undefined}
+          onScroll={[Function]}
+          role="grid"
+          style={
+            Object {
+              "WebkitOverflowScrolling": "touch",
+              "boxSizing": "border-box",
+              "direction": "ltr",
+              "height": 0,
+              "overflowX": "hidden",
+              "overflowY": "auto",
+              "position": "relative",
+              "width": 0,
+              "willChange": "transform",
+            }
+          }
+          tabIndex={0}
+        />
+      </div>
+       
+    </div>
   </div>
 </div>
 `;
@@ -270,14 +336,47 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
       </li>
     </ol>
   </header>
-  <div>
+  <div
+    className="bpk-scrollable-calendar-grid-list"
+  >
     <div
       className="bpk-scrollable-calendar-grid-list__strip"
-      style={null}
-    />
-    <div
-      className="bpk-sentinel"
-    />
+    >
+      <div
+        className={undefined}
+        style={
+          Object {
+            "height": 0,
+            "overflow": "visible",
+            "width": 0,
+          }
+        }
+      >
+        <div
+          aria-label="grid"
+          aria-readonly={true}
+          className="ReactVirtualized__Grid ReactVirtualized__List"
+          id={undefined}
+          onScroll={[Function]}
+          role="grid"
+          style={
+            Object {
+              "WebkitOverflowScrolling": "touch",
+              "boxSizing": "border-box",
+              "direction": "ltr",
+              "height": 0,
+              "overflowX": "hidden",
+              "overflowY": "auto",
+              "position": "relative",
+              "width": 0,
+              "willChange": "transform",
+            }
+          }
+          tabIndex={0}
+        />
+      </div>
+       
+    </div>
   </div>
 </div>
 `;

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
@@ -1,61 +1,226 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BpkCalendarScrollGridList should render correctly with "showWeekendSeparator" attribute set to false 1`] = `
-<div>
+<div
+  className="bpk-scrollable-calendar-grid-list"
+>
   <div
     className="bpk-scrollable-calendar-grid-list__strip"
-    style={null}
-  />
-  <div
-    className="bpk-sentinel"
-  />
+  >
+    <div
+      className={undefined}
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
+    >
+      <div
+        aria-label="grid"
+        aria-readonly={true}
+        className="ReactVirtualized__Grid ReactVirtualized__List"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
+        style={
+          Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
+            "height": 0,
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
+            "width": 0,
+            "willChange": "transform",
+          }
+        }
+        tabIndex={0}
+      />
+    </div>
+     
+  </div>
 </div>
 `;
 
 exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers" attribute 1`] = `
-<div>
+<div
+  className="bpk-scrollable-calendar-grid-list"
+>
   <div
     className="bpk-scrollable-calendar-grid-list__strip"
-    style={null}
-  />
-  <div
-    className="bpk-sentinel"
-  />
+  >
+    <div
+      className={undefined}
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
+    >
+      <div
+        aria-label="grid"
+        aria-readonly={true}
+        className="ReactVirtualized__Grid ReactVirtualized__List"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
+        style={
+          Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
+            "height": 0,
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
+            "width": 0,
+            "willChange": "transform",
+          }
+        }
+        tabIndex={0}
+      />
+    </div>
+     
+  </div>
 </div>
 `;
 
 exports[`BpkCalendarScrollGridList should render correctly with a custom date component 1`] = `
-<div>
+<div
+  className="bpk-scrollable-calendar-grid-list"
+>
   <div
     className="bpk-scrollable-calendar-grid-list__strip"
-    style={null}
-  />
-  <div
-    className="bpk-sentinel"
-  />
+  >
+    <div
+      className={undefined}
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
+    >
+      <div
+        aria-label="grid"
+        aria-readonly={true}
+        className="ReactVirtualized__Grid ReactVirtualized__List"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
+        style={
+          Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
+            "height": 0,
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
+            "width": 0,
+            "willChange": "transform",
+          }
+        }
+        tabIndex={0}
+      />
+    </div>
+     
+  </div>
 </div>
 `;
 
 exports[`BpkCalendarScrollGridList should render correctly with a different "weekStartsOn" attribute 1`] = `
-<div>
+<div
+  className="bpk-scrollable-calendar-grid-list"
+>
   <div
     className="bpk-scrollable-calendar-grid-list__strip"
-    style={null}
-  />
-  <div
-    className="bpk-sentinel"
-  />
+  >
+    <div
+      className={undefined}
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
+    >
+      <div
+        aria-label="grid"
+        aria-readonly={true}
+        className="ReactVirtualized__Grid ReactVirtualized__List"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
+        style={
+          Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
+            "height": 0,
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
+            "width": 0,
+            "willChange": "transform",
+          }
+        }
+        tabIndex={0}
+      />
+    </div>
+     
+  </div>
 </div>
 `;
 
 exports[`BpkCalendarScrollGridList should render correctly with no optional props set 1`] = `
-<div>
+<div
+  className="bpk-scrollable-calendar-grid-list"
+>
   <div
     className="bpk-scrollable-calendar-grid-list__strip"
-    style={null}
-  />
-  <div
-    className="bpk-sentinel"
-  />
+  >
+    <div
+      className={undefined}
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
+    >
+      <div
+        aria-label="grid"
+        aria-readonly={true}
+        className="ReactVirtualized__Grid ReactVirtualized__List"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
+        style={
+          Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
+            "height": 0,
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
+            "width": 0,
+            "willChange": "transform",
+          }
+        }
+        tabIndex={0}
+      />
+    </div>
+     
+  </div>
 </div>
 `;


### PR DESCRIPTION
what: revert scrollable calendar back to using react-virtualized,
why: new implementation has a bug of not automatically scrolling to the selected day. also the experience is not good

we are working on improving the component here: 
https://gojira.skyscanner.net/browse/TSS-4044
https://gojira.skyscanner.net/browse/BPK-2083