### PR TITLE
When calling `onClear`, provide input `name`

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+**Added:**
+- bpk-component-input:
+  - When calling `onClear`, provide input `name` in the event.

--- a/packages/bpk-component-input/src/BpkClearButton.js
+++ b/packages/bpk-component-input/src/BpkClearButton.js
@@ -31,7 +31,7 @@ const ClearButtonIcon = withButtonAlignment(ClearIcon);
 
 type Props = {
   label: string,
-  onClick: (SyntheticEvent<HTMLButtonElement>) => mixed,
+  onClick: (SyntheticInputEvent<HTMLButtonElement>) => mixed,
   className: ?string,
 };
 

--- a/packages/bpk-component-input/src/BpkInput-test.js
+++ b/packages/bpk-component-input/src/BpkInput-test.js
@@ -91,12 +91,7 @@ describe('BpkInput', () => {
     jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
     const tree = renderer
       .create(
-        <BpkInput
-          id="test"
-          name="test"
-          value=""
-          clearButtonMode="whileEditing"
-        />,
+        <BpkInput id="test" name="test" value="" clearButtonMode="always" />,
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
@@ -196,5 +191,28 @@ describe('BpkInput', () => {
       .at(0)
       .instance();
     expect(input).toEqual(inputRef);
+  });
+
+  it('should call "onClear" when clearing', () => {
+    const onClear = jest.fn();
+
+    const name = 'field_name';
+
+    const wrapper = mount(
+      <BpkInput
+        id="test"
+        name={name}
+        value="value"
+        clearButtonMode="always"
+        onClear={onClear}
+        clearButtonLabel="clear"
+      />,
+    );
+
+    wrapper.find('BpkClearButton').simulate('click');
+
+    expect(onClear).toHaveBeenCalledWith(
+      expect.objectContaining({ target: expect.objectContaining({ name }) }),
+    );
   });
 });

--- a/packages/bpk-component-input/src/BpkInput.js
+++ b/packages/bpk-component-input/src/BpkInput.js
@@ -49,6 +49,7 @@ const BpkInput = (props: Props) => {
     onClear,
     valid,
     value,
+    name,
     ...rest
   } = props;
 
@@ -113,6 +114,7 @@ const BpkInput = (props: Props) => {
       }}
       aria-invalid={isInvalid}
       value={value}
+      name={name}
       {...rest}
     />
   );
@@ -129,6 +131,7 @@ const BpkInput = (props: Props) => {
               ref.focus();
             }
             if (onClear) {
+              e.target.name = name;
               onClear(e);
             }
           }}

--- a/packages/bpk-component-input/src/__snapshots__/BpkInput-test.js.snap
+++ b/packages/bpk-component-input/src/__snapshots__/BpkInput-test.js.snap
@@ -28,7 +28,7 @@ exports[`BpkInput should render correctly with "clearButtonMode=always" attribut
 >
   <input
     aria-invalid={false}
-    className="bpk-input bpk-input--clearable"
+    className="bpk-input bpk-input--clearable bpk-input--persistent-clearable"
     id="test"
     name="test"
     type="text"


### PR DESCRIPTION
We're building a dynamic form and we want to use clearable input fields. It would be good to use the same callback for all the fields:

```
  onClear = evt => {
    const { onChange } = this.props;
    const { name } = evt.target;
     onChange(name, null);
  };
```

but the event target is the svg (not the input), so `evt.target.name` doesn't contain the field name.

This PR contains two possible ways of achieving this:
* Set `evt.target.name` to the input name
* Provide a second parameter to `onClear` with the input name

Would you be fine with any of these two proposals? Is there a better way to achieve this?