### PR TITLE
[NO-JIRA] Fix publish command

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fix-bpk-dependencies": "node scripts/npm/check-bpk-dependencies.js --fix",
     "test": "npm run lint && npm run check-bpk-dependencies && npm run jest && npm run flow && npm run spellcheck",
     "check-owners": "npm whoami && ( node scripts/npm/get-owners.js | grep -E $(npm whoami) ) && node scripts/npm/check-owners.js",
-    "publish": "npm run check-owners && npm run build && git pull --rebase && npm run flow stop && npm run test && lerna publish",
+    "publish": "npm run check-owners && npm run build && git pull --rebase && flow stop && npm run test && lerna publish",
     "release": "npm run publish",
     "danger": "danger ci",
     "prettier": "prettier --config .prettierrc --write \"**/*.js\"",


### PR DESCRIPTION
Now that the flow command has the `--max-warnings 0` flag `npm run flow stop` was not working, it should be just `flow stop`

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
