### PR TITLE
Fixes types for render and renderTarget to accept refs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -224,7 +224,6 @@ PropType
 PropTypes
 ref
 refs
-createRef
 SectionList
 SyntheticEvent
 TextInput

--- a/.spelling
+++ b/.spelling
@@ -224,6 +224,7 @@ PropType
 PropTypes
 ref
 refs
+createRef
 SectionList
 SyntheticEvent
 TextInput

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,7 +1,10 @@
 # Unreleased
 
 > Place your changes below this line.
+**Fixed:**
 
+- `bpk-component-popover`:
+  - Fixed target and renderTarget types to support being passed references created via `createRef`.
 
 ## How to write a good changelog entry
 

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -37,12 +37,12 @@ const getClassName = cssModules(STYLES);
 
 export type Props = {
   ...$Exact<PopoverProps>,
-  target: (() => HTMLElement) | Node,
+  target: (() => null | HTMLElement) | Node,
   isOpen: boolean,
   placement: ?('top' | 'right' | 'bottom' | 'left'),
   portalStyle: ?Object,
   portalClassName: ?string,
-  renderTarget: ?() => HTMLElement,
+  renderTarget: ?() => null | HTMLElement,
   popperModifiers: ?Object,
 };
 

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -37,12 +37,12 @@ const getClassName = cssModules(STYLES);
 
 export type Props = {
   ...$Exact<PopoverProps>,
-  target: (() => null | HTMLElement) | Node,
+  target: (() => ?HTMLElement) | Node,
   isOpen: boolean,
   placement: ?('top' | 'right' | 'bottom' | 'left'),
   portalStyle: ?Object,
   portalClassName: ?string,
-  renderTarget: ?() => null | HTMLElement,
+  renderTarget: ?() => ?HTMLElement,
   popperModifiers: ?Object,
 };
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_

The type for `React.createRef` is `() => null | T`, with `T` being a type that inherits from `HTMLElement`.

This PR updates the types for the `target` and `renderTarget` props of `bpk-component-popover` to accept this type