### PR TITLE
Remove the list--strip element from the scrollable calendar

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,7 @@
 # Unreleased
+
+**Changed:**
+
+- bpk-component-scrollable-calendar
+  - Remove an unnecessary wrapper element that complicated layouts.
+

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
@@ -123,13 +123,9 @@ class BpkScrollableCalendarGridList extends React.Component {
           this.props.className,
         )}
       >
-        <div
-          className={getClassName('bpk-scrollable-calendar-grid-list__strip')}
-        >
-          <AutoSizer>
-            {({ width, height }) => this.renderList(width, height)}
-          </AutoSizer>{' '}
-        </div>
+        <AutoSizer>
+          {({ width, height }) => this.renderList(width, height)}
+        </AutoSizer>{' '}
       </div>
     );
   }

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
@@ -86,43 +86,39 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
     className="bpk-scrollable-calendar-grid-list"
   >
     <div
-      className="bpk-scrollable-calendar-grid-list__strip"
+      className={undefined}
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
     >
       <div
-        className={undefined}
+        aria-label="grid"
+        aria-readonly={true}
+        className="ReactVirtualized__Grid ReactVirtualized__List"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
         style={
           Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
             "height": 0,
-            "overflow": "visible",
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
             "width": 0,
+            "willChange": "transform",
           }
         }
-      >
-        <div
-          aria-label="grid"
-          aria-readonly={true}
-          className="ReactVirtualized__Grid ReactVirtualized__List"
-          id={undefined}
-          onScroll={[Function]}
-          role="grid"
-          style={
-            Object {
-              "WebkitOverflowScrolling": "touch",
-              "boxSizing": "border-box",
-              "direction": "ltr",
-              "height": 0,
-              "overflowX": "hidden",
-              "overflowY": "auto",
-              "position": "relative",
-              "width": 0,
-              "willChange": "transform",
-            }
-          }
-          tabIndex={0}
-        />
-      </div>
-       
+        tabIndex={0}
+      />
     </div>
+     
   </div>
 </div>
 `;
@@ -213,43 +209,39 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
     className="bpk-scrollable-calendar-grid-list"
   >
     <div
-      className="bpk-scrollable-calendar-grid-list__strip"
+      className={undefined}
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
     >
       <div
-        className={undefined}
+        aria-label="grid"
+        aria-readonly={true}
+        className="ReactVirtualized__Grid ReactVirtualized__List"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
         style={
           Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
             "height": 0,
-            "overflow": "visible",
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
             "width": 0,
+            "willChange": "transform",
           }
         }
-      >
-        <div
-          aria-label="grid"
-          aria-readonly={true}
-          className="ReactVirtualized__Grid ReactVirtualized__List"
-          id={undefined}
-          onScroll={[Function]}
-          role="grid"
-          style={
-            Object {
-              "WebkitOverflowScrolling": "touch",
-              "boxSizing": "border-box",
-              "direction": "ltr",
-              "height": 0,
-              "overflowX": "hidden",
-              "overflowY": "auto",
-              "position": "relative",
-              "width": 0,
-              "willChange": "transform",
-            }
-          }
-          tabIndex={0}
-        />
-      </div>
-       
+        tabIndex={0}
+      />
     </div>
+     
   </div>
 </div>
 `;
@@ -340,43 +332,39 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
     className="bpk-scrollable-calendar-grid-list"
   >
     <div
-      className="bpk-scrollable-calendar-grid-list__strip"
+      className={undefined}
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
     >
       <div
-        className={undefined}
+        aria-label="grid"
+        aria-readonly={true}
+        className="ReactVirtualized__Grid ReactVirtualized__List"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
         style={
           Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
             "height": 0,
-            "overflow": "visible",
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
             "width": 0,
+            "willChange": "transform",
           }
         }
