### PR TITLE
Add "buttonProps" prop to "BpkMapMarker"

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -431,6 +431,7 @@ keydown
 keyup
 iconDisabled
 rel
+buttonProps
 
 autoScrollToSelected
 leadingScrollIndicatorClassName

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,4 @@
 # Unreleased
 
+- bpk-component-map:
+  - Added the prop `buttonProps` to `BpkMapMarker` to allow sending arbitrary props to the button element.

--- a/packages/bpk-component-breadcrumb/README.md
+++ b/packages/bpk-component-breadcrumb/README.md
@@ -46,4 +46,4 @@ export default class App extends Component {
 | children           | node                       | true     | -             |
 | href               | string                     | false    | null          |
 | active             | bool                       | false    | false         |
-| linkProps          | object                     | false    | {}            |
+| linkProps          | object                     | false    | null          |

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
@@ -83,7 +83,7 @@ BpkBreadcrumbItem.defaultProps = {
   active: false,
   href: null,
   className: null,
-  linkProps: {},
+  linkProps: null,
 };
 
 export default BpkBreadcrumbItem;

--- a/packages/bpk-component-map/README.md
+++ b/packages/bpk-component-map/README.md
@@ -112,6 +112,7 @@ When using `withGoogleMapsScript`, some additional props are available:
 | large            | bool                                         | false                    | false                |
 | onClick          | func                                         | false                    | null                 |
 | type             | oneOf('primary', 'secondary')                | false                    | MARKER_TYPES.primary |
+| buttonProps      | object                                       | false                    | null                 |
 
 ### BpkOverlayView
 

--- a/packages/bpk-component-map/src/BpkMapMarker-test.js
+++ b/packages/bpk-component-map/src/BpkMapMarker-test.js
@@ -64,4 +64,15 @@ describe('BpkMapMarker', () => {
     );
     expect(toJson(tree)).toMatchSnapshot();
   });
+
+  it('should render correctly with a "buttonProps" attribute', () => {
+    const tree = shallow(
+      <BpkMapMarker
+        position={position}
+        icon={icon}
+        buttonProps={{ testId: 'arbitrary value' }}
+      />,
+    );
+    expect(toJson(tree)).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-map/src/BpkMapMarker.js
+++ b/packages/bpk-component-map/src/BpkMapMarker.js
@@ -44,6 +44,7 @@ type Props = {
   arrowClassName: ?string,
   large: ?boolean,
   onClick: ?(event: SyntheticEvent<>) => mixed,
+  buttonProps: ?{ [string]: any },
 };
 
 const BpkMapMarker = (props: Props) => {
@@ -55,6 +56,7 @@ const BpkMapMarker = (props: Props) => {
     large,
     onClick,
     type,
+    buttonProps,
     ...rest
   } = props;
 
@@ -74,6 +76,7 @@ const BpkMapMarker = (props: Props) => {
         type="button"
         className={getClassName('bpk-map-marker__wrapper')}
         onClick={onClick}
+        {...buttonProps}
       >
         <div className={classNames}>{icon}</div>
         <div className={arrowClassNames}>
@@ -92,6 +95,7 @@ BpkMapMarker.propTypes = {
   large: PropTypes.bool,
   onClick: PropTypes.func,
   type: PropTypes.oneOf(Object.keys(MARKER_TYPES)),
+  buttonProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 BpkMapMarker.defaultProps = {
@@ -100,6 +104,7 @@ BpkMapMarker.defaultProps = {
   large: false,
   onClick: null,
   type: MARKER_TYPES.primary,
+  buttonProps: null,
 };
 
 export default BpkMapMarker;

--- a/packages/bpk-component-map/src/__snapshots__/BpkMapMarker-test.js.snap
+++ b/packages/bpk-component-map/src/__snapshots__/BpkMapMarker-test.js.snap
@@ -30,6 +30,37 @@ exports[`BpkMapMarker should render correctly with a "arrowClassName" attribute 
 </BpkBasicMapMarker>
 `;
 
+exports[`BpkMapMarker should render correctly with a "buttonProps" attribute 1`] = `
+<BpkBasicMapMarker
+  position={
+    Object {
+      "latitude": 41.386947,
+      "longitude": 2.170048,
+    }
+  }
+>
+  <button
+    className="bpk-map-marker__wrapper"
+    onClick={null}
+    testId="arbitrary value"
+    type="button"
+  >
+    <div
+      className="bpk-map-marker bpk-map-marker--primary"
+    >
+      <span>
+        Icon
+      </span>
+    </div>
+    <div
+      className="bpk-map-marker__arrow"
+    >
+      <Component />
+    </div>
+  </button>
+</BpkBasicMapMarker>
+`;
+
 exports[`BpkMapMarker should render correctly with a "className" attribute 1`] = `
 <BpkBasicMapMarker
   position={


### PR DESCRIPTION
Like in other components, it might be useful to be able to send arbitrary props to another dom element rather than the root one.

In our case, we would need to set some attribute to run some acceptance tests.