### PR TITLE
Add altText prop to BpkBackGroundImage

### DIFF
--- a/packages/bpk-component-image/src/BpkBackgroundImage-test.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage-test.js
@@ -34,6 +34,7 @@ describe('BpkBackgroundImage', () => {
             height: '20rem',
           }}
           src="./path/to/image.jpg"
+          altText="Default alt text"
         >
           <div
             style={{
@@ -60,6 +61,7 @@ describe('BpkBackgroundImage', () => {
           }}
           className="userland-classname"
           src="./path/to/image.jpg"
+          altText="Default alt text"
         />,
       )
       .toJSON();
@@ -86,6 +88,7 @@ describe('BpkBackgroundImage', () => {
             backgroundPosition: '50% 50%',
           }}
           src="./path/to/image.jpg"
+          altText="Default alt text"
         />,
       )
       .toJSON();
@@ -111,6 +114,21 @@ describe('BpkBackgroundImage', () => {
             backgroundPosition: '50% 50%',
           }}
           src="./path/to/image.jpg"
+          altText="Default alt text"
+        />,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should use userland altText', () => {
+    const tree = renderer
+      .create(
+        <BpkBackgroundImage
+          width={612}
+          height={408}
+          src="./path/to/image.jpg"
+          altText="A happy image of something nice."
         />,
       )
       .toJSON();

--- a/packages/bpk-component-image/src/BpkBackgroundImage.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.js
@@ -35,6 +35,7 @@ type BpkBackgroundImageProps = {
   loading: boolean,
   src: string,
   width: number,
+  altText: string,
   className: ?string,
   onLoad: ?() => mixed,
   style: ?{}, // eslint-disable-line react/forbid-prop-types
@@ -91,6 +92,7 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
       src,
       imageStyle,
       style,
+      altText,
     } = this.props;
 
     const aspectRatio = width / height;
@@ -145,7 +147,10 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
             </noscript>
           )}
           {!loading && (
-            <div className={getClassName('bpk-background-image__content')}>
+            <div
+              alt={altText}
+              className={getClassName('bpk-background-image__content')}
+            >
               {children}
             </div>
           )}
@@ -159,6 +164,7 @@ BpkBackgroundImage.propTypes = {
   height: PropTypes.number.isRequired,
   src: PropTypes.string.isRequired,
   width: PropTypes.number.isRequired,
+  altText: PropTypes.string.isRequired,
   className: PropTypes.string,
   inView: PropTypes.bool,
   loading: PropTypes.bool,

--- a/packages/bpk-component-image/src/__snapshots__/BpkBackgroundImage-test.js.snap
+++ b/packages/bpk-component-image/src/__snapshots__/BpkBackgroundImage-test.js.snap
@@ -28,6 +28,7 @@ exports[`BpkBackgroundImage should accept userland className 1`] = `
       }
     />
     <div
+      alt="Default alt text"
       className="bpk-background-image__content"
     />
   </div>
@@ -67,6 +68,7 @@ exports[`BpkBackgroundImage should have inView behavior 1`] = `
       }
     />
     <div
+      alt="Default alt text"
       className="bpk-background-image__content"
     />
   </div>
@@ -224,6 +226,7 @@ exports[`BpkBackgroundImage should render correctly 1`] = `
       }
     />
     <div
+      alt="Default alt text"
       className="bpk-background-image__content"
     >
       <div
@@ -236,6 +239,36 @@ exports[`BpkBackgroundImage should render correctly 1`] = `
         }
       />
     </div>
+  </div>
+</div>
+`;
+
+exports[`BpkBackgroundImage should use userland altText 1`] = `
+<div
+  className={null}
+  style={Object {}}
+>
+  <div
+    className="bpk-background-image bpk-background-image--no-background"
+    style={
+      Object {
+        "height": 0,
+        "paddingBottom": "66.66666666666667%",
+      }
+    }
+  >
+    <div
+      className="bpk-background-image__img bpk-background-image__img--shown"
+      style={
+        Object {
+          "backgroundImage": "url(./path/to/image.jpg)",
+        }
+      }
+    />
+    <div
+      alt="A happy image of something nice."
+      className="bpk-background-image__content"
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

As described in the [documentation](https://backpack.github.io/components/image?platform=web#default) `altText` is a required prop on the `BackgroundImage` component.

`alt` was not being applied correctly to the div. This PR fixes this issue.
A test has been included and other test cases updated to include this required prop.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
