### PR TITLE
[NO-JIRA] Add popover story that removes attached dom element

### DIFF
--- a/packages/bpk-component-popover/stories.js
+++ b/packages/bpk-component-popover/stories.js
@@ -99,9 +99,27 @@ class PopoverContainer extends Component<Props, State> {
   };
 
   render() {
-    const { targetFunction, changeProps, id, ...rest } = this.props;
+    const {
+      targetFunction,
+      changeProps,
+      id,
+      onButtonClick,
+      ...rest
+    } = this.props;
     let target = null;
-    let openButton = <BpkButton onClick={this.openPopover}> Open </BpkButton>;
+    let openButton = (
+      <BpkButton
+        onClick={() => {
+          this.openPopover();
+          if (onButtonClick) {
+            onButtonClick();
+          }
+        }}
+      >
+        {' '}
+        Open{' '}
+      </BpkButton>
+    );
 
     if (targetFunction != null) {
       target = targetFunction;
@@ -185,6 +203,21 @@ storiesOf('bpk-component-popover', module)
       <PopoverContainer
         id="my-popover"
         targetFunction={() => document.getElementById('attachElement')}
+      />
+    </Spacer>
+  ))
+  .add('Attach to external element which unmounts', () => (
+    <Spacer>
+      <div id="attachElement">Pop over attached here</div>
+      <p>&nbsp; </p>
+      <PopoverContainer
+        id="my-popover"
+        targetFunction={() => document.getElementById('attachElement')}
+        onButtonClick={() => {
+          setTimeout(() => {
+            document.getElementById('attachElement').remove();
+          }, 1000);
+        }}
       />
     </Spacer>
   ))


### PR DESCRIPTION
Acorn identified an issue where popover closing behaviour is unpredictable when the target element no longer exists. This PR adds a story to showcase the issue.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)