### PR TITLE
Gracefully closes popover when render target is no longer present

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,11 @@
 
 - `bpk-component-map`:
   - Added `selected` prop for when markers are selected or highlighted. See https://backpack.github.io/components/map?platform=web#map-markers.
+- `bpk-component-autosuggest`:
+- `bpk-component-datepicker`:
+- `bpk-component-popover`:
+- `bpk-react-utils`:
+  - Fixed issue that caused tests to error if a portal's render target is removed from the DOM before the portal is unmounted
 
 ## How to write a good changelog entry
 

--- a/packages/bpk-react-utils/src/Portal-test.js
+++ b/packages/bpk-react-utils/src/Portal-test.js
@@ -121,6 +121,29 @@ describe('Portal', () => {
     expect(document.body.lastChild.textContent).toEqual('Not a portal');
   });
 
+  it('should not remove portal children if render target no longer exists', () => {
+    const div = document.createElement('div');
+    div.id = 'render-target';
+    document.body.appendChild(div);
+
+    const portal = mount(
+      <Portal
+        isOpen
+        renderTarget={() => document.getElementById('render-target')}
+      >
+        <div>My portal content</div>
+      </Portal>,
+    );
+
+    expect(document.body.lastChild.textContent).toEqual('My portal content');
+
+    document.body.removeChild(div);
+
+    expect(() => {
+      portal.setProps({ isOpen: false }).update();
+    }).not.toThrow();
+  });
+
   it('should call the onClose handler on click outside', () => {
     const onCloseSpy = jest.fn();
 

--- a/packages/bpk-react-utils/src/Portal.js
+++ b/packages/bpk-react-utils/src/Portal.js
@@ -210,7 +210,11 @@ class Portal extends Component {
     }
 
     unmountComponentAtNode(this.portalElement);
-    this.getRenderTarget().removeChild(this.portalElement);
+
+    const renderTarget = this.getRenderTarget();
+    if (renderTarget) {
+      renderTarget.removeChild(this.portalElement);
+    }
 
     document.removeEventListener('touchstart', this.onDocumentMouseDown);
     document.removeEventListener('touchmove', this.onDocumentMouseMove);


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_

I have a component that renders a BpkPopover component, with a render target that exists within the component rendering the popover and is accessed via a reference:

```js
<div ref={this.renderTargetRef}>
    <div ref={this.targetRef}>
        ...
    </div>
    <BpkPopover
        ...
        target={() => this.targetRef.current}
        renderTarget={() => this.renderTargetRef.current}
        ...
    />
</div>
```

(_both refs are created using `React.createRef`, as mentioned here: https://reactjs.org/docs/refs-and-the-dom.html_)

While implementing tests for this component, using the `react-testing-library`, I kept getting the following error:
`Cannot read property 'removeChild' of null`

The stacktrace pointed towards the close method of `Portal.js`. It appears that, in this case, when the component under test is unmounted, the render target div is removed before `Portal.componentWillUnmount` is called.

It seemed that we should gracefully handle the case where the render target is no longer present, as at that point, the `portalElement` will no longer exist anyway.