### PR TITLE
[No JIRA] Remove the use of `StatusBar` on Android

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,8 @@
 # Unreleased
 
+**Fixed:**
+
+- react-native-bpk-component-navigation-bar:
+  - Remove the use of `StatusBar` on Android.
+
 

--- a/native/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.android.js
+++ b/native/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.android.js
@@ -19,13 +19,7 @@
 
 import React, { Component, isValidElement } from 'react';
 import PropTypes from 'prop-types';
-import {
-  type Element,
-  StatusBar,
-  StyleSheet,
-  View,
-  ViewPropTypes,
-} from 'react-native';
+import { type Element, StyleSheet, View, ViewPropTypes } from 'react-native';
 import {
   withTheme,
   getThemeAttributes,
@@ -34,7 +28,6 @@ import {
 import {
   colorBlue300,
   colorBlue500,
-  colorBlue700,
   colorWhite,
 } from 'bpk-tokens/tokens/base.react.native';
 
@@ -149,25 +142,6 @@ class BpkNavigationBar extends Component<Props, {}> {
     );
   }
 
-  navigationBarStyles() {
-    if (this.theme) {
-      const {
-        navigationBarStatusBarColor,
-        navigationBarStatusBarStyle,
-      } = this.theme;
-
-      return {
-        navigationBarStatusBarColor,
-        navigationBarStatusBarStyle,
-      };
-    }
-
-    return {
-      navigationBarStatusBarColor: colorBlue700,
-      navigationBarStatusBarStyle: 'light-content',
-    };
-  }
-
   render() {
     const {
       title,
@@ -247,17 +221,8 @@ class BpkNavigationBar extends Component<Props, {}> {
       outerBarStyle.push(style);
     }
 
-    const {
-      navigationBarStatusBarColor,
-      navigationBarStatusBarStyle,
-    } = this.navigationBarStyles();
-
     return (
       <View style={outerBarStyle}>
-        <StatusBar
-          backgroundColor={navigationBarStatusBarColor}
-          barStyle={navigationBarStatusBarStyle}
-        />
         <View style={barStyle}>
           {leadingButton &&
             React.cloneElement(leadingButton, {


### PR DESCRIPTION
The use of `StatusBar` causes issues when integrated into a full app and
it's not worth keeping because it makes `BpkNavigationBar` as a whole
unusable.