### PR TITLE
Add `yAxisDomain` to barchart component

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -488,6 +488,7 @@ xAxisTickEvery
 yAxisMargin
 yAxisTickValue
 yAxisNumTicks
+yAxisDomain
 withAccordionItemState
 
 BpkAccordion

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -24,3 +24,7 @@
 #   FIXED:
 #     - bpk-component-horcrux:
 #       - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+ADDED:
+  - bpk-component-barchart:
+    - New `yAxisDomain` prop to set a custom y axis domain.

--- a/packages/bpk-component-barchart/README.md
+++ b/packages/bpk-component-barchart/README.md
@@ -25,7 +25,7 @@ const priceData = [
 export default () => (
   <BpkBarchart
     xAxisLabel="Weekday"
-    yAxislabel="Price (£)"
+    yAxisLabel="Price (£)"
     xScaleDataKey="day"
     yScaleDataKey="price"
     initialWidth={500}
@@ -37,34 +37,35 @@ export default () => (
 
 ### Props
 
-| Property                                | PropType                              | Required | Default Value    |
-| --------------------------------------- | ------------------------------------- | -------- | ---------------- |
-| [data](#data)                           | custom(validates usage of scale keys) | true     | -                |
-| [xScaleDataKey](#xscaledatakey)         | string                                | true     | -                |
-| [yScaleDataKey](#yscaledatakey)         | string                                | true     | -                |
-| xAxisLabel                              | string                                | true     | -                |
-| yAxisLabel                              | string                                | true     | -                |
-| initialWidth                            | number                                | true     | -                |
-| initialHeight                           | number                                | true     | -                |
-| className                               | string                                | false    | null             |
-| leadingScrollIndicatorClassName         | string                                | false    | null             |
-| trailingScrollIndicatorClassName        | string                                | false    | null             |
-| [outlierPercentage](#outlierpercentage) | number                                | false    | null             |
-| showGridlines                           | bool                                  | false    | false            |
-| xAxisMargin                             | number                                | false    | 3                |
-| xAxisTickValue                          | func                                  | false    | identity         |
-| xAxisTickOffset                         | number                                | false    | 0                |
-| xAxisTickEvery                          | number                                | false    | 1                |
-| yAxisMargin                             | number                                | false    | 2.625            |
-| yAxisTickValue                          | func                                  | false    | identity         |
-| yAxisNumTicks                           | number                                | false    | null             |
-| [onBarClick](#onbarclick)               | func                                  | false    | null             |
-| [onBarHover](#onbarhover)               | func                                  | false    | null             |
-| [onBarFocus](#onbarfocus)               | func                                  | false    | null             |
-| [getBarLabel](#getbarlabel)             | func                                  | false    | See prop details |
-| [getBarSelection](#getbarselection)     | func                                  | false    | See prop details |
-| BarComponent                            | func                                  | false    | BpkBarchartBar   |
-| disableDataTable                        | bool                                  | false    | false            |
+| Property                                | PropType                              | Required | Default Value           |
+| --------------------------------------- | ------------------------------------- | -------- | ----------------------- |
+| [data](#data)                           | custom(validates usage of scale keys) | true     | -                       |
+| [xScaleDataKey](#xscaledatakey)         | string                                | true     | -                       |
+| [yScaleDataKey](#yscaledatakey)         | string                                | true     | -                       |
+| xAxisLabel                              | string                                | true     | -                       |
+| yAxisLabel                              | string                                | true     | -                       |
+| initialWidth                            | number                                | true     | -                       |
+| initialHeight                           | number                                | true     | -                       |
+| className                               | string                                | false    | null                    |
+| leadingScrollIndicatorClassName         | string                                | false    | null                    |
+| trailingScrollIndicatorClassName        | string                                | false    | null                    |
+| [outlierPercentage](#outlierpercentage) | number                                | false    | null                    |
+| showGridlines                           | bool                                  | false    | false                   |
+| xAxisMargin                             | number                                | false    | 3                       |
+| xAxisTickValue                          | func                                  | false    | identity                |
+| xAxisTickOffset                         | number                                | false    | 0                       |
+| xAxisTickEvery                          | number                                | false    | 1                       |
+| yAxisMargin                             | number                                | false    | 2.625                   |
+| yAxisTickValue                          | func                                  | false    | identity                |
+| yAxisNumTicks                           | number                                | false    | null                    |
+| yAxisDomain                             | array                                 | false    | Calculated by component |
+| [onBarClick](#onbarclick)               | func                                  | false    | null                    |
+| [onBarHover](#onbarhover)               | func                                  | false    | null                    |
+| [onBarFocus](#onbarfocus)               | func                                  | false    | null                    |
+| [getBarLabel](#getbarlabel)             | func                                  | false    | See prop details        |
+| [getBarSelection](#getbarselection)     | func                                  | false    | See prop details        |
+| BarComponent                            | func                                  | false    | BpkBarchartBar          |
+| disableDataTable                        | bool                                  | false    | false                   |
 
 ### Theme Props
 
@@ -121,6 +122,17 @@ The key in each data point that holds the value for the x axis of that data poin
 #### yScaleDataKey
 
 The key in each data point that holds the value for the y axis of that data point.
+
+#### yAxisDomain
+
+Override the default y axis domain.  This is an array with two elements, the lower then upper domain.  If either value is set to `null` the default value is used instead.
+
+```javascript
+<BpkBarchart
+  ...
+  yAxisDomain={[null, 100]} // The y axis will go from 0 (the default) to 100.
+/>
+```
 
 #### `outlierPercentage`
 

--- a/packages/bpk-component-barchart/src/BpkBarchart-test.js
+++ b/packages/bpk-component-barchart/src/BpkBarchart-test.js
@@ -202,4 +202,19 @@ describe('BpkBarchart', () => {
     );
     expect(toJson(tree)).toMatchSnapshot();
   });
+  it('should render correctly with "yAxisDomain" prop', () => {
+    const tree = shallow(
+      <BpkBarchart
+        xScaleDataKey="month"
+        yScaleDataKey="price"
+        xAxisLabel="Month"
+        yAxisLabel="Average price (£)"
+        initialWidth={size}
+        initialHeight={size}
+        data={prices}
+        yAxisDomain={[null, 100]}
+      />,
+    );
+    expect(toJson(tree)).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-barchart/src/BpkBarchart.js
+++ b/packages/bpk-component-barchart/src/BpkBarchart.js
@@ -109,6 +109,7 @@ class BpkBarchart extends Component {
       yAxisLabel,
       yAxisTickValue,
       yAxisNumTicks,
+      yAxisDomain,
       onBarClick,
       onBarHover,
       onBarFocus,
@@ -143,7 +144,7 @@ class BpkBarchart extends Component {
     this.xScale.rangeRound([0, width]);
     this.xScale.domain(transformedData.map(d => d[xScaleDataKey]));
     this.yScale.rangeRound([height, 0]);
-    this.yScale.domain([0, maxYValue]);
+    this.yScale.domain([yAxisDomain[0] || 0, yAxisDomain[1] || maxYValue]);
 
     return (
       <BpkMobileScrollContainer
@@ -246,6 +247,7 @@ BpkBarchart.propTypes = {
   yAxisMargin: PropTypes.number,
   yAxisTickValue: PropTypes.func,
   yAxisNumTicks: PropTypes.number,
+  yAxisDomain: PropTypes.arrayOf(PropTypes.number),
   onBarClick: PropTypes.func,
   onBarHover: PropTypes.func,
   onBarFocus: PropTypes.func,
@@ -269,6 +271,7 @@ BpkBarchart.defaultProps = {
   yAxisMargin: 4 * lineHeight + spacing,
   yAxisTickValue: identity,
   yAxisNumTicks: null,
+  yAxisDomain: [null, null],
   onBarClick: null,
   onBarHover: null,
   onBarFocus: null,

--- a/packages/bpk-component-barchart/src/__snapshots__/BpkBarchart-test.js.snap
+++ b/packages/bpk-component-barchart/src/__snapshots__/BpkBarchart-test.js.snap
@@ -812,6 +812,209 @@ exports[`BpkBarchart should render correctly with "trailingScrollIndicatorClassN
 </BpkMobileScrollContainer>
 `;
 
+exports[`BpkBarchart should render correctly with "yAxisDomain" prop 1`] = `
+<BpkMobileScrollContainer
+  className={null}
+  innerContainerTagName="div"
+  leadingIndicatorClassName={null}
+  scrollerRef={null}
+  style={null}
+  trailingIndicatorClassName={null}
+>
+  <BpkChartDataTable
+    data={
+      Array [
+        Object {
+          "month": "Jan",
+          "price": 305,
+        },
+        Object {
+          "month": "Feb",
+          "price": 348,
+        },
+        Object {
+          "month": "Mar",
+          "price": 418,
+        },
+        Object {
+          "month": "Apr",
+          "price": 448,
+        },
+        Object {
+          "month": "May",
+          "price": 344,
+        },
+        Object {
+          "month": "Jun",
+          "price": 322,
+        },
+        Object {
+          "month": "Jul",
+          "price": 340,
+        },
+        Object {
+          "month": "Aug",
+          "price": 327,
+        },
+        Object {
+          "month": "Sep",
+          "price": 444,
+        },
+        Object {
+          "month": "Oct",
+          "price": 422,
+        },
+        Object {
+          "month": "Nov",
+          "price": 344,
+        },
+        Object {
+          "month": "Dec",
+          "price": 301,
+        },
+      ]
+    }
+    xAxisLabel="Month"
+    xScaleDataKey="month"
+    yAxisLabel="Average price (£)"
+    yScaleDataKey="price"
+  />
+  <svg
+    className="bpk-barchart"
+    height={200}
+    width={200}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <BpkBarchartDefs />
+    <BpkChartMargin
+      margin={
+        Object {
+          "bottom": 48,
+          "left": 78,
+          "right": 0,
+          "top": 6,
+        }
+      }
+    >
+      <BpkChartAxis
+        height={200}
+        label="Average price (£)"
+        margin={
+          Object {
+            "bottom": 48,
+            "left": 78,
+            "right": 0,
+            "top": 6,
+          }
+        }
+        numTicks={null}
+        orientation="y"
+        scale={[Function]}
+        tickEvery={1}
+        tickOffset={0}
+        tickValue={[Function]}
+        width={200}
+      />
+      <BpkChartAxis
+        height={200}
+        label="Month"
+        margin={
+          Object {
+            "bottom": 48,
+            "left": 78,
+            "right": 0,
+            "top": 6,
+          }
+        }
+        numTicks={null}
+        orientation="x"
+        scale={[Function]}
+        tickEvery={1}
+        tickOffset={0}
+        tickValue={[Function]}
+        width={200}
+      />
+      <BpkBarchartBars
+        BarComponent={[Function]}
+        data={
+          Array [
+            Object {
+              "month": "Jan",
+              "price": 305,
+            },
+            Object {
+              "month": "Feb",
+              "price": 348,
+            },
+            Object {
+              "month": "Mar",
+              "price": 418,
+            },
+            Object {
+              "month": "Apr",
+              "price": 448,
+            },
+            Object {
+              "month": "May",
+              "price": 344,
+            },
+            Object {
+              "month": "Jun",
+              "price": 322,
+            },
+            Object {
+              "month": "Jul",
+              "price": 340,
+            },
+            Object {
+              "month": "Aug",
+              "price": 327,
+            },
+            Object {
+              "month": "Sep",
+              "price": 444,
+            },
+            Object {
+              "month": "Oct",
+              "price": 422,
+            },
+            Object {
+              "month": "Nov",
+              "price": 344,
+            },
+            Object {
+              "month": "Dec",
+              "price": 301,
+            },
+          ]
+        }
+        getBarLabel={[Function]}
+        getBarSelection={[Function]}
+        height={200}
+        innerPadding={0.35}
+        margin={
+          Object {
+            "bottom": 48,
+            "left": 78,
+            "right": 0,
+            "top": 6,
+          }
+        }
+        maxYValue={448}
+        onBarClick={null}
+        onBarFocus={null}
+        onBarHover={null}
+        outerPadding={0}
+        xScale={[Function]}
+        xScaleDataKey="month"
+        yScale={[Function]}
+        yScaleDataKey="price"
+      />
+    </BpkChartMargin>
+  </svg>
+</BpkMobileScrollContainer>
+`;
+
 exports[`BpkBarchart should render with "disableDataTable" prop 1`] = `
 <BpkMobileScrollContainer
   className={null}

--- a/packages/bpk-component-barchart/stories.js
+++ b/packages/bpk-component-barchart/stories.js
@@ -279,4 +279,34 @@ storiesOf('bpk-component-barchart', module)
       yAxisLabel="Average Price (£)"
       showGridlines
     />
+  ))
+  .add('Custom yAxisDomain', () => (
+    <div>
+      <Heading>Domain (0 - 800)</Heading>
+      <RtlBarchart
+        initialWidth={500}
+        initialHeight={300}
+        data={data.prices}
+        xScaleDataKey="month"
+        yScaleDataKey="price"
+        style={{
+          maxWidth: '580px',
+        }}
+        showGridlines
+        yAxisDomain={[0, 800]}
+      />
+      <Heading>Domain (300 - null)</Heading>
+      <RtlBarchart
+        initialWidth={500}
+        initialHeight={300}
+        data={data.prices}
+        xScaleDataKey="month"
+        yScaleDataKey="price"
+        style={{
+          maxWidth: '580px',
+        }}
+        showGridlines
+        yAxisDomain={[300, null]}
+      />
+    </div>
   ));


### PR DESCRIPTION
The y axis domain is currently hardcoded to 0 and the height of the
largest bar.  This results in the inability to accurately show
percentage based data or small variations in large values.

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
