### PR TITLE
[No JIRA] Add `greedyGestureHandling` prop to BpkMap

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -710,3 +710,4 @@ onBarHover
 onBarFocus
 getBarLabel
 getBarSelection
+greedyGestureHandling

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,10 @@
 
 > Place your changes below this line.
 
+**Added:**
+- bpk-component-map:
+  - New `greedyGestureHandling` prop for enforcing one-finger pan and zoom on touch devices.
+
 
 ## How to write a good changelog entry
 

--- a/packages/bpk-component-map/README.md
+++ b/packages/bpk-component-map/README.md
@@ -85,18 +85,19 @@ export default () => (
 
 ### BpkMap
 
-| Property	       | PropType                                                          | Required                 | Default Value                    |
-| ---------------- | ----------------------------------------------------------------- | ------------------------ | -------------------------------- |
-| bounds           | shape({north: number, east: number, south: number, west: number}) | false                    | null                             |
-| center           | shape({latitude: number, longitude: number})                      | false                    | null                             |
-| containerElement | node                                                              | false                    | <div style={{height: '100%'}} /> |
-| mapElement       | node                                                              | false                    | <div style={{height: '100%'}} /> |
-| mapRef           | func                                                              | false                    | null                             |
-| onRegionChange   | func                                                              | false                    | null                             |
-| onZoom           | func                                                              | false                    | null                             |
-| panEnabled       | bool                                                              | false                    | true                             |
-| showControls     | bool                                                              | false                    | true                             |
-| zoom             | number                                                            | false                    | 15                               |
+| Property	            | PropType                                                          | Required                 | Default Value                    |
+| --------------------- | ----------------------------------------------------------------- | ------------------------ | -------------------------------- |
+| bounds                | shape({north: number, east: number, south: number, west: number}) | false                    | null                             |
+| center                | shape({latitude: number, longitude: number})                      | false                    | null                             |
+| containerElement      | node                                                              | false                    | <div style={{height: '100%'}} /> |
+| greedyGestureHandling | bool                                                              | false                    | false                            |
+| mapElement            | node                                                              | false                    | <div style={{height: '100%'}} /> |
+| mapRef                | func                                                              | false                    | null                             |
+| onRegionChange        | func                                                              | false                    | null                             |
+| onZoom                | func                                                              | false                    | null                             |
+| panEnabled            | bool                                                              | false                    | true                             |
+| showControls          | bool                                                              | false                    | true                             |
+| zoom                  | number                                                            | false                    | 15                               |
 
 Note: One of `bounds` and `center` must be provided.
 

--- a/packages/bpk-component-map/src/BpkMap.js
+++ b/packages/bpk-component-map/src/BpkMap.js
@@ -39,6 +39,7 @@ export type MapRef = ?{
 };
 
 type Props = {
+  greedyGestureHandling: boolean,
   panEnabled: boolean,
   showControls: boolean,
   zoom: number,
@@ -56,6 +57,7 @@ const BpkMap = withGoogleMap((props: Props) => {
   const {
     bounds,
     children,
+    greedyGestureHandling,
     mapRef,
     onRegionChange,
     onZoom,
@@ -68,6 +70,14 @@ const BpkMap = withGoogleMap((props: Props) => {
 
   if (!bounds && !center) {
     throw new Error('BpkMap: Provide either `bounds` or `center` props.');
+  }
+
+  // https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.gestureHandling
+  let gestureHandling = 'auto';
+  if (!panEnabled) {
+    gestureHandling = 'none';
+  } else if (greedyGestureHandling) {
+    gestureHandling = 'greedy';
   }
 
   return (
@@ -96,7 +106,7 @@ const BpkMap = withGoogleMap((props: Props) => {
       }
       zoom={zoom}
       options={{
-        gestureHandling: panEnabled ? 'auto' : 'none',
+        gestureHandling,
         disableDefaultUI: !showControls,
         mapTypeControl: false,
         streetViewControl: false,
@@ -129,6 +139,7 @@ BpkMap.propTypes = {
   center: LatLongPropType,
   children: PropTypes.node,
   containerElement: PropTypes.node,
+  greedyGestureHandling: PropTypes.bool,
   mapElement: PropTypes.node,
   mapRef: PropTypes.func,
   onRegionChange: PropTypes.func,
@@ -143,6 +154,7 @@ BpkMap.defaultProps = {
   center: null,
   children: null,
   containerElement: <div style={{ height: '100%' }} />,
+  greedyGestureHandling: false,
   mapElement: <div style={{ height: '100%' }} />,
   mapRef: null,
   onRegionChange: null,

--- a/packages/bpk-component-map/stories.js
+++ b/packages/bpk-component-map/stories.js
@@ -88,6 +88,12 @@ storiesOf('bpk-component-map', module)
       showControls={false}
     />
   ))
+  .add('Greedy gesture handling', () => (
+    <StoryMap
+      center={{ latitude: 55.944357, longitude: -3.1967116 }}
+      greedyGestureHandling
+    />
+  ))
   .add('With onZoom and onRegionChange callbacks', () => (
     <StoryMap
       center={{ latitude: 55.944357, longitude: -3.1967116 }}


### PR DESCRIPTION
Previously we set [`gestureHandling`](https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.gestureHandling) to `auto`. This created an issue when maps were placed inside modals, as they _should_ have been scrollable with one finger but instead get the 'use two fingers' overlay which was a bad experience for travellers. 

This PR adds a new prop to override the gesture handling so that in situations like this, developers can manually override to get the more desirable behaviour.

Here's a video to illustrate the difference:

![ezgif-1-0625a5b6702b](https://user-images.githubusercontent.com/73652/57449130-10219880-7253-11e9-83f6-a7b697cc064e.gif)

Please note that this only applies to touchscreens. In the above video I'm emulating a touchscreen in Chrome.

