### PR TITLE
Fixed non-global class inside global class in scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Unreleased changes](./UNRELEASED.md).
 
+# 2019-03-26 Fix for non-global class inside global class
+
+**Fixed:**
+- bpk-stylesheets: 3.2.155 => 3.2.156
+  - Changed inner class of global class to be global itself
+
 # 2019-03-14 Replace phone input placeholder with labels
 
 **Breaking:**

--- a/packages/bpk-stylesheets/README.md
+++ b/packages/bpk-stylesheets/README.md
@@ -11,5 +11,5 @@ npm install bpk-stylesheets --save-dev
 ## Usage
 
 ```scss
-@import '~bpk-stylesheets/base';
+@import '~bpk-stylesheets';
 ```

--- a/packages/bpk-stylesheets/base.css
+++ b/packages/bpk-stylesheets/base.css
@@ -1709,15 +1709,16 @@ body {
   border: 0;
   overflow: hidden;
   clip: rect(0 0 0 0); }
-  .visuallyhidden.focusable:active, .visuallyhidden.focusable:focus,
-  .visually-hidden.focusable:active,
-  .visually-hidden.focusable:focus {
-    position: static;
-    width: auto;
-    height: auto;
-    margin: 0;
-    overflow: visible;
-    clip: auto; }
+
+.visuallyhidden.focusable:active, .visuallyhidden.focusable:focus,
+.visually-hidden.focusable:active,
+.visually-hidden.focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto; }
 
 .invisible {
   visibility: hidden; }

--- a/packages/bpk-stylesheets/index.scss
+++ b/packages/bpk-stylesheets/index.scss
@@ -59,10 +59,11 @@ body {
 :global(.visuallyhidden),
 :global(.visually-hidden) {
   @include bpk-visually-hidden;
+} 
 
-  &.focusable {
+:global(.visuallyhidden.focusable),
+:global(.visually-hidden.focusable) { 
     @include bpk-visually-hidden--focusable;
-  }
 }
 
 :global(.invisible) {

--- a/packages/bpk-stylesheets/index.scss
+++ b/packages/bpk-stylesheets/index.scss
@@ -59,11 +59,11 @@ body {
 :global(.visuallyhidden),
 :global(.visually-hidden) {
   @include bpk-visually-hidden;
-} 
+}
 
 :global(.visuallyhidden.focusable),
-:global(.visually-hidden.focusable) { 
-    @include bpk-visually-hidden--focusable;
+:global(.visually-hidden.focusable) {
+  @include bpk-visually-hidden--focusable;
 }
 
 :global(.invisible) {


### PR DESCRIPTION
(NOTE: 2nd version of this PR as CI pipeline complained about package.json being altered and a merge from upstream did not fix it.)

This is a fix in tandem with a change to base-stylesheet to stop the global scss classes being rendered with hashes.


+ [/] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
