### PR TITLE
[NO-JIRA] Add storybook deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 .sass-cache
 /dist
+/dist-storybook
 /coverage
 /packages/bpk-component-icon/*/
 !/packages/bpk-component-icon/src

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,19 @@ deploy:
   target-branch: master
   verbose: true
 
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $DEPLOY_TOKEN
+  on:
+    branch: master
+  local_dir: dist-storybook
+  skip_cleanup: true
+  detect_encoding: true
+  repo: backpack/storybook
+  target-branch: master
+  verbose: true
+
 notifications:
   slack:
     rooms:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:tokens": "lerna run tokens --scope bpk-tokens",
     "build:svgs": "lerna run svgs --scope bpk-svgs",
     "build": "npm run build:tokens && npm run build:svgs && lerna run build",
-    "storybook:dist": "build-storybook -c .storybook -o dist/storybook",
+    "storybook:dist": "build-storybook -c .storybook -o dist-storybook",
     "storybook": "start-storybook -p 9001",
     "sassdoc": "sassdoc {packages/bpk-mixins/src/**/*,packages/bpk-svgs/dist/*,packages/bpk-tokens/tokens/base.default}.scss -d dist/sassdoc -v --strict",
     "docs": "npm run submodules:pull && BPK_BUILT_AT=$( date -u +%s ) webpack-dev-server --open",


### PR DESCRIPTION
Separating the storybook deploy so that we can (later) remove the docs deploy steps without affecting how storybook is deployed

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)