### PR TITLE
Add renderTarget to tooltip

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,5 @@
 # Unreleased
 
-_Nothing yet..._
+**Added:**
+- bpk-component-tooltip:
+  - Added the prop `renderTarget` to `BpkTooltipPortal` to allow rendering it inside any DOM element.

--- a/packages/bpk-component-tooltip/README.md
+++ b/packages/bpk-component-tooltip/README.md
@@ -38,6 +38,7 @@ const App = () => (
 | portalStyle           | object                                    | false    | null          |
 | portalClassName       | string                                    | false    | null          |
 | popperModifiers       | object                                    | false    | null          |
+| renderTarget          | func                                      | false    | null          |
 
 ### Prop Details
 

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -49,6 +49,7 @@ export type Props = {
   padded: boolean,
   portalStyle: ?Object, // eslint-disable-line react/forbid-prop-types
   portalClassName: ?string,
+  renderTarget: ?() => HTMLElement,
   popperModifiers: ?Object,
 };
 
@@ -70,6 +71,7 @@ class BpkTooltipPortal extends Component<Props, State> {
     padded: PropTypes.bool,
     portalStyle: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     portalClassName: PropTypes.string,
+    renderTarget: PropTypes.func,
     popperModifiers: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   };
 
@@ -80,6 +82,7 @@ class BpkTooltipPortal extends Component<Props, State> {
     padded: true,
     portalStyle: null,
     portalClassName: null,
+    renderTarget: null,
     popperModifiers: null,
   };
 
@@ -156,6 +159,7 @@ class BpkTooltipPortal extends Component<Props, State> {
       hideOnTouchDevices,
       portalClassName,
       portalStyle,
+      renderTarget,
       popperModifiers,
       ...rest
     } = this.props;
@@ -177,6 +181,7 @@ class BpkTooltipPortal extends Component<Props, State> {
         onOpen={this.onOpen}
         onClose={this.closeTooltip}
         style={portalStyle}
+        renderTarget={renderTarget}
         className={classNames.join(' ')}
       >
         <BpkTooltip padded={padded} {...rest}>

--- a/packages/bpk-component-tooltip/src/__snapshots__/BpkTooltipPortal-test.js.snap
+++ b/packages/bpk-component-tooltip/src/__snapshots__/BpkTooltipPortal-test.js.snap
@@ -6,6 +6,7 @@ exports[`BpkTooltipPortal should render correctly 1`] = `
   isOpen={false}
   onClose={[Function]}
   onOpen={[Function]}
+  renderTarget={null}
   style={null}
   target={
     <div>
@@ -40,6 +41,7 @@ exports[`BpkTooltipPortal should render correctly with a custom portal className
   isOpen={false}
   onClose={[Function]}
   onOpen={[Function]}
+  renderTarget={null}
   style={null}
   target={
     <div>
@@ -74,6 +76,7 @@ exports[`BpkTooltipPortal should render correctly with a custom tooltip classNam
   isOpen={false}
   onClose={[Function]}
   onOpen={[Function]}
+  renderTarget={null}
   style={null}
   target={
     <div>
@@ -108,6 +111,7 @@ exports[`BpkTooltipPortal should render correctly with custom portal style 1`] =
   isOpen={false}
   onClose={[Function]}
   onOpen={[Function]}
+  renderTarget={null}
   style={
     Object {
       "color": "rgb(255, 84, 82)",


### PR DESCRIPTION
Adds the `renderTarget` to `BpkTooltipPortal` to allow it being rendered inside any DOM element, just like `BpkPopoverPortal`.

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [X] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_