### PR TITLE
[ABS-2199] Disables even when href prop present

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -1,4 +1,7 @@
 # UNRELEASED:
+FIXED:
+  - bpk-component-button:
+    - Fixed issue where `BpkButton` would ignore disabled prop when href prop is provided.
 
 # How to write a good changelog entry:
 #

--- a/packages/bpk-component-button/src/BpkButton-test.js
+++ b/packages/bpk-component-button/src/BpkButton-test.js
@@ -148,4 +148,15 @@ describe('BpkButton', () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with "disabled" and "href" attributes', () => {
+    const tree = renderer
+      .create(
+        <BpkButton href="#" disabled>
+          My button
+        </BpkButton>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-button/src/BpkButton.js
+++ b/packages/bpk-component-button/src/BpkButton.js
@@ -107,7 +107,7 @@ const BpkButton = (props: Props) => {
   const target = blank ? '_blank' : null;
   const rel = blank ? propRel || 'noopener noreferrer' : propRel;
 
-  if (href) {
+  if (!disabled && href) {
     return (
       <a
         href={href}

--- a/packages/bpk-component-button/src/__snapshots__/BpkButton-test.js.snap
+++ b/packages/bpk-component-button/src/__snapshots__/BpkButton-test.js.snap
@@ -46,6 +46,17 @@ exports[`BpkButton should render correctly with "blank" attribute 1`] = `
 </a>
 `;
 
+exports[`BpkButton should render correctly with "disabled" and "href" attributes 1`] = `
+<button
+  className="bpk-button"
+  disabled={true}
+  onClick={null}
+  type="button"
+>
+  My button
+</button>
+`;
+
 exports[`BpkButton should render correctly with "large" and "secondary" attributes 1`] = `
 <button
   className="bpk-button bpk-button--secondary bpk-button--large"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

We noticed that `BpkButton` would not accept the `disabled` prop when the `href` prop is present. This was tracked down to the code not respecting the `disabled` prop when a `href` prop is present.

This change checks the `disabled` prop before considering the `href` prop.
