### PR TITLE
[BPK-2784] Add IE11 support to Storybook webpack config

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -13,8 +13,18 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        use: ['babel-loader'],
         exclude: /node_modules\/(?!bpk-).*/,
+        loader: 'babel-loader',
+        options: {
+          presets: [
+            [
+              '@babel/preset-env',
+              {
+                targets: { browsers: ['ie >= 11'] },
+              },
+            ],
+          ],
+        },
       },
       {
         test: /\.scss$/,


### PR DESCRIPTION
Storybook wasn't working in IE11. I changed the `env` setting in the Webpack config for Storybook and it seems to be ok now 😄 

![Screen Shot 2019-08-08 at 12 37 58](https://user-images.githubusercontent.com/73652/62700322-8b712280-b9d9-11e9-8c3b-c311ae2a7372.png)
