### PR TITLE
[No JIRA] Add example of using classnames

### DIFF
--- a/packages/bpk-component-mobile-scroll-container/stories.js
+++ b/packages/bpk-component-mobile-scroll-container/stories.js
@@ -22,6 +22,7 @@ import React from 'react';
 import BpkButton from 'bpk-component-button';
 import { storiesOf } from '@storybook/react';
 import { linkTo } from '@storybook/addon-links';
+import { cssModules } from 'bpk-react-utils';
 import { onePixelRem } from 'bpk-tokens/tokens/base.es6';
 import {
   BpkTable,
@@ -32,7 +33,11 @@ import {
   BpkTableHeadCell,
 } from 'bpk-component-table';
 
+import STYLES from './stories.scss';
+
 import BpkMobileScrollContainer from './index';
+
+const getClassName = cssModules(STYLES);
 
 storiesOf('bpk-component-mobile-scroll-container', module)
   .add('Default', () => (
@@ -65,6 +70,46 @@ storiesOf('bpk-component-mobile-scroll-container', module)
       </BpkTable>
     </BpkMobileScrollContainer>
   ))
+  .add(
+    'Setting leadingIndicatorClassName and trailingIndicatorClassName',
+    () => (
+      <BpkMobileScrollContainer
+        leadingIndicatorClassName={getClassName(
+          'bpk-stories-mobile-scroll-container__leading-indicator',
+        )}
+        trailingIndicatorClassName={getClassName(
+          'bpk-stories-mobile-scroll-container__trailing-indicator',
+        )}
+      >
+        <BpkTable style={{ minWidth: `calc(500 * ${onePixelRem})` }}>
+          <BpkTableHead>
+            <BpkTableRow>
+              <BpkTableHeadCell>Column 1</BpkTableHeadCell>
+              <BpkTableHeadCell>Column 2</BpkTableHeadCell>
+              <BpkTableHeadCell>Column 3</BpkTableHeadCell>
+            </BpkTableRow>
+          </BpkTableHead>
+          <BpkTableBody>
+            <BpkTableRow>
+              <BpkTableCell>Entry 1</BpkTableCell>
+              <BpkTableCell>Entry 2</BpkTableCell>
+              <BpkTableCell>Entry 3</BpkTableCell>
+            </BpkTableRow>
+            <BpkTableRow>
+              <BpkTableCell>Entry 4</BpkTableCell>
+              <BpkTableCell>Entry 5</BpkTableCell>
+              <BpkTableCell>Entry 6</BpkTableCell>
+            </BpkTableRow>
+            <BpkTableRow>
+              <BpkTableCell>Entry 7</BpkTableCell>
+              <BpkTableCell>Entry 8</BpkTableCell>
+              <BpkTableCell>Entry 9</BpkTableCell>
+            </BpkTableRow>
+          </BpkTableBody>
+        </BpkTable>
+      </BpkMobileScrollContainer>
+    ),
+  )
   .add('Horizontal nav', () => (
     <BpkButton onClick={linkTo('bpk-component-horizontal-nav', 'Example')}>
       See horizontal nav example

--- a/packages/bpk-component-mobile-scroll-container/stories.scss
+++ b/packages/bpk-component-mobile-scroll-container/stories.scss
@@ -1,0 +1,29 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '~bpk-mixins';
+
+.bpk-stories-mobile-scroll-container {
+  &__leading-indicator {
+    @include bpk-scroll-indicator-left($bpk-color-blue-500);
+  }
+
+  &__trailing-indicator {
+    @include bpk-scroll-indicator-right($bpk-color-blue-500);
+  }
+}


### PR DESCRIPTION
Added an example of using `BpkMobileScrollContainer`'s `leadingIndicatorClassName` and `trailingIndicatorClassName` props, to demonstrate to consumers.

![Screen Shot 2019-08-08 at 15 49 47](https://user-images.githubusercontent.com/73652/62713284-6211c000-b9f4-11e9-956e-9ea460906155.png)
