### PR TITLE
[BPK-2812]: Patch for spacing issues

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -24,3 +24,7 @@
 #   FIXED:
 #     - bpk-component-horcrux:
 #       - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+FIXED:
+  - bpk-component-rating:
+    - Fixed spacing issue with vertical variant.

--- a/packages/bpk-component-rating/src/BpkRating.js
+++ b/packages/bpk-component-rating/src/BpkRating.js
@@ -56,6 +56,7 @@ const BpkRating = (props: Props) => {
   const scoreStyles = [
     getClassName('bpk-rating__component', `bpk-rating--${size}-rating`),
   ];
+  const textWrapperStyles = [getClassName('bpk-rating__text-wrapper')];
   const textStyles = [getClassName('bpk-rating__text')];
 
   let adjustedValue = value;
@@ -70,8 +71,12 @@ const BpkRating = (props: Props) => {
 
   if (vertical) {
     classNames.push(getClassName('bpk-rating--vertical'));
+    textWrapperStyles.push(getClassName('bpk-rating__text-wrapper--vertical'));
     textStyles.push(getClassName('bpk-rating__text--vertical'));
   } else {
+    textWrapperStyles.push(
+      getClassName('bpk-rating__text-wrapper--horizontal'),
+    );
     textStyles.push(getClassName('bpk-rating__text--horizontal'));
   }
 
@@ -91,7 +96,7 @@ const BpkRating = (props: Props) => {
       >
         <strong>{adjustedValue}</strong>
       </BpkText>
-      <div className={getClassName('bpk-rating__text-wrapper')}>
+      <div className={textWrapperStyles.join(' ')}>
         <BpkText
           className={textStyles.join(' ')}
           textStyle={RATING_SIZES[size]}

--- a/packages/bpk-component-rating/src/BpkRating.scss
+++ b/packages/bpk-component-rating/src/BpkRating.scss
@@ -56,11 +56,18 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+
+    &--horizontal {
+      padding-left: $bpk-spacing-sm;
+    }
+
+    &--vertical {
+      padding-top: $bpk-spacing-xs;
+    }
   }
 
   &__text {
     &--horizontal {
-      padding-left: $bpk-spacing-sm;
       text-align: left;
     }
 

--- a/packages/bpk-component-rating/src/__snapshots__/BpkRating-test.js.snap
+++ b/packages/bpk-component-rating/src/__snapshots__/BpkRating-test.js.snap
@@ -14,7 +14,7 @@ exports[`BpkRating should correctly handling values higher than 10 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
   >
     <span
       aria-hidden="true"
@@ -48,7 +48,7 @@ exports[`BpkRating should correctly handling values lower than 0 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
   >
     <span
       aria-hidden="true"
@@ -82,7 +82,7 @@ exports[`BpkRating should render a high score rating component 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
   >
     <span
       aria-hidden="true"
@@ -116,7 +116,7 @@ exports[`BpkRating should render a large rating component 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
   >
     <span
       aria-hidden="true"
@@ -150,7 +150,7 @@ exports[`BpkRating should render a low score rating component 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
   >
     <span
       aria-hidden="true"
@@ -184,7 +184,7 @@ exports[`BpkRating should render a medium score rating component 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
   >
     <span
       aria-hidden="true"
@@ -218,7 +218,7 @@ exports[`BpkRating should render a small rating component 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
   >
     <span
       aria-hidden="true"
@@ -252,7 +252,7 @@ exports[`BpkRating should render correctly 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
   >
     <span
       aria-hidden="true"
@@ -286,7 +286,7 @@ exports[`BpkRating should render vertical rating correctly 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--vertical"
   >
     <span
       aria-hidden="true"
@@ -320,7 +320,7 @@ exports[`BpkRating should support custom class names 1`] = `
     </strong>
   </span>
   <div
-    className="bpk-rating__text-wrapper"
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
   >
     <span
       aria-hidden="true"


### PR DESCRIPTION
This PR fixes a spacing issue betweewn the rating component and text on the vertical variants
![Screenshot 2019-09-13 at 12 23 09](https://user-images.githubusercontent.com/8831547/64859110-43b96880-d621-11e9-8d97-3d14cd41009e.png)
