### PR TITLE
[NO-JIRA] fix radio button accessibility

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 > Place your changes below this line.
+**Fixed:**
+
+- bpk-component-radio:
+  - Fixed an issue that caused screen readers to select and read the label twice.
 
 ## How to write a good changelog entry
 

--- a/packages/bpk-component-radio/src/BpkRadio.js
+++ b/packages/bpk-component-radio/src/BpkRadio.js
@@ -45,10 +45,11 @@ const BpkRadio = props => {
         className={getClassName('bpk-radio__input')}
         name={name}
         disabled={disabled}
+        aria-label={label}
         {...rest}
       />
       <div className={getClassName('bpk-radio__circle')} />
-      {label}
+      <span aria-hidden="true">{label}</span>
     </label>
   );
 };

--- a/packages/bpk-component-radio/src/__snapshots__/BpkRadio-test.js.snap
+++ b/packages/bpk-component-radio/src/__snapshots__/BpkRadio-test.js.snap
@@ -5,6 +5,7 @@ exports[`BpkRadio should render correctly 1`] = `
   className="bpk-radio"
 >
   <input
+    aria-label="Direct"
     className="bpk-radio__input"
     disabled={false}
     name="radio"
@@ -13,7 +14,11 @@ exports[`BpkRadio should render correctly 1`] = `
   <div
     className="bpk-radio__circle"
   />
-  Direct
+  <span
+    aria-hidden="true"
+  >
+    Direct
+  </span>
 </label>
 `;
 
@@ -22,6 +27,7 @@ exports[`BpkRadio should render correctly with checked attribute 1`] = `
   className="bpk-radio"
 >
   <input
+    aria-label="Direct"
     checked={true}
     className="bpk-radio__input"
     disabled={false}
@@ -31,7 +37,11 @@ exports[`BpkRadio should render correctly with checked attribute 1`] = `
   <div
     className="bpk-radio__circle"
   />
-  Direct
+  <span
+    aria-hidden="true"
+  >
+    Direct
+  </span>
 </label>
 `;
 
@@ -40,6 +50,7 @@ exports[`BpkRadio should render correctly with disabled attribute 1`] = `
   className="bpk-radio bpk-radio--disabled"
 >
   <input
+    aria-label="Direct"
     className="bpk-radio__input"
     disabled={true}
     name="radio"
@@ -48,7 +59,11 @@ exports[`BpkRadio should render correctly with disabled attribute 1`] = `
   <div
     className="bpk-radio__circle"
   />
-  Direct
+  <span
+    aria-hidden="true"
+  >
+    Direct
+  </span>
 </label>
 `;
 
@@ -57,6 +72,7 @@ exports[`BpkRadio should render correctly with id attribute 1`] = `
   className="bpk-radio"
 >
   <input
+    aria-label="Direct"
     className="bpk-radio__input"
     disabled={false}
     id="radio"
@@ -66,7 +82,11 @@ exports[`BpkRadio should render correctly with id attribute 1`] = `
   <div
     className="bpk-radio__circle"
   />
-  Direct
+  <span
+    aria-hidden="true"
+  >
+    Direct
+  </span>
 </label>
 `;
 
@@ -75,6 +95,7 @@ exports[`BpkRadio should render correctly with value attribute 1`] = `
   className="bpk-radio"
 >
   <input
+    aria-label="Direct"
     className="bpk-radio__input"
     disabled={false}
     name="radio"
@@ -84,7 +105,11 @@ exports[`BpkRadio should render correctly with value attribute 1`] = `
   <div
     className="bpk-radio__circle"
   />
-  Direct
+  <span
+    aria-hidden="true"
+  >
+    Direct
+  </span>
 </label>
 `;
 
@@ -93,6 +118,7 @@ exports[`BpkRadio should render correctly with white attribute 1`] = `
   className="bpk-radio bpk-radio--white"
 >
   <input
+    aria-label="Direct"
     className="bpk-radio__input"
     disabled={false}
     name="radio"
@@ -101,6 +127,10 @@ exports[`BpkRadio should render correctly with white attribute 1`] = `
   <div
     className="bpk-radio__circle"
   />
-  Direct
+  <span
+    aria-hidden="true"
+  >
+    Direct
+  </span>
 </label>
 `;


### PR DESCRIPTION
Before, the text element was able to be selected and read out independently of the radio button component:

<img width="649" alt="image" src="https://user-images.githubusercontent.com/30267516/58570350-bdbf1080-822f-11e9-83c6-ef2e98b14a69.png">
<img width="605" alt="image" src="https://user-images.githubusercontent.com/30267516/58570357-c1eb2e00-822f-11e9-8c5b-f9d56b419a0d.png">


Now they are treated as one:
<img width="614" alt="Screenshot 2019-05-29 at 16 31 44" src="https://user-images.githubusercontent.com/30267516/58570321-b26be500-822f-11e9-93d9-4ba05d41fdbe.png">
