### PR TITLE
[NO-JIRA] Fix scrollable calendar refs for react 15

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,6 @@
 # Unreleased
+
+**Fixed:**
+
+ - bpk-component-scrollable-calendar:
+   - Fixed an error that was appearing when used with React < 16.3.

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
@@ -43,7 +43,7 @@ class BpkScrollableCalendarGridList extends React.Component {
   constructor(props) {
     super(props);
 
-    this.outerDivRef = React.createRef();
+    this.outerDiv = null;
 
     const startDate = startOfDay(startOfMonth(this.props.minDate));
     const endDate = startOfDay(startOfMonth(this.props.maxDate));
@@ -88,7 +88,7 @@ class BpkScrollableCalendarGridList extends React.Component {
     this.state.monthItemHeights[index] || ESTIMATED_MONTH_ITEM_HEIGHT;
 
   setComponentHeight = () => {
-    const outerNode = this.outerDivRef.current;
+    const outerNode = this.outerDiv;
     if (outerNode) {
       const newHeight = outerNode.clientHeight;
       this.setState({ outerHeight: newHeight });
@@ -128,7 +128,9 @@ class BpkScrollableCalendarGridList extends React.Component {
           'bpk-scrollable-calendar-grid-list',
           this.props.className,
         )}
-        ref={this.outerDivRef}
+        ref={div => {
+          this.outerDiv = div;
+        }}
       >
         <List
           extraData={this.props}


### PR DESCRIPTION
To allow this to be tested, I have created a repo using react 15.
If you run the test app, you'll see an error about refs. If you copy this version of `scrollable-calendar` into `node_modules` you'll see it works 👍 
https://github.com/georgegillams/test-react-15-scroll-calendar