### PR TITLE
[BPK-2117] Fix RN text component prop type warning

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,6 @@
 # Unreleased
 
-_Nothing yet..._
+**Fixed:**
+
+- react-native-bpk-component-text:
+  - Remove warning about invalid prop type usage.

--- a/native/packages/react-native-bpk-component-text/src/common-types.js
+++ b/native/packages/react-native-bpk-component-text/src/common-types.js
@@ -87,6 +87,7 @@ export const weightPropType = (
   props: Props,
   propName: string,
   componentName: string,
+  ...rest: Array<any>
 ) => {
   if (!isWeightValid(props[propName], props.textStyle)) {
     // eslint-disable-next-line no-console
@@ -99,7 +100,12 @@ export const weightPropType = (
     );
   }
 
-  PropTypes.oneOf(Object.keys(WEIGHT_STYLES))(props, propName, componentName);
+  PropTypes.oneOf(Object.keys(WEIGHT_STYLES))(
+    props,
+    propName,
+    componentName,
+    ...rest,
+  );
 };
 
 export const propTypes = {


### PR DESCRIPTION
Removes the following warning:
```
Warning: Failed prop type: Calling PropTypes validators directly is not supported by the `prop-types` package. Use `PropTypes.checkPropTypes()` to call them. Read more at http://fb.me/use-check-prop-types
        in BpkText
```
Doing a browser search in the build log yields:

_Before:_
![image](https://user-images.githubusercontent.com/1440090/49939663-5a396480-fed5-11e8-8e12-d2a76649a981.png)

_After:_
![image](https://user-images.githubusercontent.com/1440090/49939626-468dfe00-fed5-11e8-86e9-5ad022f2a1b5.png)
