### PR TITLE
[NO-JIRA] Fix readme table borders

### DIFF
--- a/packages/bpk-docs/src/components/DocsPageBuilder/BpkMarkdownRenderer.scss
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/BpkMarkdownRenderer.scss
@@ -20,9 +20,16 @@
 
 .bpkdocs-markdown-renderer {
   &__table {
-    // Disabling as we need `!important` to override the baremetal HTML styling
-    /* stylelint-disable-next-line declaration-no-important */
+    // Using `!important` as we need to override the baremetal HTML styling, which takes precedence.
+    /* stylelint-disable declaration-no-important */
     width: auto !important;
+    // Applying a custom border to the table as the `bpk-border` mixin using box-shadow has side-effects
+    // when used inside a scroll container. This is due to the box-shadow not being measured as part of the
+    // width of the child element.
+    /* stylelint-disable-next-line unit-blacklist */
+    border: solid 1px $bpk-color-gray-300;
+    box-shadow: none !important;
+    /* stylelint-enable */
   }
 
   &__mobile-scroll-container {


### PR DESCRIPTION
_Note the screenshots below use an extra-wide border to make things more visible..._

Currently the borders around our MD tables are cut off by the mobile scroll container. This is due to us uising `box-shadow` to apply borders, which are not included in width calculations.

![Screenshot 2019-04-05 at 09 27 10](https://user-images.githubusercontent.com/30267516/55614559-30a69080-5785-11e9-89d3-d9f882abae12.png)

This PR adds an actual `border` to the table elements, so that the browser includes the border width when calculating the size of the element.

![Screenshot 2019-04-05 at 09 28 15](https://user-images.githubusercontent.com/30267516/55614565-3603db00-5785-11e9-88cb-f42ac5d2eedc.png)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
