### PR TITLE
Add a default font color to BpkBadge

### DIFF
--- a/packages/bpk-mixins/src/mixins/_badges.scss
+++ b/packages/bpk-mixins/src/mixins/_badges.scss
@@ -35,6 +35,7 @@
   padding: $bpk-badge-padding-y $bpk-badge-padding-x;
   align-items: center;
   background-color: $bpk-badge-background-color;
+  color: $bpk-font-color-base;
 
   @include bpk-border-radius-xs;
   @include bpk-text;


### PR DESCRIPTION
I noticed a possible "bug" in `BpkBadge`: currently the color is not set (only for `destructive` and `outline`) so the font color relies on the one defined in the parent. This can lead to the component not being rendered as expected if the base font color has been changed:

![image](https://user-images.githubusercontent.com/7152781/55160164-017b9800-5163-11e9-9d05-a96d76a7442f.png)

I think the font color should be defined in the component, to avoid side-effects. What do you think?

The change submitted is just a proposal to clearly show what I mean. Not sure if the correct implementation should define a new token for the color, use theming...