### PR TITLE
Use flex-box to vertically size scrollable calendar

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,5 @@
 # Unreleased
 
+- bpk-component-scrollable-calendar:
+  - Use flex-box to let components resize vertically to any height in an elegant, unhacky way
 

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.js
@@ -24,7 +24,7 @@ import {
 } from 'bpk-component-calendar';
 
 import React from 'react';
-import cssModules from 'bpk-react-utils/src/cssModules';
+import { cssModules } from 'bpk-react-utils';
 
 import BpkscrollableCalendarDate from './BpkScrollableCalendarDate';
 import BpkScrollableCalendarGridList from './BpkScrollableCalendarGridList';

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.js
@@ -22,14 +22,35 @@ import {
   withCalendarState,
   composeCalendar,
 } from 'bpk-component-calendar';
+
+import React from 'react';
+import cssModules from 'bpk-react-utils/src/cssModules';
+
 import BpkscrollableCalendarDate from './BpkScrollableCalendarDate';
 import BpkScrollableCalendarGridList from './BpkScrollableCalendarGridList';
 
-export default withCalendarState(
-  composeCalendar(
-    null,
-    BpkCalendarGridHeader,
-    BpkScrollableCalendarGridList,
-    BpkscrollableCalendarDate,
+import STYLES from './bpk-scrollable-calendar.scss';
+
+const getClassName = cssModules(STYLES);
+
+const withClassName = (Component, newClassName) => props => {
+  const className = props.className
+    ? `${props.className} ${newClassName}`
+    : newClassName;
+  return <Component {...props} className={className} />;
+};
+
+export default withClassName(
+  withCalendarState(
+    composeCalendar(
+      null,
+      withClassName(
+        BpkCalendarGridHeader,
+        getClassName('bpk-scrollable-calendar__header'),
+      ),
+      BpkScrollableCalendarGridList,
+      BpkscrollableCalendarDate,
+    ),
   ),
+  getClassName('bpk-scrollable-calendar'),
 );

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`BpkScrollableCalendar should render correctly 1`] = `
 <div
-  className="bpk-calendar bpk-calendar--fixed"
+  className="bpk-calendar bpk-scrollable-calendar bpk-calendar--fixed"
 >
   <header
-    className="bpk-calendar-header"
+    className="bpk-calendar-header bpk-scrollable-calendar__header"
   >
     <ol
       className="bpk-calendar-header__week"
@@ -96,10 +96,10 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
 
 exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
 <div
-  className="bpk-calendar bpk-calendar--fixed"
+  className="bpk-calendar bpk-scrollable-calendar bpk-calendar--fixed"
 >
   <header
-    className="bpk-calendar-header"
+    className="bpk-calendar-header bpk-scrollable-calendar__header"
   >
     <ol
       className="bpk-calendar-header__week"
@@ -190,10 +190,10 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
 
 exports[`BpkScrollableCalendar should support custom class names 1`] = `
 <div
-  className="bpk-calendar custom-classname bpk-calendar--fixed"
+  className="bpk-calendar custom-classname bpk-scrollable-calendar bpk-calendar--fixed"
 >
   <header
-    className="bpk-calendar-header"
+    className="bpk-calendar-header bpk-scrollable-calendar__header"
   >
     <ol
       className="bpk-calendar-header__week"

--- a/packages/bpk-component-scrollable-calendar/src/bpk-scrollable-calendar-grid-list.scss
+++ b/packages/bpk-component-scrollable-calendar/src/bpk-scrollable-calendar-grid-list.scss
@@ -34,6 +34,7 @@ $calendar-height: 7 * ($bpk-calendar-day-size + $bpk-calendar-day-spacing);
     height: 100%;
     min-height: $calendar-height;
     flex-direction: column;
+    flex-grow: 1;
   }
 
   &__item {

--- a/packages/bpk-component-scrollable-calendar/src/bpk-scrollable-calendar.scss
+++ b/packages/bpk-component-scrollable-calendar/src/bpk-scrollable-calendar.scss
@@ -20,4 +20,9 @@
 
 .bpk-scrollable-calendar {
   display: flex;
+  flex-direction: column;
+
+  &__header {
+    flex-shrink: 0;
+  }
 }


### PR DESCRIPTION
This significantly simplifies the code we have that uses the scrollable calendar since it now resizes to fill whatever space is available to it (our current code is full of `calc()`ed height properties that seem rather fragile to me). If it's not constrained, it will behave as it did before.