### PR TITLE
[BPK-2083] calendar performance

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,4 @@
 # Unreleased
+
+ - bpk-component-scrollable-calendar:
+   - We've swapped out `react-virtualized` for `react-window`, which reduces the prod bundle size by around 62kb!🎉

--- a/packages/bpk-component-calendar/src/date-utils.js
+++ b/packages/bpk-component-calendar/src/date-utils.js
@@ -57,6 +57,11 @@ function utc(year, month, date) {
   return new Date(Date.UTC(year, month, date));
 }
 
+function daysInMonth(year, month) {
+  // Gets the last day of the month specified
+  return new Date(year, month + 1, 0).getDate();
+}
+
 function dateAtStartOfDay(year, month, day) {
   const date = utc(year, month, day);
   const tzOffset = date.getTimezoneOffset();
@@ -200,6 +205,7 @@ export {
   lastDayOfMonth,
   startOfDay,
   format,
+  daysInMonth,
   formatIsoDate,
   formatIsoMonth,
   parseIsoDate,

--- a/packages/bpk-component-scrollable-calendar/package-lock.json
+++ b/packages/bpk-component-scrollable-calendar/package-lock.json
@@ -4,29 +4,20 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+		"@babel/runtime": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+			"integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"regenerator-runtime": "^0.12.0"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.12.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+				}
 			}
-		},
-		"classnames": {
-			"version": "2.2.6",
-			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4="
-		},
-		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha1-+XJgj/DOrWi4QaFqky0LGDeRgU4="
-		},
-		"dom-helpers": {
-			"version": "3.3.1",
-			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-helpers/-/dom-helpers-3.3.1.tgz",
-			"integrity": "sha1-/BpOFf/fYN3eA6SAqcD+zoId1KY="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -40,6 +31,11 @@
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
+		},
+		"memoize-one": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
+			"integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -55,28 +51,14 @@
 				"object-assign": "^4.1.1"
 			}
 		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-		},
-		"react-virtualized": {
-			"version": "9.21.0",
-			"resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.21.0.tgz",
-			"integrity": "sha512-duKD2HvO33mqld4EtQKm9H9H0p+xce1c++2D5xn59Ma7P8VT7CprfAe5hwjd1OGkyhqzOZiTMlTal7LxjH5yBQ==",
+		"react-window": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/react-window/-/react-window-1.5.0.tgz",
+			"integrity": "sha512-55WeZKjMNF5JdCuKghc/H65DBecoeGgH8MOX3CgT7BJ66xb4ITRuXPUlz0qU6r50wetdF/oLhorYBRvKD4Z1IQ==",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"classnames": "^2.2.3",
-				"dom-helpers": "^2.4.0 || ^3.0.0",
-				"loose-envify": "^1.3.0",
-				"prop-types": "^15.6.0",
-				"react-lifecycles-compat": "^3.0.4"
+				"@babel/runtime": "^7.0.0",
+				"memoize-one": "^3.1.1"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		}
 	}
 }

--- a/packages/bpk-component-scrollable-calendar/package.json
+++ b/packages/bpk-component-scrollable-calendar/package.json
@@ -18,6 +18,6 @@
     "bpk-mixins": "^17.11.32",
     "bpk-react-utils": "^2.7.0",
     "prop-types": "^15.5.8",
-    "react-virtualized": "^9.20.1"
+    "react-window": "^1.5.0"
   }
 }

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar-test.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar-test.js
@@ -18,7 +18,7 @@
 /* @flow */
 
 import React from 'react';
-import renderer from 'react-test-renderer';
+import Shallow from 'react-test-renderer/shallow';
 import { DateUtils } from 'bpk-component-calendar';
 
 import BpkScrollableCalendar from './BpkScrollableCalendar';
