### PR TITLE
BPK: Add Font Weight Black

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -17,9 +17,11 @@
 #       - Replaced `charmeleon` icon with new `charizard` icon. To upgrade, replace your references to `charmeleon` with `charizard`.
 #       - Upgraded `fire` dependency to `3.0.0`.
 #
-#   ADDED:
-#     - bpk-component-infinity-gauntlet:
-#       - New `timeStone` prop for controlling time. See <link to docs site>.
+ADDED:
+  - bpk-tokens:
+    - Added new token for font weight black (equivalent to 900).
+  - bpk-mixins:
+    - Added new mixins for font weight black
 #
 #   FIXED:
 #     - bpk-component-horcrux:

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -20,8 +20,6 @@
 ADDED:
   - bpk-tokens:
     - Added new token for font weight black (equivalent to 900).
-  - bpk-mixins:
-    - Added new mixins for font weight black
 #
 #   FIXED:
 #     - bpk-component-horcrux:

--- a/packages/bpk-mixins/src/mixins/_typography.scss
+++ b/packages/bpk-mixins/src/mixins/_typography.scss
@@ -261,31 +261,6 @@
   @include bpk-text--bold;
 }
 
-/// Black text style
-///
-/// @require {mixin} bpk-text
-///
-/// @example scss
-///   .selector {
-///     @include bpk-text;
-///     @include bpk-text--black;
-///   }
-
-@mixin bpk-text--black {
-  font-weight: $bpk-font-weight-black;
-}
-
-/// Black text style (without margin reset)
-///
-/// @example scss
-///   .selector {
-///     @include bpk-text-black;
-///   }
-
-@mixin bpk-text-black {
-  @include bpk-text--black;
-}
-
 /// Level 1 heading.
 ///
 /// @example scss

--- a/packages/bpk-mixins/src/mixins/_typography.scss
+++ b/packages/bpk-mixins/src/mixins/_typography.scss
@@ -261,6 +261,31 @@
   @include bpk-text--bold;
 }
 
+/// Black text style
+///
+/// @require {mixin} bpk-text
+///
+/// @example scss
+///   .selector {
+///     @include bpk-text;
+///     @include bpk-text--black;
+///   }
+
+@mixin bpk-text--black {
+  font-weight: $bpk-font-weight-black;
+}
+
+/// Black text style (without margin reset)
+///
+/// @example scss
+///   .selector {
+///     @include bpk-text-black;
+///   }
+
+@mixin bpk-text-black {
+  @include bpk-text--black;
+}
+
 /// Level 1 heading.
 ///
 /// @example scss

--- a/packages/bpk-tokens/src/web/base/aliases.json
+++ b/packages/bpk-tokens/src/web/base/aliases.json
@@ -10,6 +10,7 @@
     "FONT_SIZE_XL": "1.75rem",
     "FONT_SIZE_XXL": "2.625rem",
     "FONT_WEIGHT_BOLD": "700",
+    "FONT_WEIGHT_BLACK": "900",
     "SPACING_XS": ".375rem",
     "SPACING_SM": ".75rem",
     "SPACING_MD": "1.125rem",

--- a/packages/bpk-tokens/src/web/base/typography.json
+++ b/packages/bpk-tokens/src/web/base/typography.json
@@ -73,6 +73,11 @@
       "type": "string",
       "category": "font-weights"
     },
+    "FONT_WEIGHT_BLACK": {
+      "value": "{!FONT_WEIGHT_BLACK}",
+      "type": "string",
+      "category": "font-weights"
+    },
     "H6_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
       "type": "font-size",

