### PR TITLE
Use local storage for tokens platform switching

### DIFF
--- a/packages/bpk-docs/src/components/DocsPageBuilder/TokenSwitcher.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/TokenSwitcher.js
@@ -21,6 +21,10 @@ import PropTypes from 'prop-types';
 import BpkHorizontalNav, {
   BpkHorizontalNavItem,
 } from 'bpk-component-horizontal-nav';
+import {
+  setPlatformInLocalStorage,
+  getPlatformFromLocalStorage,
+} from '../../helpers/storage-helper';
 
 const platforms = {
   web: {
@@ -58,6 +62,7 @@ const removeListener = (switcher, toRemove) => {
 };
 
 const onSwitch = (switcher, id) => {
+  setPlatformInLocalStorage(id);
   const switcherListeners = listeners[`${switcher.id}`] || [];
   switcherListeners.forEach(listener => listener(id));
 };
@@ -69,6 +74,13 @@ class TokenSwitcher extends Component {
     this.state = {
       selectedPlatform: platforms.web.id,
     };
+  }
+
+  componentDidMount() {
+    const selectedPlatform = getPlatformFromLocalStorage();
+    if (platforms[selectedPlatform]) {
+      this.setState({ selectedPlatform });
+    }
   }
 
   componentWillUnmount() {

--- a/packages/bpk-docs/src/components/DocsPageWrapper/DocsPageWrapper.js
+++ b/packages/bpk-docs/src/components/DocsPageWrapper/DocsPageWrapper.js
@@ -124,12 +124,7 @@ const DocsPageWrapper = props => {
     if (!platformPreference) {
       return false;
     }
-    return (
-      (platformPreference === 'web' && webSubpage) ||
-      (platformPreference === 'native' && nativeSubpage) ||
-      (platformPreference === 'ios' && iosSubpage) ||
-      (platformPreference === 'android' && androidSubpage)
-    );
+    return !!platforms[platformPreference];
   };
 
   let initiallySelectedPlatform = 'web';


### PR DESCRIPTION
I realised this morning that when I completed [BPK-2168](https://github.com/Skyscanner/backpack/pull/1298) I overlooked adding the platform-selection functionality to the tokens pages, although it is just as valid there.