### PR TITLE
Add labels to Phone Input component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,4 @@
 # Unreleased
 
+- bpk-component-phone-input:
+  - Add labels for dialing code and telephone number.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,4 +1,6 @@
 # Unreleased
 
+**Breaking:**
+
 - bpk-component-phone-input:
-  - Add labels for dialing code and telephone number.
+  - Add labels for dialing code and telephone number as they are preferred over placeholders per UX guidelines.

--- a/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarGridTransition-test.js.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarGridTransition-test.js.snap
@@ -17,13 +17,13 @@ exports[`BpkCalendar should render correctly 1`] = `
     }
   >
     <div>
-      {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-01-01T00:00:00.000Z","preventKeyboardFocus":true,"isKeyboardFocusable":false,"focusedDate":"2010-01-01T01:00:00.000Z","aria-hidden":true,"className":"bpk-calendar-grid-transition__grid"}
+      {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-01-01T00:00:00.000Z","preventKeyboardFocus":true,"isKeyboardFocusable":false,"focusedDate":"2010-01-01T00:00:00.000Z","aria-hidden":true,"className":"bpk-calendar-grid-transition__grid"}
     </div>
     <div>
       {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-02-01T00:00:00.000Z","isKeyboardFocusable":true,"focusedDate":null,"aria-hidden":false,"className":"bpk-calendar-grid-transition__grid"}
     </div>
     <div>
-      {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-03-01T00:00:00.000Z","preventKeyboardFocus":true,"isKeyboardFocusable":false,"focusedDate":"2010-03-01T01:00:00.000Z","aria-hidden":true,"className":"bpk-calendar-grid-transition__grid"}
+      {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-03-01T00:00:00.000Z","preventKeyboardFocus":true,"isKeyboardFocusable":false,"focusedDate":"2010-03-01T00:00:00.000Z","aria-hidden":true,"className":"bpk-calendar-grid-transition__grid"}
     </div>
   </div>
 </div>

--- a/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarGridTransition-test.js.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarGridTransition-test.js.snap
@@ -17,13 +17,13 @@ exports[`BpkCalendar should render correctly 1`] = `
     }
   >
     <div>