-      >
-        <div
-          aria-label="grid"
-          aria-readonly={true}
-          className="ReactVirtualized__Grid ReactVirtualized__List"
-          id={undefined}
-          onScroll={[Function]}
-          role="grid"
-          style={
-            Object {
-              "WebkitOverflowScrolling": "touch",
-              "boxSizing": "border-box",
-              "direction": "ltr",
-              "height": 0,
-              "overflowX": "hidden",
-              "overflowY": "auto",
-              "position": "relative",
-              "width": 0,
-              "willChange": "transform",
-            }
-          }
-          tabIndex={0}
-        />
-      </div>
-       
+        tabIndex={0}
+      />
     </div>
+     
   </div>
 </div>
 `;

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
@@ -5,43 +5,39 @@ exports[`BpkCalendarScrollGridList should render correctly with "showWeekendSepa
   className="bpk-scrollable-calendar-grid-list"
 >
   <div
-    className="bpk-scrollable-calendar-grid-list__strip"
+    className={undefined}
+    style={
+      Object {
+        "height": 0,
+        "overflow": "visible",
+        "width": 0,
+      }
+    }
   >
     <div
-      className={undefined}
+      aria-label="grid"
+      aria-readonly={true}
+      className="ReactVirtualized__Grid ReactVirtualized__List"
+      id={undefined}
+      onScroll={[Function]}
+      role="grid"
       style={
         Object {
+          "WebkitOverflowScrolling": "touch",
+          "boxSizing": "border-box",
+          "direction": "ltr",
           "height": 0,
-          "overflow": "visible",
+          "overflowX": "hidden",
+          "overflowY": "auto",
+          "position": "relative",
           "width": 0,
+          "willChange": "transform",
         }
       }
-    >
-      <div
-        aria-label="grid"
-        aria-readonly={true}
-        className="ReactVirtualized__Grid ReactVirtualized__List"
-        id={undefined}
-        onScroll={[Function]}
-        role="grid"
-        style={
-          Object {
-            "WebkitOverflowScrolling": "touch",
-            "boxSizing": "border-box",
-            "direction": "ltr",
-            "height": 0,
-            "overflowX": "hidden",
-            "overflowY": "auto",
-            "position": "relative",
-            "width": 0,
-            "willChange": "transform",
-          }
-        }
-        tabIndex={0}
-      />
-    </div>
-     
+      tabIndex={0}
+    />
   </div>
+   
 </div>
 `;
 
@@ -50,43 +46,39 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
   className="bpk-scrollable-calendar-grid-list"
 >
   <div
-    className="bpk-scrollable-calendar-grid-list__strip"
+    className={undefined}
+    style={
+      Object {
+        "height": 0,
+        "overflow": "visible",
+        "width": 0,
+      }
+    }
   >
     <div
-      className={undefined}
+      aria-label="grid"
+      aria-readonly={true}
+      className="ReactVirtualized__Grid ReactVirtualized__List"
+      id={undefined}
+      onScroll={[Function]}
+      role="grid"
       style={
         Object {
+          "WebkitOverflowScrolling": "touch",
+          "boxSizing": "border-box",
+          "direction": "ltr",
           "height": 0,
-          "overflow": "visible",
+          "overflowX": "hidden",
+          "overflowY": "auto",
+          "position": "relative",
           "width": 0,
+          "willChange": "transform",
         }
       }
-    >
-      <div
-        aria-label="grid"
-        aria-readonly={true}
-        className="ReactVirtualized__Grid ReactVirtualized__List"
-        id={undefined}
-        onScroll={[Function]}
-        role="grid"
-        style={
-          Object {
-            "WebkitOverflowScrolling": "touch",
-            "boxSizing": "border-box",
-            "direction": "ltr",
-            "height": 0,
-            "overflowX": "hidden",
-            "overflowY": "auto",
-            "position": "relative",
-            "width": 0,
-            "willChange": "transform",
-          }
-        }
-        tabIndex={0}
-      />
-    </div>
-     
+      tabIndex={0}
+    />
   </div>
+   
 </div>
 `;
 
