### PR TITLE
[BPKR-29] Flow strict

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -19,3 +19,4 @@ module.file_ext=.js
 module.file_ext=.json
 
 [strict]
+unsafe-getters-setters

--- a/packages/bpk-component-badge/BadgeLayout.js
+++ b/packages/bpk-component-badge/BadgeLayout.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node, Children } from 'react';

--- a/packages/bpk-component-badge/index.js
+++ b/packages/bpk-component-badge/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import component, { BADGE_TYPES, type Props } from './src/BpkBadge';
 

--- a/packages/bpk-component-badge/src/BpkBadge.js
+++ b/packages/bpk-component-badge/src/BpkBadge.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/packages/bpk-component-badge/stories.js
+++ b/packages/bpk-component-badge/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-banner-alert/index.js
+++ b/packages/bpk-component-banner-alert/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import BpkBannerAlert from './src/BpkBannerAlert';
 import BpkBannerAlertDismissable from './src/BpkBannerAlertDismissable';

--- a/packages/bpk-component-banner-alert/src/AnimateAndFade-test.js
+++ b/packages/bpk-component-banner-alert/src/AnimateAndFade-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-banner-alert/src/AnimateAndFade.js
+++ b/packages/bpk-component-banner-alert/src/AnimateAndFade.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node, Component } from 'react';

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { shallow } from 'enzyme';

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlert.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 import React from 'react';
 
 import {

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertDismissable-test.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertDismissable-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { shallow } from 'enzyme';

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertDismissable.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertDismissable.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertExpandable-test.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertExpandable-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { shallow } from 'enzyme';

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertExpandable.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertExpandable.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertInner-test.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertInner-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 /* This is an internal component to Backpack that powers `BpkBannerAlert`,
  * `BpkBannerAlertDismissable` and `BpkBannerAlertExpandable`.

--- a/packages/bpk-component-banner-alert/src/common-types.js
+++ b/packages/bpk-component-banner-alert/src/common-types.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 import PropTypes from 'prop-types';
 import { type Node } from 'react';
 

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState-test.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { mount, shallow } from 'enzyme';

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { type Node, type ComponentType, Component } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-banner-alert/stories.js
+++ b/packages/bpk-component-banner-alert/stories.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-boilerplate/index.js
+++ b/packages/bpk-component-boilerplate/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import BpkBoilerplate, {
   type Props as BpkBoilerplateProps,

--- a/packages/bpk-component-boilerplate/src/BpkBoilerplate-test.js
+++ b/packages/bpk-component-boilerplate/src/BpkBoilerplate-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-boilerplate/src/BpkBoilerplate.js
+++ b/packages/bpk-component-boilerplate/src/BpkBoilerplate.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/packages/bpk-component-boilerplate/stories.js
+++ b/packages/bpk-component-boilerplate/stories.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-breadcrumb/index.js
+++ b/packages/bpk-component-breadcrumb/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkBreadcrumb, {
   type Props as BpkBreadcrumbProps,

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumb-test.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumb-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem-test.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-breadcrumb/stories.js
+++ b/packages/bpk-component-breadcrumb/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-button/index.js
+++ b/packages/bpk-component-button/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkButton from './src/BpkButton';
 import {

--- a/packages/bpk-component-button/src/BpkButton.js
+++ b/packages/bpk-component-button/src/BpkButton.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-button/stories.js
+++ b/packages/bpk-component-button/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-chip/index.js
+++ b/packages/bpk-component-chip/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkChip, { type Props } from './src/BpkChip';
 

--- a/packages/bpk-component-chip/src/BpkChip-test.js
+++ b/packages/bpk-component-chip/src/BpkChip-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { shallow } from 'enzyme';

--- a/packages/bpk-component-chip/src/BpkChip.js
+++ b/packages/bpk-component-chip/src/BpkChip.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-chip/stories.js
+++ b/packages/bpk-component-chip/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf, action } from '@storybook/react';

--- a/packages/bpk-component-code/index.js
+++ b/packages/bpk-component-code/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import BpkCode from './src/BpkCode';
 import BpkCodeBlock from './src/BpkCodeBlock';

--- a/packages/bpk-component-code/src/BpkCode-test.js
+++ b/packages/bpk-component-code/src/BpkCode-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-code/src/BpkCode.js
+++ b/packages/bpk-component-code/src/BpkCode.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-code/src/BpkCodeBlock-test.js
+++ b/packages/bpk-component-code/src/BpkCodeBlock-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-code/src/BpkCodeBlock.js
+++ b/packages/bpk-component-code/src/BpkCodeBlock.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-code/stories.js
+++ b/packages/bpk-component-code/stories.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-dialog/index.js
+++ b/packages/bpk-component-dialog/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkDialog, { type Props } from './src/BpkDialog';
 import themeAttributes from './src/themeAttributes';

--- a/packages/bpk-component-dialog/src/BpkDialog-test.js
+++ b/packages/bpk-component-dialog/src/BpkDialog-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-dialog/src/BpkDialog.js
+++ b/packages/bpk-component-dialog/src/BpkDialog.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-dialog/src/customPropTypes-test.js
+++ b/packages/bpk-component-dialog/src/customPropTypes-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import { onClosePropType } from './customPropTypes';
 

--- a/packages/bpk-component-dialog/src/customPropTypes.js
+++ b/packages/bpk-component-dialog/src/customPropTypes.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 // eslint-disable-next-line import/prefer-default-export
 export const onClosePropType = (

--- a/packages/bpk-component-dialog/src/themeAttributes-test.js
+++ b/packages/bpk-component-dialog/src/themeAttributes-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import themeAttributes from './themeAttributes';
 

--- a/packages/bpk-component-dialog/src/themeAttributes.js
+++ b/packages/bpk-component-dialog/src/themeAttributes.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import { themeAttributes as modalAttributes } from 'bpk-component-modal';
 

--- a/packages/bpk-component-dialog/stories.js
+++ b/packages/bpk-component-dialog/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { Component, type Node } from 'react';

--- a/packages/bpk-component-fieldset/index.js
+++ b/packages/bpk-component-fieldset/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import BpkFieldset, {
   type Props,

--- a/packages/bpk-component-fieldset/src/BpkFieldset-test.js
+++ b/packages/bpk-component-fieldset/src/BpkFieldset-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-fieldset/src/BpkFieldset.js
+++ b/packages/bpk-component-fieldset/src/BpkFieldset.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { cloneElement, type Element } from 'react';

--- a/packages/bpk-component-fieldset/stories.js
+++ b/packages/bpk-component-fieldset/stories.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { cloneElement, Component } from 'react';

--- a/packages/bpk-component-horizontal-nav/index.js
+++ b/packages/bpk-component-horizontal-nav/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import BpkHorizontalNav, {
   type Props as NavProps,

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { Component, type Node } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-icon/src/withDescription-test.js
+++ b/packages/bpk-component-icon/src/withDescription-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-icon/src/withDescription.js
+++ b/packages/bpk-component-icon/src/withDescription.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { type Element, type ComponentType } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-image/src/BpkBackgroundImage.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { type Node, Component } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { type Node, Component } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-image/src/withLazyLoading.js
+++ b/packages/bpk-component-image/src/withLazyLoading.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { type Node, type ComponentType } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-infinite-scroll/index.js
+++ b/packages/bpk-component-infinite-scroll/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import withInfiniteScroll, {
   type Props as WithInfiniteScrollProps,

--- a/packages/bpk-component-infinite-scroll/src/DataSource.js
+++ b/packages/bpk-component-infinite-scroll/src/DataSource.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 class DataSource<T = any> {
   listeners: Array<() => mixed>;

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { Component, type Element, type ComponentType } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-input/index.js
+++ b/packages/bpk-component-input/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import BpkInput from './src/BpkInput';
 import withOpenEvents from './src/withOpenEvents';

--- a/packages/bpk-component-input/src/BpkClearButton-test.js
+++ b/packages/bpk-component-input/src/BpkClearButton-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-input/src/BpkClearButton.js
+++ b/packages/bpk-component-input/src/BpkClearButton.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/packages/bpk-component-input/src/BpkInput-test.js
+++ b/packages/bpk-component-input/src/BpkInput-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { mount } from 'enzyme';

--- a/packages/bpk-component-input/src/BpkInput.js
+++ b/packages/bpk-component-input/src/BpkInput.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-component-input/src/common-types.js
+++ b/packages/bpk-component-input/src/common-types.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 

--- a/packages/bpk-component-input/stories.js
+++ b/packages/bpk-component-input/stories.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-label/index.js
+++ b/packages/bpk-component-label/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import BpkLabel, { type Props } from './src/BpkLabel';
 

--- a/packages/bpk-component-label/src/BpkLabel-test.js
+++ b/packages/bpk-component-label/src/BpkLabel-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-label/src/BpkLabel.js
+++ b/packages/bpk-component-label/src/BpkLabel.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes, { type Node } from 'prop-types';
 import React from 'react';

--- a/packages/bpk-component-label/stories.js
+++ b/packages/bpk-component-label/stories.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-map/index.js
+++ b/packages/bpk-component-map/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkMap from './src/BpkMap';
 import BpkMapMarker, {

--- a/packages/bpk-component-map/src/BpkBasicMapMarker-test.js
+++ b/packages/bpk-component-map/src/BpkBasicMapMarker-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { shallow } from 'enzyme';

--- a/packages/bpk-component-map/src/BpkBasicMapMarker.js
+++ b/packages/bpk-component-map/src/BpkBasicMapMarker.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-map/src/BpkMap.js
+++ b/packages/bpk-component-map/src/BpkMap.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-map/src/BpkMapMarker-test.js
+++ b/packages/bpk-component-map/src/BpkMapMarker-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { shallow } from 'enzyme';

--- a/packages/bpk-component-map/src/BpkMapMarker.js
+++ b/packages/bpk-component-map/src/BpkMapMarker.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-map/src/BpkOverlayView.js
+++ b/packages/bpk-component-map/src/BpkOverlayView.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-map/src/DefaultLoadingElement.js
+++ b/packages/bpk-component-map/src/DefaultLoadingElement.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { BpkLargeSpinner, SPINNER_TYPES } from 'bpk-component-spinner';

--- a/packages/bpk-component-map/src/common-types.js
+++ b/packages/bpk-component-map/src/common-types.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 

--- a/packages/bpk-component-map/src/withGoogleMapsScript.js
+++ b/packages/bpk-component-map/src/withGoogleMapsScript.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { type ComponentType } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-map/stories.js
+++ b/packages/bpk-component-map/stories.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-mobile-scroll-container/index.js
+++ b/packages/bpk-component-mobile-scroll-container/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkMobileScrollContainer from './src/BpkMobileScrollContainer';
 

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer-test.js
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';

--- a/packages/bpk-component-mobile-scroll-container/stories.js
+++ b/packages/bpk-component-mobile-scroll-container/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import BpkButton from 'bpk-component-button';

--- a/packages/bpk-component-modal/index.js
+++ b/packages/bpk-component-modal/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import themeAttributes from './src/themeAttributes';
 import BpkModal, { type Props, propTypes, defaultProps } from './src/BpkModal';

--- a/packages/bpk-component-modal/src/BpkModal-test.js
+++ b/packages/bpk-component-modal/src/BpkModal-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-modal/src/BpkModal.js
+++ b/packages/bpk-component-modal/src/BpkModal.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Element } from 'react';

--- a/packages/bpk-component-modal/src/BpkModalDialog-test.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-modal/src/BpkModalDialog.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import { BpkButtonLink } from 'bpk-component-link';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-modal/src/customPropTypes-test.js
+++ b/packages/bpk-component-modal/src/customPropTypes-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import {
   titlePropType,

--- a/packages/bpk-component-modal/src/customPropTypes.js
+++ b/packages/bpk-component-modal/src/customPropTypes.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 export const titlePropType = (
   props: Object,

--- a/packages/bpk-component-modal/src/themeAttributes-test.js
+++ b/packages/bpk-component-modal/src/themeAttributes-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import themeAttributes from './themeAttributes';
 

--- a/packages/bpk-component-modal/src/themeAttributes.js
+++ b/packages/bpk-component-modal/src/themeAttributes.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import { themeAttributes as linkAttributes } from 'bpk-component-link';
 

--- a/packages/bpk-component-modal/stories.js
+++ b/packages/bpk-component-modal/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node, Component } from 'react';

--- a/packages/bpk-component-navigation-bar/AirlineLogo.js
+++ b/packages/bpk-component-navigation-bar/AirlineLogo.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-component-navigation-bar/index.js
+++ b/packages/bpk-component-navigation-bar/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkNavigationBar, {
   type Props as BpkNavigationBarProps,

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar-test.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Node, type Element } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink-test.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton-test.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type ComponentType } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-navigation-bar/src/themeAttributes.js
+++ b/packages/bpk-component-navigation-bar/src/themeAttributes.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 export default [
   'navigationBarBackgroundColor',

--- a/packages/bpk-component-navigation-bar/stories.js
+++ b/packages/bpk-component-navigation-bar/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-navigation-stack/index.js
+++ b/packages/bpk-component-navigation-stack/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import withNavigationStackState, {
   type Props as StateProps,

--- a/packages/bpk-component-navigation-stack/src/BpkNavigationStack-test.js
+++ b/packages/bpk-component-navigation-stack/src/BpkNavigationStack-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-navigation-stack/src/BpkNavigationStack.js
+++ b/packages/bpk-component-navigation-stack/src/BpkNavigationStack.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import { cssModules } from 'bpk-react-utils';
 import React, { Children, type Element } from 'react';

--- a/packages/bpk-component-navigation-stack/src/utils.js
+++ b/packages/bpk-component-navigation-stack/src/utils.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 export const DIRECTIONS = {
   LTR: 'ltr',

--- a/packages/bpk-component-navigation-stack/src/withNavigationStackState-test.js
+++ b/packages/bpk-component-navigation-stack/src/withNavigationStackState-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Element } from 'react';
 import { mount } from 'enzyme';

--- a/packages/bpk-component-navigation-stack/src/withNavigationStackState.js
+++ b/packages/bpk-component-navigation-stack/src/withNavigationStackState.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, {
   Component,

--- a/packages/bpk-component-navigation-stack/stories-components.js
+++ b/packages/bpk-component-navigation-stack/stories-components.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkNavigationBar, {
   BpkNavigationBarIconButton,

--- a/packages/bpk-component-navigation-stack/stories.js
+++ b/packages/bpk-component-navigation-stack/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-component-phone-input/index.js
+++ b/packages/bpk-component-phone-input/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkPhoneInput, {
   type Props as BpkPhoneInputProps,

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput.js
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-phone-input/stories.js
+++ b/packages/bpk-component-phone-input/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-popover/index.js
+++ b/packages/bpk-component-popover/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkPopoverPortal, { type Props } from './src/BpkPopoverPortal';
 import themeAttributes from './src/themeAttributes';

--- a/packages/bpk-component-popover/src/BpkPopover-test.js
+++ b/packages/bpk-component-popover/src/BpkPopover-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { mount } from 'enzyme';

--- a/packages/bpk-component-popover/src/BpkPopover.js
+++ b/packages/bpk-component-popover/src/BpkPopover.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-popover/src/BpkPopoverPortal-test.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import Shallow from 'react-test-renderer/shallow';

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import Popper from '@skyscanner/popper.js';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-popover/src/constants.js
+++ b/packages/bpk-component-popover/src/constants.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 export const ARROW_ID = 'js-bpk-popover-arrow';
 

--- a/packages/bpk-component-popover/src/themeAttributes-test.js
+++ b/packages/bpk-component-popover/src/themeAttributes-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import themeAttributes from './themeAttributes';
 

--- a/packages/bpk-component-popover/src/themeAttributes.js
+++ b/packages/bpk-component-popover/src/themeAttributes.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import { themeAttributes as linkAttributes } from 'bpk-component-link';
 

--- a/packages/bpk-component-popover/stories.js
+++ b/packages/bpk-component-popover/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { Component, type Node } from 'react';

--- a/packages/bpk-component-scrollable-calendar/index.js
+++ b/packages/bpk-component-scrollable-calendar/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import BpkScrollableCalendar from './src/BpkScrollableCalendar';
 import BpkScrollableCalendarDate from './src/BpkScrollableCalendarDate';

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar-test.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar-test.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import Shallow from 'react-test-renderer/shallow';

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendar.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import {
   BpkCalendarGridHeader,

--- a/packages/bpk-component-section-list/index.js
+++ b/packages/bpk-component-section-list/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkSectionList from './src/BpkSectionList';
 import BpkSectionListSection from './src/BpkSectionListSection';

--- a/packages/bpk-component-section-list/src/BpkSectionList-test.js
+++ b/packages/bpk-component-section-list/src/BpkSectionList-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-section-list/src/BpkSectionList.js
+++ b/packages/bpk-component-section-list/src/BpkSectionList.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-section-list/src/BpkSectionListItem-test.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListItem-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-section-list/src/BpkSectionListItem.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListItem.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-section-list/src/BpkSectionListSection-test.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListSection-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-section-list/src/BpkSectionListSection.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListSection.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-section-list/stories.js
+++ b/packages/bpk-component-section-list/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-component-select/index.js
+++ b/packages/bpk-component-select/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import BpkSelect, { type Props } from './src/BpkSelect';
 

--- a/packages/bpk-component-select/src/BpkSelect.js
+++ b/packages/bpk-component-select/src/BpkSelect.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import PropTypes, { type Node } from 'prop-types';
 import React from 'react';

--- a/packages/bpk-component-ticket/index.js
+++ b/packages/bpk-component-ticket/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkTicket from './src/BpkTicket';
 

--- a/packages/bpk-component-ticket/src/BpkTicket.js
+++ b/packages/bpk-component-ticket/src/BpkTicket.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-ticket/stories.js
+++ b/packages/bpk-component-ticket/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/packages/bpk-component-tooltip/index.js
+++ b/packages/bpk-component-tooltip/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkTooltipPortal, { type Props } from './src/BpkTooltipPortal';
 

--- a/packages/bpk-component-tooltip/src/BpkTooltip-test.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltip-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-tooltip/src/BpkTooltip.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltip.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal-test.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import renderer from 'react-test-renderer';

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import Popper from '@skyscanner/popper.js';
 import PropTypes from 'prop-types';

--- a/packages/bpk-component-tooltip/src/constants.js
+++ b/packages/bpk-component-tooltip/src/constants.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 export const ARROW_ID = 'js-bpk-popover-arrow';
 

--- a/packages/bpk-component-tooltip/stories.js
+++ b/packages/bpk-component-tooltip/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/packages/bpk-docs/src/components/AlternatingPageContent/AlternatingPageContent.js
+++ b/packages/bpk-docs/src/components/AlternatingPageContent/AlternatingPageContent.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-docs/src/components/AlternatingPageContent/index.js
+++ b/packages/bpk-docs/src/components/AlternatingPageContent/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 import AlternatingPageContent from './AlternatingPageContent';
 
 export default AlternatingPageContent;

--- a/packages/bpk-docs/src/components/DocsPageBuilder/BpkMarkdownRenderer.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/BpkMarkdownRenderer.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 // Uses https://github.com/rexxars/react-markdown
 

--- a/packages/bpk-docs/src/components/DocsPageBuilder/PlatformSwitchingContent.js
+++ b/packages/bpk-docs/src/components/DocsPageBuilder/PlatformSwitchingContent.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import { type Node } from 'react';
 

--- a/packages/bpk-docs/src/components/HeroSection/HeroSection.js
+++ b/packages/bpk-docs/src/components/HeroSection/HeroSection.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-docs/src/components/HeroSection/index.js
+++ b/packages/bpk-docs/src/components/HeroSection/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import HeroSection from './HeroSection';
 

--- a/packages/bpk-docs/src/components/HomePageCard/HomePageCard.js
+++ b/packages/bpk-docs/src/components/HomePageCard/HomePageCard.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 import React from 'react';
 import PropTypes from 'prop-types';
 import BpkCard from 'bpk-component-card';

--- a/packages/bpk-docs/src/components/HomePageCard/index.js
+++ b/packages/bpk-docs/src/components/HomePageCard/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import HomePageCard, { type Props } from './HomePageCard';
 

--- a/packages/bpk-docs/src/components/InfoPageBuilder/InfoPageBuilder.js
+++ b/packages/bpk-docs/src/components/InfoPageBuilder/InfoPageBuilder.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-docs/src/components/PageHead/PageHead.js
+++ b/packages/bpk-docs/src/components/PageHead/PageHead.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-docs/src/layouts/SideNavLayout/MainHeroImage.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/MainHeroImage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-docs/src/layouts/SideNavLayout/NavList.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/NavList.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { Component } from 'react';
 import { NavLink as RouterNavLink } from 'react-router-dom';

--- a/packages/bpk-docs/src/layouts/SideNavLayout/NavListFilter.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/NavListFilter.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 import React from 'react';
 import { cssModules } from 'bpk-react-utils';
 import BpkRadio from 'bpk-component-radio';

--- a/packages/bpk-docs/src/layouts/SideNavLayout/SectionsList.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/SectionsList.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { Link } from 'react-router-dom';

--- a/packages/bpk-docs/src/layouts/SideNavLayout/SideNavLayout.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/SideNavLayout.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkModal from 'bpk-component-modal';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-docs/src/layouts/SideNavLayout/Sidebar.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/Sidebar.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { Link } from 'react-router-dom';

--- a/packages/bpk-docs/src/layouts/SideNavLayout/common-types.js
+++ b/packages/bpk-docs/src/layouts/SideNavLayout/common-types.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 import { type Node } from 'react';
 
 export type Link = {

--- a/packages/bpk-docs/src/layouts/links.js
+++ b/packages/bpk-docs/src/layouts/links.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import * as routes from '../constants/routes';
 import ComponentsImage from '../static/components_hero.jpg';

--- a/packages/bpk-docs/src/pages/BadgePage/BadgePage.js
+++ b/packages/bpk-docs/src/pages/BadgePage/BadgePage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/BadgePage/index.js
+++ b/packages/bpk-docs/src/pages/BadgePage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './BadgePage';
 

--- a/packages/bpk-docs/src/pages/BagCheckPage/BagCheckPage.js
+++ b/packages/bpk-docs/src/pages/BagCheckPage/BagCheckPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import BpkLink from 'bpk-component-link';

--- a/packages/bpk-docs/src/pages/BagCheckPage/index.js
+++ b/packages/bpk-docs/src/pages/BagCheckPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './BagCheckPage';
 

--- a/packages/bpk-docs/src/pages/BannerAlertPage/BannerAlertPage.js
+++ b/packages/bpk-docs/src/pages/BannerAlertPage/BannerAlertPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/BannerAlertPage/index.js
+++ b/packages/bpk-docs/src/pages/BannerAlertPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './BannerAlertPage';
 

--- a/packages/bpk-docs/src/pages/BreadcrumbPage/index.js
+++ b/packages/bpk-docs/src/pages/BreadcrumbPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './BreadcrumbPage';
 

--- a/packages/bpk-docs/src/pages/ButtonPage/ButtonPage.js
+++ b/packages/bpk-docs/src/pages/ButtonPage/ButtonPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/ButtonPage/index.js
+++ b/packages/bpk-docs/src/pages/ButtonPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './ButtonPage';
 

--- a/packages/bpk-docs/src/pages/CardPage/CardPage.js
+++ b/packages/bpk-docs/src/pages/CardPage/CardPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/CardPage/index.js
+++ b/packages/bpk-docs/src/pages/CardPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './CardPage';
 

--- a/packages/bpk-docs/src/pages/CarouselPage/CarouselPage.js
+++ b/packages/bpk-docs/src/pages/CarouselPage/CarouselPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/CarouselPage/index.js
+++ b/packages/bpk-docs/src/pages/CarouselPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './CarouselPage';
 

--- a/packages/bpk-docs/src/pages/ChipsPage/ChipsPage.js
+++ b/packages/bpk-docs/src/pages/ChipsPage/ChipsPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/ChipsPage/index.js
+++ b/packages/bpk-docs/src/pages/ChipsPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './ChipsPage';
 

--- a/packages/bpk-docs/src/pages/DialogsPage/DialogsPage.js
+++ b/packages/bpk-docs/src/pages/DialogsPage/DialogsPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/DialogsPage/index.js
+++ b/packages/bpk-docs/src/pages/DialogsPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './DialogsPage';
 

--- a/packages/bpk-docs/src/pages/HomePage/UpdatedAt.js
+++ b/packages/bpk-docs/src/pages/HomePage/UpdatedAt.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/bpk-docs/src/pages/HorizontalNavPage/HorizontalNavPage.js
+++ b/packages/bpk-docs/src/pages/HorizontalNavPage/HorizontalNavPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/HorizontalNavPage/index.js
+++ b/packages/bpk-docs/src/pages/HorizontalNavPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './HorizontalNavPage';
 

--- a/packages/bpk-docs/src/pages/IconPage/IconPage.js
+++ b/packages/bpk-docs/src/pages/IconPage/IconPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/IconPage/index.js
+++ b/packages/bpk-docs/src/pages/IconPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './IconPage';
 

--- a/packages/bpk-docs/src/pages/ImagesPage/ImagesPage.js
+++ b/packages/bpk-docs/src/pages/ImagesPage/ImagesPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/ImagesPage/index.js
+++ b/packages/bpk-docs/src/pages/ImagesPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './ImagesPage';
 

--- a/packages/bpk-docs/src/pages/LinkPage/LinkPage.js
+++ b/packages/bpk-docs/src/pages/LinkPage/LinkPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/LinkPage/index.js
+++ b/packages/bpk-docs/src/pages/LinkPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './LinkPage';
 

--- a/packages/bpk-docs/src/pages/MapPage/MapPage.js
+++ b/packages/bpk-docs/src/pages/MapPage/MapPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import BpkMap, {

--- a/packages/bpk-docs/src/pages/MobileScrollContainerPage/BlockExample.js
+++ b/packages/bpk-docs/src/pages/MobileScrollContainerPage/BlockExample.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Node } from 'react';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-docs/src/pages/MobileScrollContainerPage/MobileScrollContainerPage.js
+++ b/packages/bpk-docs/src/pages/MobileScrollContainerPage/MobileScrollContainerPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import mobileScrollContainerReadme from 'bpk-component-mobile-scroll-container/README.md';

--- a/packages/bpk-docs/src/pages/MobileScrollContainerPage/index.js
+++ b/packages/bpk-docs/src/pages/MobileScrollContainerPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './MobileScrollContainerPage';
 

--- a/packages/bpk-docs/src/pages/ModalsPage/LoginFormExample.js
+++ b/packages/bpk-docs/src/pages/ModalsPage/LoginFormExample.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import BpkLabel from 'bpk-component-label';
 import BpkButton from 'bpk-component-button';

--- a/packages/bpk-docs/src/pages/ModalsPage/ModalsPage.js
+++ b/packages/bpk-docs/src/pages/ModalsPage/ModalsPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { Component, type Node } from 'react';
 import BpkModal from 'bpk-component-modal';

--- a/packages/bpk-docs/src/pages/ModalsPage/index.js
+++ b/packages/bpk-docs/src/pages/ModalsPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './ModalsPage';
 

--- a/packages/bpk-docs/src/pages/NativeNavigationBarPage/NativeNavigationBarPage.js
+++ b/packages/bpk-docs/src/pages/NativeNavigationBarPage/NativeNavigationBarPage.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/NativeProgressPage/NativeProgressPage.js
+++ b/packages/bpk-docs/src/pages/NativeProgressPage/NativeProgressPage.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/NavigationBarPage/NavigationBarPage.js
+++ b/packages/bpk-docs/src/pages/NavigationBarPage/NavigationBarPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/NavigationBarPage/index.js
+++ b/packages/bpk-docs/src/pages/NavigationBarPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './NavigationBarPage';
 

--- a/packages/bpk-docs/src/pages/NavigationStackPage/NavigationStackPage.js
+++ b/packages/bpk-docs/src/pages/NavigationStackPage/NavigationStackPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import navigationStackReadme from 'bpk-component-navigation-stack/README.md';

--- a/packages/bpk-docs/src/pages/NavigationStackPage/page-components.js
+++ b/packages/bpk-docs/src/pages/NavigationStackPage/page-components.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { type Element, type Node } from 'react';
 import ArrowIcon from 'bpk-component-icon/sm/long-arrow-left';

--- a/packages/bpk-docs/src/pages/NudgerPage/NudgerPage.js
+++ b/packages/bpk-docs/src/pages/NudgerPage/NudgerPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/NudgerPage/index.js
+++ b/packages/bpk-docs/src/pages/NudgerPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './NudgerPage';
 

--- a/packages/bpk-docs/src/pages/PanelPage/PanelPage.js
+++ b/packages/bpk-docs/src/pages/PanelPage/PanelPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/PanelPage/index.js
+++ b/packages/bpk-docs/src/pages/PanelPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './PanelPage';
 

--- a/packages/bpk-docs/src/pages/PhoneInputPage/PhoneInputPage.js
+++ b/packages/bpk-docs/src/pages/PhoneInputPage/PhoneInputPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { Component } from 'react';
 import BpkPhoneInput from 'bpk-component-phone-input';

--- a/packages/bpk-docs/src/pages/PhoneInputPage/index.js
+++ b/packages/bpk-docs/src/pages/PhoneInputPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './PhoneInputPage';
 

--- a/packages/bpk-docs/src/pages/ProgressPage/ProgressPage.js
+++ b/packages/bpk-docs/src/pages/ProgressPage/ProgressPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/ProgressPage/index.js
+++ b/packages/bpk-docs/src/pages/ProgressPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './ProgressPage';
 

--- a/packages/bpk-docs/src/pages/ScrollableCalendarPage/ScrollableCalendarPage.js
+++ b/packages/bpk-docs/src/pages/ScrollableCalendarPage/ScrollableCalendarPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/ScrollableCalendarPage/index.js
+++ b/packages/bpk-docs/src/pages/ScrollableCalendarPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './ScrollableCalendarPage';
 

--- a/packages/bpk-docs/src/pages/SectionListPage/SectionListPage.js
+++ b/packages/bpk-docs/src/pages/SectionListPage/SectionListPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/SectionListPage/index.js
+++ b/packages/bpk-docs/src/pages/SectionListPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './SectionListPage';
 

--- a/packages/bpk-docs/src/pages/SpinnerPage/SpinnerPage.js
+++ b/packages/bpk-docs/src/pages/SpinnerPage/SpinnerPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/SpinnerPage/index.js
+++ b/packages/bpk-docs/src/pages/SpinnerPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './SpinnerPage';
 

--- a/packages/bpk-docs/src/pages/StarRatingPage/StarRatingPage.js
+++ b/packages/bpk-docs/src/pages/StarRatingPage/StarRatingPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/StarRatingPage/index.js
+++ b/packages/bpk-docs/src/pages/StarRatingPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './StarRatingPage';
 

--- a/packages/bpk-docs/src/pages/TextPage/TextPage.js
+++ b/packages/bpk-docs/src/pages/TextPage/TextPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 

--- a/packages/bpk-docs/src/pages/TextPage/index.js
+++ b/packages/bpk-docs/src/pages/TextPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './TextPage';
 

--- a/packages/bpk-docs/src/pages/WebBannerAlertsPage/BannerAlertsPage.js
+++ b/packages/bpk-docs/src/pages/WebBannerAlertsPage/BannerAlertsPage.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import React, { Component, type Node } from 'react';
 import { durationSm, fontWeightBold } from 'bpk-tokens/tokens/base.es6';

--- a/packages/bpk-docs/src/pages/WebBannerAlertsPage/index.js
+++ b/packages/bpk-docs/src/pages/WebBannerAlertsPage/index.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow */
+/* @flow strict */
 
 import page from './BannerAlertsPage';
 

--- a/packages/bpk-docs/src/pages/WebButtonsPage/ButtonsPage.js
+++ b/packages/bpk-docs/src/pages/WebButtonsPage/ButtonsPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { Component } from 'react';
 import BpkButton from 'bpk-component-button';

--- a/packages/bpk-docs/src/pages/WebChipsPage/ChipsPage.js
+++ b/packages/bpk-docs/src/pages/WebChipsPage/ChipsPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React, { Component } from 'react';
 import BpkChip from 'bpk-component-chip';

--- a/packages/bpk-docs/src/pages/WebChipsPage/index.js
+++ b/packages/bpk-docs/src/pages/WebChipsPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './ChipsPage';
 

--- a/packages/bpk-docs/src/pages/WebDialogPage/DialogExamples.js
+++ b/packages/bpk-docs/src/pages/WebDialogPage/DialogExamples.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 /* eslint-disable react/no-multi-comp */
 
 import PropTypes from 'prop-types';

--- a/packages/bpk-docs/src/pages/WebDialogPage/DialogsPage.js
+++ b/packages/bpk-docs/src/pages/WebDialogPage/DialogsPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import dialogReadme from 'bpk-component-dialog/README.md';

--- a/packages/bpk-docs/src/pages/WebDialogPage/index.js
+++ b/packages/bpk-docs/src/pages/WebDialogPage/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import page from './DialogsPage';
 

--- a/packages/bpk-docs/src/pages/WebNavigationBarPage/AirlineLogo.js
+++ b/packages/bpk-docs/src/pages/WebNavigationBarPage/AirlineLogo.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import { cssModules } from 'bpk-react-utils';

--- a/packages/bpk-docs/src/pages/WebNavigationBarPage/NavigationBarPage.js
+++ b/packages/bpk-docs/src/pages/WebNavigationBarPage/NavigationBarPage.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import React from 'react';
 import ArrowIcon from 'bpk-component-icon/sm/long-arrow-left';

--- a/packages/bpk-react-utils/src/deprecated.js
+++ b/packages/bpk-react-utils/src/deprecated.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 import { type PropType } from 'prop-types';
 
 const deprecated = (propType: PropType, alternativeSuggestion: string) => (

--- a/packages/bpk-scrim-utils/src/customPropTypes-test.js
+++ b/packages/bpk-scrim-utils/src/customPropTypes-test.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import { onClosePropType } from './customPropTypes';
 

--- a/packages/bpk-scrim-utils/src/customPropTypes.js
+++ b/packages/bpk-scrim-utils/src/customPropTypes.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 // eslint-disable-next-line import/prefer-default-export
 export const onClosePropType = (

--- a/packages/bpk-svgs/tasks/getIconFontMetadataProvider.js
+++ b/packages/bpk-svgs/tasks/getIconFontMetadataProvider.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow */
+/* @flow strict */
 
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
Suggestion:

If a backpack consumer has
```
[strict]
nonstrict-import
```
in their `flowconfig` then Backpack imports will result in an error, as Backpack does not have `strict` Flow annotations. 

This results in either consumers adding Backpack modules to be `[ignored]`'d in their Flow config, so not benefitting from Backpack types, or not being able to use `nonstrict-import`.

It would be great to support `@flow strict` so that consumers were able to easily benefit from Backpack's own use of Flow. 

Currently Backpack has no `strict` rules so I do not think this would have any effect on Backpack.

I added the [unsafe-getters-setters](https://flow.org/en/docs/linting/rule-reference/#toc-unsafe-getters-setters) rule as an example of a strict rule, that is currently being followed anyway.

What do you think?

------

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
