### PR TITLE
OC-693 - Invalid inputs should have a white background

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -1,3 +1,7 @@
+FIXED:
+  - bpk-component-input:
+      - Restoring white background for invalid input fields
+
 # UNRELEASED:
 # How to write a good changelog entry:
 #

--- a/packages/bpk-mixins/src/mixins/_forms.scss
+++ b/packages/bpk-mixins/src/mixins/_forms.scss
@@ -110,7 +110,7 @@
 @mixin bpk-input--invalid {
   padding-right: $bpk-spacing-base;
   border-color: $bpk-color-red-500;
-  background: $bpk-color-red-50 url(map-get($bpk-icons-sm, exclamation-circle-red-500)) no-repeat right $bpk-spacing-sm center;
+  background: $bpk-color-white url(map-get($bpk-icons-sm, exclamation-circle-red-500)) no-repeat right $bpk-spacing-sm center;
   background-size: $bpk-spacing-md $bpk-spacing-md;
 
   @include bpk-rtl {


### PR DESCRIPTION
This removes the red background on invalid fields and restores it to white

![image](https://user-images.githubusercontent.com/12796494/63876469-79bde200-c9bd-11e9-9c1f-f1bd538935e7.png)


Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
