### PR TITLE
Fix warning message when hydrating BpkImage

### DIFF
--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -38,6 +38,7 @@ type BpkImageProps = {
   className: ?string,
   onLoad: ?() => mixed,
   style: ?{}, // eslint-disable-line react/forbid-prop-types
+  suppressHydrationWarning: boolean,
 };
 
 type ImageProps = {

--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -144,6 +144,7 @@ class BpkImage extends Component<BpkImageProps> {
           }}
           style={{ height: 0, paddingBottom: aspectRatioPc }}
           className={classNames.join(' ')}
+          suppressHydrationWarning={this.props.suppressHydrationWarning || false}
         >
           {/*
             Image needs to come before the spinner to avoid a problem where

--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -144,7 +144,7 @@ class BpkImage extends Component<BpkImageProps> {
           }}
           style={{ height: 0, paddingBottom: aspectRatioPc }}
           className={classNames.join(' ')}
-          suppressHydrationWarning={this.props.suppressHydrationWarning || false}
+          suppressHydrationWarning={this.props.suppressHydrationWarning}
         >
           {/*
             Image needs to come before the spinner to avoid a problem where
@@ -201,6 +201,7 @@ BpkImage.propTypes = {
   loading: PropTypes.bool,
   onLoad: PropTypes.func,
   style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  suppressHydrationWarning: PropTypes.bool,
 };
 
 BpkImage.defaultProps = {
@@ -209,6 +210,7 @@ BpkImage.defaultProps = {
   loading: false,
   onLoad: null,
   style: {},
+  suppressHydrationWarning: false,
 };
 
 export default BpkImage;

--- a/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
+++ b/packages/bpk-component-image/src/__snapshots__/BpkImage-test.js.snap
@@ -17,12 +17,14 @@ exports[`BpkImage should accept userland className 1`] = `
         "paddingBottom": "66.66666666666667%",
       }
     }
+    suppressHydrationWarning={false}
   >
     <img
       alt="image description"
       className="bpk-image__img"
       onLoad={[Function]}
       src="./path/to/image.jpg"
+      suppressHydrationWarning={false}
     />
   </div>
 </div>
@@ -45,12 +47,14 @@ exports[`BpkImage should accept userland styling 1`] = `
         "paddingBottom": "66.66666666666667%",
       }
     }
+    suppressHydrationWarning={false}
   >
     <img
       alt="image description"
       className="bpk-image__img"
       onLoad={[Function]}
       src="./path/to/image.jpg"
+      suppressHydrationWarning={false}
     />
   </div>
 </div>
@@ -62,6 +66,7 @@ exports[`BpkImage should call onLoadCallback 1`] = `
   className="bpk-image__img"
   onLoad={[Function]}
   src="./path/to/image.jpg"
+  suppressHydrationWarning={false}
 />
 `;
 
@@ -78,6 +83,7 @@ exports[`BpkImage should have !inView behavior 1`] = `
         "paddingBottom": "66.66666666666667%",
       }
     }
+    suppressHydrationWarning={false}
   />
 </div>
 `;
@@ -95,12 +101,14 @@ exports[`BpkImage should have loading behavior 1`] = `
         "paddingBottom": "66.66666666666667%",
       }
     }
+    suppressHydrationWarning={false}
   >
     <img
       alt="image description"
       className="bpk-image__img bpk-image__img--hidden"
       onLoad={[Function]}
       src="./path/to/image.jpg"
+      suppressHydrationWarning={false}
     />
     <div
       className="bpk-image__spinner"
@@ -198,6 +206,7 @@ exports[`BpkImage should load even without onLoadCallback 1`] = `
   className="bpk-image__img"
   onLoad={[Function]}
   src="./path/to/image.jpg"
+  suppressHydrationWarning={false}
 />
 `;
 
@@ -214,12 +223,14 @@ exports[`BpkImage should render correctly 1`] = `
         "paddingBottom": "66.66666666666667%",
       }
     }
+    suppressHydrationWarning={false}
   >
     <img
       alt="image description"
       className="bpk-image__img"
       onLoad={[Function]}
       src="./path/to/image.jpg"
+      suppressHydrationWarning={false}
     />
   </div>
 </div>
@@ -238,6 +249,7 @@ exports[`BpkImage should support srcSet 1`] = `
         "paddingBottom": "66.66666666666667%",
       }
     }
+    suppressHydrationWarning={false}
   >
     <img
       alt="image description"
@@ -246,6 +258,7 @@ exports[`BpkImage should support srcSet 1`] = `
       sizes="(min-width: 71.25rem) 48rem, (min-width: 50.25rem) calc(100vw - 18rem), calc(100vw - 4.5rem)"
       src="./path/to/image_1640.jpg"
       srcSet="./path/to/image_320px.jpg 320w, ./path/to/image_640px.jpg 640w, ./path/to/image_1640px.jpg 1640w, ./path/to/image_3200px.jpg 3200w"
+      suppressHydrationWarning={false}
     />
   </div>
 </div>


### PR DESCRIPTION
## Background

This PR adds the suppressHydrationWarning flag to BpkImage, allowing for the warning to be suppressed in special circumstances.

## Changes

* Adds optional `suppressHydrationWarning` prop to BpkImage component

[React Docs on the suppressHydrationWarning flag](https://reactjs.org/docs/react-dom.html#hydrate)
