### PR TITLE
[BPK-2938]: Added title only support by making subtitle optional

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -24,3 +24,7 @@
 #   FIXED:
 #     - bpk-component-horcrux:
 #       - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+ADDED:
+  - bpk-component-rating:
+    - Made `subtitle` prop optional to support title only variant of rating component.

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -27,4 +27,4 @@
 
 ADDED:
   - bpk-component-rating:
-    - Made `subtitle` prop optional to support title only variant of rating component.
+    - Made `subtitle` prop optional to support title-only variant of rating component.

--- a/packages/bpk-component-rating/README.md
+++ b/packages/bpk-component-rating/README.md
@@ -32,7 +32,7 @@ export default () => (
 | value     | number                | true     | -                 |
 | className | string                | false    | null              |
 | size      | oneOf(RATING_SIZES)   | false    | RATING_SIZES.base |
-| subtitle  | string                | false    | -                 |
+| subtitle  | string                | false    | null              |
 | vertical  | boolean               | false    | false             |
 
 ## Theme props

--- a/packages/bpk-component-rating/README.md
+++ b/packages/bpk-component-rating/README.md
@@ -18,7 +18,6 @@ export default () => (
   <BpkRating
     ariaLabel="9 Excellent would recommend"
     title="Excellent"
-    subtitle="Would recommend"
     value={9}
   />
 );
@@ -30,10 +29,10 @@ export default () => (
 | --------- | --------------------- | -------- | ----------------- |
 | ariaLabel | string                | true     | -                 |
 | title     | string                | true     | -                 |
-| subtitle  | string                | true     | -                 |
 | value     | number                | true     | -                 |
 | className | string                | false    | null              |
 | size      | oneOf(RATING_SIZES)   | false    | RATING_SIZES.base |
+| subtitle  | string                | false    | -                 |
 | vertical  | boolean               | false    | false             |
 
 ## Theme props

--- a/packages/bpk-component-rating/src/BpkRating-test.js
+++ b/packages/bpk-component-rating/src/BpkRating-test.js
@@ -37,6 +37,19 @@ describe('BpkRating', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should render title only correctly', () => {
+    const tree = renderer
+      .create(
+        <BpkRating
+          ariaLabel="6.7 Average might recommend"
+          title="Average"
+          value={6.7}
+        />,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should render vertical rating correctly', () => {
     const tree = renderer
       .create(

--- a/packages/bpk-component-rating/src/BpkRating.js
+++ b/packages/bpk-component-rating/src/BpkRating.js
@@ -80,10 +80,6 @@ const BpkRating = (props: Props) => {
     textStyles.push(getClassName('bpk-rating__text--horizontal'));
   }
 
-  // if(!subtitle) {
-
-  // }
-
   if (adjustedValue >= MAX_VALUE || adjustedValue <= MIN_VALUE) {
     adjustedValue = clamp(adjustedValue, MIN_VALUE, MAX_VALUE);
   } else {

--- a/packages/bpk-component-rating/src/BpkRating.js
+++ b/packages/bpk-component-rating/src/BpkRating.js
@@ -35,7 +35,7 @@ const MIN_VALUE = 0;
 export type Props = {
   ariaLabel: string,
   title: string,
-  subtitle: string,
+  subtitle: ?string,
   size: string,
   value: number,
   className: ?string,
@@ -80,6 +80,10 @@ const BpkRating = (props: Props) => {
     textStyles.push(getClassName('bpk-rating__text--horizontal'));
   }
 
+  // if(!subtitle) {
+
+  // }
+
   if (adjustedValue >= MAX_VALUE || adjustedValue <= MIN_VALUE) {
     adjustedValue = clamp(adjustedValue, MIN_VALUE, MAX_VALUE);
   } else {
@@ -105,14 +109,16 @@ const BpkRating = (props: Props) => {
         >
           <strong>{title}</strong>
         </BpkText>
-        <BpkText
-          className={textStyles.join(' ')}
-          textStyle={size === RATING_SIZES.lg ? 'base' : 'sm'}
-          tagName="span"
-          aria-hidden="true"
-        >
-          {subtitle}
-        </BpkText>
+        {subtitle && (
+          <BpkText
+            className={textStyles.join(' ')}
+            textStyle={size === RATING_SIZES.lg ? 'base' : 'sm'}
+            tagName="span"
+            aria-hidden="true"
+          >
+            {subtitle}
+          </BpkText>
+        )}
       </div>
     </div>
   );
@@ -121,16 +127,17 @@ const BpkRating = (props: Props) => {
 BpkRating.propTypes = {
   ariaLabel: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
   value: PropTypes.number.isRequired,
   className: PropTypes.string,
   size: PropTypes.oneOf(Object.keys(RATING_SIZES)),
+  subtitle: PropTypes.string,
   vertical: PropTypes.bool,
 };
 
 BpkRating.defaultProps = {
   className: null,
   size: RATING_SIZES.base,
+  subtitle: null,
   vertical: false,
 };
 

--- a/packages/bpk-component-rating/src/__snapshots__/BpkRating-test.js.snap
+++ b/packages/bpk-component-rating/src/__snapshots__/BpkRating-test.js.snap
@@ -272,6 +272,34 @@ exports[`BpkRating should render correctly 1`] = `
 </div>
 `;
 
+exports[`BpkRating should render title only correctly 1`] = `
+<div
+  aria-label="6.7 Average might recommend"
+  className="bpk-rating"
+>
+  <span
+    aria-hidden="true"
+    className="bpk-text bpk-text--base bpk-rating__component bpk-rating--base-rating bpk-rating--medium-rating"
+  >
+    <strong>
+      6.7
+    </strong>
+  </span>
+  <div
+    className="bpk-rating__text-wrapper bpk-rating__text-wrapper--horizontal"
+  >
+    <span
+      aria-hidden="true"
+      className="bpk-text bpk-text--base bpk-rating__text bpk-rating__text--horizontal"
+    >
+      <strong>
+        Average
+      </strong>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`BpkRating should render vertical rating correctly 1`] = `
 <div
   aria-label="6.7 Average might recommend"

--- a/packages/bpk-component-rating/stories.js
+++ b/packages/bpk-component-rating/stories.js
@@ -201,4 +201,53 @@ storiesOf('bpk-component-rating', module)
         vertical
       />
     </div>
+  ))
+  .add('Title only ratings', () => (
+    <div>
+      <BpkRating
+        ariaLabel="9 Excellent would recommend"
+        title="Excellent"
+        value={9}
+        size={RATING_SIZES.sm}
+      />
+      <br />
+      <BpkRating
+        ariaLabel="6.7 Average might recommend"
+        title="Average"
+        value={6.7}
+      />
+      <br />
+      <BpkRating
+        ariaLabel="2.3 Bad avoid here"
+        title="Bad"
+        value={2.3}
+        size={RATING_SIZES.lg}
+      />
+      <br />
+      <BpkRating
+        className={getClassName('bpk-rating-story')}
+        ariaLabel="9 Excellent would recommend"
+        title="Excellent"
+        value={9}
+        size={RATING_SIZES.sm}
+        vertical
+      />
+      <br />
+      <BpkRating
+        className={getClassName('bpk-rating-story')}
+        ariaLabel="6.7 Average might recommend"
+        title="Average"
+        value={6.7}
+        vertical
+      />
+      <br />
+      <BpkRating
+        className={getClassName('bpk-rating-story')}
+        ariaLabel="2.3 Bad avoid here"
+        title="Bad"
+        value={2.3}
+        size={RATING_SIZES.lg}
+        vertical
+      />
+    </div>
   ));


### PR DESCRIPTION
Added support to the `BpkRating` component to support title only scenario.

![Screenshot 2019-09-13 at 16 02 54](https://user-images.githubusercontent.com/8831547/64873068-411a3b80-d640-11e9-9288-870cd1d5c588.png)
