### PR TITLE
[NO-JIRA] Fix flow for infinite scroll

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -18,5 +18,9 @@ emoji=true
 module.file_ext=.js
 module.file_ext=.json
 
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
+suppress_comment=\\(.\\|\n\\)*\\$ExpectError
+include_warnings=true
+
 [strict]
 unsafe-getters-setters

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- bpk-component-infinite-scroll:
+  - Fixed flow definition.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).
@@ -15,14 +20,17 @@ Don't worry about adding the specific version number or the date. This will be d
 See [`CHANGELOG.md`](CHANGELOG.md) for real-world examples of good changelog entries.
 
 **Breaking:**
-  - `bpk-svgs`:
-    - Replaced `charmeleon` icon with new `charizard` icon. To upgrade, replace your references to `charmeleon` with `charizard`.
-    - Upgraded `fire` dependency to `3.0.0`.
+
+- `bpk-svgs`:
+  - Replaced `charmeleon` icon with new `charizard` icon. To upgrade, replace your references to `charmeleon` with `charizard`.
+  - Upgraded `fire` dependency to `3.0.0`.
 
 **Added:**
-  - `bpk-component-infinity-gauntlet`:
-    - New `timeStone` prop for controlling time. See &lt;link to docs site&gt;.
+
+- `bpk-component-infinity-gauntlet`:
+  - New `timeStone` prop for controlling time. See &lt;link to docs site&gt;.
 
 **Fixed:**
-  - `bpk-component-horcrux`:
-    - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+- `bpk-component-horcrux`:
+  - Fixed issue where `BpkHorcrux` would occasionally possess the living.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jest:update": "jest --updateSnapshot",
     "jest:watch": "jest --watch",
     "jest": "TZ=Europe/London jest --coverage",
-    "flow": "flow",
+    "flow": "flow --max-warnings 0",
     "flow-typed": "flow-typed",
     "build:tokens": "lerna run tokens --scope bpk-tokens",
     "build:svgs": "lerna run svgs --scope bpk-svgs",

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.flow.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.flow.js
@@ -1,0 +1,86 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+import React from 'react';
+
+import withInfiniteScroll from './withInfiniteScroll';
+import { ArrayDataSource } from './DataSource';
+
+const elementsArray = [];
+
+for (let i = 0; i < 5; i += 1) {
+  elementsArray.push(`Element ${i}`);
+}
+
+type ListProps = {
+  elements: Array<any>,
+  'aria-label': string,
+  onClick?: ?() => void,
+};
+
+const List = ({ elements, ...rest }: ListProps) => (
+  <div id="list" {...rest}>
+    {elements.forEach(element => (
+      <div key={element}>{element}</div>
+    ))}
+  </div>
+);
+
+List.defaultProps = {
+  onClick: null,
+};
+
+const InfiniteList = withInfiniteScroll(List);
+
+(() => (
+  <React.Fragment>
+    {/* $ExpectError (aria-label is required) */}
+    <InfiniteList dataSource={new ArrayDataSource([])} />
+
+    {/* $ExpectError (dataSource is required) */}
+    <InfiniteList aria-label="infinite list" />
+
+    {/* $ExpectError (incompatible type) */}
+    <InfiniteList dataSource={new ArrayDataSource([])} aria-label={null} />
+
+    {/* Test default props */}
+    <InfiniteList
+      dataSource={new ArrayDataSource([])}
+      aria-label="infinite list"
+    />
+
+    {/* Test all props */}
+    <InfiniteList
+      dataSource={new ArrayDataSource([])}
+      aria-label="infinite list"
+      onClick={() => {}}
+      elementsPerScroll={5}
+      initiallyLoadedElements={1}
+      loaderIntersectionTrigger="small"
+      onScroll={evt => {}} // eslint-disable-line
+      onScrollFinished={evt => {}} // eslint-disable-line
+      renderLoadingComponent={() => <div />}
+      renderSeeMoreComponent={onClick => (
+        <button type="button" onClick={onClick} />
+      )}
+      seeMoreAfter={5}
+    />
+  </React.Fragment>
+))();

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -18,7 +18,12 @@
 
 /* @flow strict */
 
-import React, { Component, type Element, type ComponentType } from 'react';
+import React, {
+  Component,
+  type Element,
+  type Config,
+  type AbstractComponent,
+} from 'react';
 import PropTypes from 'prop-types';
 import { cssModules } from 'bpk-react-utils';
 import omit from 'lodash/omit';
@@ -86,9 +91,11 @@ const defaultProps = {
   seeMoreAfter: null,
 };
 
-const withInfiniteScroll = (
-  ComponentToExtend: ComponentType<ExtendedProps>,
-): ComponentType<Props> =>
+type PropsWithDefault = Config<Props, typeof defaultProps>;
+
+const withInfiniteScroll = <T: ExtendedProps>(
+  ComponentToExtend: AbstractComponent<T>,
+): AbstractComponent<PropsWithDefault & $Diff<T, ExtendedProps>> =>
   class WithInfiniteScroll extends Component<Props, State> {
     handleIntersection: IntersectionObserverCallback;
 

--- a/packages/bpk-component-infinite-scroll/stories.js
+++ b/packages/bpk-component-infinite-scroll/stories.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { storiesOf, action } from '@storybook/react';
@@ -25,14 +27,19 @@ import { BpkSpinner, SPINNER_TYPES } from 'bpk-component-spinner';
 
 import withInfiniteScroll, { ArrayDataSource, DataSource } from './index';
 
-const elementsArray = [];
+const elementsArray: Array<any> = [];
 
 for (let i = 0; i < 100; i += 1) {
   elementsArray.push(`Element ${i}`);
 }
 
-const List = ({ elements }) => (
-  <div>
+type ListProps = {
+  elements: Array<any>,
+  'aria-label': ?string, // defined just to test flow definition with extra props
+};
+
+const List = ({ elements, ...rest }: ListProps) => (
+  <div {...rest}>
     {elements.map(element => (
       <BpkCard
         style={{
@@ -49,6 +56,11 @@ const List = ({ elements }) => (
 
 List.propTypes = {
   elements: PropTypes.arrayOf(PropTypes.any).isRequired,
+  'aria-label': PropTypes.string.isRequired,
+};
+
+List.defaultProps = {
+  'aria-label': null,
 };
 
 const InfiniteList = withInfiniteScroll(List);
@@ -62,6 +74,8 @@ class DelayedDataSource extends ArrayDataSource {
 }
 
 class InfiniteDataSource extends DataSource {
+  elements: Array<any>;
+
   constructor() {
     super();
     this.elements = [];
@@ -95,6 +109,7 @@ storiesOf('bpk-component-infinite-scroll', module)
       dataSource={new ArrayDataSource(elementsArray)}
       onScrollFinished={action('scroll finished')}
       onScroll={action('onScroll')}
+      aria-label="Inifinite list"
     />
   ))
   .add('Stopping after 5 scrolls', () => (


### PR DESCRIPTION
I've introduced a test file for flow here, the idea is to test if required and default props are working as expected.

Lines with the `$ExpectError` annotation will suppress the error in the next line, if any, or show a warning saying there are no errors in the next line, which means the flow typing is wrong as we are expecting an error.

Because it only throw a warning in this case I have also changed the build to fail if any warnings are shown, so if we break the flow typing in any way the build will fail.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