--- a/packages/bpk-tokens/tokens/base.common.js
+++ b/packages/bpk-tokens/tokens/base.common.js
@@ -252,6 +252,7 @@ module.exports = {
   fontSizeSm: ".75rem",
   fontSizeXl: "1.75rem",
   fontSizeXxl: "2.625rem",
+  fontWeightBlack: "900",
   fontWeightBold: "700",
   formValidationArrowSize: ".375rem",
   formValidationBackgroundColor: "rgb(255, 84, 82)",

--- a/packages/bpk-tokens/tokens/base.default.scss
+++ b/packages/bpk-tokens/tokens/base.default.scss
@@ -1,21 +1,21 @@
 /*
- *
+ * 
  * Backpack - Skyscanner's Design System
- *
+ * 
  * Copyright 2016-2019 Skyscanner Ltd
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ * 
  */
 /// @group autosuggest
 $bpk-autosuggest-list-background-color: rgb(255, 255, 255) !default;
@@ -484,9 +484,9 @@ $bpk-font-size-xl: 1.75rem !default;
 /// @group typesettings
 $bpk-font-size-xxl: 2.625rem !default;
 /// @group font-weights
-$bpk-font-weight-bold: 700 !default;
-/// @group font-weights
 $bpk-font-weight-black: 900 !default;
+/// @group font-weights
+$bpk-font-weight-bold: 700 !default;
 /// @group forms
 $bpk-form-validation-arrow-size: .375rem !default;
 /// @group forms

--- a/packages/bpk-tokens/tokens/base.default.scss
+++ b/packages/bpk-tokens/tokens/base.default.scss
@@ -1,21 +1,21 @@
 /*
- * 
+ *
  * Backpack - Skyscanner's Design System
- * 
+ *
  * Copyright 2016-2019 Skyscanner Ltd
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 /// @group autosuggest
 $bpk-autosuggest-list-background-color: rgb(255, 255, 255) !default;
@@ -485,6 +485,8 @@ $bpk-font-size-xl: 1.75rem !default;
 $bpk-font-size-xxl: 2.625rem !default;
 /// @group font-weights
 $bpk-font-weight-bold: 700 !default;
+/// @group font-weights
+$bpk-font-weight-black: 900 !default;
 /// @group forms
 $bpk-form-validation-arrow-size: .375rem !default;
 /// @group forms

--- a/packages/bpk-tokens/tokens/base.es6.js
+++ b/packages/bpk-tokens/tokens/base.es6.js
@@ -250,6 +250,7 @@ export const fontSizeRoot = "100%";
 export const fontSizeSm = ".75rem";
 export const fontSizeXl = "1.75rem";
 export const fontSizeXxl = "2.625rem";
+export const fontWeightBlack = "900";
 export const fontWeightBold = "700";
 export const formValidationArrowSize = ".375rem";
 export const formValidationBackgroundColor = "rgb(255, 84, 82)";
@@ -658,6 +659,7 @@ textXsFontSize,
 textXxlFontSize,
 };
 export const fontWeights = {
+fontWeightBlack,
 fontWeightBold,
 h1FontWeight,
 h2FontWeight,

--- a/packages/bpk-tokens/tokens/base.raw.json
+++ b/packages/bpk-tokens/tokens/base.raw.json
@@ -90,6 +90,9 @@
     "FONT_SIZE_XXL": {
       "value": "2.625rem"
     },
+    "FONT_WEIGHT_BLACK": {
+      "value": "900"
+    },
     "FONT_WEIGHT_BOLD": {
       "value": "700"
     },
@@ -1937,6 +1940,13 @@
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "FONT_SIZE_XXL"
     },
+    "FONT_WEIGHT_BLACK": {
+      "value": "900",
+      "type": "string",
+      "category": "font-weights",
+      "originalValue": "{!FONT_WEIGHT_BLACK}",
+      "name": "FONT_WEIGHT_BLACK"
+    },
     "FONT_WEIGHT_BOLD": {
       "value": "700",
       "type": "string",
@@ -3340,6 +3350,7 @@
     "FONT_SIZE_SM",
     "FONT_SIZE_XL",
     "FONT_SIZE_XXL",
+    "FONT_WEIGHT_BLACK",
     "FONT_WEIGHT_BOLD",
     "FORM_VALIDATION_ARROW_SIZE",
     "FORM_VALIDATION_BACKGROUND_COLOR",

--- a/packages/bpk-tokens/tokens/base.scss
+++ b/packages/bpk-tokens/tokens/base.scss
@@ -1,21 +1,21 @@
 /*
- * 
+ *
  * Backpack - Skyscanner's Design System
- * 
+ *
  * Copyright 2016-2019 Skyscanner Ltd
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 /// @group autosuggest
 $bpk-autosuggest-list-background-color: rgb(255, 255, 255);
@@ -485,6 +485,8 @@ $bpk-font-size-xl: 1.75rem;
 $bpk-font-size-xxl: 2.625rem;
 /// @group font-weights
 $bpk-font-weight-bold: 700;
+/// @group font-weights
+$bpk-font-weight-black: 900;
 /// @group forms
 $bpk-form-validation-arrow-size: .375rem;
 /// @group forms

--- a/packages/bpk-tokens/tokens/base.scss
+++ b/packages/bpk-tokens/tokens/base.scss
@@ -1,21 +1,21 @@
 /*
- *
+ * 
  * Backpack - Skyscanner's Design System
- *
+ * 
  * Copyright 2016-2019 Skyscanner Ltd
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ * 
  */
 /// @group autosuggest
 $bpk-autosuggest-list-background-color: rgb(255, 255, 255);
@@ -484,9 +484,9 @@ $bpk-font-size-xl: 1.75rem;
 /// @group typesettings
 $bpk-font-size-xxl: 2.625rem;
 /// @group font-weights
-$bpk-font-weight-bold: 700;
-/// @group font-weights
 $bpk-font-weight-black: 900;
+/// @group font-weights
+$bpk-font-weight-bold: 700;
 /// @group forms
 $bpk-form-validation-arrow-size: .375rem;
 /// @group forms

--- a/packages/bpk-tokens/tokens/breakpoints.raw.json
+++ b/packages/bpk-tokens/tokens/breakpoints.raw.json
@@ -90,6 +90,9 @@
     "FONT_SIZE_XXL": {
       "value": "2.625rem"
     },
+    "FONT_WEIGHT_BLACK": {
+      "value": "900"
+    },
     "FONT_WEIGHT_BOLD": {
       "value": "700"
     },

--- a/packages/bpk-tokens/tokens/travelpro.raw.json
+++ b/packages/bpk-tokens/tokens/travelpro.raw.json
@@ -114,6 +114,9 @@
     "FONT_SIZE_XXL": {
       "value": "2.625rem"
     },
+    "FONT_WEIGHT_BLACK": {
+      "value": "900"
+    },
     "FONT_WEIGHT_BOLD": {
       "value": "700"
     },


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

## Description

Adding a new bpk token for font weight of 900. The name is `bpk-font-weight-black`. 
Also adding mixins similar to `bpk-font-weight-bold`.

https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping