### PR TITLE
[NoJira] Add Flow types for BpkText props

### DIFF
--- a/packages/bpk-component-text/src/BpkText-test.js
+++ b/packages/bpk-component-text/src/BpkText-test.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 import renderer from 'react-test-renderer';
 

--- a/packages/bpk-component-text/src/BpkText.js
+++ b/packages/bpk-component-text/src/BpkText.js
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type Node } from 'react';
 import { cssModules } from 'bpk-react-utils';
 
 import STYLES from './BpkText.scss';
@@ -31,7 +33,15 @@ TEXT_STYLES.forEach(textStyle => {
   classes[textStyle] = getClassName(`bpk-text--${textStyle}`);
 });
 
-const BpkText = props => {
+type Props = {
+  children: Node,
+  textStyle: 'xs' | 'sm' | 'base' | 'lg' | 'xl' | 'xxl',
+  tagName: 'span' | 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  className: ?string,
+  bold: boolean,
+};
+
+const BpkText = (props: Props) => {
   const {
     bold,
     className,


### PR DESCRIPTION
Adds Flow typed Props definition in the same style as other backpack components. 

The optional props, such as `bold`, are not marked as `bold?: boolean` as 
> Flow will make sure that foo is optional if you have a default prop for foo.

https://flow.org/en/docs/react/components/#toc-using-default-props

`className` is marked as a maybe type, `className: ?string,`, as this supports `null` values and  its default value is `null`. This is done in the same style as in existing Backpack components.



-----
+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
