### PR TITLE
add a different percentage of intersection prop for infinite scroll loading component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,8 @@
 # Unreleased
+
+# 2019-01-10 Infinite scroll observer threshold prop
+
+**Added:**
+
+- bpk-component-infinite-scroll:
+  - Added `loaderIntersectionTrigger` so that consumers can decide which percentage of the loading component needs to be visible before triggering the fetch method. Options are `small`, `half` and `full`, being `full` the default option.

--- a/packages/bpk-component-infinite-scroll/README.md
+++ b/packages/bpk-component-infinite-scroll/README.md
@@ -162,13 +162,14 @@ Updates the internal array and triggers all listeners.
 
 ## Props
 
-| Property                | PropType               | Required | Default Value |
-| ----------------------- | ---------------------- | -------- | ------------- |
-| dataSource              | instanceOf(DataSource) | true     | -             |
-| elementsPerScroll       | number                 | false    | 5             |
-| initiallyLoadedElements | number                 | false    | 5             |
-| onScroll                | func                   | false    | null          |
-| onScrollFinished        | func                   | false    | null          |
-| renderLoadingComponent  | func                   | false    | null          |
-| renderSeeMoreComponent  | func                   | false    | null          |
-| seeMoreAfter            | number                 | false    | null          |
+| Property                | PropType                         | Required | Default Value |
+| ----------------------- | -------------------------------- | -------- | ------------- |
+| dataSource              | instanceOf(DataSource)           | true     | -             |
+| elementsPerScroll       | number                           | false    | 5             |
+| initiallyLoadedElements | number                           | false    | 5             |
+| loaderMinDisplay        | oneOf(['small', 'half', 'full']) | false    | 'full'        |
+| onScroll                | func                             | false    | null          |
+| onScrollFinished        | func                             | false    | null          |
+| renderLoadingComponent  | func                             | false    | null          |
+| renderSeeMoreComponent  | func                             | false    | null          |
+| seeMoreAfter            | number                           | false    | null          |

