### PR TITLE
[NO-JIRA] Fix date-picker README

### DIFF
--- a/packages/bpk-component-calendar/README.md
+++ b/packages/bpk-component-calendar/README.md
@@ -213,7 +213,7 @@ The BpkCalendarGrid component displays a month as a table.
 | Property              | PropType             | Required | Default Value    |
 | --------------------- | -------------------- | -------- | ---------------- |
 | DateComponent         | func                 | true     | -                |
-| daysOfWeek            | object               | true     | -                |
+| daysOfWeek            | array(object)        | true     | -                |
 | formatDateFull        | func                 | true     | -                |
 | formatMonth           | func                 | true     | -                |
 | month                 | Date                 | true     | -                |

--- a/packages/bpk-component-datepicker/README.md
+++ b/packages/bpk-component-datepicker/README.md
@@ -75,30 +75,30 @@ For more information on some these props, check the BpkCalendar documentation.
 > `getApplicationElement` prop (see the example above) - this is to "hide" your application from
 > screenreaders whilst the datepicker is open. The `pagewrap` element id is a convention we use internally at Skyscanner. In most cases it should "just work".
 
-| Property              | PropType | Required | Default Value         |
-| --------------------- | -------- | -------- | --------------------- |
-| changeMonthLabel      | string   | true     | -                     |
-| closeButtonText       | string   | true     | -                     |
-| title                 | string   | true     | -                     |
-| id                    | string   | true     | -                     |
-| getApplicationElement | func     | true     | -                     |
-| daysOfWeek            | object   | true     | -                     |
-| formatDate            | func     | true     | -                     |
-| formatDateFull        | func     | true     | -                     |
-| formatMonth           | func     | true     | -                     |
-| date                  | Date     | false    | null                  |
-| DateComponent         | func     | false    | BpkCalendarDate (\*)  |
-| dateModifiers         | object   | false    | {} (\*)               |
-| inputProps            | object   | false    | {}                    |
-| markOutsideDays       | bool     | false    | true (\*)             |
-| markToday             | bool     | false    | true (\*)             |
-| maxDate               | Date     | false    | new Date() + 1yr (\*) |
-| minDate               | Date     | false    | new Date() (\*)       |
-| onDateSelect          | func     | false    | null                  |
-| showWeekendSeparator  | bool     | false    | true (\*)             |
-| weekStartsOn          | number   | false    | 1 (\*)                |
-| initiallyFocusedDate  | Date     | false    | null                  |
-| renderTarget          | func     | false    | null                  |
+| Property              | PropType        | Required | Default Value         |
+| --------------------- | --------------- | -------- | --------------------- |
+| changeMonthLabel      | string          | true     | -                     |
+| closeButtonText       | string          | true     | -                     |
+| title                 | string          | true     | -                     |
+| id                    | string          | true     | -                     |
+| getApplicationElement | func            | true     | -                     |
+| daysOfWeek            | arrayOf(object) | true     | -                     |
+| formatDate            | func            | true     | -                     |
+| formatDateFull        | func            | true     | -                     |
+| formatMonth           | func            | true     | -                     |
+| date                  | Date            | false    | null                  |
+| DateComponent         | func            | false    | BpkCalendarDate (\*)  |
+| dateModifiers         | object          | false    | {} (\*)               |
+| inputProps            | object          | false    | {}                    |
+| markOutsideDays       | bool            | false    | true (\*)             |
+| markToday             | bool            | false    | true (\*)             |
+| maxDate               | Date            | false    | new Date() + 1yr (\*) |
+| minDate               | Date            | false    | new Date() (\*)       |
+| onDateSelect          | func            | false    | null                  |
+| showWeekendSeparator  | bool            | false    | true (\*)             |
+| weekStartsOn          | number          | false    | 1 (\*)                |
+| initiallyFocusedDate  | Date            | false    | null                  |
+| renderTarget          | func            | false    | null                  |
 
 > (\*) Default value is defined on child component
 


### PR DESCRIPTION
As you can see here, the proptype for `daysOfWeek` should in fact be an array of week objects.
https://github.com/Skyscanner/backpack/blob/master/packages/bpk-component-calendar/src/custom-proptypes.js#L28