### PR TITLE
BPK-2519 Add  to datepicker's input field by default

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 > Place your changes below this line.
+**Added:**
+
+- bpk-component-datepicker:
+  - Add `readOnly` to input field by default.
 
 ## How to write a good changelog entry
 

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -73,6 +73,34 @@ describe('BpkDatepicker', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('"readOnly" can be overriden in "inputProps"', () => {
+    const noReadOnlyInputProps = Object.assign({}, inputProps, {
+      readOnly: false,
+    });
+    const tree = renderer
+      .create(
+        <BpkDatepicker
+          id="myDatepicker"
+          closeButtonText="Close"
+          daysOfWeek={weekDays}
+          changeMonthLabel="Change month"
+          title="Departure date"
+          weekStartsOn={1}
+          getApplicationElement={() => document.createElement('div')}
+          formatDate={formatDate}
+          formatMonth={formatMonth}
+          formatDateFull={formatDateFull}
+          inputProps={noReadOnlyInputProps}
+          minDate={new Date(2010, 1, 15)}
+          maxDate={new Date(2010, 2, 15)}
+          date={new Date(2010, 1, 15)}
+        />,
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should open on click', () => {
     const datepicker = mount(
       <BpkDatepicker

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -104,6 +104,7 @@ class BpkDatepicker extends Component {
         onChange={() => null}
         onOpen={this.onOpen}
         isOpen={this.state.isOpen}
+        readOnly
         {...inputProps}
       />
     );

--- a/packages/bpk-component-datepicker/src/__snapshots__/BpkDatepicker-test.js.snap
+++ b/packages/bpk-component-datepicker/src/__snapshots__/BpkDatepicker-test.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BpkDatepicker "readOnly" can be overriden in "inputProps" 1`] = `
+<input
+  aria-atomic="true"
+  aria-invalid={false}
+  aria-label="Monday, 15th February 2010"
+  aria-live="assertive"
+  className="bpk-input bpk-input--large bpk-input--with-open-events bpk-datepicker__input"
+  id="myDatepicker"
+  name="myDatepicker_input"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  placeholder="placeholder"
+  readOnly={false}
+  type="text"
+  value="15/02/2010"
+/>
+`;
+
 exports[`BpkDatepicker should render correctly 1`] = `
 <input
   aria-atomic="true"
@@ -16,6 +38,7 @@ exports[`BpkDatepicker should render correctly 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   placeholder="placeholder"
+  readOnly={true}
   type="text"
   value="15/02/2010"
 />


### PR DESCRIPTION
After selecting a date in `BpkDatepicker`, the text cursor is placed inside the text input field (although the value can’t be changed typing in it). Adding `readOnly: true` to the `inputProps` “fixes” this behaviour (the input field is still focused, but the text cursor is not in there anymore).