@@ -95,43 +87,39 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
   className="bpk-scrollable-calendar-grid-list"
 >
   <div
-    className="bpk-scrollable-calendar-grid-list__strip"
+    className={undefined}
+    style={
+      Object {
+        "height": 0,
+        "overflow": "visible",
+        "width": 0,
+      }
+    }
   >
     <div
-      className={undefined}
+      aria-label="grid"
+      aria-readonly={true}
+      className="ReactVirtualized__Grid ReactVirtualized__List"
+      id={undefined}
+      onScroll={[Function]}
+      role="grid"
       style={
         Object {
+          "WebkitOverflowScrolling": "touch",
+          "boxSizing": "border-box",
+          "direction": "ltr",
           "height": 0,
-          "overflow": "visible",
+          "overflowX": "hidden",
+          "overflowY": "auto",
+          "position": "relative",
           "width": 0,
+          "willChange": "transform",
         }
       }
-    >
-      <div
-        aria-label="grid"
-        aria-readonly={true}
-        className="ReactVirtualized__Grid ReactVirtualized__List"
-        id={undefined}
-        onScroll={[Function]}
-        role="grid"
-        style={
-          Object {
-            "WebkitOverflowScrolling": "touch",
-            "boxSizing": "border-box",
-            "direction": "ltr",
-            "height": 0,
-            "overflowX": "hidden",
-            "overflowY": "auto",
-            "position": "relative",
-            "width": 0,
-            "willChange": "transform",
-          }
-        }
-        tabIndex={0}
-      />
-    </div>
-     
+      tabIndex={0}
+    />
   </div>
+   
 </div>
 `;
 
@@ -140,43 +128,39 @@ exports[`BpkCalendarScrollGridList should render correctly with a different "wee
   className="bpk-scrollable-calendar-grid-list"
 >
   <div
-    className="bpk-scrollable-calendar-grid-list__strip"
+    className={undefined}
+    style={
+      Object {
+        "height": 0,
+        "overflow": "visible",
+        "width": 0,
+      }
+    }
   >
     <div
-      className={undefined}
+      aria-label="grid"
+      aria-readonly={true}
+      className="ReactVirtualized__Grid ReactVirtualized__List"
+      id={undefined}
+      onScroll={[Function]}
+      role="grid"
       style={
         Object {
+          "WebkitOverflowScrolling": "touch",
+          "boxSizing": "border-box",
+          "direction": "ltr",
           "height": 0,
-          "overflow": "visible",
+          "overflowX": "hidden",
+          "overflowY": "auto",
+          "position": "relative",
           "width": 0,
+          "willChange": "transform",
         }
       }
-    >
-      <div
-        aria-label="grid"
-        aria-readonly={true}
-        className="ReactVirtualized__Grid ReactVirtualized__List"
-        id={undefined}
-        onScroll={[Function]}
-        role="grid"
-        style={
-          Object {
-            "WebkitOverflowScrolling": "touch",
-            "boxSizing": "border-box",
-            "direction": "ltr",
-            "height": 0,
-            "overflowX": "hidden",
-            "overflowY": "auto",
-            "position": "relative",
-            "width": 0,
-            "willChange": "transform",
-          }
-        }
-        tabIndex={0}
-      />
-    </div>
-     
+      tabIndex={0}
+    />
   </div>
+   
 </div>
 `;
 
@@ -185,42 +169,38 @@ exports[`BpkCalendarScrollGridList should render correctly with no optional prop
   className="bpk-scrollable-calendar-grid-list"
 >
   <div
-    className="bpk-scrollable-calendar-grid-list__strip"
+    className={undefined}
+    style={
+      Object {
+        "height": 0,
+        "overflow": "visible",
+        "width": 0,
+      }
+    }
   >
     <div