-      {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-01-01T00:00:00.000Z","preventKeyboardFocus":true,"isKeyboardFocusable":false,"focusedDate":"2010-01-01T00:00:00.000Z","aria-hidden":true,"className":"bpk-calendar-grid-transition__grid"}
+      {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-01-01T00:00:00.000Z","preventKeyboardFocus":true,"isKeyboardFocusable":false,"focusedDate":"2010-01-01T01:00:00.000Z","aria-hidden":true,"className":"bpk-calendar-grid-transition__grid"}
     </div>
     <div>
       {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-02-01T00:00:00.000Z","isKeyboardFocusable":true,"focusedDate":null,"aria-hidden":false,"className":"bpk-calendar-grid-transition__grid"}
     </div>
     <div>
-      {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-03-01T00:00:00.000Z","preventKeyboardFocus":true,"isKeyboardFocusable":false,"focusedDate":"2010-03-01T00:00:00.000Z","aria-hidden":true,"className":"bpk-calendar-grid-transition__grid"}
+      {"minDate":"2009-02-01T00:00:00.000Z","maxDate":"2011-02-01T00:00:00.000Z","month":"2010-03-01T00:00:00.000Z","preventKeyboardFocus":true,"isKeyboardFocusable":false,"focusedDate":"2010-03-01T01:00:00.000Z","aria-hidden":true,"className":"bpk-calendar-grid-transition__grid"}
     </div>
   </div>
 </div>

--- a/packages/bpk-component-phone-input/README.md
+++ b/packages/bpk-component-phone-input/README.md
@@ -47,7 +47,6 @@ export default class extends Component {
         id="phone-input-id"
         name="Telephone input"
         label="Telephone number"
-        placeholder="Telephone number"
         onChange={this.onChange}
         onDialingCodeChange={this.onDialingCodeChange}
         value={this.state.phoneNumber}

--- a/packages/bpk-component-phone-input/README.md
+++ b/packages/bpk-component-phone-input/README.md
@@ -30,23 +30,23 @@ const getFlag = dialingCode => {
 export default class extends Component {
   constructor(props) {
     super(props);
-    this.state = { dialingCode: '44', phoneNumber: '' }
+    this.state = { dialingCode: '44', phoneNumber: '' };
   }
 
-  onChange = (evt) => {
+  onChange = evt => {
     this.setState({ phoneNumber: evt.target.value });
-  }
+  };
 
-  onDialingCodeChange = (evt) => {
+  onDialingCodeChange = evt => {
     this.setState({ dialingCode: evt.target.value });
-  }
-
+  };
 
   render() {
     return (
       <BpkPhoneInput
         id="phone-input-id"
         name="Telephone input"
+        label="Telephone number"
         placeholder="Telephone number"
         onChange={this.onChange}
         onDialingCodeChange={this.onDialingCodeChange}
@@ -59,36 +59,38 @@ export default class extends Component {
         dialingCodeProps={{
           id: 'dialing-code',
           name: 'Dialing code',
+          label: 'Dialing code',
           'aria-label': 'Dialing code',
-          image: getFlag(this.state.dialingCode)
+          image: getFlag(this.state.dialingCode),
         }}
       />
-    )
+    );
   }
 }
 ```
 
 ## Props
 
-| Property              | PropType                                              | Required   | Default Value    |
-| --------------------- | ----------------------------------------------------- | ---------- | ---------------- |
-| dialingCode           | string                                                | true       | -                |
-| dialingCodeProps      | shape({ id: string, name: string })                   | true       | -                |
-| dialingCodes          | arrayOf(shape({ code: string, description: string })) | true       | -                |
-| id                    | string                                                | true       | -                |
-| name                  | string                                                | true       | -                |
-| onChange              | func                                                  | true       | -                |
-| onDialingCodeChange   | func                                                  | true       | -                |
-| value                 | string                                                | true       | -                |
-| className             | string                                                | false      | null             |
-| disabled              | boolean                                               | false      | false            |
-| large                 | boolean                                               | false      | false            |
-| valid                 | boolean                                               | false      | null             |
-| wrapperProps          | object                                                | false      | {}               |
+| Property            | PropType                                              | Required | Default Value |
+| ------------------- | ----------------------------------------------------- | -------- | ------------- |
+| dialingCode         | string                                                | true     | -             |
+| dialingCodeProps    | shape({ id: string, name: string, label: string })    | true     | -             |
+| dialingCodes        | arrayOf(shape({ code: string, description: string })) | true     | -             |
+| id                  | string                                                | true     | -             |
+| name                | string                                                | true     | -             |
+| label               | string                                                | true     | -             |
+| onChange            | func                                                  | true     | -             |
+| onDialingCodeChange | func                                                  | true     | -             |
+| value               | string                                                | true     | -             |
+| className           | string                                                | false    | null          |
+| disabled            | boolean                                               | false    | false         |
+| large               | boolean                                               | false    | false         |
+| valid               | boolean                                               | false    | null          |
+| wrapperProps        | object                                                | false    | {}            |
 
 ### dialingCodeProps
 
-Note that `id` and `name` are required but more properties can be provided, e.g. `dialingCodeProps={{ id: 'id', name: 'name', className: 'some-class' }}`. All
+Note that `id`, `name` and `label` are required but more properties can be provided, e.g. `dialingCodeProps={{ id: 'id', name: 'name', label: 'label', className: 'some-class' }}`. All
 properties will be forwarded to the underlying `BpkSelect` component.
 
 ### dialingCodes

--- a/packages/bpk-component-phone-input/package.json
+++ b/packages/bpk-component-phone-input/package.json
@@ -14,7 +14,9 @@
   },
   "dependencies": {
     "bpk-component-input": "^3.3.68",
+    "bpk-component-label": "^3.2.116",
     "bpk-component-select": "^2.2.48",
+    "bpk-component-text": "^1.0.108",
     "bpk-mixins": "^17.16.1",
     "bpk-react-utils": "^2.7.3",
     "bpk-tokens": "^27.4.9",

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput-test.js
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput-test.js
@@ -27,6 +27,7 @@ import BpkPhoneInput from './BpkPhoneInput';
 const dialingCodeProps = {
   id: 'dialing-code',
   name: 'Dialing code',
+  label: 'Dialing code',
   className: 'dialing-code',
   wrapperClassName: 'dialing-wrapper',
 };
@@ -39,6 +40,7 @@ const dialingCodes = [
 const defaultProps = {
   id: 'phone-input-id',
   name: 'Telephone input',
+  label: 'Telephone number',
   placeholder: 'Telephone number',
   value: '1234',
   dialingCode: '44',

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput-test.js
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput-test.js
@@ -41,7 +41,6 @@ const defaultProps = {
   id: 'phone-input-id',
   name: 'Telephone input',
   label: 'Telephone number',
-  placeholder: 'Telephone number',
   value: '1234',
   dialingCode: '44',
   className: 'fancy-input',

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput.js
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput.js
@@ -88,13 +88,11 @@ const BpkPhoneInput = (props: Props) => {
       {...wrapperProps}
       className={getClassName('bpk-phone-input', wrapperProps.className)}
     >
-      <BpkFieldset
-        label={dialingCodeProps.label}
-        className={getClassName('bpk-phone-input__dialing-code-wrapper')}
-      >
+      <BpkFieldset label={dialingCodeProps.label}>
         <BpkSelect
           {...commonProps}
           {...dialingCodeProps}
+          className={getClassName(dialingCodeProps.className)}
           wrapperClassName={getClassName(dialingCodeProps.wrapperClassName)}
           value={dialingCode}
           onChange={onDialingCodeChange}

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput.js
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput.js
@@ -22,6 +22,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { cssModules } from 'bpk-react-utils';
 import BpkInput, { INPUT_TYPES } from 'bpk-component-input';
+import BpkFieldset from 'bpk-component-fieldset';
 import BpkSelect from 'bpk-component-select';
 
 import STYLES from './BpkPhoneInput.scss';
@@ -33,12 +34,14 @@ export type Props = {
   dialingCodeProps: {
     id: string,
     name: string,
+    label: string,
     className?: string,
     wrapperClassName?: string,
   },
   dialingCodes: Array<{ code: string, description: string }>,
   id: string,
   name: string,
+  label: string,
   onChange: (SyntheticInputEvent<HTMLElement>) => mixed,
   onDialingCodeChange: (SyntheticInputEvent<HTMLElement>) => mixed,
   value: string,
@@ -60,6 +63,7 @@ const BpkPhoneInput = (props: Props) => {
     id,
     className,
     name,
+    label,
     disabled,
     onChange,
     onDialingCodeChange,
@@ -84,36 +88,39 @@ const BpkPhoneInput = (props: Props) => {
       {...wrapperProps}
       className={getClassName('bpk-phone-input', wrapperProps.className)}
     >
-      <BpkSelect
-        {...commonProps}
-        {...dialingCodeProps}
-        wrapperClassName={getClassName(
-          'bpk-phone-input__dialing-code-wrapper',
-          dialingCodeProps.wrapperClassName,
-        )}
-        className={getClassName(
-          'bpk-phone-input__dialing-code',
-          dialingCodeProps.className,
-        )}
-        value={dialingCode}
-        onChange={onDialingCodeChange}
+      <BpkFieldset
+        label={dialingCodeProps.label}
+        className={getClassName('bpk-phone-input__dialing-code-wrapper')}
       >
-        {dialingCodes.map(({ code, description, ...extraDialingProps }) => (
-          <option key={code} value={code} {...extraDialingProps}>
-            {description}
-          </option>
-        ))}
-      </BpkSelect>
-      <BpkInput
-        {...commonProps}
-        {...rest}
-        id={id}
-        name={name}
-        className={getClassName('bpk-phone-input__phone-number', className)}
-        value={value}
-        type={INPUT_TYPES.number}
-        onChange={onChange}
-      />
+        <BpkSelect
+          {...commonProps}
+          {...dialingCodeProps}
+          wrapperClassName={getClassName(dialingCodeProps.wrapperClassName)}
+          value={dialingCode}
+          onChange={onDialingCodeChange}
+        >
+          {dialingCodes.map(({ code, description, ...extraDialingProps }) => (
+            <option key={code} value={code} {...extraDialingProps}>
+              {description}
+            </option>
+          ))}
+        </BpkSelect>
+      </BpkFieldset>
+      <BpkFieldset
+        label={label}
+        className={getClassName('bpk-phone-input__phone-number')}
+      >
+        <BpkInput
+          {...commonProps}
+          {...rest}
+          id={id}
+          name={name}
+          value={value}
+          type={INPUT_TYPES.number}
+          onChange={onChange}
+          className={getClassName(className)}
+        />
+      </BpkFieldset>
     </span>
   );
 };
@@ -123,12 +130,14 @@ BpkPhoneInput.propTypes = {
   dialingCodeProps: PropTypes.shape({
     id: PropTypes.string,
     name: PropTypes.string,
+    label: PropTypes.string,
   }).isRequired,
   dialingCodes: PropTypes.arrayOf(
     PropTypes.shape({ code: PropTypes.string, description: PropTypes.string }),
   ).isRequired,
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onDialingCodeChange: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput.js
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput.js
@@ -22,7 +22,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { cssModules } from 'bpk-react-utils';
 import BpkInput, { INPUT_TYPES } from 'bpk-component-input';
-import BpkFieldset from 'bpk-component-fieldset';
+import BpkLabel from 'bpk-component-label';
 import BpkSelect from 'bpk-component-select';
 
 import STYLES from './BpkPhoneInput.scss';
@@ -86,42 +86,53 @@ const BpkPhoneInput = (props: Props) => {
   return (
     <span
       {...wrapperProps}
-      className={getClassName('bpk-phone-input', wrapperProps.className)}
+      className={getClassName(
+        'bpk-phone-input',
+        large && 'bpk-phone-input--large',
+        wrapperProps.className,
+      )}
     >
-      <BpkFieldset
-        label={dialingCodeProps.label}
-        className={getClassName('bpk-phone-input__dialing-code')}
+      <BpkLabel
+        htmlFor={dialingCodeProps.id}
+        className={getClassName('bpk-phone-input__dialing-code-label')}
+        disabled={disabled}
       >
-        <BpkSelect
-          {...commonProps}
-          {...dialingCodeProps}
-          className={getClassName(dialingCodeProps.className)}
-          wrapperClassName={getClassName(dialingCodeProps.wrapperClassName)}
-          value={dialingCode}
-          onChange={onDialingCodeChange}
-        >
-          {dialingCodes.map(({ code, description, ...extraDialingProps }) => (
-            <option key={code} value={code} {...extraDialingProps}>
-              {description}
-            </option>
-          ))}
-        </BpkSelect>
-      </BpkFieldset>
-      <BpkFieldset
-        label={label}
-        className={getClassName('bpk-phone-input__phone-number')}
+        {dialingCodeProps.label}
+      </BpkLabel>
+      <BpkSelect
+        {...commonProps}
+        {...dialingCodeProps}
+        className={getClassName(
+          'bpk-phone-input__dialing-code',
+          dialingCodeProps.className,
+        )}
+        wrapperClassName={getClassName(dialingCodeProps.wrapperClassName)}
+        value={dialingCode}
+        onChange={onDialingCodeChange}
       >
-        <BpkInput
-          {...commonProps}
-          {...rest}
-          id={id}
-          name={name}
-          value={value}
-          type={INPUT_TYPES.number}
-          onChange={onChange}
-          className={getClassName(className)}
-        />
-      </BpkFieldset>
+        {dialingCodes.map(({ code, description, ...extraDialingProps }) => (
+          <option key={code} value={code} {...extraDialingProps}>
+            {description}
+          </option>
+        ))}
+      </BpkSelect>
+      <BpkLabel
+        htmlFor={id}
+        className={getClassName('bpk-phone-input__phone-number-label')}
+        disabled={disabled}
+      >
+        {label}
+      </BpkLabel>
+      <BpkInput
+        {...commonProps}
+        {...rest}
+        id={id}
+        name={name}
+        value={value}
+        type={INPUT_TYPES.number}
+        onChange={onChange}
+        className={getClassName('bpk-phone-input__phone-number', className)}
+      />
     </span>
   );
 };

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput.js
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput.js
@@ -88,7 +88,10 @@ const BpkPhoneInput = (props: Props) => {
       {...wrapperProps}
       className={getClassName('bpk-phone-input', wrapperProps.className)}
     >
-      <BpkFieldset label={dialingCodeProps.label}>
+      <BpkFieldset
+        label={dialingCodeProps.label}
+        className={getClassName('bpk-phone-input__dialing-code')}
+      >
         <BpkSelect
           {...commonProps}
           {...dialingCodeProps}

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput.scss
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput.scss
@@ -15,24 +15,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 @import '~bpk-mixins/index';
 
 .bpk-phone-input {
-  display: flex;
+  display: grid;
+  grid-template-rows: auto auto;
+  grid-template-columns: max-content auto;
+  grid-template-areas:
+    'dialingCodeLabel numberLabel'
+    'dialingCode number';
+  grid-column-gap: $bpk-spacing-sm;
 
-  &__dialing-code,
-  &__dialing-code-wrapper {
-    width: 9rem;
-    white-space: nowrap;
-    overflow: hidden;
+  @include bpk-breakpoint-mobile {
+    grid-template-columns: 9 * $bpk-spacing-sm auto;
   }
 
-  &__phone-number {
-    flex-grow: 1;
-    white-space: nowrap;
-    overflow: hidden;
+  &--large {
+    @include bpk-breakpoint-mobile {
+      grid-template-columns: 10 * $bpk-spacing-sm auto;
+    }
+  }
 
-    @include bpk-margin-leading($bpk-spacing-sm);
+  &__dialing-code-label {
+    grid-area: dialingCodeLabel;
+    align-self: end;
+  }
+
+  &__dialing-code {
+    grid-area: dialingCode;
+  }
+
+  &__phone-number-label {
+    grid-area: numberLabel;
+    align-self: end;
+  }
+
+  &__phone-number-code {
+    grid-area: number;
   }
 }

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput.scss
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput.scss
@@ -23,11 +23,15 @@
 
   &__dialing-code,
   &__dialing-code-wrapper {
-    width: auto;
+    width: 9rem;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   &__phone-number {
     flex-grow: 1;
+    white-space: nowrap;
+    overflow: hidden;
 
     @include bpk-margin-leading($bpk-spacing-sm);
   }

--- a/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
+++ b/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
@@ -4,59 +4,49 @@ exports[`BpkPhoneInput should render correctly 1`] = `
 <span
   className="bpk-phone-input"
 >
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code"
+  <label
+    className="bpk-label bpk-phone-input__dialing-code-label"
+    htmlFor="dialing-code"
   >
-    <label
-      className="bpk-label"
-      htmlFor="dialing-code"
-    >
-      Dialing code
-    </label>
-    <select
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-select dialing-code"
-      disabled={false}
-      id="dialing-code"
-      label="Dialing code"
-      name="Dialing code"
-      onChange={[Function]}
+    Dialing code
+  </label>
+  <select
+    aria-invalid={false}
+    className="bpk-select bpk-phone-input__dialing-code dialing-code"
+    disabled={false}
+    id="dialing-code"
+    label="Dialing code"
+    name="Dialing code"
+    onChange={[Function]}
+    value="44"
+  >
+    <option
       value="44"
     >
-      <option
-        value="44"
-      >
-        +44
-      </option>
-      <option
-        value="55"
-      >
-        +55
-      </option>
-    </select>
-  </fieldset>
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__phone-number"
-  >
-    <label
-      className="bpk-label"
-      htmlFor="phone-input-id"
+      +44
+    </option>
+    <option
+      value="55"
     >
-      Telephone number
-    </label>
-    <input
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-input fancy-input"
-      disabled={false}
-      id="phone-input-id"
-      name="Telephone input"
-      onChange={[Function]}
-      type="number"
-      value="1234"
-    />
-  </fieldset>
+      +55
+    </option>
+  </select>
+  <label
+    className="bpk-label bpk-phone-input__phone-number-label"
+    htmlFor="phone-input-id"
+  >
+    Telephone number
+  </label>
+  <input
+    aria-invalid={false}
+    className="bpk-input bpk-phone-input__phone-number fancy-input"
+    disabled={false}
+    id="phone-input-id"
+    name="Telephone input"
+    onChange={[Function]}
+    type="number"
+    value="1234"
+  />
 </span>
 `;
 
@@ -64,119 +54,99 @@ exports[`BpkPhoneInput should render correctly with a "disabled" attribute 1`] =
 <span
   className="bpk-phone-input"
 >
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code"
+  <label
+    className="bpk-label bpk-label--disabled bpk-phone-input__dialing-code-label"
+    htmlFor="dialing-code"
   >
-    <label
-      className="bpk-label"
-      htmlFor="dialing-code"
-    >
-      Dialing code
-    </label>
-    <select
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-select dialing-code"
-      disabled={false}
-      id="dialing-code"
-      label="Dialing code"
-      name="Dialing code"
-      onChange={[Function]}
+    Dialing code
+  </label>
+  <select
+    aria-invalid={false}
+    className="bpk-select bpk-phone-input__dialing-code dialing-code"
+    disabled={true}
+    id="dialing-code"
+    label="Dialing code"
+    name="Dialing code"
+    onChange={[Function]}
+    value="44"
+  >
+    <option
       value="44"
     >
-      <option
-        value="44"
-      >
-        +44
-      </option>
-      <option
-        value="55"
-      >
-        +55
-      </option>
-    </select>
-  </fieldset>
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__phone-number"
-  >
-    <label
-      className="bpk-label"
-      htmlFor="phone-input-id"
+      +44
+    </option>
+    <option
+      value="55"
     >
-      Telephone number
-    </label>
-    <input
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-input fancy-input"
-      disabled={false}
-      id="phone-input-id"
-      name="Telephone input"
-      onChange={[Function]}
-      type="number"
-      value="1234"
-    />
-  </fieldset>
+      +55
+    </option>
+  </select>
+  <label
+    className="bpk-label bpk-label--disabled bpk-phone-input__phone-number-label"
+    htmlFor="phone-input-id"
+  >
+    Telephone number
+  </label>
+  <input
+    aria-invalid={false}
+    className="bpk-input bpk-phone-input__phone-number fancy-input"
+    disabled={true}
+    id="phone-input-id"
+    name="Telephone input"
+    onChange={[Function]}
+    type="number"
+    value="1234"
+  />
 </span>
 `;
 
 exports[`BpkPhoneInput should render correctly with a "large" attribute 1`] = `
 <span
-  className="bpk-phone-input"
+  className="bpk-phone-input bpk-phone-input--large"
 >
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code"
+  <label
+    className="bpk-label bpk-phone-input__dialing-code-label"
+    htmlFor="dialing-code"
   >
-    <label
-      className="bpk-label"
-      htmlFor="dialing-code"
-    >
-      Dialing code
-    </label>
-    <select
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-select bpk-select--large dialing-code"
-      disabled={false}
-      id="dialing-code"
-      label="Dialing code"
-      name="Dialing code"
-      onChange={[Function]}
+    Dialing code
+  </label>
+  <select
+    aria-invalid={false}
+    className="bpk-select bpk-select--large bpk-phone-input__dialing-code dialing-code"
+    disabled={false}
+    id="dialing-code"
+    label="Dialing code"
+    name="Dialing code"
+    onChange={[Function]}
+    value="44"
+  >
+    <option
       value="44"
     >
-      <option
-        value="44"
-      >
-        +44
-      </option>
-      <option
-        value="55"
-      >
-        +55
-      </option>
-    </select>
-  </fieldset>
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__phone-number"
-  >
-    <label
-      className="bpk-label"
-      htmlFor="phone-input-id"
+      +44
+    </option>
+    <option
+      value="55"
     >
-      Telephone number
-    </label>
-    <input
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-input bpk-input--large fancy-input"
-      disabled={false}
-      id="phone-input-id"
-      name="Telephone input"
-      onChange={[Function]}
-      type="number"
-      value="1234"
-    />
-  </fieldset>
+      +55
+    </option>
+  </select>
+  <label
+    className="bpk-label bpk-phone-input__phone-number-label"
+    htmlFor="phone-input-id"
+  >
+    Telephone number
+  </label>
+  <input
+    aria-invalid={false}
+    className="bpk-input bpk-input--large bpk-phone-input__phone-number fancy-input"
+    disabled={false}
+    id="phone-input-id"
+    name="Telephone input"
+    onChange={[Function]}
+    type="number"
+    value="1234"
+  />
 </span>
 `;
 
@@ -184,59 +154,49 @@ exports[`BpkPhoneInput should render correctly with a "valid" attribute 1`] = `
 <span
   className="bpk-phone-input"
 >
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code"
+  <label
+    className="bpk-label bpk-phone-input__dialing-code-label"
+    htmlFor="dialing-code"
   >
-    <label
-      className="bpk-label"
-      htmlFor="dialing-code"
-    >
-      Dialing code
-    </label>
-    <select
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-select dialing-code"
-      disabled={false}
-      id="dialing-code"
-      label="Dialing code"
-      name="Dialing code"
-      onChange={[Function]}
+    Dialing code
+  </label>
+  <select
+    aria-invalid={false}
+    className="bpk-select bpk-phone-input__dialing-code dialing-code"
+    disabled={false}
+    id="dialing-code"
+    label="Dialing code"
+    name="Dialing code"
+    onChange={[Function]}
+    value="44"
+  >
+    <option
       value="44"
     >
-      <option
-        value="44"
-      >
-        +44
-      </option>
-      <option
-        value="55"
-      >
-        +55
-      </option>
-    </select>
-  </fieldset>
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__phone-number"
-  >
-    <label
-      className="bpk-label"
-      htmlFor="phone-input-id"
+      +44
+    </option>
+    <option
+      value="55"
     >
-      Telephone number
-    </label>
-    <input
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-input bpk-input--valid fancy-input"
-      disabled={false}
-      id="phone-input-id"
-      name="Telephone input"
-      onChange={[Function]}
-      type="number"
-      value="1234"
-    />
-  </fieldset>
+      +55
+    </option>
+  </select>
+  <label
+    className="bpk-label bpk-phone-input__phone-number-label"
+    htmlFor="phone-input-id"
+  >
+    Telephone number
+  </label>
+  <input
+    aria-invalid={false}
+    className="bpk-input bpk-input--valid bpk-phone-input__phone-number fancy-input"
+    disabled={false}
+    id="phone-input-id"
+    name="Telephone input"
+    onChange={[Function]}
+    type="number"
+    value="1234"
+  />
 </span>
 `;
 
@@ -245,19 +205,71 @@ exports[`BpkPhoneInput should render correctly with a "wrapperProps" attribute 1
   aria-label="container"
   className="bpk-phone-input container"
 >
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code"
+  <label
+    className="bpk-label bpk-phone-input__dialing-code-label"
+    htmlFor="dialing-code"
   >
-    <label
-      className="bpk-label"
-      htmlFor="dialing-code"
+    Dialing code
+  </label>
+  <select
+    aria-invalid={false}
+    className="bpk-select bpk-phone-input__dialing-code dialing-code"
+    disabled={false}
+    id="dialing-code"
+    label="Dialing code"
+    name="Dialing code"
+    onChange={[Function]}
+    value="44"
+  >
+    <option
+      value="44"
     >
-      Dialing code
-    </label>
+      +44
+    </option>
+    <option
+      value="55"
+    >
+      +55
+    </option>
+  </select>
+  <label
+    className="bpk-label bpk-phone-input__phone-number-label"
+    htmlFor="phone-input-id"
+  >
+    Telephone number
+  </label>
+  <input
+    aria-invalid={false}
+    className="bpk-input bpk-phone-input__phone-number fancy-input"
+    disabled={false}
+    id="phone-input-id"
+    name="Telephone input"
+    onChange={[Function]}
+    type="number"
+    value="1234"
+  />
+</span>
+`;
+
+exports[`BpkPhoneInput should render correctly with a dialing code image attribute 1`] = `
+<span
+  className="bpk-phone-input"
+>
+  <label
+    className="bpk-label bpk-phone-input__dialing-code-label"
+    htmlFor="dialing-code"
+  >
+    Dialing code
+  </label>
+  <div
+    className="bpk-select-wrapper dialing-wrapper"
+  >
+    <span
+      className="bpk-select-wrapper__image"
+    />
     <select
       aria-invalid={false}
-      aria-required={false}
-      className="bpk-select dialing-code"
+      className="bpk-select bpk-select--with-image bpk-phone-input__dialing-code dialing-code"
       disabled={false}
       id="dialing-code"
       label="Dialing code"
@@ -276,94 +288,22 @@ exports[`BpkPhoneInput should render correctly with a "wrapperProps" attribute 1
         +55
       </option>
     </select>
-  </fieldset>
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__phone-number"
+  </div>
+  <label
+    className="bpk-label bpk-phone-input__phone-number-label"
+    htmlFor="phone-input-id"
   >
-    <label
-      className="bpk-label"
-      htmlFor="phone-input-id"
-    >
-      Telephone number
-    </label>
-    <input
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-input fancy-input"
-      disabled={false}
-      id="phone-input-id"
-      name="Telephone input"
-      onChange={[Function]}
-      type="number"
-      value="1234"
-    />
-  </fieldset>
-</span>
-`;
-
-exports[`BpkPhoneInput should render correctly with a dialing code image attribute 1`] = `
-<span
-  className="bpk-phone-input"
->
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code"
-  >
-    <label
-      className="bpk-label"
-      htmlFor="dialing-code"
-    >
-      Dialing code
-    </label>
-    <div
-      className="bpk-select-wrapper dialing-wrapper"
-    >
-      <span
-        className="bpk-select-wrapper__image"
-      />
-      <select
-        aria-invalid={false}
-        aria-required={false}
-        className="bpk-select bpk-select--with-image dialing-code"
-        disabled={false}
-        id="dialing-code"
-        label="Dialing code"
-        name="Dialing code"
-        onChange={[Function]}
-        value="44"
-      >
-        <option
-          value="44"
-        >
-          +44
-        </option>
-        <option
-          value="55"
-        >
-          +55
-        </option>
-      </select>
-    </div>
-  </fieldset>
-  <fieldset
-    className="bpk-fieldset bpk-phone-input__phone-number"
-  >
-    <label
-      className="bpk-label"
-      htmlFor="phone-input-id"
-    >
-      Telephone number
-    </label>
-    <input
-      aria-invalid={false}
-      aria-required={false}
-      className="bpk-input fancy-input"
-      disabled={false}
-      id="phone-input-id"
-      name="Telephone input"
-      onChange={[Function]}
-      type="number"
-      value="1234"
-    />
-  </fieldset>
+    Telephone number
+  </label>
+  <input
+    aria-invalid={false}
+    className="bpk-input bpk-phone-input__phone-number fancy-input"
+    disabled={false}
+    id="phone-input-id"
+    name="Telephone input"
+    onChange={[Function]}
+    type="number"
+    value="1234"
+  />
 </span>
 `;

--- a/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
+++ b/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
@@ -5,7 +5,7 @@ exports[`BpkPhoneInput should render correctly 1`] = `
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset"
+    className="bpk-fieldset bpk-phone-input__dialing-code"
   >
     <label
       className="bpk-label"
@@ -65,7 +65,7 @@ exports[`BpkPhoneInput should render correctly with a "disabled" attribute 1`] =
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset"
+    className="bpk-fieldset bpk-phone-input__dialing-code"
   >
     <label
       className="bpk-label"
@@ -125,7 +125,7 @@ exports[`BpkPhoneInput should render correctly with a "large" attribute 1`] = `
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset"
+    className="bpk-fieldset bpk-phone-input__dialing-code"
   >
     <label
       className="bpk-label"
@@ -185,7 +185,7 @@ exports[`BpkPhoneInput should render correctly with a "valid" attribute 1`] = `
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset"
+    className="bpk-fieldset bpk-phone-input__dialing-code"
   >
     <label
       className="bpk-label"
@@ -246,7 +246,7 @@ exports[`BpkPhoneInput should render correctly with a "wrapperProps" attribute 1
   className="bpk-phone-input container"
 >
   <fieldset
-    className="bpk-fieldset"
+    className="bpk-fieldset bpk-phone-input__dialing-code"
   >
     <label
       className="bpk-label"
@@ -306,7 +306,7 @@ exports[`BpkPhoneInput should render correctly with a dialing code image attribu
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset"
+    className="bpk-fieldset bpk-phone-input__dialing-code"
   >
     <label
       className="bpk-label"

--- a/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
+++ b/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
@@ -5,7 +5,7 @@ exports[`BpkPhoneInput should render correctly 1`] = `
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+    className="bpk-fieldset"
   >
     <label
       className="bpk-label"
@@ -65,7 +65,7 @@ exports[`BpkPhoneInput should render correctly with a "disabled" attribute 1`] =
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+    className="bpk-fieldset"
   >
     <label
       className="bpk-label"
@@ -125,7 +125,7 @@ exports[`BpkPhoneInput should render correctly with a "large" attribute 1`] = `
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+    className="bpk-fieldset"
   >
     <label
       className="bpk-label"
@@ -185,7 +185,7 @@ exports[`BpkPhoneInput should render correctly with a "valid" attribute 1`] = `
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+    className="bpk-fieldset"
   >
     <label
       className="bpk-label"
@@ -246,7 +246,7 @@ exports[`BpkPhoneInput should render correctly with a "wrapperProps" attribute 1
   className="bpk-phone-input container"
 >
   <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+    className="bpk-fieldset"
   >
     <label
       className="bpk-label"
@@ -306,7 +306,7 @@ exports[`BpkPhoneInput should render correctly with a dialing code image attribu
   className="bpk-phone-input"
 >
   <fieldset
-    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+    className="bpk-fieldset"
   >
     <label
       className="bpk-label"

--- a/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
+++ b/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
@@ -4,208 +4,22 @@ exports[`BpkPhoneInput should render correctly 1`] = `
 <span
   className="bpk-phone-input"
 >
-  <select
-    aria-invalid={false}
-    className="bpk-select bpk-phone-input__dialing-code dialing-code"
-    disabled={false}
-    id="dialing-code"
-    name="Dialing code"
-    onChange={[Function]}
-    value="44"
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
   >
-    <option
-      value="44"
+    <label
+      className="bpk-label"
+      htmlFor="dialing-code"
     >
-      +44
-    </option>
-    <option
-      value="55"
-    >
-      +55
-    </option>
-  </select>
-  <input
-    aria-invalid={false}
-    className="bpk-input bpk-phone-input__phone-number fancy-input"
-    disabled={false}
-    id="phone-input-id"
-    name="Telephone input"
-    onChange={[Function]}
-    placeholder="Telephone number"
-    type="number"
-    value="1234"
-  />
-</span>
-`;
-
-exports[`BpkPhoneInput should render correctly with a "disabled" attribute 1`] = `
-<span
-  className="bpk-phone-input"
->
-  <select
-    aria-invalid={false}
-    className="bpk-select bpk-phone-input__dialing-code dialing-code"
-    disabled={true}
-    id="dialing-code"
-    name="Dialing code"
-    onChange={[Function]}
-    value="44"
-  >
-    <option
-      value="44"
-    >
-      +44
-    </option>
-    <option
-      value="55"
-    >
-      +55
-    </option>
-  </select>
-  <input
-    aria-invalid={false}
-    className="bpk-input bpk-phone-input__phone-number fancy-input"
-    disabled={true}
-    id="phone-input-id"
-    name="Telephone input"
-    onChange={[Function]}
-    placeholder="Telephone number"
-    type="number"
-    value="1234"
-  />
-</span>
-`;
-
-exports[`BpkPhoneInput should render correctly with a "large" attribute 1`] = `
-<span
-  className="bpk-phone-input"
->
-  <select
-    aria-invalid={false}
-    className="bpk-select bpk-select--large bpk-phone-input__dialing-code dialing-code"
-    disabled={false}
-    id="dialing-code"
-    name="Dialing code"
-    onChange={[Function]}
-    value="44"
-  >
-    <option
-      value="44"
-    >
-      +44
-    </option>
-    <option
-      value="55"
-    >
-      +55
-    </option>
-  </select>
-  <input
-    aria-invalid={false}
-    className="bpk-input bpk-input--large bpk-phone-input__phone-number fancy-input"
-    disabled={false}
-    id="phone-input-id"
-    name="Telephone input"
-    onChange={[Function]}
-    placeholder="Telephone number"
-    type="number"
-    value="1234"
-  />
-</span>
-`;
-
-exports[`BpkPhoneInput should render correctly with a "valid" attribute 1`] = `
-<span
-  className="bpk-phone-input"
->
-  <select
-    aria-invalid={false}
-    className="bpk-select bpk-phone-input__dialing-code dialing-code"
-    disabled={false}
-    id="dialing-code"
-    name="Dialing code"
-    onChange={[Function]}
-    value="44"
-  >
-    <option
-      value="44"
-    >
-      +44
-    </option>
-    <option
-      value="55"
-    >
-      +55
-    </option>
-  </select>
-  <input
-    aria-invalid={false}
-    className="bpk-input bpk-input--valid bpk-phone-input__phone-number fancy-input"
-    disabled={false}
-    id="phone-input-id"
-    name="Telephone input"
-    onChange={[Function]}
-    placeholder="Telephone number"
-    type="number"
-    value="1234"
-  />
-</span>
-`;
-
-exports[`BpkPhoneInput should render correctly with a "wrapperProps" attribute 1`] = `
-<span
-  aria-label="container"
-  className="bpk-phone-input container"
->
-  <select
-    aria-invalid={false}
-    className="bpk-select bpk-phone-input__dialing-code dialing-code"
-    disabled={false}
-    id="dialing-code"
-    name="Dialing code"
-    onChange={[Function]}
-    value="44"
-  >
-    <option
-      value="44"
-    >
-      +44
-    </option>
-    <option
-      value="55"
-    >
-      +55
-    </option>
-  </select>
-  <input
-    aria-invalid={false}
-    className="bpk-input bpk-phone-input__phone-number fancy-input"
-    disabled={false}
-    id="phone-input-id"
-    name="Telephone input"
-    onChange={[Function]}
-    placeholder="Telephone number"
-    type="number"
-    value="1234"
-  />
-</span>
-`;
-
-exports[`BpkPhoneInput should render correctly with a dialing code image attribute 1`] = `
-<span
-  className="bpk-phone-input"
->
-  <div
-    className="bpk-select-wrapper bpk-phone-input__dialing-code-wrapper dialing-wrapper"
-  >
-    <span
-      className="bpk-select-wrapper__image"
-    />
+      Dialing code
+    </label>
     <select
       aria-invalid={false}
-      className="bpk-select bpk-select--with-image bpk-phone-input__dialing-code dialing-code"
+      aria-required={false}
+      className="bpk-select dialing-code"
       disabled={false}
       id="dialing-code"
+      label="Dialing code"
       name="Dialing code"
       onChange={[Function]}
       value="44"
@@ -221,17 +35,341 @@ exports[`BpkPhoneInput should render correctly with a dialing code image attribu
         +55
       </option>
     </select>
-  </div>
-  <input
-    aria-invalid={false}
-    className="bpk-input bpk-phone-input__phone-number fancy-input"
-    disabled={false}
-    id="phone-input-id"
-    name="Telephone input"
-    onChange={[Function]}
-    placeholder="Telephone number"
-    type="number"
-    value="1234"
-  />
+  </fieldset>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__phone-number"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="phone-input-id"
+    >
+      Telephone number
+    </label>
+    <input
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-input fancy-input"
+      disabled={false}
+      id="phone-input-id"
+      name="Telephone input"
+      onChange={[Function]}
+      placeholder="Telephone number"
+      type="number"
+      value="1234"
+    />
+  </fieldset>
+</span>
+`;
+
+exports[`BpkPhoneInput should render correctly with a "disabled" attribute 1`] = `
+<span
+  className="bpk-phone-input"
+>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="dialing-code"
+    >
+      Dialing code
+    </label>
+    <select
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-select dialing-code"
+      disabled={false}
+      id="dialing-code"
+      label="Dialing code"
+      name="Dialing code"
+      onChange={[Function]}
+      value="44"
+    >
+      <option
+        value="44"
+      >
+        +44
+      </option>
+      <option
+        value="55"
+      >
+        +55
+      </option>
+    </select>
+  </fieldset>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__phone-number"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="phone-input-id"
+    >
+      Telephone number
+    </label>
+    <input
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-input fancy-input"
+      disabled={false}
+      id="phone-input-id"
+      name="Telephone input"
+      onChange={[Function]}
+      placeholder="Telephone number"
+      type="number"
+      value="1234"
+    />
+  </fieldset>
+</span>
+`;
+
+exports[`BpkPhoneInput should render correctly with a "large" attribute 1`] = `
+<span
+  className="bpk-phone-input"
+>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="dialing-code"
+    >
+      Dialing code
+    </label>
+    <select
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-select bpk-select--large dialing-code"
+      disabled={false}
+      id="dialing-code"
+      label="Dialing code"
+      name="Dialing code"
+      onChange={[Function]}
+      value="44"
+    >
+      <option
+        value="44"
+      >
+        +44
+      </option>
+      <option
+        value="55"
+      >
+        +55
+      </option>
+    </select>
+  </fieldset>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__phone-number"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="phone-input-id"
+    >
+      Telephone number
+    </label>
+    <input
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-input bpk-input--large fancy-input"
+      disabled={false}
+      id="phone-input-id"
+      name="Telephone input"
+      onChange={[Function]}
+      placeholder="Telephone number"
+      type="number"
+      value="1234"
+    />
+  </fieldset>
+</span>
+`;
+
+exports[`BpkPhoneInput should render correctly with a "valid" attribute 1`] = `
+<span
+  className="bpk-phone-input"
+>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="dialing-code"
+    >
+      Dialing code
+    </label>
+    <select
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-select dialing-code"
+      disabled={false}
+      id="dialing-code"
+      label="Dialing code"
+      name="Dialing code"
+      onChange={[Function]}
+      value="44"
+    >
+      <option
+        value="44"
+      >
+        +44
+      </option>
+      <option
+        value="55"
+      >
+        +55
+      </option>
+    </select>
+  </fieldset>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__phone-number"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="phone-input-id"
+    >
+      Telephone number
+    </label>
+    <input
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-input bpk-input--valid fancy-input"
+      disabled={false}
+      id="phone-input-id"
+      name="Telephone input"
+      onChange={[Function]}
+      placeholder="Telephone number"
+      type="number"
+      value="1234"
+    />
+  </fieldset>
+</span>
+`;
+
+exports[`BpkPhoneInput should render correctly with a "wrapperProps" attribute 1`] = `
+<span
+  aria-label="container"
+  className="bpk-phone-input container"
+>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="dialing-code"
+    >
+      Dialing code
+    </label>
+    <select
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-select dialing-code"
+      disabled={false}
+      id="dialing-code"
+      label="Dialing code"
+      name="Dialing code"
+      onChange={[Function]}
+      value="44"
+    >
+      <option
+        value="44"
+      >
+        +44
+      </option>
+      <option
+        value="55"
+      >
+        +55
+      </option>
+    </select>
+  </fieldset>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__phone-number"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="phone-input-id"
+    >
+      Telephone number
+    </label>
+    <input
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-input fancy-input"
+      disabled={false}
+      id="phone-input-id"
+      name="Telephone input"
+      onChange={[Function]}
+      placeholder="Telephone number"
+      type="number"
+      value="1234"
+    />
+  </fieldset>
+</span>
+`;
+
+exports[`BpkPhoneInput should render correctly with a dialing code image attribute 1`] = `
+<span
+  className="bpk-phone-input"
+>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__dialing-code-wrapper"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="dialing-code"
+    >
+      Dialing code
+    </label>
+    <div
+      className="bpk-select-wrapper dialing-wrapper"
+    >
+      <span
+        className="bpk-select-wrapper__image"
+      />
+      <select
+        aria-invalid={false}
+        aria-required={false}
+        className="bpk-select bpk-select--with-image dialing-code"
+        disabled={false}
+        id="dialing-code"
+        label="Dialing code"
+        name="Dialing code"
+        onChange={[Function]}
+        value="44"
+      >
+        <option
+          value="44"
+        >
+          +44
+        </option>
+        <option
+          value="55"
+        >
+          +55
+        </option>
+      </select>
+    </div>
+  </fieldset>
+  <fieldset
+    className="bpk-fieldset bpk-phone-input__phone-number"
+  >
+    <label
+      className="bpk-label"
+      htmlFor="phone-input-id"
+    >
+      Telephone number
+    </label>
+    <input
+      aria-invalid={false}
+      aria-required={false}
+      className="bpk-input fancy-input"
+      disabled={false}
+      id="phone-input-id"
+      name="Telephone input"
+      onChange={[Function]}
+      placeholder="Telephone number"
+      type="number"
+      value="1234"
+    />
+  </fieldset>
 </span>
 `;

--- a/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
+++ b/packages/bpk-component-phone-input/src/__snapshots__/BpkPhoneInput-test.js.snap
@@ -53,7 +53,6 @@ exports[`BpkPhoneInput should render correctly 1`] = `
       id="phone-input-id"
       name="Telephone input"
       onChange={[Function]}
-      placeholder="Telephone number"
       type="number"
       value="1234"
     />
@@ -114,7 +113,6 @@ exports[`BpkPhoneInput should render correctly with a "disabled" attribute 1`] =
       id="phone-input-id"
       name="Telephone input"
       onChange={[Function]}
-      placeholder="Telephone number"
       type="number"
       value="1234"
     />
@@ -175,7 +173,6 @@ exports[`BpkPhoneInput should render correctly with a "large" attribute 1`] = `
       id="phone-input-id"
       name="Telephone input"
       onChange={[Function]}
-      placeholder="Telephone number"
       type="number"
       value="1234"
     />
@@ -236,7 +233,6 @@ exports[`BpkPhoneInput should render correctly with a "valid" attribute 1`] = `
       id="phone-input-id"
       name="Telephone input"
       onChange={[Function]}
-      placeholder="Telephone number"
       type="number"
       value="1234"
     />
@@ -298,7 +294,6 @@ exports[`BpkPhoneInput should render correctly with a "wrapperProps" attribute 1
       id="phone-input-id"
       name="Telephone input"
       onChange={[Function]}
-      placeholder="Telephone number"
       type="number"
       value="1234"
     />
@@ -366,7 +361,6 @@ exports[`BpkPhoneInput should render correctly with a dialing code image attribu
       id="phone-input-id"
       name="Telephone input"
       onChange={[Function]}
-      placeholder="Telephone number"
       type="number"
       value="1234"
     />

--- a/packages/bpk-component-phone-input/stories.js
+++ b/packages/bpk-component-phone-input/stories.js
@@ -84,7 +84,6 @@ class StoryContainer extends Component<
 
     return (
       <BpkFieldSet
-        label="Telephone"
         validationMessage={validationMessage}
         description={description}
         disabled={!!disabled}
@@ -93,6 +92,7 @@ class StoryContainer extends Component<
         <BpkPhoneInput
           id="phone-input-id"
           name="Telephone input"
+          label="Telephone number"
           placeholder="Telephone number"
           disabled={disabled}
           valid={value && validNumber ? validNumber === value : null}
@@ -108,6 +108,7 @@ class StoryContainer extends Component<
           dialingCodeProps={{
             id: 'dialing-code',
             name: 'Dialing code',
+            label: 'Dialing code',
             'aria-label': 'Dialing code',
             image: getFlag(dialingCode),
           }}

--- a/packages/bpk-component-phone-input/stories.js
+++ b/packages/bpk-component-phone-input/stories.js
@@ -26,8 +26,10 @@ import BpkImage from 'bpk-component-image';
 import BpkPhoneInput from './index';
 
 const DIALING_CODE_TO_ID_MAP = {
+  '1': 'us',
   '44': 'uk',
   '55': 'br',
+  '998': 'uz',
 };
 
 const getFlag = dialingCode => {
@@ -112,8 +114,10 @@ class StoryContainer extends Component<
           value={value}
           dialingCode={dialingCode}
           dialingCodes={[
+            { code: '1', description: '+1' },
             { code: '44', description: '+44' },
             { code: '55', description: '+55' },
+            { code: '998', description: '+998' },
           ]}
           dialingCodeProps={{
             id: 'dialing-code',

--- a/packages/bpk-component-phone-input/stories.js
+++ b/packages/bpk-component-phone-input/stories.js
@@ -43,6 +43,7 @@ type Props = {
   description: ?string,
   disabled: boolean,
   required: ?boolean,
+  useLongLabels: boolean,
 };
 
 class StoryContainer extends Component<
@@ -56,6 +57,7 @@ class StoryContainer extends Component<
     description: null,
     disabled: false,
     required: false,
+    useLongLabels: false,
   };
 
   constructor(props: Props) {
@@ -79,8 +81,17 @@ class StoryContainer extends Component<
       description,
       disabled,
       required,
+      useLongLabels,
     } = this.props;
     const { value, dialingCode } = this.state;
+
+    let dialingCodeLabel = 'Dialing code';
+    let phoneNumberLabel = 'Telephone number';
+
+    if (useLongLabels) {
+      dialingCodeLabel = dialingCodeLabel.repeat(2);
+      phoneNumberLabel = phoneNumberLabel.repeat(2);
+    }
 
     return (
       <BpkFieldSet
@@ -92,7 +103,7 @@ class StoryContainer extends Component<
         <BpkPhoneInput
           id="phone-input-id"
           name="Telephone input"
-          label="Telephone number"
+          label={phoneNumberLabel}
           disabled={disabled}
           valid={value && validNumber ? validNumber === value : null}
           large={large}
@@ -107,7 +118,7 @@ class StoryContainer extends Component<
           dialingCodeProps={{
             id: 'dialing-code',
             name: 'Dialing code',
-            label: 'Dialing code',
+            label: `${dialingCodeLabel}`,
             'aria-label': 'Dialing code',
             image: getFlag(dialingCode),
           }}
@@ -128,4 +139,5 @@ storiesOf('bpk-component-phone-input', module)
     />
   ))
   .add('Disabled', () => <StoryContainer disabled />)
-  .add('Required', () => <StoryContainer required />);
+  .add('Required', () => <StoryContainer required />)
+  .add('Double length labels', () => <StoryContainer useLongLabels />);

--- a/packages/bpk-component-phone-input/stories.js
+++ b/packages/bpk-component-phone-input/stories.js
@@ -93,7 +93,6 @@ class StoryContainer extends Component<
           id="phone-input-id"
           name="Telephone input"
           label="Telephone number"
-          placeholder="Telephone number"
           disabled={disabled}
           valid={value && validNumber ? validNumber === value : null}
           large={large}

--- a/packages/bpk-docs/src/pages/PhoneInputPage/PhoneInputPage.js
+++ b/packages/bpk-docs/src/pages/PhoneInputPage/PhoneInputPage.js
@@ -71,6 +71,7 @@ class StoryContainer extends Component<Props, State> {
       <BpkPhoneInput
         id="phone-input-id"
         name="Telephone input"
+        label="Telephone number"
         placeholder="Telephone number"
         large={this.props.large}
         onChange={this.onChange}
@@ -84,6 +85,7 @@ class StoryContainer extends Component<Props, State> {
         dialingCodeProps={{
           id: 'dialing-code',
           name: 'Dialing code',
+          label: 'Dialing code',
           'aria-label': 'Dialing code',
           image: getFlag(this.state.dialingCode),
         }}

--- a/packages/bpk-docs/src/pages/PhoneInputPage/PhoneInputPage.js
+++ b/packages/bpk-docs/src/pages/PhoneInputPage/PhoneInputPage.js
@@ -72,7 +72,6 @@ class StoryContainer extends Component<Props, State> {
         id="phone-input-id"
         name="Telephone input"
         label="Telephone number"
-        placeholder="Telephone number"
         large={this.props.large}
         onChange={this.onChange}
         onDialingCodeChange={this.onDialingCodeChange}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

As discussed with @georgegillams and @k0nserv this is a breaking change to `BpkPhoneInput`. It adds labels to both Dialing code `BpkSelect` and Telephone number `BpkInput`.

<img width="490" alt="phone_input_with_labels" src="https://user-images.githubusercontent.com/885513/54218654-e152a480-44e5-11e9-934b-a7ea54d39648.png">

With long labels:
<img width="759" alt="Screenshot 2019-03-13 at 15 44 28" src="https://user-images.githubusercontent.com/885513/54292980-078c4900-45a7-11e9-9a55-25be163287f7.png">


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
