### PR TITLE
[BPK-2211] Add prop to disable no-script

### DIFF
--- a/packages/bpk-component-image/README.md
+++ b/packages/bpk-component-image/README.md
@@ -147,6 +147,7 @@ export default () => (
 | width            | number    | true     | -                   |
 | className        | string    | false    | null                |
 | inView           | bool      | false    | true                |
+| supportNoScript  | bool      | false    | true                |
 | loading          | bool      | false    | false               |
 | onLoad           | func      | false    | null                |
 

--- a/packages/bpk-component-image/package.json
+++ b/packages/bpk-component-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpk-component-image",
-  "version": "2.1.18",
+  "version": "2.1.19--beta.0",
   "description": "Backpack image component.",
   "main": "index.js",
   "repository": {

--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -113,14 +113,15 @@ class BpkImage extends Component<BpkImageProps> {
 
   render(): Node {
     const {
-      width,
-      height,
       altText,
       className,
+      height,
       inView,
       loading,
       onLoad,
       style,
+      supportNoScript,
+      width,
       ...rest
     } = this.props;
 
@@ -175,15 +176,17 @@ class BpkImage extends Component<BpkImageProps> {
               </div>
             </CSSTransition>
           )}
-          {typeof window === 'undefined' && (!inView || loading) && (
-            <noscript>
-              <Image // eslint-disable-line backpack/use-components
-                altText={altText}
-                onImageLoad={this.onImageLoad}
-                {...rest}
-              />
-            </noscript>
-          )}
+          {supportNoScript &&
+            typeof window === 'undefined' &&
+            (!inView || loading) && (
+              <noscript>
+                <Image // eslint-disable-line backpack/use-components
+                  altText={altText}
+                  onImageLoad={this.onImageLoad}
+                  {...rest}
+                />
+              </noscript>
+            )}
         </div>
       </div>
     );
@@ -200,6 +203,7 @@ BpkImage.propTypes = {
   loading: PropTypes.bool,
   onLoad: PropTypes.func,
   style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  supportNoScript: PropTypes.bool,
 };
 
 BpkImage.defaultProps = {
@@ -208,6 +212,7 @@ BpkImage.defaultProps = {
   loading: false,
   onLoad: null,
   style: {},
+  supportNoScript: true,
 };
 
 export default BpkImage;

--- a/packages/bpk-component-image/stories.js
+++ b/packages/bpk-component-image/stories.js
@@ -161,4 +161,14 @@ storiesOf('bpk-component-image', module)
         </BpkText>
       </div>
     </FadingLazyLoadedBackgroundImage>
+  ))
+  .add('no-script disabled', () => (
+    <BpkImage
+      altText="image"
+      supportNoScript={false}
+      width={612}
+      height={408}
+      style={{ width: imageWidth, height: imageHeight }}
+      src={image}
+    />
   ));


### PR DESCRIPTION
This is a non-breaking addition of a prop that allows us to disable the no-script tag. I have introduced it as an intermediate solution to the issues described in BPK-2211 which are preventing car-hire from leveraging Backpack's lazyloading image functionality.

Initially I will release this as a beta version, to enable us to confirm our assumptions about the cause of the issue.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
