### PR TITLE
[NO-JIRA] Remove package lock version numbers

### DIFF
--- a/packages/bpk-animate-height/package-lock.json
+++ b/packages/bpk-animate-height/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-animate-height",
-	"version": "1.1.75",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-accordion/package-lock.json
+++ b/packages/bpk-component-accordion/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-accordion",
-	"version": "1.2.62",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-autosuggest/package-lock.json
+++ b/packages/bpk-component-autosuggest/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-autosuggest",
-	"version": "3.0.129",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-badge/package-lock.json
+++ b/packages/bpk-component-badge/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-badge",
-	"version": "1.1.53",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-banner-alert/package-lock.json
+++ b/packages/bpk-component-banner-alert/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-banner-alert",
-	"version": "2.0.66",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-barchart/package-lock.json
+++ b/packages/bpk-component-barchart/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-barchart",
-	"version": "2.3.43",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-blockquote/package-lock.json
+++ b/packages/bpk-component-blockquote/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-blockquote",
-	"version": "1.1.96",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-boilerplate/package-lock.json
+++ b/packages/bpk-component-boilerplate/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-boilerplate",
-	"version": "0.0.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-breadcrumb/package-lock.json
+++ b/packages/bpk-component-breadcrumb/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-breadcrumb",
-	"version": "1.0.43",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-breakpoint/package-lock.json
+++ b/packages/bpk-component-breakpoint/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-breakpoint",
-	"version": "1.1.39",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-button/package-lock.json
+++ b/packages/bpk-component-button/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-button",
-	"version": "2.1.40",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-calendar/package-lock.json
+++ b/packages/bpk-component-calendar/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-calendar",
-	"version": "4.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-card/package-lock.json
+++ b/packages/bpk-component-card/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-card",
-	"version": "1.1.53",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-checkbox/package-lock.json
+++ b/packages/bpk-component-checkbox/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-checkbox",
-	"version": "1.4.69",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-chip/package-lock.json
+++ b/packages/bpk-component-chip/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-chip",
-	"version": "2.0.58",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-close-button/package-lock.json
+++ b/packages/bpk-component-close-button/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-close-button",
-	"version": "1.0.105",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-code/package-lock.json
+++ b/packages/bpk-component-code/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-code",
-	"version": "1.1.44",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-content-container/package-lock.json
+++ b/packages/bpk-component-content-container/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-content-container",
-	"version": "1.3.44",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-datatable/package-lock.json
+++ b/packages/bpk-component-datatable/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-datatable",
-	"version": "0.1.59",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-datepicker/package-lock.json
+++ b/packages/bpk-component-datepicker/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-datepicker",
-	"version": "8.1.36",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-description-list/package-lock.json
+++ b/packages/bpk-component-description-list/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-description-list",
-	"version": "1.0.66",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-dialog/package-lock.json
+++ b/packages/bpk-component-dialog/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-dialog",
-	"version": "1.1.32",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-drawer/package-lock.json
+++ b/packages/bpk-component-drawer/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-drawer",
-	"version": "1.2.59",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-fieldset/package-lock.json
+++ b/packages/bpk-component-fieldset/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-fieldset",
-	"version": "1.1.66",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-form-validation/package-lock.json
+++ b/packages/bpk-component-form-validation/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-form-validation",
-	"version": "1.0.108",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-grid-toggle/package-lock.json
+++ b/packages/bpk-component-grid-toggle/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-grid-toggle",
-	"version": "1.1.58",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-grid/package-lock.json
+++ b/packages/bpk-component-grid/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-grid",
-	"version": "1.1.109",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-heading/package-lock.json
+++ b/packages/bpk-component-heading/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-heading",
-	"version": "2.1.109",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-horizontal-nav/package-lock.json
+++ b/packages/bpk-component-horizontal-nav/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-horizontal-nav",
-	"version": "2.3.42",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-icon/package-lock.json
+++ b/packages/bpk-component-icon/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-icon",
-	"version": "3.23.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-image/package-lock.json
+++ b/packages/bpk-component-image/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-image",
-	"version": "2.1.10",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-infinite-scroll/package-lock.json
+++ b/packages/bpk-component-infinite-scroll/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-infinite-scroll",
-	"version": "2.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-input/package-lock.json
+++ b/packages/bpk-component-input/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-input",
-	"version": "3.3.60",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-label/package-lock.json
+++ b/packages/bpk-component-label/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-label",
-	"version": "3.2.108",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-link/package-lock.json
+++ b/packages/bpk-component-link/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-link",
-	"version": "1.2.39",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-list/package-lock.json
+++ b/packages/bpk-component-list/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-list",
-	"version": "1.1.79",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-loading-button/package-lock.json
+++ b/packages/bpk-component-loading-button/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-loading-button",
-	"version": "2.0.63",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-map/package-lock.json
+++ b/packages/bpk-component-map/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-map",
-	"version": "2.0.37",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-mobile-scroll-container/package-lock.json
+++ b/packages/bpk-component-mobile-scroll-container/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-mobile-scroll-container",
-	"version": "1.1.43",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-modal/package-lock.json
+++ b/packages/bpk-component-modal/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-modal",
-	"version": "1.8.32",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-navigation-bar/package-lock.json
+++ b/packages/bpk-component-navigation-bar/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-navigation-bar",
-	"version": "1.2.43",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-navigation-stack/package-lock.json
+++ b/packages/bpk-component-navigation-stack/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-navigation-stack",
-	"version": "1.0.46",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-nudger/package-lock.json
+++ b/packages/bpk-component-nudger/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-nudger",
-	"version": "1.0.108",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-pagination/package-lock.json
+++ b/packages/bpk-component-pagination/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-pagination",
-	"version": "1.0.72",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-panel/package-lock.json
+++ b/packages/bpk-component-panel/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-panel",
-	"version": "1.0.102",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-paragraph/package-lock.json
+++ b/packages/bpk-component-paragraph/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-paragraph",
-	"version": "1.0.102",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-phone-input/package-lock.json
+++ b/packages/bpk-component-phone-input/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-phone-input",
-	"version": "1.0.49",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-popover/package-lock.json
+++ b/packages/bpk-component-popover/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-popover",
-	"version": "2.2.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-progress/package-lock.json
+++ b/packages/bpk-component-progress/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-progress",
-	"version": "1.0.108",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-radio/package-lock.json
+++ b/packages/bpk-component-radio/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-radio",
-	"version": "1.2.68",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-router-link/package-lock.json
+++ b/packages/bpk-component-router-link/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-router-link",
-	"version": "2.0.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-rtl-toggle/package-lock.json
+++ b/packages/bpk-component-rtl-toggle/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-rtl-toggle",
-	"version": "1.1.58",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-scrollable-calendar/package-lock.json
+++ b/packages/bpk-component-scrollable-calendar/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-scrollable-calendar",
-	"version": "0.1.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-section-list/package-lock.json
+++ b/packages/bpk-component-section-list/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-section-list",
-	"version": "1.0.42",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-select/package-lock.json
+++ b/packages/bpk-component-select/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-select",
-	"version": "2.2.40",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-slider/package-lock.json
+++ b/packages/bpk-component-slider/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-slider",
-	"version": "1.1.71",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-spinner/package-lock.json
+++ b/packages/bpk-component-spinner/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-spinner",
-	"version": "2.2.70",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-star-rating/package-lock.json
+++ b/packages/bpk-component-star-rating/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-star-rating",
-	"version": "1.0.104",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-table/package-lock.json
+++ b/packages/bpk-component-table/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-table",
-	"version": "1.1.44",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-text/package-lock.json
+++ b/packages/bpk-component-text/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-text",
-	"version": "1.0.100",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-textarea/package-lock.json
+++ b/packages/bpk-component-textarea/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-textarea",
-	"version": "1.0.102",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-theme-toggle/package-lock.json
+++ b/packages/bpk-component-theme-toggle/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-theme-toggle",
-	"version": "1.0.77",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-ticket/package-lock.json
+++ b/packages/bpk-component-ticket/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-ticket",
-	"version": "1.2.34",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-tile/package-lock.json
+++ b/packages/bpk-component-tile/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-tile",
-	"version": "0.0.109",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-tooltip/package-lock.json
+++ b/packages/bpk-component-tooltip/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-component-tooltip",
-	"version": "3.1.55",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-docs/package-lock.json
+++ b/packages/bpk-docs/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-docs",
-	"version": "0.0.347",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-react-utils/package-lock.json
+++ b/packages/bpk-react-utils/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-react-utils",
-	"version": "2.7.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-scrim-utils/package-lock.json
+++ b/packages/bpk-scrim-utils/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-scrim-utils",
-	"version": "3.2.38",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-stylesheets/package-lock.json
+++ b/packages/bpk-stylesheets/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-stylesheets",
-	"version": "3.2.147",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-theming/package-lock.json
+++ b/packages/bpk-theming/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-theming",
-	"version": "1.1.27",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-tokens/package-lock.json
+++ b/packages/bpk-tokens/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "bpk-tokens",
-	"version": "27.4.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Package lock files no longer need to have a version, and as NPM isn't updating them anymore they are not only obsolete but also out of date. 