-      className={undefined}
+      aria-label="grid"
+      aria-readonly={true}
+      className="ReactVirtualized__Grid ReactVirtualized__List"
+      id={undefined}
+      onScroll={[Function]}
+      role="grid"
       style={
         Object {
+          "WebkitOverflowScrolling": "touch",
+          "boxSizing": "border-box",
+          "direction": "ltr",
           "height": 0,
-          "overflow": "visible",
+          "overflowX": "hidden",
+          "overflowY": "auto",
+          "position": "relative",
           "width": 0,
+          "willChange": "transform",
         }
       }
-    >
-      <div
-        aria-label="grid"
-        aria-readonly={true}
-        className="ReactVirtualized__Grid ReactVirtualized__List"
-        id={undefined}
-        onScroll={[Function]}
-        role="grid"
-        style={
-          Object {
-            "WebkitOverflowScrolling": "touch",
-            "boxSizing": "border-box",
-            "direction": "ltr",
-            "height": 0,
-            "overflowX": "hidden",
-            "overflowY": "auto",
-            "position": "relative",
-            "width": 0,
-            "willChange": "transform",
-          }
-        }
-        tabIndex={0}
-      />
-    </div>
-     
+      tabIndex={0}
+    />
   </div>
+   
 </div>
 `;

--- a/packages/bpk-component-scrollable-calendar/src/bpk-scrollable-calendar-grid-list.scss
+++ b/packages/bpk-component-scrollable-calendar/src/bpk-scrollable-calendar-grid-list.scss
@@ -24,16 +24,10 @@ $calendar-height: 7 * ($bpk-calendar-day-size + $bpk-calendar-day-spacing);
   position: relative;
   width: 100%;
   height: 100%;
+  min-height: $calendar-height;
   overflow-x: hidden;
   box-sizing: border-box;
   -ms-overflow-style: -ms-autohiding-scrollbar;
-
-  &__strip {
-    z-index: 0;
-    height: 100%;
-    min-height: $calendar-height;
-    flex-direction: column;
-  }
 
   &__item {
     display: inline-table;

--- a/packages/bpk-component-scrollable-calendar/stories.js
+++ b/packages/bpk-component-scrollable-calendar/stories.js
@@ -18,6 +18,8 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import startOfMonth from 'date-fns/start_of_month';
+import endOfMonth from 'date-fns/end_of_month';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { DateUtils } from 'bpk-component-calendar';
@@ -93,6 +95,38 @@ storiesOf('bpk-component-scrollable-calendar', module)
       minDate={DateUtils.addDays(new Date(), -1)}
       maxDate={DateUtils.addMonths(new Date(), 12)}
     />
+  ))
+  .add('Scrollable Calendar in a tall container', () => (
+    <div style={{ height: '500px', display: 'flex' }}>
+      <ScrollableCal
+        weekStartsOn={1}
+        daysOfWeek={weekDays}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        DateComponent={BpkScrollableCalendarDate}
+        showWeekendSeparator
+        selectTodaysDate
+        // Subtract one day from today's date to make today selectable by default
+        minDate={DateUtils.addDays(new Date(), -1)}
+        maxDate={DateUtils.addMonths(new Date(), 12)}
+      />
+    </div>
+  ))
+  .add('Scrollable Calendar with a single month', () => (
+    <div style={{ height: '500px', display: 'flex' }}>
+      <ScrollableCal
+        weekStartsOn={1}
+        daysOfWeek={weekDays}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        DateComponent={BpkScrollableCalendarDate}
+        showWeekendSeparator
+        selectTodaysDate
+        // Subtract one day from today's date to make today selectable by default
+        minDate={startOfMonth(new Date())}
+        maxDate={endOfMonth(new Date())}
+      />
+    </div>
   ))
   .add('BpkScrollableCalendarDate', () => (
     <BpkScrollableCalendarDate


### PR DESCRIPTION
Why:
1. It's unnecessary.
2. It has no className property, making it impossible to customize
   with additional CSS classes.