@@ -28,58 +28,55 @@ const testDate = new Date(2010, 1, 15);
 
 describe('BpkScrollableCalendar', () => {
   it('should render correctly', () => {
-    const tree = renderer
-      .create(
-        <BpkScrollableCalendar
-          weekStartsOn={1}
-          daysOfWeek={weekDays}
-          formatMonth={formatMonth}
-          formatDateFull={formatDateFull}
-          showWeekendSeparator
-          // Subtract one day from today's date to make today selectable by default
-          minDate={DateUtils.addDays(testDate, -1)}
-          maxDate={DateUtils.addMonths(testDate, 12)}
-        />,
-      )
-      .toJSON();
+    const shallowRenderer = Shallow.createRenderer();
+    const tree = shallowRenderer.render(
+      <BpkScrollableCalendar
+        weekStartsOn={1}
+        daysOfWeek={weekDays}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        showWeekendSeparator
+        // Subtract one day from today's date to make today selectable by default
+        minDate={DateUtils.addDays(testDate, -1)}
+        maxDate={DateUtils.addMonths(testDate, 12)}
+      />,
+    );
     expect(tree).toMatchSnapshot();
   });
 
   it('should support custom class names', () => {
-    const tree = renderer
-      .create(
-        <BpkScrollableCalendar
-          weekStartsOn={1}
-          daysOfWeek={weekDays}
-          formatMonth={formatMonth}
-          formatDateFull={formatDateFull}
-          showWeekendSeparator
-          // Subtract one day from today's date to make today selectable by default
-          minDate={DateUtils.addDays(testDate, -1)}
-          maxDate={DateUtils.addMonths(testDate, 12)}
-          className="custom-classname"
-        />,
-      )
-      .toJSON();
+    const shallowRenderer = Shallow.createRenderer();
+    const tree = shallowRenderer.render(
+      <BpkScrollableCalendar
+        weekStartsOn={1}
+        daysOfWeek={weekDays}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        showWeekendSeparator
+        // Subtract one day from today's date to make today selectable by default
+        minDate={DateUtils.addDays(testDate, -1)}
+        maxDate={DateUtils.addMonths(testDate, 12)}
+        className="custom-classname"
+      />,
+    );
     expect(tree).toMatchSnapshot();
   });
 
   it('should support arbitrary props', () => {
-    const tree = renderer
-      .create(
-        <BpkScrollableCalendar
-          weekStartsOn={1}
-          daysOfWeek={weekDays}
-          formatMonth={formatMonth}
-          formatDateFull={formatDateFull}
-          showWeekendSeparator
-          // Subtract one day from today's date to make today selectable by default
-          minDate={DateUtils.addDays(testDate, -1)}
-          maxDate={DateUtils.addMonths(testDate, 12)}
-          testID="123"
-        />,
-      )
-      .toJSON();
+    const shallowRenderer = Shallow.createRenderer();
+    const tree = shallowRenderer.render(
+      <BpkScrollableCalendar
+        weekStartsOn={1}
+        daysOfWeek={weekDays}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        showWeekendSeparator
+        // Subtract one day from today's date to make today selectable by default
+        minDate={DateUtils.addDays(testDate, -1)}
+        maxDate={DateUtils.addMonths(testDate, 12)}
+        testID="123"
+      />,
+    );
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.js
@@ -18,7 +18,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import renderer from 'react-test-renderer';
+import Shallow from 'react-test-renderer/shallow';
 
 import isWeekend from 'date-fns/is_weekend';
 import { DateUtils } from 'bpk-component-calendar';
@@ -33,80 +33,77 @@ const testDate = new Date(2010, 1, 15);
 
 describe('BpkCalendarScrollGridList', () => {
   it('should render correctly with no optional props set', () => {
-    const tree = renderer
-      .create(
-        <BpkScrollableCalendarGridList
-          minDate={DateUtils.addDays(testDate, -1)}
-          maxDate={DateUtils.addMonths(testDate, 12)}
-          formatMonth={formatMonth}
-          formatDateFull={formatDateFull}
-          DateComponent={BpkCalendarScrollDate}
-          daysOfWeek={weekDays}
-        />,
-      )
-      .toJSON();
+    const shallowRenderer = Shallow.createRenderer();
+    const tree = shallowRenderer.render(
+      <BpkScrollableCalendarGridList
+        minDate={DateUtils.addDays(testDate, -1)}
+        maxDate={DateUtils.addMonths(testDate, 12)}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        DateComponent={BpkCalendarScrollDate}
+        daysOfWeek={weekDays}
+      />,
+    );
     expect(tree).toMatchSnapshot();
   });
 
   it('should render correctly with "showWeekendSeparator" attribute set to false', () => {
-    const tree = renderer
-      .create(
-        <BpkScrollableCalendarGridList
-          minDate={DateUtils.addDays(testDate, -1)}
-          maxDate={DateUtils.addMonths(testDate, 12)}
-          formatMonth={formatMonth}
-          formatDateFull={formatDateFull}
-          DateComponent={BpkCalendarScrollDate}
-          daysOfWeek={weekDays}
-          weekStartsOn={0}
-          showWeekendSeparator={false}
-        />,
-      )
-      .toJSON();
+    const shallowRenderer = Shallow.createRenderer();
+    const tree = shallowRenderer.render(
+      <BpkScrollableCalendarGridList
+        minDate={DateUtils.addDays(testDate, -1)}
+        maxDate={DateUtils.addMonths(testDate, 12)}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        DateComponent={BpkCalendarScrollDate}
+        daysOfWeek={weekDays}
+        weekStartsOn={0}
+        showWeekendSeparator={false}
+      />,
+    );
     expect(tree).toMatchSnapshot();
   });
 
   it('should render correctly with a different "weekStartsOn" attribute', () => {
-    const tree = renderer
-      .create(
-        <BpkScrollableCalendarGridList
-          minDate={DateUtils.addDays(testDate, -1)}
-          maxDate={DateUtils.addMonths(testDate, 12)}
-          formatMonth={formatMonth}
-          formatDateFull={formatDateFull}
-          DateComponent={BpkCalendarScrollDate}
-          daysOfWeek={weekDays}
-          weekStartsOn={3}
-          showWeekendSeparator
-        />,
-      )
-      .toJSON();
+    const shallowRenderer = Shallow.createRenderer();
+    const tree = shallowRenderer.render(
+      <BpkScrollableCalendarGridList
+        minDate={DateUtils.addDays(testDate, -1)}
+        maxDate={DateUtils.addMonths(testDate, 12)}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        DateComponent={BpkCalendarScrollDate}
+        daysOfWeek={weekDays}
+        weekStartsOn={3}
+        showWeekendSeparator
+      />,
+    );
     expect(tree).toMatchSnapshot();
   });
 
   it('should render correctly with a "dateModifiers" attribute', () => {
+    const shallowRenderer = Shallow.createRenderer();
     const modifiers = {
       someClass: () => true,
     };
-    const tree = renderer
-      .create(
-        <BpkScrollableCalendarGridList
-          minDate={DateUtils.addDays(testDate, -1)}
-          maxDate={DateUtils.addMonths(testDate, 12)}
-          formatMonth={formatMonth}
-          formatDateFull={formatDateFull}
-          DateComponent={BpkCalendarScrollDate}
-          daysOfWeek={weekDays}
-          weekStartsOn={1}
-          dateModifiers={modifiers}
-          showWeekendSeparator
-        />,
-      )
-      .toJSON();
+    const tree = shallowRenderer.render(
+      <BpkScrollableCalendarGridList
+        minDate={DateUtils.addDays(testDate, -1)}
+        maxDate={DateUtils.addMonths(testDate, 12)}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        DateComponent={BpkCalendarScrollDate}
+        daysOfWeek={weekDays}
+        weekStartsOn={1}
+        dateModifiers={modifiers}
+        showWeekendSeparator
+      />,
+    );
     expect(tree).toMatchSnapshot();
   });
 
   it('should render correctly with a custom date component', () => {
+    const shallowRenderer = Shallow.createRenderer();
     const MyCustomDate = props => {
       const cx = {
         backgroundColor: colorRed500,
@@ -123,20 +120,18 @@ describe('BpkCalendarScrollGridList', () => {
     MyCustomDate.propTypes = {
       date: PropTypes.instanceOf(Date).isRequired,
     };
-    const tree = renderer
-      .create(
-        <BpkScrollableCalendarGridList
-          minDate={DateUtils.addDays(testDate, -1)}
-          maxDate={DateUtils.addMonths(testDate, 12)}
-          formatMonth={formatMonth}
-          formatDateFull={formatDateFull}
-          DateComponent={MyCustomDate}
-          daysOfWeek={weekDays}
-          weekStartsOn={1}
-          showWeekendSeparator
-        />,
-      )
-      .toJSON();
+    const tree = shallowRenderer.render(
+      <BpkScrollableCalendarGridList
+        minDate={DateUtils.addDays(testDate, -1)}
+        maxDate={DateUtils.addMonths(testDate, 12)}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        DateComponent={MyCustomDate}
+        daysOfWeek={weekDays}
+        weekStartsOn={1}
+        showWeekendSeparator
+      />,
+    );
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
@@ -22,12 +22,7 @@ import React from 'react';
 import { cssModules } from 'bpk-react-utils';
 import { DateUtils, BpkCalendarGridPropTypes } from 'bpk-component-calendar';
 import { startOfDay, startOfMonth, isSameMonth } from 'date-fns';
-import {
-  AutoSizer,
-  List,
-  CellMeasurer,
-  CellMeasurerCache,
-} from 'react-virtualized';
+import { VariableSizeList as List } from 'react-window';
 
 import STYLES from './bpk-scrollable-calendar-grid-list.scss';
 import BpkScrollableCalendarGrid from './BpkScrollableCalendarGrid';
@@ -35,12 +30,20 @@ import getMonthsArray from './utils';
 
 const getClassName = cssModules(STYLES);
 
+// The `react-window` API requires the height in pixels to be specified.
+// These constants are here to facilitate calculating the height.
+const ROW_HEIGHT = 42;
+// This is the additional height of each grid without any rows.
+const BASE_MONTH_ITEM_HEIGHT = 60;
+const COLUMN_COUNT = 7;
+// Most calendar grids have 5 rows:
+const ESTIMATED_MONTH_ITEM_HEIGHT = BASE_MONTH_ITEM_HEIGHT + 5 * ROW_HEIGHT;
+
 class BpkScrollableCalendarGridList extends React.Component {
   constructor(props) {
     super(props);
 
-    this.rowRenderer = this.rowRenderer.bind(this);
-    this.renderList = this.renderList.bind(this);
+    this.outerDivRef = React.createRef();
 
     const startDate = startOfDay(startOfMonth(this.props.minDate));
     const endDate = startOfDay(startOfMonth(this.props.maxDate));
@@ -49,71 +52,74 @@ class BpkScrollableCalendarGridList extends React.Component {
       startDate,
     );
     const months = getMonthsArray(startDate, monthsCount);
-
-    const cache = new CellMeasurerCache({
-      fixedWidth: true,
-      defaultHeight: 276, // most common height (in px) of BpkScrollableCalendarGrid
+    // Here we calculate the height of each calendar grid item in pixels, as the `react-window` API
+    // requires that these are provided so that they can be efficiently rendered.
+    const monthItemHeights = months.map(month => {
+      const firstDayOffset = (month.getDay() + 7 - props.weekStartsOn) % 7;
+      const monthLength = DateUtils.daysInMonth(
+        month.getYear(),
+        month.getMonth(),
+      );
+      const calendarGridSpaces = firstDayOffset + monthLength;
+      const rowCount = Math.ceil(calendarGridSpaces / COLUMN_COUNT);
+      return BASE_MONTH_ITEM_HEIGHT + ROW_HEIGHT * rowCount;
     });
+
     this.state = {
       months,
-      cache,
+      monthItemHeights,
+      outerHeight: ESTIMATED_MONTH_ITEM_HEIGHT,
     };
   }
+
+  componentDidMount = () => {
+    this.setComponentHeight();
+    if (typeof document !== 'undefined') {
+      document.addEventListener('resize', this.setComponentHeight);
+      document.addEventListener('orientationchange', this.setComponentHeight);
+      document.addEventListener('fullscreenchange', this.setComponentHeight);
+    }
+  };
 
   getHtmlElement = () =>
     typeof document !== 'undefined' ? document.querySelector('html') : {};
 
-  rowRenderer({ index, key, style, parent }) {
-    return (
-      <CellMeasurer
-        key={key}
-        cache={this.state.cache}
-        parent={parent}
-        columnIndex={0}
-        rowIndex={index}
-      >
-        <div style={style}>
-          <BpkScrollableCalendarGrid
-            onDateClick={this.props.onDateClick}
-            {...this.props}
-            key={key}
-            month={this.state.months[index]}
-            focusedDate={this.props.focusedDate}
-            preventKeyboardFocus={this.props.preventKeyboardFocus}
-            aria-hidden={index !== 1}
-            className={getClassName('bpk-scrollable-calendar-grid-list__item')}
-          />
-        </div>
-      </CellMeasurer>
-    );
-  }
+  getItemSize = index =>
+    this.state.monthItemHeights[index] || ESTIMATED_MONTH_ITEM_HEIGHT;
 
-  renderList(width, height) {
-    return (
-      <List
-        extraData={this.props}
-        style={this.getHtmlElement().dir === 'rtl' ? { direction: 'rtl' } : {}}
-        width={width}
-        height={height}
-        deferredMeasurementCache={this.state.cache}
-        rowHeight={this.state.cache.rowHeight}
-        rowRenderer={this.rowRenderer}
-        rowCount={this.state.months.length}
-        overscanRowCount={0}
-        scrollToIndex={
-          isSameMonth(this.props.focusedDate, this.props.selectedDate)
-            ? DateUtils.differenceInCalendarMonths(
-                this.props.selectedDate,
-                this.props.minDate,
-              )
-            : DateUtils.differenceInCalendarMonths(
-                this.props.focusedDate,
-                this.props.minDate,
-              )
-        }
+  setComponentHeight = () => {
+    const outerNode = this.outerDivRef.current;
+    if (outerNode) {
+      const newHeight = outerNode.clientHeight;
+      this.setState({ outerHeight: newHeight });
+    } else {
+      this.setState({ outerHeight: ESTIMATED_MONTH_ITEM_HEIGHT });
+    }
+  };
+
+  rowRenderer = ({ index, style }) => (
+    <div style={style}>
+      <BpkScrollableCalendarGrid
+        onDateClick={this.props.onDateClick}
+        {...this.props}
+        month={this.state.months[index]}
+        focusedDate={this.props.focusedDate}
+        preventKeyboardFocus={this.props.preventKeyboardFocus}
+        aria-hidden={index !== 1}
+        className={getClassName('bpk-scrollable-calendar-grid-list__item')}
       />
-    );
-  }
+    </div>
+  );
+
+  calculateOffsetInPixels = numberOfMonths => {
+    // The `react-window` API requires the scroll offset to be provided in pixels.
+    // Here we use the pre-calculated item heights to find the correct pixel offset
+    let result = 0;
+    for (let i = 0; i < numberOfMonths; i += 1) {
+      result += this.getItemSize(i);
+    }
+    return result;
+  };
 
   render() {
     return (
@@ -122,10 +128,34 @@ class BpkScrollableCalendarGridList extends React.Component {
           'bpk-scrollable-calendar-grid-list',
           this.props.className,
         )}
+        ref={this.outerDivRef}
       >
-        <AutoSizer>
-          {({ width, height }) => this.renderList(width, height)}
-        </AutoSizer>{' '}
+        <List
+          extraData={this.props}
+          style={
+            this.getHtmlElement().dir === 'rtl' ? { direction: 'rtl' } : {}
+          }
+          width="100%"
+          height={this.state.outerHeight}
+          estimatedItemSize={ESTIMATED_MONTH_ITEM_HEIGHT}
+          itemSize={this.getItemSize}
+          itemCount={this.state.months.length}
+          rowCount={this.state.months.length}
+          overscanCount={1}
+          initialScrollOffset={this.calculateOffsetInPixels(
+            isSameMonth(this.props.focusedDate, this.props.selectedDate)
+              ? DateUtils.differenceInCalendarMonths(
+                  this.props.selectedDate,
+                  this.props.minDate,
+                )
+              : DateUtils.differenceInCalendarMonths(
+                  this.props.focusedDate,
+                  this.props.minDate,
+                ),
+          )}
+        >
+          {this.rowRenderer}
+        </List>
       </div>
     );
   }

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
@@ -1,370 +1,230 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BpkScrollableCalendar should render correctly 1`] = `
-<div
-  className="bpk-calendar bpk-calendar--fixed"
->
-  <header
-    className="bpk-calendar-header"
-  >
-    <ol
-      className="bpk-calendar-header__week"
-    >
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Monday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Mon
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Tuesday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Tue
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Wednesday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Wed
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Thursday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Thu
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Friday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Fri
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday bpk-calendar-header__weekday--weekend bpk-calendar-header__weekday--weekend-start"
-        title="Saturday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Sat
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday bpk-calendar-header__weekday--weekend bpk-calendar-header__weekday--weekend-end"
-        title="Sunday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Sun
-        </span>
-      </li>
-    </ol>
-  </header>
-  <div
-    className="bpk-scrollable-calendar-grid-list"
-  >
-    <div
-      className={undefined}
-      style={
-        Object {
-          "height": 0,
-          "overflow": "visible",
-          "width": 0,
-        }
-      }
-    >
-      <div
-        aria-label="grid"
-        aria-readonly={true}
-        className="ReactVirtualized__Grid ReactVirtualized__List"
-        id={undefined}
-        onScroll={[Function]}
-        role="grid"
-        style={
-          Object {
-            "WebkitOverflowScrolling": "touch",
-            "boxSizing": "border-box",
-            "direction": "ltr",
-            "height": 0,
-            "overflowX": "hidden",
-            "overflowY": "auto",
-            "position": "relative",
-            "width": 0,
-            "willChange": "transform",
-          }
-        }
-        tabIndex={0}
-      />
-    </div>
-     
-  </div>
-</div>
+<BpkCalendar
+  changeMonthLabel={null}
+  className={null}
+  dateModifiers={Object {}}
+  dateProps={null}
+  daysOfWeek={
+    Array [
+      Object {
+        "index": 0,
+        "isWeekend": true,
+        "name": "Sunday",
+        "nameAbbr": "Sun",
+      },
+      Object {
+        "index": 1,
+        "isWeekend": false,
+        "name": "Monday",
+        "nameAbbr": "Mon",
+      },
+      Object {
+        "index": 2,
+        "isWeekend": false,
+        "name": "Tuesday",
+        "nameAbbr": "Tue",
+      },
+      Object {
+        "index": 3,
+        "isWeekend": false,
+        "name": "Wednesday",
+        "nameAbbr": "Wed",
+      },
+      Object {
+        "index": 4,
+        "isWeekend": false,
+        "name": "Thursday",
+        "nameAbbr": "Thu",
+      },
+      Object {
+        "index": 5,
+        "isWeekend": false,
+        "name": "Friday",
+        "nameAbbr": "Fri",
+      },
+      Object {
+        "index": 6,
+        "isWeekend": true,
+        "name": "Saturday",
+        "nameAbbr": "Sat",
+      },
+    ]
+  }
+  fixedWidth={true}
+  focusedDate={2010-02-14T00:00:00.000Z}
+  formatDateFull={[Function]}
+  formatMonth={[Function]}
+  gridClassName={null}
+  gridProps={null}
+  headerProps={null}
+  initiallyFocusedDate={null}
+  markOutsideDays={true}
+  markToday={true}
+  maxDate={2011-02-15T00:00:00.000Z}
+  minDate={2010-02-14T00:00:00.000Z}
+  month={2010-02-01T00:00:00.000Z}
+  navProps={null}
+  onDateClick={[Function]}
+  onDateKeyDown={[Function]}
+  onMonthChange={[Function]}
+  preventKeyboardFocus={true}
+  selectedDate={null}
+  showWeekendSeparator={true}
+  weekStartsOn={1}
+/>
 `;
 
 exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
-<div
-  className="bpk-calendar bpk-calendar--fixed"
->
-  <header
-    className="bpk-calendar-header"
-  >
-    <ol
-      className="bpk-calendar-header__week"
-    >
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Monday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Mon
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Tuesday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Tue
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Wednesday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Wed
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Thursday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Thu
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Friday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Fri
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday bpk-calendar-header__weekday--weekend bpk-calendar-header__weekday--weekend-start"
-        title="Saturday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Sat
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday bpk-calendar-header__weekday--weekend bpk-calendar-header__weekday--weekend-end"
-        title="Sunday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Sun
-        </span>
-      </li>
-    </ol>
-  </header>
-  <div
-    className="bpk-scrollable-calendar-grid-list"
-  >
-    <div
-      className={undefined}
-      style={
-        Object {
-          "height": 0,
-          "overflow": "visible",
-          "width": 0,
-        }
-      }
-    >
-      <div
-        aria-label="grid"
-        aria-readonly={true}
-        className="ReactVirtualized__Grid ReactVirtualized__List"
-        id={undefined}
-        onScroll={[Function]}
-        role="grid"
-        style={
-          Object {
-            "WebkitOverflowScrolling": "touch",
-            "boxSizing": "border-box",
-            "direction": "ltr",
-            "height": 0,
-            "overflowX": "hidden",
-            "overflowY": "auto",
-            "position": "relative",
-            "width": 0,
-            "willChange": "transform",
-          }
-        }
-        tabIndex={0}
-      />
-    </div>
-     
-  </div>
-</div>
+<BpkCalendar
+  changeMonthLabel={null}
+  className={null}
+  dateModifiers={Object {}}
+  dateProps={null}
+  daysOfWeek={
+    Array [
+      Object {
+        "index": 0,
+        "isWeekend": true,
+        "name": "Sunday",
+        "nameAbbr": "Sun",
+      },
+      Object {
+        "index": 1,
+        "isWeekend": false,
+        "name": "Monday",
+        "nameAbbr": "Mon",
+      },
+      Object {
+        "index": 2,
+        "isWeekend": false,
+        "name": "Tuesday",
+        "nameAbbr": "Tue",
+      },
+      Object {
+        "index": 3,
+        "isWeekend": false,
+        "name": "Wednesday",
+        "nameAbbr": "Wed",
+      },
+      Object {
+        "index": 4,
+        "isWeekend": false,
+        "name": "Thursday",
+        "nameAbbr": "Thu",
+      },
+      Object {
+        "index": 5,
+        "isWeekend": false,
+        "name": "Friday",
+        "nameAbbr": "Fri",
+      },
+      Object {
+        "index": 6,
+        "isWeekend": true,
+        "name": "Saturday",
+        "nameAbbr": "Sat",
+      },
+    ]
+  }
+  fixedWidth={true}
+  focusedDate={2010-02-14T00:00:00.000Z}
+  formatDateFull={[Function]}
+  formatMonth={[Function]}
+  gridClassName={null}
+  gridProps={null}
+  headerProps={null}
+  initiallyFocusedDate={null}
+  markOutsideDays={true}
+  markToday={true}
+  maxDate={2011-02-15T00:00:00.000Z}
+  minDate={2010-02-14T00:00:00.000Z}
+  month={2010-02-01T00:00:00.000Z}
+  navProps={null}
+  onDateClick={[Function]}
+  onDateKeyDown={[Function]}
+  onMonthChange={[Function]}
+  preventKeyboardFocus={true}
+  selectedDate={null}
+  showWeekendSeparator={true}
+  testID="123"
+  weekStartsOn={1}
+/>
 `;
 
 exports[`BpkScrollableCalendar should support custom class names 1`] = `
-<div
-  className="bpk-calendar custom-classname bpk-calendar--fixed"
->
-  <header
-    className="bpk-calendar-header"
-  >
-    <ol
-      className="bpk-calendar-header__week"
-    >
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Monday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Mon
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Tuesday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Tue
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Wednesday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Wed
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Thursday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Thu
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday"
-        title="Friday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Fri
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday bpk-calendar-header__weekday--weekend bpk-calendar-header__weekday--weekend-start"
-        title="Saturday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Sat
-        </span>
-      </li>
-      <li
-        className="bpk-calendar-header__weekday bpk-calendar-header__weekday--weekend bpk-calendar-header__weekday--weekend-end"
-        title="Sunday"
-      >
-        <span
-          aria-hidden="true"
-        >
-          Sun
-        </span>
-      </li>
-    </ol>
-  </header>
-  <div
-    className="bpk-scrollable-calendar-grid-list"
-  >
-    <div
-      className={undefined}
-      style={
-        Object {
-          "height": 0,
-          "overflow": "visible",
-          "width": 0,
-        }
-      }
-    >
-      <div
-        aria-label="grid"
-        aria-readonly={true}
-        className="ReactVirtualized__Grid ReactVirtualized__List"
-        id={undefined}
-        onScroll={[Function]}
-        role="grid"
-        style={
-          Object {
-            "WebkitOverflowScrolling": "touch",
-            "boxSizing": "border-box",
-            "direction": "ltr",
-            "height": 0,
-            "overflowX": "hidden",
-            "overflowY": "auto",
-            "position": "relative",
-            "width": 0,
-            "willChange": "transform",
-          }
-        }
-        tabIndex={0}
-      />
-    </div>
-     
-  </div>
-</div>
+<BpkCalendar
+  changeMonthLabel={null}
+  className="custom-classname"
+  dateModifiers={Object {}}
+  dateProps={null}
+  daysOfWeek={
+    Array [
+      Object {
+        "index": 0,
+        "isWeekend": true,
+        "name": "Sunday",
+        "nameAbbr": "Sun",
+      },
+      Object {
+        "index": 1,
+        "isWeekend": false,
+        "name": "Monday",
+        "nameAbbr": "Mon",
+      },
+      Object {
+        "index": 2,
+        "isWeekend": false,
+        "name": "Tuesday",
+        "nameAbbr": "Tue",
+      },
+      Object {
+        "index": 3,
+        "isWeekend": false,
+        "name": "Wednesday",
+        "nameAbbr": "Wed",
+      },
+      Object {
+        "index": 4,
+        "isWeekend": false,
+        "name": "Thursday",
+        "nameAbbr": "Thu",
+      },
+      Object {
+        "index": 5,
+        "isWeekend": false,
+        "name": "Friday",
+        "nameAbbr": "Fri",
+      },
+      Object {
+        "index": 6,
+        "isWeekend": true,
+        "name": "Saturday",
+        "nameAbbr": "Sat",
+      },
+    ]
+  }
+  fixedWidth={true}
+  focusedDate={2010-02-14T00:00:00.000Z}
+  formatDateFull={[Function]}
+  formatMonth={[Function]}
+  gridClassName={null}
+  gridProps={null}
+  headerProps={null}
+  initiallyFocusedDate={null}
+  markOutsideDays={true}
+  markToday={true}
+  maxDate={2011-02-15T00:00:00.000Z}
+  minDate={2010-02-14T00:00:00.000Z}
+  month={2010-02-01T00:00:00.000Z}
+  navProps={null}
+  onDateClick={[Function]}
+  onDateKeyDown={[Function]}
+  onMonthChange={[Function]}
+  preventKeyboardFocus={true}
+  selectedDate={null}
+  showWeekendSeparator={true}
+  weekStartsOn={1}
+/>
 `;

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
@@ -4,40 +4,79 @@ exports[`BpkCalendarScrollGridList should render correctly with "showWeekendSepa
 <div
   className="bpk-scrollable-calendar-grid-list"
 >
-  <div
-    className={undefined}
-    style={
+  <List
+    direction="vertical"
+    estimatedItemSize={270}
+    extraData={
       Object {
-        "height": 0,
-        "overflow": "visible",
-        "width": 0,
+        "DateComponent": [Function],
+        "className": null,
+        "daysOfWeek": Array [
+          Object {
+            "index": 0,
+            "isWeekend": true,
+            "name": "Sunday",
+            "nameAbbr": "Sun",
+          },
+          Object {
+            "index": 1,
+            "isWeekend": false,
+            "name": "Monday",
+            "nameAbbr": "Mon",
+          },
+          Object {
+            "index": 2,
+            "isWeekend": false,
+            "name": "Tuesday",
+            "nameAbbr": "Tue",
+          },
+          Object {
+            "index": 3,
+            "isWeekend": false,
+            "name": "Wednesday",
+            "nameAbbr": "Wed",
+          },
+          Object {
+            "index": 4,
+            "isWeekend": false,
+            "name": "Thursday",
+            "nameAbbr": "Thu",
+          },
+          Object {
+            "index": 5,
+            "isWeekend": false,
+            "name": "Friday",
+            "nameAbbr": "Fri",
+          },
+          Object {
+            "index": 6,
+            "isWeekend": true,
+            "name": "Saturday",
+            "nameAbbr": "Sat",
+          },
+        ],
+        "focusedDate": null,
+        "formatDateFull": [Function],
+        "formatMonth": [Function],
+        "maxDate": 2011-02-15T00:00:00.000Z,
+        "minDate": 2010-02-14T00:00:00.000Z,
+        "showWeekendSeparator": false,
+        "weekStartsOn": 0,
       }
     }
+    height={270}
+    initialScrollOffset={0}
+    itemCount={13}
+    itemData={undefined}
+    itemSize={[Function]}
+    overscanCount={1}
+    rowCount={13}
+    style={Object {}}
+    useIsScrolling={false}
+    width="100%"
   >
-    <div
-      aria-label="grid"
-      aria-readonly={true}
-      className="ReactVirtualized__Grid ReactVirtualized__List"
-      id={undefined}
-      onScroll={[Function]}
-      role="grid"
-      style={
-        Object {
-          "WebkitOverflowScrolling": "touch",
-          "boxSizing": "border-box",
-          "direction": "ltr",
-          "height": 0,
-          "overflowX": "hidden",
-          "overflowY": "auto",
-          "position": "relative",
-          "width": 0,
-          "willChange": "transform",
-        }
-      }
-      tabIndex={0}
-    />
-  </div>
-   
+    [Function]
+  </List>
 </div>
 `;
 
@@ -45,40 +84,82 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
 <div
   className="bpk-scrollable-calendar-grid-list"
 >
-  <div
-    className={undefined}
-    style={
+  <List
+    direction="vertical"
+    estimatedItemSize={270}
+    extraData={
       Object {
-        "height": 0,
-        "overflow": "visible",
-        "width": 0,
+        "DateComponent": [Function],
+        "className": null,
+        "dateModifiers": Object {
+          "someClass": [Function],
+        },
+        "daysOfWeek": Array [
+          Object {
+            "index": 0,
+            "isWeekend": true,
+            "name": "Sunday",
+            "nameAbbr": "Sun",
+          },
+          Object {
+            "index": 1,
+            "isWeekend": false,
+            "name": "Monday",
+            "nameAbbr": "Mon",
+          },
+          Object {
+            "index": 2,
+            "isWeekend": false,
+            "name": "Tuesday",
+            "nameAbbr": "Tue",
+          },
+          Object {
+            "index": 3,
+            "isWeekend": false,
+            "name": "Wednesday",
+            "nameAbbr": "Wed",
+          },
+          Object {
+            "index": 4,
+            "isWeekend": false,
+            "name": "Thursday",
+            "nameAbbr": "Thu",
+          },
+          Object {
+            "index": 5,
+            "isWeekend": false,
+            "name": "Friday",
+            "nameAbbr": "Fri",
+          },
+          Object {
+            "index": 6,
+            "isWeekend": true,
+            "name": "Saturday",
+            "nameAbbr": "Sat",
+          },
+        ],
+        "focusedDate": null,
+        "formatDateFull": [Function],
+        "formatMonth": [Function],
+        "maxDate": 2011-02-15T00:00:00.000Z,
+        "minDate": 2010-02-14T00:00:00.000Z,
+        "showWeekendSeparator": true,
+        "weekStartsOn": 1,
       }
     }
+    height={270}
+    initialScrollOffset={0}
+    itemCount={13}
+    itemData={undefined}
+    itemSize={[Function]}
+    overscanCount={1}
+    rowCount={13}
+    style={Object {}}
+    useIsScrolling={false}
+    width="100%"
   >
-    <div
-      aria-label="grid"
-      aria-readonly={true}
-      className="ReactVirtualized__Grid ReactVirtualized__List"
-      id={undefined}
-      onScroll={[Function]}
-      role="grid"
-      style={
-        Object {
-          "WebkitOverflowScrolling": "touch",
-          "boxSizing": "border-box",
-          "direction": "ltr",
-          "height": 0,
-          "overflowX": "hidden",
-          "overflowY": "auto",
-          "position": "relative",
-          "width": 0,
-          "willChange": "transform",
-        }
-      }
-      tabIndex={0}
-    />
-  </div>
-   
+    [Function]
+  </List>
 </div>
 `;
 
@@ -86,40 +167,79 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
 <div
   className="bpk-scrollable-calendar-grid-list"
 >
-  <div
-    className={undefined}
-    style={
+  <List
+    direction="vertical"
+    estimatedItemSize={270}
+    extraData={
       Object {
-        "height": 0,
-        "overflow": "visible",
-        "width": 0,
+        "DateComponent": [Function],
+        "className": null,
+        "daysOfWeek": Array [
+          Object {
+            "index": 0,
+            "isWeekend": true,
+            "name": "Sunday",
+            "nameAbbr": "Sun",
+          },
+          Object {
+            "index": 1,
+            "isWeekend": false,
+            "name": "Monday",
+            "nameAbbr": "Mon",
+          },
+          Object {
+            "index": 2,
+            "isWeekend": false,
+            "name": "Tuesday",
+            "nameAbbr": "Tue",
+          },
+          Object {
+            "index": 3,
+            "isWeekend": false,
+            "name": "Wednesday",
+            "nameAbbr": "Wed",
+          },
+          Object {
+            "index": 4,
+            "isWeekend": false,
+            "name": "Thursday",
+            "nameAbbr": "Thu",
+          },
+          Object {
+            "index": 5,
+            "isWeekend": false,
+            "name": "Friday",
+            "nameAbbr": "Fri",
+          },
+          Object {
+            "index": 6,
+            "isWeekend": true,
+            "name": "Saturday",
+            "nameAbbr": "Sat",
+          },
+        ],
+        "focusedDate": null,
+        "formatDateFull": [Function],
+        "formatMonth": [Function],
+        "maxDate": 2011-02-15T00:00:00.000Z,
+        "minDate": 2010-02-14T00:00:00.000Z,
+        "showWeekendSeparator": true,
+        "weekStartsOn": 1,
       }
     }
+    height={270}
+    initialScrollOffset={0}
+    itemCount={13}
+    itemData={undefined}
+    itemSize={[Function]}
+    overscanCount={1}
+    rowCount={13}
+    style={Object {}}
+    useIsScrolling={false}
+    width="100%"
   >
-    <div
-      aria-label="grid"
-      aria-readonly={true}
-      className="ReactVirtualized__Grid ReactVirtualized__List"
-      id={undefined}
-      onScroll={[Function]}
-      role="grid"
-      style={
-        Object {
-          "WebkitOverflowScrolling": "touch",
-          "boxSizing": "border-box",
-          "direction": "ltr",
-          "height": 0,
-          "overflowX": "hidden",
-          "overflowY": "auto",
-          "position": "relative",
-          "width": 0,
-          "willChange": "transform",
-        }
-      }
-      tabIndex={0}
-    />
-  </div>
-   
+    [Function]
+  </List>
 </div>
 `;
 
@@ -127,40 +247,79 @@ exports[`BpkCalendarScrollGridList should render correctly with a different "wee
 <div
   className="bpk-scrollable-calendar-grid-list"
 >
-  <div
-    className={undefined}
-    style={
+  <List
+    direction="vertical"
+    estimatedItemSize={270}
+    extraData={
       Object {
-        "height": 0,
-        "overflow": "visible",
-        "width": 0,
+        "DateComponent": [Function],
+        "className": null,
+        "daysOfWeek": Array [
+          Object {
+            "index": 0,
+            "isWeekend": true,
+            "name": "Sunday",
+            "nameAbbr": "Sun",
+          },
+          Object {
+            "index": 1,
+            "isWeekend": false,
+            "name": "Monday",
+            "nameAbbr": "Mon",
+          },
+          Object {
+            "index": 2,
+            "isWeekend": false,
+            "name": "Tuesday",
+            "nameAbbr": "Tue",
+          },
+          Object {
+            "index": 3,
+            "isWeekend": false,
+            "name": "Wednesday",
+            "nameAbbr": "Wed",
+          },
+          Object {
+            "index": 4,
+            "isWeekend": false,
+            "name": "Thursday",
+            "nameAbbr": "Thu",
+          },
+          Object {
+            "index": 5,
+            "isWeekend": false,
+            "name": "Friday",
+            "nameAbbr": "Fri",
+          },
+          Object {
+            "index": 6,
+            "isWeekend": true,
+            "name": "Saturday",
+            "nameAbbr": "Sat",
+          },
+        ],
+        "focusedDate": null,
+        "formatDateFull": [Function],
+        "formatMonth": [Function],
+        "maxDate": 2011-02-15T00:00:00.000Z,
+        "minDate": 2010-02-14T00:00:00.000Z,
+        "showWeekendSeparator": true,
+        "weekStartsOn": 3,
       }
     }
+    height={270}
+    initialScrollOffset={0}
+    itemCount={13}
+    itemData={undefined}
+    itemSize={[Function]}
+    overscanCount={1}
+    rowCount={13}
+    style={Object {}}
+    useIsScrolling={false}
+    width="100%"
   >
-    <div
-      aria-label="grid"
-      aria-readonly={true}
-      className="ReactVirtualized__Grid ReactVirtualized__List"
-      id={undefined}
-      onScroll={[Function]}
-      role="grid"
-      style={
-        Object {
-          "WebkitOverflowScrolling": "touch",
-          "boxSizing": "border-box",
-          "direction": "ltr",
-          "height": 0,
-          "overflowX": "hidden",
-          "overflowY": "auto",
-          "position": "relative",
-          "width": 0,
-          "willChange": "transform",
-        }
-      }
-      tabIndex={0}
-    />
-  </div>
-   
+    [Function]
+  </List>
 </div>
 `;
 
@@ -168,39 +327,76 @@ exports[`BpkCalendarScrollGridList should render correctly with no optional prop
 <div
   className="bpk-scrollable-calendar-grid-list"
 >
-  <div
-    className={undefined}
-    style={
+  <List
+    direction="vertical"
+    estimatedItemSize={270}
+    extraData={
       Object {
-        "height": 0,
-        "overflow": "visible",
-        "width": 0,
+        "DateComponent": [Function],
+        "className": null,
+        "daysOfWeek": Array [
+          Object {
+            "index": 0,
+            "isWeekend": true,
+            "name": "Sunday",
+            "nameAbbr": "Sun",
+          },
+          Object {
+            "index": 1,
+            "isWeekend": false,
+            "name": "Monday",
+            "nameAbbr": "Mon",
+          },
+          Object {
+            "index": 2,
+            "isWeekend": false,
+            "name": "Tuesday",
+            "nameAbbr": "Tue",
+          },
+          Object {
+            "index": 3,
+            "isWeekend": false,
+            "name": "Wednesday",
+            "nameAbbr": "Wed",
+          },
+          Object {
+            "index": 4,
+            "isWeekend": false,
+            "name": "Thursday",
+            "nameAbbr": "Thu",
+          },
+          Object {
+            "index": 5,
+            "isWeekend": false,
+            "name": "Friday",
+            "nameAbbr": "Fri",
+          },
+          Object {
+            "index": 6,
+            "isWeekend": true,
+            "name": "Saturday",
+            "nameAbbr": "Sat",
+          },
+        ],
+        "focusedDate": null,
+        "formatDateFull": [Function],
+        "formatMonth": [Function],
+        "maxDate": 2011-02-15T00:00:00.000Z,
+        "minDate": 2010-02-14T00:00:00.000Z,
       }
     }
+    height={270}
+    initialScrollOffset={0}
+    itemCount={13}
+    itemData={undefined}
+    itemSize={[Function]}
+    overscanCount={1}
+    rowCount={13}
+    style={Object {}}
+    useIsScrolling={false}
+    width="100%"
   >
-    <div
-      aria-label="grid"
-      aria-readonly={true}
-      className="ReactVirtualized__Grid ReactVirtualized__List"
-      id={undefined}
-      onScroll={[Function]}
-      role="grid"
-      style={
-        Object {
-          "WebkitOverflowScrolling": "touch",
-          "boxSizing": "border-box",
-          "direction": "ltr",
-          "height": 0,
-          "overflowX": "hidden",
-          "overflowY": "auto",
-          "position": "relative",
-          "width": 0,
-          "willChange": "transform",
-        }
-      }
-      tabIndex={0}
-    />
-  </div>
-   
+    [Function]
+  </List>
 </div>
 `;

--- a/packages/bpk-component-scrollable-calendar/stories.js
+++ b/packages/bpk-component-scrollable-calendar/stories.js
@@ -81,8 +81,9 @@ ScrollableCal.defaultProps = {
   selectTodaysDate: true,
 };
 
-storiesOf('bpk-component-scrollable-calendar', module)
-  .add('Scrollable Calendar - default', () => (
+storiesOf('bpk-component-scrollable-calendar', module).add(
+  'Scrollable Calendar - default',
+  () => (
     <ScrollableCal
       weekStartsOn={1}
       daysOfWeek={weekDays}
@@ -93,6 +94,40 @@ storiesOf('bpk-component-scrollable-calendar', module)
       selectTodaysDate
       // Subtract one day from today's date to make today selectable by default
       minDate={DateUtils.addDays(new Date(), -1)}
+      maxDate={DateUtils.addMonths(new Date(), 12)}
+    />
+  ),
+);
+storiesOf('bpk-component-scrollable-calendar', module).add(
+  'Scrollable Calendar - week starts on 7',
+  () => (
+    <ScrollableCal
+      weekStartsOn={7}
+      daysOfWeek={weekDays}
+      formatMonth={formatMonth}
+      formatDateFull={formatDateFull}
+      DateComponent={BpkScrollableCalendarDate}
+      showWeekendSeparator
+      selectTodaysDate
+      // Subtract one day from today's date to make today selectable by default
+      minDate={DateUtils.addDays(new Date(), -1)}
+      maxDate={DateUtils.addMonths(new Date(), 12)}
+    />
+  ),
+);
+storiesOf('bpk-component-scrollable-calendar', module)
+  .add('Scrollable Calendar - with focused date', () => (
+    <ScrollableCal
+      weekStartsOn={1}
+      daysOfWeek={weekDays}
+      formatMonth={formatMonth}
+      formatDateFull={formatDateFull}
+      DateComponent={BpkScrollableCalendarDate}
+      showWeekendSeparator
+      selectTodaysDate
+      // Subtract one day from today's date to make today selectable by default
+      minDate={DateUtils.addDays(new Date(), -1)}
+      focusedDate={DateUtils.addMonths(new Date(), 11)}
       maxDate={DateUtils.addMonths(new Date(), 12)}
     />
   ))


### PR DESCRIPTION
This PR doesn't actually address anything performance related, but it does replace `react-virtualised` with `react-window` (a new, cut-down version written from scratch).

The improvement in prod bundle size is approximately 64.5kb => 2.8kb!

From testing so far, performance seems to at least be similar to before. See profiling screenshots below.

Note that profiling is only available in React 16.5 - so I created [this repo](https://github.com/georgegillams/bpk-calendar-performance-react-16.5) for profiling the component.

## API differences:
The `react-window` API is somewhat different to `react-virtualized`. It requires the height to display at (in pixels) as well as the heights of each item.
To get the item heights, I have added code to the constructor that calculates the heights of the grids based on the number of days etc.
In order to get the component height, I am measuring the outer height using `componentDidMount` and listeners on the window size.
These are two necessary evils if we want to use `react-window`.
It also requires the initial offset to be specified in pixels. For this, I am using the pre-calculated `itemHeight` values to convert the item index to pixels.

## Testing differences:
With `react-virtualized`, the first render doesn't include any children. The subsequent render then renders children as needed.
`react-window` is more clever. Because it knows the height and itemHeights at first render, it can populate the children at the same time.
As a result, the snapshot tests are much larger (as they include the children)
I have therefore employed shallow rendering.

## Profiling before and after:
![screenshot 2019-01-08 at 09 50 30](https://user-images.githubusercontent.com/30267516/50822972-e00ccc00-132a-11e9-8759-d08fb80d8077.png)

![react-virtualized](https://user-images.githubusercontent.com/30267516/50598137-bcb4cd80-0ea1-11e9-904d-ce5c405049a7.png)

![react-window](https://user-images.githubusercontent.com/30267516/50598138-bd4d6400-0ea1-11e9-9213-b15039f87e66.png)

