### PR TITLE
[BPK-2168] Allow docs to remember selected platform

### DIFF
--- a/packages/bpk-docs/src/components/DocsPageWrapper/DocsPageWrapper.js
+++ b/packages/bpk-docs/src/components/DocsPageWrapper/DocsPageWrapper.js
@@ -24,6 +24,10 @@ import BpkHorizontalNav, {
   BpkHorizontalNavItem,
 } from 'bpk-component-horizontal-nav';
 import { cssModules } from 'bpk-react-utils';
+import {
+  setPlatformInLocalStorage,
+  getPlatformFromLocalStorage,
+} from '../../helpers/storage-helper';
 
 import Heading from '../Heading';
 import Blurb from './Blurb';
@@ -116,17 +120,28 @@ const DocsPageWrapper = props => {
     web: webSubpage,
   };
 
+  const canUsePlatformPreference = platformPreference => {
+    if (!platformPreference) {
+      return false;
+    }
+    return (
+      (platformPreference === 'web' && webSubpage) ||
+      (platformPreference === 'native' && nativeSubpage) ||
+      (platformPreference === 'ios' && iosSubpage) ||
+      (platformPreference === 'android' && androidSubpage)
+    );
+  };
+
   let initiallySelectedPlatform = 'web';
-  let initiallyRenderedSubpage = webSubpage;
-  if (androidSubpage) {
+  const platformFromLocalStorage = getPlatformFromLocalStorage();
+  if (canUsePlatformPreference(platformFromLocalStorage)) {
+    initiallySelectedPlatform = platformFromLocalStorage;
+  } else if (androidSubpage) {
     initiallySelectedPlatform = 'android';
-    initiallyRenderedSubpage = androidSubpage;
   } else if (iosSubpage) {
     initiallySelectedPlatform = 'ios';
-    initiallyRenderedSubpage = iosSubpage;
   } else if (nativeSubpage) {
     initiallySelectedPlatform = 'native';
-    initiallyRenderedSubpage = nativeSubpage;
   }
 
   const platformQueryParamMatches = platformQueryParamRegex.exec(
@@ -135,12 +150,14 @@ const DocsPageWrapper = props => {
   if (platformQueryParamMatches && platforms[platformQueryParamMatches[1]]) {
     const platformQueryParam = platformQueryParamMatches[1];
     initiallySelectedPlatform = platformQueryParam;
-    initiallyRenderedSubpage = platforms[platformQueryParam];
   } else {
     history.replace(`${path}?platform=${initiallySelectedPlatform}`);
   }
 
+  const initiallyRenderedSubpage = platforms[initiallySelectedPlatform];
+
   const onPlatformClick = platformName => {
+    setPlatformInLocalStorage(platformName);
     history.push(`${path}?platform=${platformName}`);
   };
 

--- a/packages/bpk-docs/src/helpers/storage-helper.js
+++ b/packages/bpk-docs/src/helpers/storage-helper.js
@@ -1,0 +1,36 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const LOCAL_STORAGE_KEY = 'BPK_DOCS_platform_preference';
+
+const LOCAL_STORAGE_EXISTS = typeof localStorage !== 'undefined';
+
+export const getPlatformFromLocalStorage = () => {
+  if (!LOCAL_STORAGE_EXISTS) {
+    return null;
+  }
+  const currentPlatform = localStorage.getItem(LOCAL_STORAGE_KEY);
+  return currentPlatform;
+};
+
+export const setPlatformInLocalStorage = platformName => {
+  if (!LOCAL_STORAGE_EXISTS || platformName === 'all') {
+    return;
+  }
+  localStorage.setItem(LOCAL_STORAGE_KEY, platformName);
+};

--- a/packages/bpk-docs/src/layouts/SideNavLayout/NavList.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/NavList.js
@@ -30,6 +30,7 @@ import {
   type CategoryPropType,
   type Category,
 } from './common-types';
+import { setPlatformInLocalStorage } from '../../helpers/storage-helper';
 
 const getClassName = cssModules(STYLES);
 
@@ -111,6 +112,7 @@ class NavList extends Component<NavListPropTypes, NavListState> {
   }
 
   onSelectedFilterChange = (selectedFilter: FilterOption) => {
+    setPlatformInLocalStorage(selectedFilter);
     this.setState({ selectedFilter });
   };
 


### PR DESCRIPTION
Behaviour:
 - If a user navigates to a component page with no preference already set, it will show the first platform available. Their preference will remain unset.
 - If a user navigates to a component page with a preference already set, it will show their prefered platform (iff it exists), falling back to the first one available. Their preference will not change either way.
 - If a user navigates to a component page with the platform specified as a URL parameter, then the URL parameter will take precedence. Their current preference will remain, but won't be used in favour of the URL parameter.
 - If a user selects a platform from the horizontal nav, their platform preference will be set/updated
 - If a user selects a platform from the nav filter (Web or Native), their platform preference will be set/updated
 - If a user selects `all` from the nav filter, their platform preference will remain the same.
 - If a user navigates to a component page with a preference already set, the nav list filter will be set to `all` regardless

This should provide a better experience for most consumers.
Those only interested in Android may notice no improvement, as they are already used to Android being selected by default!