### PR TITLE
[BPK-2120] Fix issue with content in BpkBackgroundImage

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,6 @@
 # Unreleased
 
+**Fixed:**
+
+- bpk-component-image
+  - Fixed a bug with `BpkBackgroundImage` where inner content would not display unless it had an explicit opacity set.

--- a/packages/bpk-component-image/src/BpkBackgroundImage.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.js
@@ -145,7 +145,11 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
                 />
               </noscript>
             )}
-          {!loading && children}
+          {!loading && (
+            <div className={getClassName('bpk-background-image__content')}>
+              {children}
+            </div>
+          )}
         </div>
       </div>
     );

--- a/packages/bpk-component-image/src/__snapshots__/BpkBackgroundImage-test.js.snap
+++ b/packages/bpk-component-image/src/__snapshots__/BpkBackgroundImage-test.js.snap
@@ -27,6 +27,9 @@ exports[`BpkBackgroundImage should accept userland className 1`] = `
         }
       }
     />
+    <div
+      className="bpk-background-image__content"
+    />
   </div>
 </div>
 `;
@@ -62,6 +65,9 @@ exports[`BpkBackgroundImage should have inView behavior 1`] = `
           "width": "100%",
         }
       }
+    />
+    <div
+      className="bpk-background-image__content"
     />
   </div>
 </div>
@@ -218,14 +224,18 @@ exports[`BpkBackgroundImage should render correctly 1`] = `
       }
     />
     <div
-      style={
-        Object {
-          "marginLeft": ".75rem",
-          "opacity": 0.7,
-          "paddingTop": ".75rem",
+      className="bpk-background-image__content"
+    >
+      <div
+        style={
+          Object {
+            "marginLeft": ".75rem",
+            "opacity": 0.7,
+            "paddingTop": ".75rem",
+          }
         }
-      }
-    />
+      />
+    </div>
   </div>
 </div>
 `;

--- a/packages/bpk-component-image/src/bpk-background-image.scss
+++ b/packages/bpk-component-image/src/bpk-background-image.scss
@@ -36,6 +36,10 @@
     }
   }
 
+  &__content {
+    position: relative;
+  }
+
   &--no-background {
     @include bpk-image--no-background;
   }

--- a/packages/bpk-component-image/stories.js
+++ b/packages/bpk-component-image/stories.js
@@ -136,9 +136,7 @@ storiesOf('bpk-component-image', module)
       }}
       src={image}
     >
-      <div
-        style={{ opacity: 0.7, marginLeft: spacingSm, paddingTop: spacingSm }}
-      >
+      <div style={{ marginLeft: spacingSm, paddingTop: spacingSm }}>
         <BpkText tagName="h2" textStyle="lg">
           Lorem ipsum dolor sit amet
         </BpkText>
@@ -157,9 +155,7 @@ storiesOf('bpk-component-image', module)
       }}
       src={image}
     >
-      <div
-        style={{ opacity: 0.7, marginLeft: spacingSm, paddingTop: spacingSm }}
-      >
+      <div style={{ marginLeft: spacingSm, paddingTop: spacingSm }}>
         <BpkText tagName="h2" textStyle="lg">
           Lorem ipsum dolor sit amet
         </BpkText>


### PR DESCRIPTION
The inner content wasn't displaying because positioned elements (that is to say any elements with the CSS property `position`) are displayed in front of non-positioned elements. The image was positioned but the inner content was not. [Further reading &raquo;](https://philipwalton.com/articles/what-no-one-told-you-about-z-index/)

So I fixed this by wrapping the inner content in a positioned element.

Two possible pure-CSS ways to fix this would have been to:

1) Use the sibling selector alongside the background image to apply the positioning.

```
  &__img {
    @include bpk-image__img;

    + * {
      position: relative;
    }
  }
```

2) Apply a negative z-index to the image:

```
  &__img {
    z-index: -1;
    @include bpk-image__img;
  }
```

However those feel hacky and I prefer the explicit approach of adding a wrapper.