### PR TITLE
Shift first and last date by 1ms to deal with edge cases

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,7 @@
 # Unreleased
 
+**Fixed:**
+
+- bpk-component-calendar
+  - Fix edge cases with Week component
+

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -3,5 +3,5 @@
 **Fixed:**
 
 - bpk-component-calendar
-  - Fix edge cases with Week component
+  - Fix edge cases with Week component's support for range selection
 

--- a/packages/bpk-component-calendar/src/Week-test.js
+++ b/packages/bpk-component-calendar/src/Week-test.js
@@ -157,6 +157,10 @@ describe('Week', () => {
     ['0605', '0620', '0605', '0608', true, 'end moves from after to before'],
     ['0605', '0608', '0605', '0620', true, 'end moves from before to after'],
     ['0602', '0605', '0622', '0625', false, 'moves entirely past the week'],
+    ['0610', '0617', '0611', '0617', true, 'moves from start edge into week'],
+    ['0612', '0616', '0612', '0615', true, 'moves from end edge into week'],
+    ['0610', '0617', '0609', '0617', true, 'moves from start edge out of week'],
+    ['0611', '0616', '0611', '0617', true, 'moves from end edge out of week'],
   ].forEach(([start, end, newStart, newEnd, expected, reason]) => {
     it(`should${
       expected ? '' : ' not'

--- a/packages/bpk-component-calendar/src/Week.js
+++ b/packages/bpk-component-calendar/src/Week.js
@@ -22,6 +22,7 @@ import { cssModules } from 'bpk-react-utils';
 import areRangesOverlapping from 'date-fns/are_ranges_overlapping';
 import dateMin from 'date-fns/min';
 import dateMax from 'date-fns/max';
+import startOfDay from 'date-fns/start_of_day';
 
 import {
   getDay,
@@ -116,8 +117,9 @@ class Week extends Component {
     );
 
     if (selectionStartChanged || selectionEndChanged) {
-      const firstDate = nextProps.dates[0];
-      const lastDate = nextProps.dates[nextProps.dates.length - 1];
+      const firstDate = startOfDay(nextProps.dates[0]).getTime() - 1;
+      const lastDate =
+        startOfDay(nextProps.dates[nextProps.dates.length - 1]).getTime() + 1;
       if (
         areRangesOverlapping(
           this.props.selectionStart,


### PR DESCRIPTION
My last commit had a bug in it. areRangesOverlapping is not inclusive
(uses strict less-than comparison) and so right now changing the selection
from the very edge doesn't work properly.

To fix it I just enlarged the range we compare against by 1ms in either
direction.