### PR TITLE
[NO-JIRA] Fix text area widths

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+ - bpk-mixins:
+ - bpk-component-textarea:
+   - Set `max-width` property to provide a more predictable experience when a user resizes the component in their browser.

--- a/packages/bpk-mixins/src/mixins/_forms.scss
+++ b/packages/bpk-mixins/src/mixins/_forms.scss
@@ -774,6 +774,7 @@
 @mixin bpk-textarea {
   display: inline-block;
   width: 100%;
+  max-width: 100%;
   min-height: $bpk-textarea-min-height;
   padding: $bpk-input-padding-y $bpk-input-padding-x;
   border: $bpk-input-border;


### PR DESCRIPTION
We should set `max-width` on text-areas so that they behave in a predictable way when a user resizes them in-browser.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
