### PR TITLE
[BPK-2350] Text input validation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,7 +9,9 @@
   - Added a default font colour to badges to prevent the badge colour changing due to cascading styles.
 
 **Breaking:**
-- bpk-mixins, bpk-component-input, bpk-component-fieldset:
+- bpk-mixins:
+- bpk-component-input: 
+- bpk-component-fieldset:
     - `_forms.scss`:
         - Added `border-color` to `bpk-input--invalid` mixin for input fields to highlight red when there is an error on the input.
         - Updated `background` to `bpk-input--invalid` mixin for fields to change the color from white to red.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,3 +15,5 @@
     - `_forms.scss`:
         - Added `border-color` to `bpk-input--invalid` mixin for input fields to highlight red when there is an error on the input.
         - Updated `background` to `bpk-input--invalid` mixin for fields to change the color from white to red.
+
+**Note**: The API hasn't changed, it's only breaking because it's a major visual change.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,7 +9,7 @@
   - Added a default font colour to badges to prevent the badge colour changing due to cascading styles.
 
 **Breaking:**
-- bpk-mixins:
-    - Added `border-color` to input fields to highlight red when there is an error on the input
-    - Updated `background` to change the color from white to red
-    - Added `background-color` to set background to red and also add transparency to the field
+- bpk-mixins, bpk-component-input, bpk-component-fieldset:
+    - `_forms.scss`:
+        - Added `border-color` to `bpk-input--invalid` mixin for input fields to highlight red when there is an error on the input.
+        - Updated `background` to `bpk-input--invalid` mixin for fields to change the color from white to red.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,3 +7,9 @@
 **Fixed:**
 - bpk-component-badge:
   - Added a default font colour to badges to prevent the badge colour changing due to cascading styles.
+
+**Breaking:**
+- bpk-mixins:
+    - Added `border-color` to input fields to highlight red when there is an error on the input
+    - Updated `background` to change the color from white to red
+    - Added `background-color` to set background to red and also add transparency to the field

--- a/packages/bpk-mixins/src/mixins/_forms.scss
+++ b/packages/bpk-mixins/src/mixins/_forms.scss
@@ -110,7 +110,7 @@
   padding-right: $bpk-spacing-base;
   border-color: $bpk-color-red-500;
   background: $bpk-color-red-500 url(map-get($bpk-icons-sm, exclamation-circle-red-500)) no-repeat right $bpk-spacing-sm center;
-  background-color: rgba($bpk-color-red-500, .2);
+  background-color: rgba($bpk-color-red-500, .1);
   background-size: $bpk-spacing-md $bpk-spacing-md;
 
   @include bpk-rtl {

--- a/packages/bpk-mixins/src/mixins/_forms.scss
+++ b/packages/bpk-mixins/src/mixins/_forms.scss
@@ -108,7 +108,9 @@
 
 @mixin bpk-input--invalid {
   padding-right: $bpk-spacing-base;
-  background: $bpk-color-white url(map-get($bpk-icons-sm, exclamation-circle-red-500)) no-repeat right $bpk-spacing-sm center;
+  border-color: $bpk-color-red-500;
+  background: $bpk-color-red-500 url(map-get($bpk-icons-sm, exclamation-circle-red-500)) no-repeat right $bpk-spacing-sm center;
+  background-color: rgba($bpk-color-red-500, .2);
   background-size: $bpk-spacing-md $bpk-spacing-md;
 
   @include bpk-rtl {

--- a/packages/bpk-mixins/src/mixins/_forms.scss
+++ b/packages/bpk-mixins/src/mixins/_forms.scss
@@ -109,7 +109,7 @@
 @mixin bpk-input--invalid {
   padding-right: $bpk-spacing-base;
   border-color: $bpk-color-red-500;
-  background: rgba($bpk-color-red-500, .1) url(map-get($bpk-icons-sm, exclamation-circle-red-500)) no-repeat right $bpk-spacing-sm center;
+  background: $bpk-color-red-50 url(map-get($bpk-icons-sm, exclamation-circle-red-500)) no-repeat right $bpk-spacing-sm center;
   background-size: $bpk-spacing-md $bpk-spacing-md;
 
   @include bpk-rtl {

--- a/packages/bpk-mixins/src/mixins/_forms.scss
+++ b/packages/bpk-mixins/src/mixins/_forms.scss
@@ -109,8 +109,7 @@
 @mixin bpk-input--invalid {
   padding-right: $bpk-spacing-base;
   border-color: $bpk-color-red-500;
-  background: $bpk-color-red-500 url(map-get($bpk-icons-sm, exclamation-circle-red-500)) no-repeat right $bpk-spacing-sm center;
-  background-color: rgba($bpk-color-red-500, .1);
+  background: rgba($bpk-color-red-500, .1) url(map-get($bpk-icons-sm, exclamation-circle-red-500)) no-repeat right $bpk-spacing-sm center;
   background-size: $bpk-spacing-md $bpk-spacing-md;
 
   @include bpk-rtl {


### PR DESCRIPTION
Updated the mixins to change the styling of input fields to highlight red when an invalid input is entered into the fields.

The field will add a red border and the background will change red when incorrect entry is input, please see below screenshot as result of the change.

![Screenshot 2019-04-03 at 17 07 43](https://user-images.githubusercontent.com/8831547/55494635-1066bc80-5633-11e9-92eb-f9e1f29b1beb.png)
