### PR TITLE
[No JIRA] A bit of housekeeping on Danger

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,3 @@
 Thanks for contributing to Backpack :pray:
 Please include a description of the changes you are introducing and some screenshots if appropriate.
 -->
-
-+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)
-
-
-_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -20,13 +20,17 @@
 
 // See http://danger.systems/js if you're not sure what this is.
 
+// @flow
+
 import fs from 'fs';
 
 import { includes } from 'lodash';
-import { danger, fail, warn, message } from 'danger';
+import { danger, fail, warn, message, markdown } from 'danger';
 import { commonFileWarnings } from 'danger-plugin-toolbox';
 
 import * as meta from './meta.json';
+
+const getRandomFromArray = arr => arr[Math.floor(Math.random() * arr.length)];
 
 const AVOID_EXACT_WORDS = [
   { word: 'react native', reason: 'Please use React Native with capitals' },
@@ -42,11 +46,37 @@ const createdFiles = danger.git.created_files;
 const modifiedFiles = danger.git.modified_files;
 const fileChanges = [...modifiedFiles, ...createdFiles];
 const declaredTrivial = danger.github.pr.title.includes('#trivial');
-const markdown = fileChanges.filter(path => path.endsWith('md'));
+const markdownChanges = fileChanges.filter(path => path.endsWith('md'));
+
+const thanksGifs = [
+  'https://media.giphy.com/media/KJ1f5iTl4Oo7u/giphy.gif', // T.Hanks
+  'https://media.giphy.com/media/6tHy8UAbv3zgs/giphy.gif', // Spongebob
+  'https://media.giphy.com/media/xULW8v7LtZrgcaGvC0/giphy.gif', // Dog
+  'https://media.giphy.com/media/GghJ32T5oPR8Q/giphy.gif', // Leslie Knope
+  'https://media.giphy.com/media/26AHAw0aMmWwRI4Hm/giphy.gif', // David Mitchell
+  'https://media.giphy.com/media/mbhseRYedlG5W/giphy.gif', // That guy from Who's Line Is It Anyway who looks like Bill Murray
+  'https://media.giphy.com/media/3o6ZsXRBB9E67nUjL2/giphy.gif', // We love you
+  'https://media.giphy.com/media/l3V0sNZ0NGomeurCM/giphy.gif', // Bowie
+  'https://media.giphy.com/media/3rgXBvoeXt3MXlqhO0/giphy.gif', // Amazement
+  'https://media.giphy.com/media/1OnDp7RwgphjG/giphy.gif', // Kumamon
+  'https://media.giphy.com/media/1lk1IcVgqPLkA/giphy.gif', // Cap salute
+];
 
 // Be nice to our neighbours.
 if (isPrExternal) {
-  message('Thanks for the PR 🎉.');
+  markdown(`
+  # Hi ${author}!
+
+  Thanks for the PR 🎉! Contributions like yours help to improve the design system
+  for everybody and we appreciate you taking the effort to create this PR.
+
+  ![Thanks](${getRandomFromArray(thanksGifs)})
+
+  - [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)
+
+  If you're curious about how we review, please read through the
+  [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md).
+  `);
 }
 
 // Ensure new components are extensible by consumers.
@@ -58,6 +88,25 @@ if (componentIntroduced) {
   warn(
     'It looks like you are introducing a new component. Ensure the component style is extensible via `className`.',
   );
+}
+
+const componentChangedOrCreated = fileChanges.some(filePath =>
+  filePath.match(/packages\/bpk-component.+\/src\/.+\.js/),
+);
+
+if (componentChangedOrCreated) {
+  message(`
+  ## Browser support
+
+  Please complete this list of browsers that you've checked this works in.
+
+  - [ ] IE11
+  - [ ] Edge
+  - [ ] Safari (iOS)
+  - [ ] Chrome (Android)
+  - [ ] Chrome (Desktop)
+  - [ ] Firefox (Deesktop)
+  `);
 }
 
 // If any of the packages have changed, the UNRELEASED log should have been updated.
@@ -118,7 +167,7 @@ if (unlicensedFiles.length > 0) {
   );
 }
 
-markdown.forEach(path => {
+markdownChanges.forEach(path => {
   const fileContent = fs.readFileSync(path);
 
   fileContent

--- a/meta.json
+++ b/meta.json
@@ -14,7 +14,7 @@
     },
     {
       "npm": "shaundon",
-      "github": "shaundontest"
+      "github": "shaundon"
     },
     {
       "npm": "tiagohngl",

--- a/meta.json
+++ b/meta.json
@@ -14,7 +14,7 @@
     },
     {
       "npm": "shaundon",
-      "github": "shaundon"
+      "github": "shaundontest"
     },
     {
       "npm": "tiagohngl",


### PR DESCRIPTION
I think we can utilise Danger more than we currently are to improve the contribution process and remind us/consumers to do certain things, like cross-browser testing.

This PR:

- Moves the 'have you read the contribution guide' message to a Danger rule that is only shown to contributors.
- Sends a nice motivational message as well as a random gif to external contributors.
- Prints a checklist of browsers to check in when components have changed.

**This is a first step.** We can put more things in here later, but I thought this would be a good way to get the ball rolling.

There's a comment below from Backpack bot showing what users would see. I changed my github username in `meta.json` so Danger would think I was external, but ordinarily only external squad members would see this.