### PR TITLE
[NO-JIRA] Make docs imports ready for migration

### DIFF
--- a/packages/bpk-docs/src/pages/DatepickerPage/DatepickerPage.js
+++ b/packages/bpk-docs/src/pages/DatepickerPage/DatepickerPage.js
@@ -20,14 +20,14 @@ import React, { Component } from 'react';
 import BpkDatepicker from 'bpk-component-datepicker';
 import BpkRouterLink from 'bpk-component-router-link';
 import datepickerReadme from 'bpk-component-datepicker/README.md';
+import format from 'date-fns/format';
+import { weekDays } from 'bpk-component-calendar/test-utils';
 
 import * as ROUTES from '../../constants/routes';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
-import format from '../../../../bpk-component-calendar/node_modules/date-fns/format';
 import Paragraph from '../../components/Paragraph';
 import IntroBlurb from '../../components/IntroBlurb';
-import { weekDays } from '../../../../bpk-component-calendar/test-utils';
 
 const formatDate = date => format(date, 'DD/MM/YYYY');
 const formatMonth = date => format(date, 'MMMM YYYY');

--- a/packages/bpk-docs/src/pages/InfiniteScrollPage/InfiniteScrollPage.js
+++ b/packages/bpk-docs/src/pages/InfiniteScrollPage/InfiniteScrollPage.js
@@ -26,8 +26,8 @@ import BpkButton from 'bpk-component-button';
 import { BpkSpinner, SPINNER_TYPES } from 'bpk-component-spinner';
 import { cssModules } from 'bpk-react-utils';
 import { BpkList, BpkListItem } from 'bpk-component-list';
+import infiniteScrollReadme from 'bpk-component-infinite-scroll/README.md';
 
-import infiniteScrollReadme from '../../../../bpk-component-infinite-scroll/README.md';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 import IntroBlurb from '../../components/IntroBlurb';
 import DocsPageWrapper from '../../components/DocsPageWrapper';

--- a/packages/bpk-docs/src/pages/WebCalendarPage/WebCalendarPage.js
+++ b/packages/bpk-docs/src/pages/WebCalendarPage/WebCalendarPage.js
@@ -27,10 +27,7 @@ import BpkCalendar, {
 import BpkMobileScrollContainer from 'bpk-component-mobile-scroll-container';
 import { cssModules } from 'bpk-react-utils';
 import calendarReadme from 'bpk-component-calendar/README.md';
-
-import DocsPageBuilder from '../../components/DocsPageBuilder';
-import Paragraph from '../../components/Paragraph';
-import addMonths from '../../../../bpk-component-calendar/node_modules/date-fns/add_months';
+import addMonths from 'date-fns/add_months';
 import {
   weekDays,
   weekDaysArabic,
@@ -38,7 +35,10 @@ import {
   formatDateFullArabic,
   formatMonth,
   formatMonthArabic,
-} from '../../../../bpk-component-calendar/test-utils';
+} from 'bpk-component-calendar/test-utils';
+
+import DocsPageBuilder from '../../components/DocsPageBuilder';
+import Paragraph from '../../components/Paragraph';
 
 import STYLES from './calendar-page.scss';
 


### PR DESCRIPTION
Update some imports so that when we migrate the docs code to the new repo it can be done more easily.