### PR TITLE
[BPK-2062] Move deprecated prop into the root object for tokens

### DIFF
--- a/packages/bpk-tokens/src/android/base/typography.json
+++ b/packages/bpk-tokens/src/android/base/typography.json
@@ -1,5 +1,7 @@
 {
-  "imports": ["./aliases.json"],
+  "imports": [
+    "./aliases.json"
+  ],
   "props": {
     "FONT_FAMILY": {
       "value": "{!FONT_FAMILY}",
@@ -16,7 +18,6 @@
       "type": "font",
       "category": "typesettings"
     },
-
     "FONT_SIZE_CAPS": {
       "value": "{!FONT_SIZE_CAPS}",
       "type": "font-size",
@@ -127,7 +128,6 @@
       "type": "letter-spacing",
       "category": "letter-spacings"
     },
-
     "TEXT_CAPS_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_CAPS}",
       "type": "letter-spacing",
@@ -162,9 +162,7 @@
       "value": "{!LINE_HEIGHT_XS}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_SM_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_SM}",
@@ -185,9 +183,7 @@
       "value": "{!LINE_HEIGHT_SM}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_BASE_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_BASE}",
@@ -208,9 +204,7 @@
       "value": "{!LINE_HEIGHT_BASE}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_LG_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_LG}",
@@ -231,9 +225,7 @@
       "value": "{!LINE_HEIGHT_LG}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_XL_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_XL}",
@@ -254,9 +246,7 @@
       "value": "{!LINE_HEIGHT_XL}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_XXL_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_XXL}",
@@ -277,9 +267,7 @@
       "value": "{!LINE_HEIGHT_XXL}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_XXXL_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_XXXL}",

--- a/packages/bpk-tokens/src/ios/base/box-shadows.json
+++ b/packages/bpk-tokens/src/ios/base/box-shadows.json
@@ -57,41 +57,31 @@
       "value": "{!GRAY_900}",
       "type": "color",
       "category": "box-shadows",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "SHADOW_XL_OFFSET_HEIGHT": {
       "value": 12,
       "type": "size",
       "category": "box-shadows",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "SHADOW_XL_OFFSET_WIDTH": {
       "value": 0,
       "type": "size",
       "category": "box-shadows",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "SHADOW_XL_OPACITY": {
       "value": 0.2,
       "type": "size",
       "category": "box-shadows",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "SHADOW_XL_RADIUS": {
       "value": 50,
       "type": "size",
       "category": "box-shadows",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     }
   }
 }

--- a/packages/bpk-tokens/src/ios/base/touchables.json
+++ b/packages/bpk-tokens/src/ios/base/touchables.json
@@ -9,16 +9,12 @@
     "UNDERLAY_COLOR": {
       "value": "{!GRAY_900}",
       "type": "color",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "UNDERLAY_OPACITY": {
       "value": "0.15",
       "type": "number",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TOUCHABLE_OVERLAY_COLOR": {
       "value": "{!GRAY_900}",

--- a/packages/bpk-tokens/src/ios/base/typography.json
+++ b/packages/bpk-tokens/src/ios/base/typography.json
@@ -1,12 +1,13 @@
 {
-  "imports": ["./aliases.json"],
+  "imports": [
+    "./aliases.json"
+  ],
   "props": {
     "FONT_FAMILY": {
       "value": "{!FONT_FAMILY}",
       "type": "font",
       "category": "typesettings"
     },
-
     "FONT_SIZE_CAPS": {
       "value": "{!FONT_SIZE_CAPS}",
       "type": "font-size",
@@ -117,7 +118,6 @@
       "type": "letter-spacing",
       "category": "letter-spacings"
     },
-
     "TEXT_CAPS_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_CAPS}",
       "type": "letter-spacing",
@@ -152,9 +152,7 @@
       "value": "{!LINE_HEIGHT_XS}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_SM_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_SM}",
@@ -175,9 +173,7 @@
       "value": "{!LINE_HEIGHT_SM}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_BASE_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_BASE}",
@@ -198,9 +194,7 @@
       "value": "{!LINE_HEIGHT_BASE}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_LG_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_LG}",
@@ -221,9 +215,7 @@
       "value": "{!LINE_HEIGHT_LG}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_XL_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_XL}",
@@ -244,9 +236,7 @@
       "value": "{!LINE_HEIGHT_XL}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_XXL_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_XXL}",
@@ -267,9 +257,7 @@
       "value": "{!LINE_HEIGHT_XXL}",
       "type": "size",
       "category": "line-heights",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "TEXT_XXXL_LETTER_SPACING": {
       "value": "{!LETTER_SPACING_XXXL}",

--- a/packages/bpk-tokens/src/web/base/buttons.json
+++ b/packages/bpk-tokens/src/web/base/buttons.json
@@ -33,9 +33,7 @@
     "BUTTON_BACKGROUND_IMAGE": {
       "value": "linear-gradient(-180deg, {!GREEN_500} 0%, {!GREEN_600} 100%)",
       "type": "background-image",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "BUTTON_GRADIENT_START_COLOR": {
       "value": "{!GREEN_500}",
@@ -188,23 +186,17 @@
     "BUTTON_SECONDARY_BOX_SHADOW": {
       "value": "0 0 0 2px {!GRAY_100} inset",
       "type": "box-shadow",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "BUTTON_SECONDARY_HOVER_BOX_SHADOW": {
       "value": "0 0 0 2px {!BLUE_500} inset",
       "type": "box-shadow",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "BUTTON_SECONDARY_ACTIVE_BOX_SHADOW": {
       "value": "0 0 0 3px {!BLUE_500} inset",
       "type": "box-shadow",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "BUTTON_SECONDARY_BORDER_COLOR": {
       "value": "{!GRAY_100}",

--- a/packages/bpk-tokens/src/web/base/calendar.json
+++ b/packages/bpk-tokens/src/web/base/calendar.json
@@ -25,9 +25,7 @@
     "CALENDAR_DAY_BACKGROUND_COLOR": {
       "value": "{!WHITE}",
       "type": "color",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "CALENDAR_DAY_SELECTED_COLOR": {
       "value": "{!WHITE}",
@@ -60,9 +58,7 @@
     "CALENDAR_DAY_DISABLED_BACKGROUND_COLOR": {
       "value": "{!WHITE}",
       "type": "color",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "CALENDAR_DAY_OUTSIDE_COLOR": {
       "value": "{!GRAY_300}",
@@ -71,9 +67,7 @@
     "CALENDAR_DAY_OUTSIDE_BACKGROUND_COLOR": {
       "value": "{!WHITE}",
       "type": "color",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "CALENDAR_NAV_ICON_FILL": {
       "value": "{!BLUE_500}",

--- a/packages/bpk-tokens/src/web/base/modals.json
+++ b/packages/bpk-tokens/src/web/base/modals.json
@@ -9,30 +9,22 @@
     "MODAL_SCRIM_BACKGROUND_COLOR": {
       "value": "{!GRAY_300}",
       "type": "color",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "MODAL_SCRIM_INITIAL_OPACITY": {
       "value": "0",
       "type": "number",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "MODAL_SCRIM_OPACITY": {
       "value": ".7",
       "type": "number",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "MODAL_SCRIM_MOBILE_OPACITY": {
       "value": "1",
       "type": "number",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "MODAL_BACKGROUND_COLOR": {
       "value": "{!WHITE}",
@@ -61,16 +53,12 @@
     "MODAL_CLOSE_ICON_FILL": {
       "value": "{!GRAY_500}",
       "type": "color",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "MODAL_CLOSE_ICON_HOVER_FILL": {
       "value": "{!GRAY_700}",
       "type": "color",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "MODAL_CONTENT_PADDING": {
       "value": "{!SPACING_SM}",

--- a/packages/bpk-tokens/src/web/base/z-index.json
+++ b/packages/bpk-tokens/src/web/base/z-index.json
@@ -18,9 +18,7 @@
     },
     "ZINDEX_MODAL_SCRIM": {
       "value": "{!ZINDEX_SCRIM}",
-      "meta": {
-        "deprecated": true
-      }
+      "deprecated": true
     },
     "ZINDEX_SCRIM": {
       "value": "{!ZINDEX_SCRIM}"

--- a/packages/bpk-tokens/tokens/base.ios.json
+++ b/packages/bpk-tokens/tokens/base.ios.json
@@ -788,36 +788,41 @@
       "value": "#252033ff",
       "type": "color",
       "category": "box-shadows",
-      "name": "shadowXlColor",
-      "originalValue": "{!GRAY_900}"
+      "deprecated": true,
+      "originalValue": "{!GRAY_900}",
+      "name": "shadowXlColor"
     },
     {
       "value": 12,
       "type": "size",
       "category": "box-shadows",
-      "name": "shadowXlOffsetHeight",
-      "originalValue": 12
+      "deprecated": true,
+      "originalValue": 12,
+      "name": "shadowXlOffsetHeight"
     },
     {
       "value": 0,
       "type": "size",
       "category": "box-shadows",
-      "name": "shadowXlOffsetWidth",
-      "originalValue": 0
+      "deprecated": true,
+      "originalValue": 0,
+      "name": "shadowXlOffsetWidth"
     },
     {
       "value": 0.2,
       "type": "size",
       "category": "box-shadows",
-      "name": "shadowXlOpacity",
-      "originalValue": 0.2
+      "deprecated": true,
+      "originalValue": 0.2,
+      "name": "shadowXlOpacity"
     },
     {
       "value": 50,
       "type": "size",
       "category": "box-shadows",
-      "name": "shadowXlRadius",
-      "originalValue": 50
+      "deprecated": true,
+      "originalValue": 50,
+      "name": "shadowXlRadius"
     },
     {
       "type": "size",
@@ -893,8 +898,9 @@
       "value": "19",
       "type": "size",
       "category": "line-heights",
-      "name": "textBaseLineHeight",
-      "originalValue": "{!LINE_HEIGHT_BASE}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_BASE}",
+      "name": "textBaseLineHeight"
     },
     {
       "value": "10",
@@ -949,8 +955,9 @@
       "value": "24",
       "type": "size",
       "category": "line-heights",
-      "name": "textLgLineHeight",
-      "originalValue": "{!LINE_HEIGHT_LG}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_LG}",
+      "name": "textLgLineHeight"
     },
     {
       "value": "14",
@@ -977,8 +984,9 @@
       "value": "17",
       "type": "size",
       "category": "line-heights",
-      "name": "textSmLineHeight",
-      "originalValue": "{!LINE_HEIGHT_SM}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_SM}",
+      "name": "textSmLineHeight"
     },
     {
       "value": "24",
@@ -1005,8 +1013,9 @@
       "value": "29",
       "type": "size",
       "category": "line-heights",
-      "name": "textXlLineHeight",
-      "originalValue": "{!LINE_HEIGHT_XL}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_XL}",
+      "name": "textXlLineHeight"
     },
     {
       "value": "12",
@@ -1033,8 +1042,9 @@
       "value": "14",
       "type": "size",
       "category": "line-heights",
-      "name": "textXsLineHeight",
-      "originalValue": "{!LINE_HEIGHT_XS}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_XS}",
+      "name": "textXsLineHeight"
     },
     {
       "value": "30",
@@ -1061,8 +1071,9 @@
       "value": "43",
       "type": "size",
       "category": "line-heights",
-      "name": "textXxlLineHeight",
-      "originalValue": "{!LINE_HEIGHT_XXL}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_XXL}",
+      "name": "textXxlLineHeight"
     },
     {
       "value": "36",
@@ -1103,15 +1114,17 @@
       "category": "touchables",
       "value": "#252033ff",
       "type": "color",
-      "name": "underlayColor",
-      "originalValue": "{!GRAY_900}"
+      "deprecated": true,
+      "originalValue": "{!GRAY_900}",
+      "name": "underlayColor"
     },
     {
       "category": "touchables",
       "value": "0.15",
       "type": "number",
-      "name": "underlayOpacity",
-      "originalValue": "0.15"
+      "deprecated": true,
+      "originalValue": "0.15",
+      "name": "underlayOpacity"
     }
   ]
 }

--- a/packages/bpk-tokens/tokens/base.raw.android.json
+++ b/packages/bpk-tokens/tokens/base.raw.android.json
@@ -1188,8 +1188,9 @@
       "value": "19",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_BASE_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_BASE}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_BASE}",
+      "name": "TEXT_BASE_LINE_HEIGHT"
     },
     "TEXT_CAPS_FONT_SIZE": {
       "value": "10",
@@ -1244,8 +1245,9 @@
       "value": "23",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_LG_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_LG}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_LG}",
+      "name": "TEXT_LG_LINE_HEIGHT"
     },
     "TEXT_SM_FONT_SIZE": {
       "value": "14",
@@ -1272,8 +1274,9 @@
       "value": "16",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_SM_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_SM}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_SM}",
+      "name": "TEXT_SM_LINE_HEIGHT"
     },
     "TEXT_XL_FONT_SIZE": {
       "value": "24",
@@ -1300,8 +1303,9 @@
       "value": "28",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_XL_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_XL}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_XL}",
+      "name": "TEXT_XL_LINE_HEIGHT"
     },
     "TEXT_XS_FONT_SIZE": {
       "value": "12",
@@ -1328,8 +1332,9 @@
       "value": "14",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_XS_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_XS}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_XS}",
+      "name": "TEXT_XS_LINE_HEIGHT"
     },
     "TEXT_XXL_FONT_SIZE": {
       "value": "30",
@@ -1356,8 +1361,9 @@
       "value": "42",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_XXL_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_XXL}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_XXL}",
+      "name": "TEXT_XXL_LINE_HEIGHT"
     },
     "TEXT_XXXL_FONT_SIZE": {
       "value": "36",

--- a/packages/bpk-tokens/tokens/base.raw.ios.json
+++ b/packages/bpk-tokens/tokens/base.raw.ios.json
@@ -1111,36 +1111,41 @@
       "value": "#252033ff",
       "type": "color",
       "category": "box-shadows",
-      "name": "SHADOW_XL_COLOR",
-      "originalValue": "{!GRAY_900}"
+      "deprecated": true,
+      "originalValue": "{!GRAY_900}",
+      "name": "SHADOW_XL_COLOR"
     },
     "SHADOW_XL_OFFSET_HEIGHT": {
       "value": 12,
       "type": "size",
       "category": "box-shadows",
-      "name": "SHADOW_XL_OFFSET_HEIGHT",
-      "originalValue": 12
+      "deprecated": true,
+      "originalValue": 12,
+      "name": "SHADOW_XL_OFFSET_HEIGHT"
     },
     "SHADOW_XL_OFFSET_WIDTH": {
       "value": 0,
       "type": "size",
       "category": "box-shadows",
-      "name": "SHADOW_XL_OFFSET_WIDTH",
-      "originalValue": 0
+      "deprecated": true,
+      "originalValue": 0,
+      "name": "SHADOW_XL_OFFSET_WIDTH"
     },
     "SHADOW_XL_OPACITY": {
       "value": 0.2,
       "type": "size",
       "category": "box-shadows",
-      "name": "SHADOW_XL_OPACITY",
-      "originalValue": 0.2
+      "deprecated": true,
+      "originalValue": 0.2,
+      "name": "SHADOW_XL_OPACITY"
     },
     "SHADOW_XL_RADIUS": {
       "value": 50,
       "type": "size",
       "category": "box-shadows",
-      "name": "SHADOW_XL_RADIUS",
-      "originalValue": 50
+      "deprecated": true,
+      "originalValue": 50,
+      "name": "SHADOW_XL_RADIUS"
     },
     "SPACING_BASE": {
       "type": "size",
@@ -1216,8 +1221,9 @@
       "value": "19",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_BASE_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_BASE}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_BASE}",
+      "name": "TEXT_BASE_LINE_HEIGHT"
     },
     "TEXT_CAPS_FONT_SIZE": {
       "value": "10",
@@ -1272,8 +1278,9 @@
       "value": "24",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_LG_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_LG}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_LG}",
+      "name": "TEXT_LG_LINE_HEIGHT"
     },
     "TEXT_SM_FONT_SIZE": {
       "value": "14",
@@ -1300,8 +1307,9 @@
       "value": "17",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_SM_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_SM}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_SM}",
+      "name": "TEXT_SM_LINE_HEIGHT"
     },
     "TEXT_XL_FONT_SIZE": {
       "value": "24",
@@ -1328,8 +1336,9 @@
       "value": "29",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_XL_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_XL}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_XL}",
+      "name": "TEXT_XL_LINE_HEIGHT"
     },
     "TEXT_XS_FONT_SIZE": {
       "value": "12",
@@ -1356,8 +1365,9 @@
       "value": "14",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_XS_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_XS}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_XS}",
+      "name": "TEXT_XS_LINE_HEIGHT"
     },
     "TEXT_XXL_FONT_SIZE": {
       "value": "30",
@@ -1384,8 +1394,9 @@
       "value": "43",
       "type": "size",
       "category": "line-heights",
-      "name": "TEXT_XXL_LINE_HEIGHT",
-      "originalValue": "{!LINE_HEIGHT_XXL}"
+      "deprecated": true,
+      "originalValue": "{!LINE_HEIGHT_XXL}",
+      "name": "TEXT_XXL_LINE_HEIGHT"
     },
     "TEXT_XXXL_FONT_SIZE": {
       "value": "36",
@@ -1426,15 +1437,17 @@
       "category": "touchables",
       "value": "#252033ff",
       "type": "color",
-      "name": "UNDERLAY_COLOR",
-      "originalValue": "{!GRAY_900}"
+      "deprecated": true,
+      "originalValue": "{!GRAY_900}",
+      "name": "UNDERLAY_COLOR"
     },
     "UNDERLAY_OPACITY": {
       "category": "touchables",
       "value": "0.15",
       "type": "number",
-      "name": "UNDERLAY_OPACITY",
-      "originalValue": "0.15"
+      "deprecated": true,
+      "originalValue": "0.15",
+      "name": "UNDERLAY_OPACITY"
     }
   },
   "propKeys": [

--- a/packages/bpk-tokens/tokens/base.raw.json
+++ b/packages/bpk-tokens/tokens/base.raw.json
@@ -601,8 +601,9 @@
       "category": "buttons",
       "value": "linear-gradient(-180deg, #00d775 0%, #00bd68 100%)",
       "type": "background-image",
-      "name": "BUTTON_BACKGROUND_IMAGE",
-      "originalValue": "linear-gradient(-180deg, {!GREEN_500} 0%, {!GREEN_600} 100%)"
+      "deprecated": true,
+      "originalValue": "linear-gradient(-180deg, {!GREEN_500} 0%, {!GREEN_600} 100%)",
+      "name": "BUTTON_BACKGROUND_IMAGE"
     },
     "BUTTON_BORDER_RADIUS": {
       "category": "buttons",
@@ -937,8 +938,9 @@
       "category": "buttons",
       "value": "0 0 0 3px #00b2d6 inset",
       "type": "box-shadow",
-      "name": "BUTTON_SECONDARY_ACTIVE_BOX_SHADOW",
-      "originalValue": "0 0 0 3px {!BLUE_500} inset"
+      "deprecated": true,
+      "originalValue": "0 0 0 3px {!BLUE_500} inset",
+      "name": "BUTTON_SECONDARY_ACTIVE_BOX_SHADOW"
     },
     "BUTTON_SECONDARY_ACTIVE_COLOR": {
       "category": "buttons",
@@ -972,8 +974,9 @@
       "category": "buttons",
       "value": "0 0 0 2px #E6E4EB inset",
       "type": "box-shadow",
-      "name": "BUTTON_SECONDARY_BOX_SHADOW",
-      "originalValue": "0 0 0 2px {!GRAY_100} inset"
+      "deprecated": true,
+      "originalValue": "0 0 0 2px {!GRAY_100} inset",
+      "name": "BUTTON_SECONDARY_BOX_SHADOW"
     },
     "BUTTON_SECONDARY_COLOR": {
       "category": "buttons",
@@ -1035,8 +1038,9 @@
       "category": "buttons",
       "value": "0 0 0 2px #00b2d6 inset",
       "type": "box-shadow",
-      "name": "BUTTON_SECONDARY_HOVER_BOX_SHADOW",
-      "originalValue": "0 0 0 2px {!BLUE_500} inset"
+      "deprecated": true,
+      "originalValue": "0 0 0 2px {!BLUE_500} inset",
+      "name": "BUTTON_SECONDARY_HOVER_BOX_SHADOW"
     },
     "BUTTON_SECONDARY_HOVER_COLOR": {
       "category": "buttons",
@@ -1161,8 +1165,9 @@
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
-      "name": "CALENDAR_DAY_BACKGROUND_COLOR",
-      "originalValue": "{!WHITE}"
+      "deprecated": true,
+      "originalValue": "{!WHITE}",
+      "name": "CALENDAR_DAY_BACKGROUND_COLOR"
     },
     "CALENDAR_DAY_COLOR": {
       "category": "calendar",
@@ -1175,8 +1180,9 @@
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
-      "name": "CALENDAR_DAY_DISABLED_BACKGROUND_COLOR",
-      "originalValue": "{!WHITE}"
+      "deprecated": true,
+      "originalValue": "{!WHITE}",
+      "name": "CALENDAR_DAY_DISABLED_BACKGROUND_COLOR"
     },
     "CALENDAR_DAY_DISABLED_COLOR": {
       "category": "calendar",
@@ -1203,8 +1209,9 @@
       "category": "calendar",
       "value": "rgb(255, 255, 255)",
       "type": "color",
-      "name": "CALENDAR_DAY_OUTSIDE_BACKGROUND_COLOR",
-      "originalValue": "{!WHITE}"
+      "deprecated": true,
+      "originalValue": "{!WHITE}",
+      "name": "CALENDAR_DAY_OUTSIDE_BACKGROUND_COLOR"
     },
     "CALENDAR_DAY_OUTSIDE_COLOR": {
       "category": "calendar",
@@ -2330,15 +2337,17 @@
       "category": "modals",
       "value": "rgb(129, 123, 143)",
       "type": "color",
-      "name": "MODAL_CLOSE_ICON_FILL",
-      "originalValue": "{!GRAY_500}"
+      "deprecated": true,
+      "originalValue": "{!GRAY_500}",
+      "name": "MODAL_CLOSE_ICON_FILL"
     },
     "MODAL_CLOSE_ICON_HOVER_FILL": {
       "category": "modals",
       "value": "rgb(82, 76, 97)",
       "type": "color",
-      "name": "MODAL_CLOSE_ICON_HOVER_FILL",
-      "originalValue": "{!GRAY_700}"
+      "deprecated": true,
+      "originalValue": "{!GRAY_700}",
+      "name": "MODAL_CLOSE_ICON_HOVER_FILL"
     },
     "MODAL_CONTENT_PADDING": {
       "category": "modals",
@@ -2379,29 +2388,33 @@
       "category": "modals",
       "value": "rgb(178, 174, 189)",
       "type": "color",
-      "name": "MODAL_SCRIM_BACKGROUND_COLOR",
-      "originalValue": "{!GRAY_300}"
+      "deprecated": true,
+      "originalValue": "{!GRAY_300}",
+      "name": "MODAL_SCRIM_BACKGROUND_COLOR"
     },
     "MODAL_SCRIM_INITIAL_OPACITY": {
       "category": "modals",
       "value": "0",
       "type": "number",
-      "name": "MODAL_SCRIM_INITIAL_OPACITY",
-      "originalValue": "0"
+      "deprecated": true,
+      "originalValue": "0",
+      "name": "MODAL_SCRIM_INITIAL_OPACITY"
     },
     "MODAL_SCRIM_MOBILE_OPACITY": {
       "category": "modals",
       "value": "1",
       "type": "number",
-      "name": "MODAL_SCRIM_MOBILE_OPACITY",
-      "originalValue": "1"
+      "deprecated": true,
+      "originalValue": "1",
+      "name": "MODAL_SCRIM_MOBILE_OPACITY"
     },
     "MODAL_SCRIM_OPACITY": {
       "category": "modals",
       "value": ".7",
       "type": "number",
-      "name": "MODAL_SCRIM_OPACITY",
-      "originalValue": ".7"
+      "deprecated": true,
+      "originalValue": ".7",
+      "name": "MODAL_SCRIM_OPACITY"
     },
     "MODAL_WIDE_MAX_WIDTH": {
       "category": "modals",
@@ -2862,8 +2875,9 @@
       "type": "number",
       "category": "z-indices",
       "value": "1000",
-      "name": "ZINDEX_MODAL_SCRIM",
-      "originalValue": "{!ZINDEX_SCRIM}"
+      "deprecated": true,
+      "originalValue": "{!ZINDEX_SCRIM}",
+      "name": "ZINDEX_MODAL_SCRIM"
     },
     "ZINDEX_POPOVER": {
       "type": "number",


### PR DESCRIPTION
We need this to hide deprecated tokens in the docs site. According to theo's doc the meta prop is only used in transformers and removed before sending the token to formatters. https://www.npmjs.com/package/theo

**NOTE** I didn't update UNRELEASED.md because I don't think this is relevant to users.