### PR TITLE
[BPK-2079] Activate the bagcheck link

### DIFF
--- a/packages/bpk-docs/src/bag-check-bookmarklet/index.js
+++ b/packages/bpk-docs/src/bag-check-bookmarklet/index.js
@@ -17,7 +17,7 @@
  */
 
 const BUCKET_BASE_PATH =
-  'https://s3-eu-west-1.amazonaws.com/skyscanner-prod-sttc-int-eu-west-1/sttc/bag-check';
+  'https://s3-eu-west-1.amazonaws.com/skyscanner-prod-sttc-int-eu-west-1/sttc/backpack/bag-check';
 
 const error = msg => alert(`${msg} - Please contact #backpack`); // eslint-disable-line no-alert
 
@@ -32,29 +32,17 @@ const fetchLatest = basePath => {
 
 // Called when latest.js loads
 window.bagCheckLatestLoaded = latest => {
-  if (!Object.prototype.hasOwnProperty.call(latest, 'css')) {
-    error('`css` key missing in latest.js.');
-    return;
-  }
-
   if (!Object.prototype.hasOwnProperty.call(latest, 'js')) {
     error('`js` key missing in latest.js.');
     return;
   }
 
-  const cssPath = `${BUCKET_BASE_PATH}/${latest.css}`;
   const jsPath = `${BUCKET_BASE_PATH}/${latest.js}`;
-
-  const link = document.createElement('link');
-  link.href = cssPath;
-  link.type = 'text/css';
-  link.rel = 'stylesheet';
 
   const script = document.createElement('script');
   script.src = jsPath;
   script.type = 'text/javascript';
 
-  document.getElementsByTagName('head')[0].appendChild(link);
   document.getElementsByTagName('body')[0].appendChild(script);
   delete window.bagCheckLatestLoaded;
 };

--- a/packages/bpk-docs/src/constants/routes.js
+++ b/packages/bpk-docs/src/constants/routes.js
@@ -111,3 +111,4 @@ export const UTILITIES = '/components/utilities';
 // MISC
 export const GRID_COLUMN_DEMO = '/grid-column-demo';
 export const GRID_OFFSET_DEMO = '/grid-offset-demo';
+export const BAG_CHECK = '/bag-check-bookmarklet';

--- a/packages/bpk-docs/src/helpers/globals-helper-test.js
+++ b/packages/bpk-docs/src/helpers/globals-helper-test.js
@@ -1,0 +1,53 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import getGlobal from './globals-helper';
+
+const origWindow = global;
+
+describe('globals-helper', () => {
+  describe('getGlobal', () => {
+    afterEach(() => {
+      global = origWindow; // eslint-disable-line
+      global.BPK_DOC_GLOBALS = undefined;
+    });
+
+    it('should get a value', () => {
+      global.BPK_DOC_GLOBALS = {};
+      global.BPK_DOC_GLOBALS.foo = 'foo';
+      global.BPK_DOC_GLOBALS.bar = { baz: 'baz' };
+      expect(getGlobal('foo', 'bar')).toEqual('foo');
+      expect(getGlobal('bar.baz', 'bar')).toEqual('baz');
+    });
+
+    it('should return the default when window is not present', () => {
+      global = undefined; // eslint-disable-line
+      expect(getGlobal('foo', 'bar')).toEqual('bar');
+    });
+
+    it('should return the default when BPK_DOC_GLOBALS is not present', () => {
+      expect(getGlobal('foo', 'bar')).toEqual('bar');
+    });
+
+    it('should return the default when value not present', () => {
+      global.BPK_DOC_GLOBALS = {};
+      global.BPK_DOC_GLOBALS.foo = 'foo';
+      expect(getGlobal('bar', 'foo')).toEqual('foo');
+    });
+  });
+});

--- a/packages/bpk-docs/src/helpers/globals-helper.js
+++ b/packages/bpk-docs/src/helpers/globals-helper.js
@@ -1,0 +1,33 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { get } from 'lodash';
+
+const getGlobal = (path, defaultVal = null) => {
+  const hasGlobalObject =
+    typeof window !== 'undefined' &&
+    typeof window.BPK_DOC_GLOBALS !== 'undefined';
+
+  if (!hasGlobalObject) {
+    return defaultVal;
+  }
+
+  return get(window.BPK_DOC_GLOBALS, `${path}`, defaultVal);
+};
+
+export default getGlobal;

--- a/packages/bpk-docs/src/pages/BagCheckPage/BagCheckPage.js
+++ b/packages/bpk-docs/src/pages/BagCheckPage/BagCheckPage.js
@@ -40,7 +40,7 @@ const Page = () => {
   return (
     <div className={getClassName('bpk-docs-bag-check-page')}>
       <BpkText tagName="h1" textStyle="lg">
-        Drag and drop the link bellow to your bookmarks toolbar
+        Drag and drop the link below to your bookmarks toolbar.
       </BpkText>
       <BpkLink
         href={script}

--- a/packages/bpk-docs/src/pages/BagCheckPage/BagCheckPage.js
+++ b/packages/bpk-docs/src/pages/BagCheckPage/BagCheckPage.js
@@ -1,0 +1,55 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import BpkLink from 'bpk-component-link';
+import BpkText from 'bpk-component-text';
+import { cssModules } from 'bpk-react-utils';
+import getGlobal from '../../helpers/globals-helper';
+import STYLES from './bag-check-page.scss';
+
+const getClassName = cssModules(STYLES);
+
+const Page = () => {
+  if (typeof window === 'undefined' || !window.location) {
+    return null;
+  }
+
+  // NOTE: this is updated with the proper hash during the prod build.
+  const bagCheckFile = getGlobal('entries.bagCheck', 'bagCheck.js');
+  const link = `${window.location.origin}/${bagCheckFile}`;
+  const script = `javascript:(function(){var t=document.createElement("script");t.type="application/javascript",t.src="${link}",document.getElementsByTagName("body")[0].appendChild(t)}());`;
+
+  return (
+    <div className={getClassName('bpk-docs-bag-check-page')}>
+      <BpkText tagName="h1" textStyle="lg">
+        Drag and drop the link bellow to your bookmarks toolbar
+      </BpkText>
+      <BpkLink
+        href={script}
+        className={getClassName('bpk-docs-bag-check-page__link')}
+      >
+        <BpkText textStyle="xl">BagCheck</BpkText>
+      </BpkLink>
+    </div>
+  );
+};
+
+export default Page;

--- a/packages/bpk-docs/src/pages/BagCheckPage/bag-check-page.scss
+++ b/packages/bpk-docs/src/pages/BagCheckPage/bag-check-page.scss
@@ -1,0 +1,32 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins/index';
+
+.bpk-docs-bag-check-page {
+  display: flex;
+  height: calc(100vh - 8rem);
+  padding-top: 10%;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+
+  &__link {
+    margin-top: $bpk-spacing-sm;
+  }
+}

--- a/packages/bpk-docs/src/pages/BagCheckPage/index.js
+++ b/packages/bpk-docs/src/pages/BagCheckPage/index.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import page from './BagCheckPage';
+
+export default page;

--- a/packages/bpk-docs/src/routes/Routes.js
+++ b/packages/bpk-docs/src/routes/Routes.js
@@ -104,6 +104,7 @@ import TextPage from '../pages/TextPage';
 import ThemingPage from '../pages/ThemingPage';
 import TicketsPage from '../pages/TicketsPage';
 import TooltipsPage from '../pages/TooltipsPage';
+import BagCheckPage from '../pages/BagCheckPage';
 
 import { GridColumnDemoPage, GridOffsetDemoPage } from '../pages/GridDemoPages';
 
@@ -273,6 +274,7 @@ export const ROUTES_MAPPINGS = [
   },
   { path: ROUTES.GRID_COLUMN_DEMO, component: GridColumnDemoPage },
   { path: ROUTES.GRID_OFFSET_DEMO, component: GridOffsetDemoPage },
+  { path: ROUTES.BAG_CHECK, component: BagCheckPage },
   ...Object.keys(redirects).map(from => ({
     path: from,
     redirect: redirects[from],

--- a/packages/bpk-docs/src/template.js
+++ b/packages/bpk-docs/src/template.js
@@ -39,6 +39,13 @@ export default ({ head = {}, html = '', assets = {} }) => `<!doctype html>
   ${html}
 </div>
 
+<script type="text/javascript">
+  window.BPK_DOC_GLOBALS = window.BPK_DOC_GLOBALS || {};
+  window.BPK_DOC_GLOBALS.entries = {
+    bagCheck: '${assets.bagCheck.js}',
+  }
+</script>
+
 <script src="/${assets.docs.js}" async></script>
 
 </body>

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -57,6 +57,7 @@ const sassOptions = {
 const config = {
   entry: {
     docs: './packages/bpk-docs/src/index.js',
+    bagCheck: './packages/bpk-docs/src/bag-check-bookmarklet/index.js',
   },
 
   output: {


### PR DESCRIPTION
I've added a new page in `/bag-check-bookmarklet` that looks like this:

![0 0 0 0_8080_bag-check-bookmarklet](https://user-images.githubusercontent.com/1457263/49884622-2c98e080-fe2d-11e8-8189-ecc71e1759ad.png)

I've implemented this a bit different from the original implementation, which was using the raw file loader, because that meant we wouldn't be able to update the code that downloads the bookmarklet since it would be inlined there. With the current implementation we can update both the bag check lib and the code that loads it, and it will be picked up automatically by everyone that has the link.
