### PR TITLE
Add className property to BpkCalendarDate

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+**Added:**
+- bpk-component-calendar
+  - Added `className` property to BpkCalendarDate component

--- a/packages/bpk-component-calendar/src/BpkCalendarDate-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate-test.js
@@ -76,7 +76,12 @@ describe('BpkCalendarDate', () => {
 
   it('should set a custom class', () => {
     const tree = renderer
-      .create(<BpkCalendarDate date={new Date(2010, 1, 15)} className="fake" />)
+      .create(
+        <BpkCalendarDate
+          date={new Date(2010, 1, 15)}
+          className="userlandClassName"
+        />,
+      )
       .toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/bpk-component-calendar/src/BpkCalendarDate-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate-test.js
@@ -73,4 +73,11 @@ describe('BpkCalendarDate', () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should set a custom class', () => {
+    const tree = renderer
+      .create(<BpkCalendarDate date={new Date(2010, 1, 15)} className="fake" />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-calendar/src/BpkCalendarDate.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate.js
@@ -86,6 +86,7 @@ class BpkCalendarDate extends PureComponent {
       isOutside,
       isToday,
       isKeyboardFocusable,
+      className,
       ...buttonProps
     } = this.props;
     const classNames = [getClassName('bpk-calendar-date')];
@@ -112,6 +113,9 @@ class BpkCalendarDate extends PureComponent {
     }
     if (isToday) {
       classNames.push(getClassName('bpk-calendar-date--today'));
+    }
+    if (className) {
+      classNames.push(className);
     }
 
     delete buttonProps.preventKeyboardFocus;
@@ -153,6 +157,7 @@ export const propTypes = {
   onClick: PropTypes.func,
   onDateKeyDown: PropTypes.func,
   preventKeyboardFocus: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 BpkCalendarDate.propTypes = propTypes;
@@ -168,6 +173,7 @@ BpkCalendarDate.defaultProps = {
   onClick: null,
   onDateKeyDown: null,
   preventKeyboardFocus: true,
+  className: null,
 };
 
 export default BpkCalendarDate;

--- a/packages/bpk-component-calendar/src/BpkCalendarDate.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate.js
@@ -147,6 +147,7 @@ export const propTypes = {
   // Required
   date: PropTypes.instanceOf(Date).isRequired,
   // Optional
+  className: PropTypes.string,
   isBlocked: PropTypes.bool,
   isFocused: PropTypes.bool,
   isKeyboardFocusable: PropTypes.bool,
@@ -157,12 +158,12 @@ export const propTypes = {
   onClick: PropTypes.func,
   onDateKeyDown: PropTypes.func,
   preventKeyboardFocus: PropTypes.bool,
-  className: PropTypes.string,
 };
 
 BpkCalendarDate.propTypes = propTypes;
 
 BpkCalendarDate.defaultProps = {
+  className: null,
   isBlocked: false,
   isFocused: false,
   isKeyboardFocusable: true,
@@ -173,7 +174,6 @@ BpkCalendarDate.defaultProps = {
   onClick: null,
   onDateKeyDown: null,
   preventKeyboardFocus: true,
-  className: null,
 };
 
 export default BpkCalendarDate;

--- a/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarDate-test.js.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarDate-test.js.snap
@@ -95,3 +95,22 @@ exports[`BpkCalendarDate should render with a click and keyDown handler 1`] = `
   </span>
 </button>
 `;
+
+exports[`BpkCalendarDate should set a custom class 1`] = `
+<button
+  aria-label={15}
+  aria-pressed={false}
+  className="bpk-calendar-date fake"
+  disabled={false}
+  onClick={[Function]}
+  onKeyDown={null}
+  tabIndex="-1"
+  type="button"
+>
+  <span
+    aria-hidden="true"
+  >
+    15
+  </span>
+</button>
+`;

--- a/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarDate-test.js.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarDate-test.js.snap
@@ -100,7 +100,7 @@ exports[`BpkCalendarDate should set a custom class 1`] = `
 <button
   aria-label={15}
   aria-pressed={false}
-  className="bpk-calendar-date fake"
+  className="bpk-calendar-date userlandClassName"
   disabled={false}
   onClick={[Function]}
   onKeyDown={null}


### PR DESCRIPTION
This adds the ability to add a custom className to a BpkCalendarDate for people doing custom stuff to the calendar.