--- a/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
+++ b/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
@@ -29,6 +29,7 @@ exports[`withInfiniteScroll renders correctly with different initial and onScrol
   }
   elementsPerScroll={2}
   initiallyLoadedElements={3}
+  loaderIntersectionTrigger="full"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -68,6 +69,7 @@ exports[`withInfiniteScroll renders items after the first render 1`] = `
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  loaderIntersectionTrigger="full"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -142,6 +144,7 @@ exports[`withInfiniteScroll should pass extra props to the decorated component 1
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  loaderIntersectionTrigger="full"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -183,6 +186,7 @@ exports[`withInfiniteScroll should refresh data when data changes 1`] = `
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  loaderIntersectionTrigger="full"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -221,6 +225,7 @@ exports[`withInfiniteScroll should refresh data when data changes 2`] = `
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  loaderIntersectionTrigger="full"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -260,6 +265,7 @@ exports[`withInfiniteScroll should render correctly when no more elements 1`] = 
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  loaderIntersectionTrigger="full"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -312,7 +318,7 @@ exports[`withInfiniteScroll should render correctly when no more elements 1`] = 
 </WithInfiniteScroll>
 `;
 
-exports[`withInfiniteScroll should render correctly with a "loaderMinDisplay" attribute 1`] = `
+exports[`withInfiniteScroll should render correctly with a "loaderIntersectionTrigger" attribute 1`] = `
 <WithInfiniteScroll
   dataSource={
     ArrayDataSource {
@@ -330,7 +336,7 @@ exports[`withInfiniteScroll should render correctly with a "loaderMinDisplay" at
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
-  loaderMinDisplay="small"
+  loaderIntersectionTrigger="small"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={[Function]}
@@ -374,6 +380,7 @@ exports[`withInfiniteScroll should render correctly with a "renderLoadingCompone
   }
   elementsPerScroll={5}
   initiallyLoadedElements={5}
+  loaderIntersectionTrigger="full"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={[Function]}
@@ -417,6 +424,7 @@ exports[`withInfiniteScroll should render correctly with a "renderSeeMoreCompone
   }
   elementsPerScroll={1}
   initiallyLoadedElements={5}
+  loaderIntersectionTrigger="full"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}
@@ -469,6 +477,7 @@ exports[`withInfiniteScroll should render correctly with an "elementsPerScroll" 
   }
   elementsPerScroll={1}
   initiallyLoadedElements={5}
+  loaderIntersectionTrigger="full"
   onScroll={null}
   onScrollFinished={null}
   renderLoadingComponent={null}

--- a/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
+++ b/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
@@ -312,6 +312,50 @@ exports[`withInfiniteScroll should render correctly when no more elements 1`] = 
 </WithInfiniteScroll>
 `;
 
+exports[`withInfiniteScroll should render correctly with a "loaderMinDisplay" attribute 1`] = `
+<WithInfiniteScroll
+  dataSource={
+    ArrayDataSource {
+      "elements": Array [
+        "Element 0",
+        "Element 1",
+        "Element 2",
+        "Element 3",
+        "Element 4",
+      ],
+      "listeners": Array [
+        [Function],
+      ],
+    }
+  }
+  elementsPerScroll={5}
+  initiallyLoadedElements={5}
+  loaderMinDisplay="small"
+  onScroll={null}
+  onScrollFinished={null}
+  renderLoadingComponent={[Function]}
+  renderSeeMoreComponent={null}
+  seeMoreAfter={null}
+>
+  <div>
+    <List
+      elements={Array []}
+    >
+      <div
+        id="list"
+      />
+    </List>
+    <div
+      className={null}
+    >
+      <span>
+        Loading
+      </span>
+    </div>
+  </div>
+</WithInfiniteScroll>
+`;
+
 exports[`withInfiniteScroll should render correctly with a "renderLoadingComponent" attribute 1`] = `
 <WithInfiniteScroll
   dataSource={

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
@@ -145,6 +145,18 @@ describe('withInfiniteScroll', () => {
     expect(toJson(tree)).toMatchSnapshot();
   });
 
+  it('should render correctly with a "loaderMinDisplay" attribute', () => {
+    const tree = mount(
+      <InfiniteList
+        dataSource={new ArrayDataSource(elementsArray)}
+        renderLoadingComponent={() => <span>Loading</span>}
+        loaderMinDisplay="small"
+      />,
+    );
+
+    expect(toJson(tree)).toMatchSnapshot();
+  });
+
   it('should pass extra props to the decorated component', () => {
     const tree = mount(
       <InfiniteList

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
@@ -46,11 +46,13 @@ describe('withInfiniteScroll', () => {
 
   const InfiniteList = withInfiniteScroll(List);
   let intersect;
+  let currentOptions = {};
 
   beforeEach(() => {
     global.IntersectionObserver = class {
-      constructor(callback) {
+      constructor(callback, options) {
         intersect = async () => callback([{ isIntersecting: true }]);
+        currentOptions = options;
       }
       observe() {} // eslint-disable-line
       unobserve() {} // eslint-disable-line
@@ -145,16 +147,70 @@ describe('withInfiniteScroll', () => {
     expect(toJson(tree)).toMatchSnapshot();
   });
 
-  it('should render correctly with a "loaderMinDisplay" attribute', () => {
+  it('should render correctly with a "loaderIntersectionTrigger" attribute', () => {
     const tree = mount(
       <InfiniteList
         dataSource={new ArrayDataSource(elementsArray)}
         renderLoadingComponent={() => <span>Loading</span>}
-        loaderMinDisplay="small"
+        loaderIntersectionTrigger="small"
       />,
     );
 
     expect(toJson(tree)).toMatchSnapshot();
+  });
+
+  it('should create the IntersectionObserver with a 0.01 threshold if the prop is set to "small"', () => {
+    mount(
+      <InfiniteList
+        dataSource={new ArrayDataSource(elementsArray)}
+        renderLoadingComponent={() => <span>Loading</span>}
+        loaderIntersectionTrigger="small"
+      />,
+    );
+
+    expect(currentOptions).toEqual({ threshold: 0.01 });
+  });
+
+  it('should create the IntersectionObserver with a 0.5 threshold if the prop is set to "half"', () => {
+    mount(
+      <InfiniteList
+        dataSource={new ArrayDataSource(elementsArray)}
+        renderLoadingComponent={() => <span>Loading</span>}
+        loaderIntersectionTrigger="half"
+      />,
+    );
+
+    expect(currentOptions).toEqual({ threshold: 0.5 });
+  });
+
+  it('should create the IntersectionObserver with a 0.99 threshold if the prop is set to "full"', () => {
+    mount(
+      <InfiniteList
+        dataSource={new ArrayDataSource(elementsArray)}
+        renderLoadingComponent={() => <span>Loading</span>}
+        loaderIntersectionTrigger="full"
+      />,
+    );
+
+    expect(currentOptions).toEqual({ threshold: 0.99 });
+  });
+
+  it('should create the IntersectionObserver with a 0.99 threshold if the prop is not set', () => {
+    mount(<InfiniteList dataSource={new ArrayDataSource(elementsArray)} />);
+
+    expect(currentOptions).toEqual({ threshold: 0.99 });
+  });
+
+  it('should create the IntersectionObserver with a 0.99 threshold if the prop is set with an invalid value', () => {
+    mount(
+      <InfiniteList
+        dataSource={new ArrayDataSource(elementsArray)}
+        renderLoadingComponent={() => <span>Loading</span>}
+        loaderIntersectionTrigger="invalid"
+      />,
+    );
+
+    expect(currentOptions).toEqual({ threshold: 0.99 });
   });
 
   it('should pass extra props to the decorated component', () => {

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -43,7 +43,7 @@ export type Props = {
   dataSource: DataSource<any>,
   elementsPerScroll: number,
   initiallyLoadedElements: number,
-  loaderMinDisplay: ?('small' | 'half' | 'full'),
+  loaderIntersectionTrigger: ?('small' | 'half' | 'full'),
   onScroll: ?(o: ScrollEvent) => void,
   onScrollFinished: ?(o: ScrollFinishedEvent) => void,
   renderLoadingComponent: ?() => Element<any>,
@@ -68,7 +68,7 @@ const propTypes = {
   initiallyLoadedElements: PropTypes.number,
   elementsPerScroll: PropTypes.number,
   dataSource: PropTypes.instanceOf(DataSource).isRequired,
-  loaderMinDisplay: PropTypes.oneOf(['small', 'half', 'full']),
+  loaderIntersectionTrigger: PropTypes.oneOf(['small', 'half', 'full']),
   onScroll: PropTypes.func,
   onScrollFinished: PropTypes.func,
   renderLoadingComponent: PropTypes.func,
@@ -79,6 +79,7 @@ const propTypes = {
 const defaultProps = {
   initiallyLoadedElements: 5,
   elementsPerScroll: 5,
+  loaderIntersectionTrigger: 'full',
   onScroll: null,
   onScrollFinished: null,
   renderLoadingComponent: null,
@@ -121,9 +122,9 @@ const withInfiniteScroll = (
         half: 0.5,
         full: 0.99, // using 0.99 instead of 1 to avoid problems with float precision in IE11
       };
-      const displaySize = this.props.loaderMinDisplay || 'full';
+      const displaySize = this.props.loaderIntersectionTrigger || 'full';
       this.observer = new IntersectionObserver(this.handleIntersection, {
-        threshold: thresholds[displaySize],
+        threshold: thresholds[displaySize] || thresholds.full,
       });
     }
 

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -40,9 +40,10 @@ type ScrollFinishedEvent = {
 };
 
 export type Props = {
-  initiallyLoadedElements: number,
-  elementsPerScroll: number,
   dataSource: DataSource<any>,
+  elementsPerScroll: number,
+  initiallyLoadedElements: number,
+  loaderMinDisplay: ?('small' | 'half' | 'full'),
   onScroll: ?(o: ScrollEvent) => void,
   onScrollFinished: ?(o: ScrollFinishedEvent) => void,
   renderLoadingComponent: ?() => Element<any>,
@@ -67,6 +68,7 @@ const propTypes = {
   initiallyLoadedElements: PropTypes.number,
   elementsPerScroll: PropTypes.number,
   dataSource: PropTypes.instanceOf(DataSource).isRequired,
+  loaderMinDisplay: PropTypes.oneOf(['small', 'half', 'full']),
   onScroll: PropTypes.func,
   onScrollFinished: PropTypes.func,
   renderLoadingComponent: PropTypes.func,
@@ -113,8 +115,15 @@ const withInfiniteScroll = (
       };
 
       this.props.dataSource.onDataChange(this.updateData);
+
+      const thresholds = {
+        small: 0.01,
+        half: 0.5,
+        full: 0.99, // using 0.99 instead of 1 to avoid problems with float precision in IE11
+      };
+      const displaySize = this.props.loaderMinDisplay || 'full';
       this.observer = new IntersectionObserver(this.handleIntersection, {
-        threshold: 0.99, // using 0.99 instead of 1 to avoid problems with float precision in IE11
+        threshold: thresholds[displaySize],
       });
     }
 


### PR DESCRIPTION
Current implementation of the infinite scroll does not allow using big elements, like an animated card placeholder, as a loading component. The reason is that the pagination is only triggered if the loading component is visible at 0.99%. In small devices that may never be the case if the element is bigger than the viewport which results in a broken infinite scroll.
This PR introduces a prop to the component to require visibility of smaller parts of the element to trigger the pagination.
Default value keeps the current behaviour to avoid any potential conflict with existing usages of the component.