### PR TITLE
[DINGO-1449] Add "sideEffects" hint to all packages

### DIFF
--- a/packages/bpk-animate-height/package.json
+++ b/packages/bpk-animate-height/package.json
@@ -19,5 +19,9 @@
     "bpk-component-button": "^2.3.5",
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-accordion/package.json
+++ b/packages/bpk-component-accordion/package.json
@@ -23,5 +23,9 @@
     "bpk-component-checkbox": "^1.4.95",
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-autosuggest/package.json
+++ b/packages/bpk-component-autosuggest/package.json
@@ -22,5 +22,9 @@
   "devDependencies": {
     "bpk-component-icon": "^3.30.0"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-badge/package.json
+++ b/packages/bpk-component-badge/package.json
@@ -21,5 +21,9 @@
     "bpk-component-icon": "^3.30.0",
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-banner-alert/package.json
+++ b/packages/bpk-component-banner-alert/package.json
@@ -22,5 +22,9 @@
     "prop-types": "^15.6.2",
     "react-transition-group": "^2.5.3"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-barchart/package.json
+++ b/packages/bpk-component-barchart/package.json
@@ -28,5 +28,9 @@
     "bpk-component-rtl-toggle": "^1.1.83",
     "bpk-component-text": "^1.0.124"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-blockquote/package.json
+++ b/packages/bpk-component-blockquote/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-boilerplate/package.json
+++ b/packages/bpk-component-boilerplate/package.json
@@ -16,5 +16,9 @@
   "dependencies": {
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.5.8"
-  }
+  },
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-breadcrumb/package.json
+++ b/packages/bpk-component-breadcrumb/package.json
@@ -20,5 +20,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-breakpoint/package.json
+++ b/packages/bpk-component-breakpoint/package.json
@@ -20,5 +20,9 @@
   "devDependencies": {
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-button/package.json
+++ b/packages/bpk-component-button/package.json
@@ -16,5 +16,9 @@
     "bpk-mixins": "^17.23.0",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-calendar/package.json
+++ b/packages/bpk-component-calendar/package.json
@@ -25,5 +25,9 @@
     "bpk-component-button": "^2.3.5",
     "bpk-component-text": "^1.0.124"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-card/package.json
+++ b/packages/bpk-component-card/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-checkbox/package.json
+++ b/packages/bpk-component-checkbox/package.json
@@ -21,5 +21,9 @@
   "devDependencies": {
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-chip/package.json
+++ b/packages/bpk-component-chip/package.json
@@ -18,5 +18,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-close-button/package.json
+++ b/packages/bpk-component-close-button/package.json
@@ -18,5 +18,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-code/package.json
+++ b/packages/bpk-component-code/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-content-container/package.json
+++ b/packages/bpk-component-content-container/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-datatable/package.json
+++ b/packages/bpk-component-datatable/package.json
@@ -23,5 +23,9 @@
   "devDependencies": {
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-datepicker/package.json
+++ b/packages/bpk-component-datepicker/package.json
@@ -22,5 +22,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-description-list/package.json
+++ b/packages/bpk-component-description-list/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-dialog/package.json
+++ b/packages/bpk-component-dialog/package.json
@@ -23,5 +23,9 @@
     "bpk-mixins": "^17.23.0",
     "bpk-react-utils": "^2.7.8"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-drawer/package.json
+++ b/packages/bpk-component-drawer/package.json
@@ -27,5 +27,9 @@
     "bpk-component-button": "^2.3.5",
     "bpk-component-text": "^1.0.124"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-fieldset/package.json
+++ b/packages/bpk-component-fieldset/package.json
@@ -24,5 +24,9 @@
     "bpk-component-input": "^4.1.12",
     "bpk-component-select": "^2.2.65"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-form-validation/package.json
+++ b/packages/bpk-component-form-validation/package.json
@@ -23,5 +23,9 @@
     "bpk-component-icon": "^3.30.0",
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-grid-toggle/package.json
+++ b/packages/bpk-component-grid-toggle/package.json
@@ -18,5 +18,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-grid/package.json
+++ b/packages/bpk-component-grid/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-heading/package.json
+++ b/packages/bpk-component-heading/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-horizontal-nav/package.json
+++ b/packages/bpk-component-horizontal-nav/package.json
@@ -21,5 +21,9 @@
   "devDependencies": {
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-icon/package.json
+++ b/packages/bpk-component-icon/package.json
@@ -22,5 +22,9 @@
     "bpk-tokens": "^27.6.2",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-image/package.json
+++ b/packages/bpk-component-image/package.json
@@ -24,5 +24,9 @@
     "bpk-component-text": "^1.0.124",
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-infinite-scroll/package.json
+++ b/packages/bpk-component-infinite-scroll/package.json
@@ -23,5 +23,10 @@
     "bpk-component-card": "^1.1.78",
     "bpk-component-spinner": "^2.2.95"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "./src/intersection-observer.js",
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-input/package.json
+++ b/packages/bpk-component-input/package.json
@@ -21,5 +21,9 @@
   "devDependencies": {
     "bpk-component-text": "^1.0.124"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-label/package.json
+++ b/packages/bpk-component-label/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-link/package.json
+++ b/packages/bpk-component-link/package.json
@@ -20,5 +20,9 @@
   "devDependencies": {
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-list/package.json
+++ b/packages/bpk-component-list/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-loading-button/package.json
+++ b/packages/bpk-component-loading-button/package.json
@@ -20,5 +20,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-map/package.json
+++ b/packages/bpk-component-map/package.json
@@ -24,5 +24,9 @@
     "bpk-component-text": "^1.0.124",
     "prop-types": "^15.5.8"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-mobile-scroll-container/package.json
+++ b/packages/bpk-component-mobile-scroll-container/package.json
@@ -23,5 +23,9 @@
     "bpk-component-table": "^1.1.69",
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-modal/package.json
+++ b/packages/bpk-component-modal/package.json
@@ -25,5 +25,9 @@
     "bpk-component-button": "^2.3.5",
     "bpk-component-text": "^1.0.124"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-navigation-bar/package.json
+++ b/packages/bpk-component-navigation-bar/package.json
@@ -24,5 +24,9 @@
     "bpk-component-icon": "^3.30.0",
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-navigation-stack/package.json
+++ b/packages/bpk-component-navigation-stack/package.json
@@ -25,5 +25,9 @@
     "bpk-component-navigation-bar": "^1.2.68",
     "bpk-component-rtl-toggle": "^1.1.83"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-nudger/package.json
+++ b/packages/bpk-component-nudger/package.json
@@ -24,5 +24,9 @@
   "devDependencies": {
     "bpk-component-label": "^3.2.133"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-pagination/package.json
+++ b/packages/bpk-component-pagination/package.json
@@ -21,5 +21,9 @@
   "devDependencies": {
     "bpk-component-icon": "^3.30.0"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-panel/package.json
+++ b/packages/bpk-component-panel/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-paragraph/package.json
+++ b/packages/bpk-component-paragraph/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-phone-input/package.json
+++ b/packages/bpk-component-phone-input/package.json
@@ -26,5 +26,9 @@
     "bpk-component-fieldset": "^1.1.93",
     "bpk-component-image": "^2.1.36"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-popover/package.json
+++ b/packages/bpk-component-popover/package.json
@@ -27,5 +27,9 @@
     "bpk-component-button": "^2.3.5",
     "bpk-component-content-container": "^1.3.69"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-progress/package.json
+++ b/packages/bpk-component-progress/package.json
@@ -22,5 +22,9 @@
   "devDependencies": {
     "bpk-component-button": "^2.3.5"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-radio/package.json
+++ b/packages/bpk-component-radio/package.json
@@ -20,5 +20,9 @@
   "devDependencies": {
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-router-link/package.json
+++ b/packages/bpk-component-router-link/package.json
@@ -18,5 +18,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-rtl-toggle/package.json
+++ b/packages/bpk-component-rtl-toggle/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-scrollable-calendar/package.json
+++ b/packages/bpk-component-scrollable-calendar/package.json
@@ -20,5 +20,9 @@
     "prop-types": "^15.5.8",
     "react-window": "^1.5.0"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-section-list/package.json
+++ b/packages/bpk-component-section-list/package.json
@@ -20,5 +20,9 @@
     "bpk-tokens": "^27.6.2",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-select/package.json
+++ b/packages/bpk-component-select/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-slider/package.json
+++ b/packages/bpk-component-slider/package.json
@@ -22,5 +22,9 @@
   "devDependencies": {
     "bpk-component-rtl-toggle": "^1.1.83"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-spinner/package.json
+++ b/packages/bpk-component-spinner/package.json
@@ -18,5 +18,9 @@
     "bpk-svgs": "^6.7.0",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-star-rating/package.json
+++ b/packages/bpk-component-star-rating/package.json
@@ -21,5 +21,9 @@
   "devDependencies": {
     "bpk-component-table": "^1.1.69"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-table/package.json
+++ b/packages/bpk-component-table/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-text/package.json
+++ b/packages/bpk-component-text/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-textarea/package.json
+++ b/packages/bpk-component-textarea/package.json
@@ -17,5 +17,9 @@
     "bpk-react-utils": "^2.7.8",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-theme-toggle/package.json
+++ b/packages/bpk-component-theme-toggle/package.json
@@ -20,5 +20,9 @@
     "bpk-tokens": "^27.6.2",
     "prop-types": "^15.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-ticket/package.json
+++ b/packages/bpk-component-ticket/package.json
@@ -21,5 +21,9 @@
     "bpk-component-button": "^2.3.5",
     "bpk-component-icon": "^3.30.0"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-tile/package.json
+++ b/packages/bpk-component-tile/package.json
@@ -20,5 +20,9 @@
   },
   "devDependencies": {
     "bpk-react-utils": "^2.7.8"
-  }
+  },
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-component-tooltip/package.json
+++ b/packages/bpk-component-tooltip/package.json
@@ -22,5 +22,9 @@
     "bpk-component-text": "^1.0.124",
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-mixins/package.json
+++ b/packages/bpk-mixins/package.json
@@ -19,5 +19,9 @@
   "peerDependencies": {
     "node-sass": "^4.1.1"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-react-utils/package.json
+++ b/packages/bpk-react-utils/package.json
@@ -18,5 +18,9 @@
     "prop-types": "^15.6.2",
     "react-transition-group": "^2.5.3",
     "recompose": "^0.30.0"
-  }
+  },
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-scrim-utils/package.json
+++ b/packages/bpk-scrim-utils/package.json
@@ -15,5 +15,9 @@
     "bpk-mixins": "^17.23.0",
     "bpk-react-utils": "^2.7.8"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-stylesheets/package.json
+++ b/packages/bpk-stylesheets/package.json
@@ -18,8 +18,5 @@
     "normalize.css": "4.2.0"
   },
   "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
-  "sideEffects": [
-    "*.css",
-    "*.scss"
-  ]
+  "sideEffects": true
 }

--- a/packages/bpk-stylesheets/package.json
+++ b/packages/bpk-stylesheets/package.json
@@ -17,5 +17,9 @@
     "bpk-tokens": "^27.6.2",
     "normalize.css": "4.2.0"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-svgs/package.json
+++ b/packages/bpk-svgs/package.json
@@ -15,5 +15,9 @@
   "devDependencies": {
     "bpk-tokens": "^27.6.2"
   },
-  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a"
+  "gitHead": "94c737cc11d819f87c993fb3e43ef81d0151135a",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-theming/package.json
+++ b/packages/bpk-theming/package.json
@@ -15,5 +15,9 @@
   "dependencies": {
     "bpk-tokens": "^27.6.2",
     "prop-types": "^15.6.2"
-  }
+  },
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }

--- a/packages/bpk-tokens/package.json
+++ b/packages/bpk-tokens/package.json
@@ -14,5 +14,9 @@
   "license": "Apache-2.0",
   "dependencies": {
     "color": "^3.0.0"
-  }
+  },
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ]
 }


### PR DESCRIPTION
- Based off of previous failed attempt in #1474
- Scoped to `.js` files (or rather blacklist `.css` and `.scss`)

Worth reading the webpack docs for `"sideEffects"` -> https://webpack.js.org/guides/tree-shaking

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
