### PR TITLE
[ABS-2408]: Add 'roundRating' prop to Star Ratings

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -741,3 +741,6 @@ greedyGestureHandling
 ariaLabel
 props.label
 semver.org
+ - packages/bpk-component-star-rating/README.md
+ROUNDING_TYPES
+ROUNDING_TYPES.down

--- a/.spelling
+++ b/.spelling
@@ -741,6 +741,5 @@ greedyGestureHandling
 ariaLabel
 props.label
 semver.org
- - packages/bpk-component-star-rating/README.md
 ROUNDING_TYPES
 ROUNDING_TYPES.down

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -27,4 +27,4 @@
 
 ADDED:
   - bpk-component-star-rating
-    - Added `roundRating` prop to control rounding behaviour.
+    - Added `rounding` prop to control rounding behaviour.

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -24,3 +24,7 @@
 #   FIXED:
 #     - bpk-component-horcrux:
 #       - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+ADDED:
+  - bpk-component-star-rating
+    - Added `roundRating` prop to control rounding behaviour.

--- a/packages/bpk-component-star-rating/README.md
+++ b/packages/bpk-component-star-rating/README.md
@@ -51,7 +51,7 @@ export default () => (
 | large          | bool                    | false    | false         |
 | maxRating      | number                  | false    | 5             |
 | rating         | number                  | false    | 0             |
-| roundRating    | bool                    | false    | false         |
+| rounding       | func                    | false    | n => n        |
 
 ### BpkStar
 

--- a/packages/bpk-component-star-rating/README.md
+++ b/packages/bpk-component-star-rating/README.md
@@ -44,14 +44,14 @@ export default () => (
 
 ### BpkStarRating
 
-| Property       | PropType                | Required | Default Value |
-| -------------- | ----------------------- | -------- | ------------- |
-| ratingLabel    | oneOfType(string, func) | true     | -             |
-| className      | string                  | false    | null          |
-| large          | bool                    | false    | false         |
-| maxRating      | number                  | false    | 5             |
-| rating         | number                  | false    | 0             |
-| rounding       | func                    | false    | n => n        |
+| Property       | PropType                | Required | Default Value       |
+| -------------- | ----------------------- | -------- | ------------------- |
+| ratingLabel    | oneOfType(string, func) | true     | -                   |
+| className      | string                  | false    | null                |
+| large          | bool                    | false    | false               |
+| maxRating      | number                  | false    | 5                   |
+| rating         | number                  | false    | 0                   |
+| rounding       | oneOf(ROUNDING_TYPES)   | false    | ROUNDING_TYPES.down |
 
 ### BpkStar
 

--- a/packages/bpk-component-star-rating/README.md
+++ b/packages/bpk-component-star-rating/README.md
@@ -51,6 +51,7 @@ export default () => (
 | large          | bool                    | false    | false         |
 | maxRating      | number                  | false    | 5             |
 | rating         | number                  | false    | 0             |
+| roundRating    | bool                    | false    | false         |
 
 ### BpkStar
 

--- a/packages/bpk-component-star-rating/index.js
+++ b/packages/bpk-component-star-rating/index.js
@@ -18,7 +18,7 @@
 
 import BpkStar, { STAR_TYPES } from './src/BpkStar';
 import BpkInteractiveStar from './src/BpkInteractiveStar';
-import BpkStarRating from './src/BpkStarRating';
+import BpkStarRating, { ROUNDING_TYPES } from './src/BpkStarRating';
 import BpkInteractiveStarRating from './src/BpkInteractiveStarRating';
 import withInteractiveStarRatingState from './src/withInteractiveStarRatingState';
 import themeAttributes from './src/themeAttributes';
@@ -26,6 +26,7 @@ import themeAttributes from './src/themeAttributes';
 export {
   BpkStar,
   STAR_TYPES,
+  ROUNDING_TYPES,
   BpkInteractiveStar,
   BpkInteractiveStarRating,
   withInteractiveStarRatingState,

--- a/packages/bpk-component-star-rating/src/BpkStarRating-test.js
+++ b/packages/bpk-component-star-rating/src/BpkStarRating-test.js
@@ -20,7 +20,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-import BpkStarRating, { getTypeByRating } from './BpkStarRating';
+import BpkStarRating, {
+  getTypeByRating,
+  ROUNDING_TYPES,
+} from './BpkStarRating';
 import { STAR_TYPES } from './BpkStar';
 
 describe('BpkStarRating', () => {
@@ -101,7 +104,7 @@ describe('BpkStarRating', () => {
       <BpkStarRating
         ratingLabel={(r, m) => `Rated ${r} out of ${m} stars`}
         rating={3.4}
-        rounding={n => Math.round(n * 2) / 2}
+        rounding={ROUNDING_TYPES.nearest}
       />,
     );
     expect(toJson(tree)).toMatchSnapshot();

--- a/packages/bpk-component-star-rating/src/BpkStarRating-test.js
+++ b/packages/bpk-component-star-rating/src/BpkStarRating-test.js
@@ -96,6 +96,17 @@ describe('BpkStarRating', () => {
     expect(toJson(tree)).toMatchSnapshot();
   });
 
+  it('should render correctly with "rounding" attribute', () => {
+    const tree = shallow(
+      <BpkStarRating
+        ratingLabel={(r, m) => `Rated ${r} out of ${m} stars`}
+        rating={3.4}
+        rounding={n => Math.round(n * 2) / 2}
+      />,
+    );
+    expect(toJson(tree)).toMatchSnapshot();
+  });
+
   describe('getTypeByRating()', () => {
     it('should be a function', () => {
       expect(typeof getTypeByRating === 'function').toBe(true);
@@ -118,16 +129,6 @@ describe('BpkStarRating', () => {
       expect(getTypeByRating(1, 0.5)).toBe(STAR_TYPES.HALF);
       expect(getTypeByRating(1, 0.9)).toBe(STAR_TYPES.HALF);
       expect(getTypeByRating(1, 1)).not.toBe(STAR_TYPES.HALF);
-    });
-
-    it('should round to the nearest half star if roundRating is true', () => {
-      expect(getTypeByRating(1, 0, true)).toBe(STAR_TYPES.EMPTY);
-      expect(getTypeByRating(1, 0.2, true)).toBe(STAR_TYPES.EMPTY);
-      expect(getTypeByRating(1, 0.25, true)).toBe(STAR_TYPES.HALF);
-      expect(getTypeByRating(1, 0.5, true)).toBe(STAR_TYPES.HALF);
-      expect(getTypeByRating(1, 0.7, true)).toBe(STAR_TYPES.HALF);
-      expect(getTypeByRating(1, 0.75, true)).toBe(STAR_TYPES.FULL);
-      expect(getTypeByRating(1, 1, true)).toBe(STAR_TYPES.FULL);
     });
   });
 });

--- a/packages/bpk-component-star-rating/src/BpkStarRating-test.js
+++ b/packages/bpk-component-star-rating/src/BpkStarRating-test.js
@@ -119,5 +119,15 @@ describe('BpkStarRating', () => {
       expect(getTypeByRating(1, 0.9)).toBe(STAR_TYPES.HALF);
       expect(getTypeByRating(1, 1)).not.toBe(STAR_TYPES.HALF);
     });
+
+    it('should round to the nearest half star if roundRating is true', () => {
+      expect(getTypeByRating(1, 0, true)).toBe(STAR_TYPES.EMPTY);
+      expect(getTypeByRating(1, 0.2, true)).toBe(STAR_TYPES.EMPTY);
+      expect(getTypeByRating(1, 0.25, true)).toBe(STAR_TYPES.HALF);
+      expect(getTypeByRating(1, 0.5, true)).toBe(STAR_TYPES.HALF);
+      expect(getTypeByRating(1, 0.7, true)).toBe(STAR_TYPES.HALF);
+      expect(getTypeByRating(1, 0.75, true)).toBe(STAR_TYPES.FULL);
+      expect(getTypeByRating(1, 1, true)).toBe(STAR_TYPES.FULL);
+    });
   });
 });

--- a/packages/bpk-component-star-rating/src/BpkStarRating.js
+++ b/packages/bpk-component-star-rating/src/BpkStarRating.js
@@ -25,16 +25,13 @@ import STYLES from './BpkStarRating.scss';
 
 const getClassName = cssModules(STYLES);
 
-export const getTypeByRating = (starNumber, rating, roundRating) => {
+export const getTypeByRating = (starNumber, rating) => {
   if (starNumber <= rating) {
     return STAR_TYPES.FULL;
   }
 
   const rest = rating - (starNumber - 1);
-  if (roundRating && rest >= 0.75) {
-    return STAR_TYPES.FULL;
-  }
-  if (rest >= (roundRating ? 0.25 : 0.5) && rest < 1) {
+  if (rest >= 0.5 && rest < 1) {
     return STAR_TYPES.HALF;
   }
 
@@ -48,7 +45,7 @@ const BpkStarRating = props => {
     maxRating,
     large,
     className,
-    roundRating,
+    rounding,
     ...rest
   } = props;
 
@@ -62,7 +59,7 @@ const BpkStarRating = props => {
   }
 
   for (let starNumber = 1; starNumber <= maxRating; starNumber += 1) {
-    const type = getTypeByRating(starNumber, currentRating, roundRating);
+    const type = getTypeByRating(starNumber, rounding(currentRating));
 
     stars.push(
       <BpkStar key={`star-${starNumber}`} type={type} large={large} />,
@@ -88,7 +85,7 @@ BpkStarRating.propTypes = {
   large: PropTypes.bool,
   maxRating: PropTypes.number,
   rating: PropTypes.number,
-  roundRating: PropTypes.bool,
+  rounding: PropTypes.func,
 };
 
 BpkStarRating.defaultProps = {
@@ -96,7 +93,7 @@ BpkStarRating.defaultProps = {
   large: false,
   maxRating: 5,
   rating: 0,
-  roundRating: false,
+  rounding: n => n,
 };
 
 export default BpkStarRating;

--- a/packages/bpk-component-star-rating/src/BpkStarRating.js
+++ b/packages/bpk-component-star-rating/src/BpkStarRating.js
@@ -25,13 +25,16 @@ import STYLES from './BpkStarRating.scss';
 
 const getClassName = cssModules(STYLES);
 
-export const getTypeByRating = (starNumber, rating) => {
+export const getTypeByRating = (starNumber, rating, roundRating) => {
   if (starNumber <= rating) {
     return STAR_TYPES.FULL;
   }
 
   const rest = rating - (starNumber - 1);
-  if (rest >= 0.5 && rest < 1) {
+  if (roundRating && rest >= 0.75) {
+    return STAR_TYPES.FULL;
+  }
+  if (rest >= (roundRating ? 0.25 : 0.5) && rest < 1) {
     return STAR_TYPES.HALF;
   }
 
@@ -39,7 +42,15 @@ export const getTypeByRating = (starNumber, rating) => {
 };
 
 const BpkStarRating = props => {
-  const { rating, ratingLabel, maxRating, large, className, ...rest } = props;
+  const {
+    rating,
+    ratingLabel,
+    maxRating,
+    large,
+    className,
+    roundRating,
+    ...rest
+  } = props;
 
   const stars = [];
   const classNames = [getClassName('bpk-star-rating')];
@@ -51,7 +62,7 @@ const BpkStarRating = props => {
   }
 
   for (let starNumber = 1; starNumber <= maxRating; starNumber += 1) {
-    const type = getTypeByRating(starNumber, currentRating);
+    const type = getTypeByRating(starNumber, currentRating, roundRating);
 
     stars.push(
       <BpkStar key={`star-${starNumber}`} type={type} large={large} />,
@@ -77,6 +88,7 @@ BpkStarRating.propTypes = {
   large: PropTypes.bool,
   maxRating: PropTypes.number,
   rating: PropTypes.number,
+  roundRating: PropTypes.bool,
 };
 
 BpkStarRating.defaultProps = {
@@ -84,6 +96,7 @@ BpkStarRating.defaultProps = {
   large: false,
   maxRating: 5,
   rating: 0,
+  roundRating: false,
 };
 
 export default BpkStarRating;

--- a/packages/bpk-component-star-rating/src/BpkStarRating.js
+++ b/packages/bpk-component-star-rating/src/BpkStarRating.js
@@ -38,6 +38,12 @@ export const getTypeByRating = (starNumber, rating) => {
   return STAR_TYPES.EMPTY;
 };
 
+export const ROUNDING_TYPES = {
+  down: n => Math.floor(n * 2) / 2,
+  up: n => Math.ceil(n * 2) / 2,
+  nearest: n => Math.round(n * 2) / 2,
+};
+
 const BpkStarRating = props => {
   const {
     rating,
@@ -85,7 +91,11 @@ BpkStarRating.propTypes = {
   large: PropTypes.bool,
   maxRating: PropTypes.number,
   rating: PropTypes.number,
-  rounding: PropTypes.func,
+  rounding: PropTypes.oneOf([
+    ROUNDING_TYPES.down,
+    ROUNDING_TYPES.up,
+    ROUNDING_TYPES.nearest,
+  ]),
 };
 
 BpkStarRating.defaultProps = {
@@ -93,7 +103,7 @@ BpkStarRating.defaultProps = {
   large: false,
   maxRating: 5,
   rating: 0,
-  rounding: n => n,
+  rounding: ROUNDING_TYPES.down,
 };
 
 export default BpkStarRating;

--- a/packages/bpk-component-star-rating/src/__snapshots__/BpkStarRating-test.js.snap
+++ b/packages/bpk-component-star-rating/src/__snapshots__/BpkStarRating-test.js.snap
@@ -132,6 +132,44 @@ exports[`BpkStarRating should render correctly with "maxRating" attribute 1`] = 
 </div>
 `;
 
+exports[`BpkStarRating should render correctly with "rounding" attribute 1`] = `
+<div
+  aria-label="Rated 3.4 out of 5 stars"
+  className="bpk-star-rating"
+>
+  <withRtlSupport(BpkStar)
+    className={null}
+    key="star-1"
+    large={false}
+    type="full"
+  />
+  <withRtlSupport(BpkStar)
+    className={null}
+    key="star-2"
+    large={false}
+    type="full"
+  />
+  <withRtlSupport(BpkStar)
+    className={null}
+    key="star-3"
+    large={false}
+    type="full"
+  />
+  <withRtlSupport(BpkStar)
+    className={null}
+    key="star-4"
+    large={false}
+    type="half"
+  />
+  <withRtlSupport(BpkStar)
+    className={null}
+    key="star-5"
+    large={false}
+    type="empty"
+  />
+</div>
+`;
+
 exports[`BpkStarRating should render correctly with 0 stars 1`] = `
 <div
   aria-label="Rated 0 out of 5 stars"

--- a/packages/bpk-component-star-rating/stories.js
+++ b/packages/bpk-component-star-rating/stories.js
@@ -116,11 +116,25 @@ storiesOf('bpk-component-star-rating', module)
       <StarRating rating={3.3} large />
     </div>
   ))
-  .add('3.7 Stars', () => (
+  .add('3.8 Stars', () => (
     <div>
-      <StarRating rating={3.7} />
+      <StarRating rating={3.8} />
       <br />
-      <StarRating rating={3.7} large />
+      <StarRating rating={3.8} large />
+    </div>
+  ))
+  .add('3.3 Stars Rounded', () => (
+    <div>
+      <StarRating rating={3.3} roundRating />
+      <br />
+      <StarRating rating={3.3} large roundRating />
+    </div>
+  ))
+  .add('3.8 Stars Rounded', () => (
+    <div>
+      <StarRating rating={3.8} roundRating />
+      <br />
+      <StarRating rating={3.8} large roundRating />
     </div>
   ))
   .add('Interactive', () => (

--- a/packages/bpk-component-star-rating/stories.js
+++ b/packages/bpk-component-star-rating/stories.js
@@ -125,16 +125,16 @@ storiesOf('bpk-component-star-rating', module)
   ))
   .add('3.3 Stars Rounded', () => (
     <div>
-      <StarRating rating={3.3} roundRating />
+      <StarRating rating={3.3} rounding={n => Math.round(n * 2) / 2} />
       <br />
-      <StarRating rating={3.3} large roundRating />
+      <StarRating rating={3.3} large rounding={n => Math.round(n * 2) / 2} />
     </div>
   ))
   .add('3.8 Stars Rounded', () => (
     <div>
-      <StarRating rating={3.8} roundRating />
+      <StarRating rating={3.8} rounding={n => Math.round(n * 2) / 2} />
       <br />
-      <StarRating rating={3.8} large roundRating />
+      <StarRating rating={3.8} large rounding={n => Math.round(n * 2) / 2} />
     </div>
   ))
   .add('Interactive', () => (

--- a/packages/bpk-component-star-rating/stories.js
+++ b/packages/bpk-component-star-rating/stories.js
@@ -31,7 +31,7 @@ import {
 import BpkInteractiveStarRating from './src/BpkInteractiveStarRating';
 import withInteractiveStarRatingState from './src/withInteractiveStarRatingState';
 
-import BpkStarRating, { BpkStar, STAR_TYPES } from './index';
+import BpkStarRating, { BpkStar, STAR_TYPES, ROUNDING_TYPES } from './index';
 
 const InteractiveStarRating = withInteractiveStarRatingState(
   BpkInteractiveStarRating,
@@ -125,16 +125,16 @@ storiesOf('bpk-component-star-rating', module)
   ))
   .add('3.3 Stars Rounded', () => (
     <div>
-      <StarRating rating={3.3} rounding={n => Math.round(n * 2) / 2} />
+      <StarRating rating={3.3} rounding={ROUNDING_TYPES.nearest} />
       <br />
-      <StarRating rating={3.3} large rounding={n => Math.round(n * 2) / 2} />
+      <StarRating rating={3.3} large rounding={ROUNDING_TYPES.nearest} />
     </div>
   ))
   .add('3.8 Stars Rounded', () => (
     <div>
-      <StarRating rating={3.8} rounding={n => Math.round(n * 2) / 2} />
+      <StarRating rating={3.8} rounding={ROUNDING_TYPES.nearest} />
       <br />
-      <StarRating rating={3.8} large rounding={n => Math.round(n * 2) / 2} />
+      <StarRating rating={3.8} large rounding={ROUNDING_TYPES.nearest} />
     </div>
   ))
   .add('Interactive', () => (


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
Adds an optional prop to bpk-component-star-rating, `roundRating`. This defaults to false - if true, the rating is rounded to the nearest half star, instead of always being rounded down.

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
