### PR TITLE
[No JIRA] Use StatusBar component API

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,10 +1,13 @@
 # Unreleased
-   
+
 **Added:**
+
 - bpk-component-popover:
   - Added `closeButtonProps` so that consumers can set props on the close button - for example, `tabIndex`.
-  
+
 **Fixed:**
+
  - react-native-bpk-component-navigation-bar:
    - Long titles are now truncated.
-   
+   - **Android** Fixed a bug where the navigation bar would change the status bar colour and style without changing it back when being unmounted.
+

--- a/native/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.android.js
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.android.js
@@ -142,32 +142,30 @@ class BpkNavigationBar extends Component<Props, {}> {
     );
   }
 
-  componentDidMount() {
-    this.updateStatusBar();
-  }
-
   componentDidUpdate() {
     this.theme = getThemeAttributes(
       ANDROID_THEME_ATTRIBUTES,
       this.props.theme || {},
     );
-
-    this.updateStatusBar();
   }
 
-  updateStatusBar() {
+  navigationBarStyles() {
     if (this.theme) {
       const {
         navigationBarStatusBarColor,
         navigationBarStatusBarStyle,
       } = this.theme;
 
-      StatusBar.setBackgroundColor(navigationBarStatusBarColor);
-      StatusBar.setBarStyle(navigationBarStatusBarStyle);
-    } else {
-      StatusBar.setBackgroundColor(colorBlue700);
-      StatusBar.setBarStyle('light-content');
+      return {
+        navigationBarStatusBarColor,
+        navigationBarStatusBarStyle,
+      };
     }
+
+    return {
+      navigationBarStatusBarColor: colorBlue700,
+      navigationBarStatusBarStyle: 'light-content',
+    };
   }
 
   render() {
@@ -249,8 +247,17 @@ class BpkNavigationBar extends Component<Props, {}> {
       outerBarStyle.push(style);
     }
 
+    const {
+      navigationBarStatusBarColor,
+      navigationBarStatusBarStyle,
+    } = this.navigationBarStyles();
+
     return (
       <View style={outerBarStyle}>
+        <StatusBar
+          backgroundColor={navigationBarStatusBarColor}
+          barStyle={navigationBarStatusBarStyle}
+        />
         <View style={barStyle}>
           {leadingButton &&
             React.cloneElement(leadingButton, {


### PR DESCRIPTION
Using the `StatusBar`'s imperative API was causing long lasting changes
to any app using `BpkNavigationBar` on Android even after the component
was no longer being rendered. With this change the status bar is
restored when the component is unmounted.