### PR TITLE
[NO-JIRA] fix checkbox accessibility

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 > Place your changes below this line.
+**Fixed:**
+
+- `bpk-component-checkbox`:
+  - Fixed issue that caused screen-readers to read and select checkbox labels twice.
 
 ## How to write a good changelog entry
 

--- a/packages/bpk-component-checkbox/src/BpkCheckbox.js
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.js
@@ -60,13 +60,14 @@ const BpkCheckbox = props => {
         className={getClassName('bpk-checkbox__input')}
         name={name}
         disabled={disabled}
+        aria-label={label}
         {...rest}
       />
       <Tick
         className={getClassName('bpk-checkbox__icon')}
         style={{ width: spacingSm, height: spacingSm }}
       />
-      <span className={labelClassNames.join(' ')}>
+      <span className={labelClassNames.join(' ')} aria-hidden="true">
         {label}
         {required && (
           <span className={getClassName('bpk-checkbox__asterisk')}>*</span>

--- a/packages/bpk-component-checkbox/src/__snapshots__/BpkCheckbox-test.js.snap
+++ b/packages/bpk-component-checkbox/src/__snapshots__/BpkCheckbox-test.js.snap
@@ -5,6 +5,7 @@ exports[`BpkCheckbox should render correctly 1`] = `
   className="bpk-checkbox"
 >
   <input
+    aria-label="Prefer directs"
     className="bpk-checkbox__input"
     disabled={false}
     name="checkbox"
@@ -28,6 +29,7 @@ exports[`BpkCheckbox should render correctly 1`] = `
     />
   </svg>
   <span
+    aria-hidden="true"
     className="bpk-checkbox__label"
   >
     Prefer directs
@@ -40,6 +42,7 @@ exports[`BpkCheckbox should render correctly with a small label 1`] = `
   className="bpk-checkbox"
 >
   <input
+    aria-label="Prefer directs"
     className="bpk-checkbox__input"
     disabled={false}
     name="checkbox"
@@ -63,6 +66,7 @@ exports[`BpkCheckbox should render correctly with a small label 1`] = `
     />
   </svg>
   <span
+    aria-hidden="true"
     className="bpk-checkbox__label bpk-checkbox__label--small"
   >
     Prefer directs
@@ -75,6 +79,7 @@ exports[`BpkCheckbox should render correctly with checked attribute 1`] = `
   className="bpk-checkbox"
 >
   <input
+    aria-label="Prefer directs"
     checked={true}
     className="bpk-checkbox__input"
     disabled={false}
@@ -99,6 +104,7 @@ exports[`BpkCheckbox should render correctly with checked attribute 1`] = `
     />
   </svg>
   <span
+    aria-hidden="true"
     className="bpk-checkbox__label"
   >
     Prefer directs
@@ -111,6 +117,7 @@ exports[`BpkCheckbox should render correctly with disabled attribute 1`] = `
   className="bpk-checkbox bpk-checkbox--disabled"
 >
   <input
+    aria-label="Prefer directs"
     className="bpk-checkbox__input"
     disabled={true}
     name="checkbox"
@@ -134,6 +141,7 @@ exports[`BpkCheckbox should render correctly with disabled attribute 1`] = `
     />
   </svg>
   <span
+    aria-hidden="true"
     className="bpk-checkbox__label"
   >
     Prefer directs
@@ -146,6 +154,7 @@ exports[`BpkCheckbox should render correctly with id attribute 1`] = `
   className="bpk-checkbox"
 >
   <input
+    aria-label="Prefer directs"
     className="bpk-checkbox__input"
     disabled={false}
     id="checkbox"
@@ -170,6 +179,7 @@ exports[`BpkCheckbox should render correctly with id attribute 1`] = `
     />
   </svg>
   <span
+    aria-hidden="true"
     className="bpk-checkbox__label"
   >
     Prefer directs
@@ -182,6 +192,7 @@ exports[`BpkCheckbox should render correctly with required attribute 1`] = `
   className="bpk-checkbox"
 >
   <input
+    aria-label="Prefer directs"
     className="bpk-checkbox__input"
     disabled={false}
     name="checkbox"
@@ -205,6 +216,7 @@ exports[`BpkCheckbox should render correctly with required attribute 1`] = `
     />
   </svg>
   <span
+    aria-hidden="true"
     className="bpk-checkbox__label"
   >
     Prefer directs
@@ -222,6 +234,7 @@ exports[`BpkCheckbox should render correctly with value attribute 1`] = `
   className="bpk-checkbox"
 >
   <input
+    aria-label="Prefer directs"
     className="bpk-checkbox__input"
     disabled={false}
     name="checkbox"
@@ -246,6 +259,7 @@ exports[`BpkCheckbox should render correctly with value attribute 1`] = `
     />
   </svg>
   <span
+    aria-hidden="true"
     className="bpk-checkbox__label"
   >
     Prefer directs
@@ -258,6 +272,7 @@ exports[`BpkCheckbox should render correctly with white attribute 1`] = `
   className="bpk-checkbox bpk-checkbox--white"
 >
   <input
+    aria-label="Prefer directs"
     className="bpk-checkbox__input"
     disabled={false}
     name="checkbox"
@@ -281,6 +296,7 @@ exports[`BpkCheckbox should render correctly with white attribute 1`] = `
     />
   </svg>
   <span
+    aria-hidden="true"
     className="bpk-checkbox__label"
   >
     Prefer directs

--- a/packages/bpk-component-fieldset/src/__snapshots__/BpkFieldset-test.js.snap
+++ b/packages/bpk-component-fieldset/src/__snapshots__/BpkFieldset-test.js.snap
@@ -57,6 +57,7 @@ exports[`BpkFieldset should render correctly with checkbox component 1`] = `
     className="bpk-checkbox"
   >
     <input
+      aria-label="I accept the terms and conditions"
       className="bpk-checkbox__input"
       disabled={false}
       id="terms_and_conditions_checkbox"
@@ -81,6 +82,7 @@ exports[`BpkFieldset should render correctly with checkbox component 1`] = `
       />
     </svg>
     <span
+      aria-hidden="true"
       className="bpk-checkbox__label"
     >
       I accept the terms and conditions
@@ -152,6 +154,7 @@ exports[`BpkFieldset should render correctly with checkbox component and "requir
     className="bpk-checkbox"
   >
     <input
+      aria-label="I accept the terms and conditions"
       className="bpk-checkbox__input"
       disabled={false}
       id="terms_and_conditions_checkbox"
@@ -176,6 +179,7 @@ exports[`BpkFieldset should render correctly with checkbox component and "requir
       />
     </svg>
     <span
+      aria-hidden="true"
       className="bpk-checkbox__label"
     >
       I accept the terms and conditions


### PR DESCRIPTION
Previously, when navigating through a page, you would first see/hear this:
<img width="624" alt="Screenshot 2019-05-29 at 15 29 52" src="https://user-images.githubusercontent.com/30267516/58567203-d298a580-8229-11e9-8a69-629a79fb95a4.png">

And then this:
<img width="609" alt="Screenshot 2019-05-29 at 15 30 02" src="https://user-images.githubusercontent.com/30267516/58567218-dc220d80-8229-11e9-93bf-0fd05b199854.png">

Now it will only select and read it once:
<img width="596" alt="Screenshot 2019-05-29 at 15 53 32" src="https://user-images.githubusercontent.com/30267516/58567295-070c6180-822a-11e9-83ea-39e504f632b5.png">
