### PR TITLE
a11y fixes for accordion

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -24,3 +24,8 @@
 #   FIXED:
 #     - bpk-component-horcrux:
 #       - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+
+FIXED:
+  - bpk-component-accordion:
+    - Fixed a11y errors for `BpkAccordionItem` component.

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -45,14 +45,13 @@ const BpkAccordionItem = props => {
     );
   }
 
-  const titleId = `${id}_title`;
   const contentId = `${id}_content`;
 
   return (
     <div id={id} {...rest}>
       <dt
-        role="heading"
         aria-level="3"
+        aria-labelledby={id}
         className={getClassName('bpk-accordion__title')}
       >
         <button
@@ -76,16 +75,15 @@ const BpkAccordionItem = props => {
           </span>
         </button>
       </dt>
-      <AnimateHeight duration={200} height={expanded ? 'auto' : 0}>
-        <dd
-          id={contentId}
-          role="region"
-          aria-labelledby={titleId}
-          className={getClassName('bpk-accordion__content-container')}
-        >
+      <dd
+        id={contentId}
+        aria-labelledby={contentId}
+        className={getClassName('bpk-accordion__content-container')}
+      >
+        <AnimateHeight duration={200} height={expanded ? 'auto' : 0}>
           {children}
-        </dd>
-      </AnimateHeight>
+        </AnimateHeight>
+      </dd>
     </div>
   );
 };

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -32,7 +32,16 @@ const ExpandIcon = withButtonAlignment(ChevronDownIcon);
 
 const BpkAccordionItem = props => {
   const iconClassNames = [getClassName('bpk-accordion__item-expand-icon')];
-  const { id, title, children, expanded, onClick, tagName, ...rest } = props;
+  const {
+    id,
+    title,
+    children,
+    expanded,
+    onClick,
+    tagName,
+    textStyle,
+    ...rest
+  } = props;
 
   // if this component is passed initiallyExpanded, this makes sure it doesn't
   // end up on the node. Not ideal as our container component shouldn't be passing
@@ -63,7 +72,7 @@ const BpkAccordionItem = props => {
         >
           <span className={getClassName('bpk-accordion__flex-container')}>
             <BpkText
-              textStyle="base"
+              textStyle={textStyle}
               tagName={tagName}
               className={getClassName('bpk-accordion__title-text')}
             >
@@ -92,6 +101,7 @@ BpkAccordionItem.propTypes = {
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   tagName: PropTypes.string,
+  textStyle: PropTypes.string,
   children: PropTypes.node.isRequired,
   expanded: PropTypes.bool,
   onClick: PropTypes.func,
@@ -99,6 +109,7 @@ BpkAccordionItem.propTypes = {
 
 BpkAccordionItem.defaultProps = {
   tagName: 'span',
+  textStyle: 'bsae',
   expanded: false,
   onClick: () => null,
 };

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -5,9 +5,9 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
   id="my-accordion"
 >
   <dt
+    aria-labelledby="my-accordion"
     aria-level="3"
     className="bpk-accordion__title"
-    role="heading"
   >
     <button
       aria-controls="my-accordion_content"
@@ -59,31 +59,30 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
       </span>
     </button>
   </dt>
-  <div
-    onTransitionEnd={[Function]}
-    style={
-      Object {
-        "MozTransition": "height 200ms ease ",
-        "OTransition": "height 200ms ease ",
-        "WebkitTransition": "height 200ms ease ",
-        "height": 0,
-        "msTransition": "height 200ms ease ",
-        "overflow": "hidden",
-        "transition": "height 200ms ease ",
-      }
-    }
+  <dd
+    aria-labelledby="my-accordion_content"
+    className="bpk-accordion__content-container"
+    id="my-accordion_content"
   >
-    <div>
-      <dd
-        aria-labelledby="my-accordion_title"
-        className="bpk-accordion__content-container"
-        id="my-accordion_content"
-        role="region"
-      >
+    <div
+      onTransitionEnd={[Function]}
+      style={
+        Object {
+          "MozTransition": "height 200ms ease ",
+          "OTransition": "height 200ms ease ",
+          "WebkitTransition": "height 200ms ease ",
+          "height": 0,
+          "msTransition": "height 200ms ease ",
+          "overflow": "hidden",
+          "transition": "height 200ms ease ",
+        }
+      }
+    >
+      <div>
         My accordion content
-      </dd>
+      </div>
     </div>
-  </div>
+  </dd>
 </div>
 `;
 
@@ -92,9 +91,9 @@ exports[`BpkAccordionItem should render correctly 1`] = `
   id="my-accordion"
 >
   <dt
+    aria-labelledby="my-accordion"
     aria-level="3"
     className="bpk-accordion__title"
-    role="heading"
   >
     <button
       aria-controls="my-accordion_content"
@@ -146,31 +145,30 @@ exports[`BpkAccordionItem should render correctly 1`] = `
       </span>
     </button>
   </dt>
-  <div
-    onTransitionEnd={[Function]}
-    style={
-      Object {
-        "MozTransition": "height 200ms ease ",
-        "OTransition": "height 200ms ease ",
-        "WebkitTransition": "height 200ms ease ",
-        "height": 0,
-        "msTransition": "height 200ms ease ",
-        "overflow": "hidden",
-        "transition": "height 200ms ease ",
-      }
-    }
+  <dd
+    aria-labelledby="my-accordion_content"
+    className="bpk-accordion__content-container"
+    id="my-accordion_content"
   >
-    <div>
-      <dd
-        aria-labelledby="my-accordion_title"
-        className="bpk-accordion__content-container"
-        id="my-accordion_content"
-        role="region"
-      >
+    <div
+      onTransitionEnd={[Function]}
+      style={
+        Object {
+          "MozTransition": "height 200ms ease ",
+          "OTransition": "height 200ms ease ",
+          "WebkitTransition": "height 200ms ease ",
+          "height": 0,
+          "msTransition": "height 200ms ease ",
+          "overflow": "hidden",
+          "transition": "height 200ms ease ",
+        }
+      }
+    >
+      <div>
         My accordion content
-      </dd>
+      </div>
     </div>
-  </div>
+  </dd>
 </div>
 `;
 
@@ -180,9 +178,9 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
   id="my-accordion"
 >
   <dt
+    aria-labelledby="my-accordion"
     aria-level="3"
     className="bpk-accordion__title"
-    role="heading"
   >
     <button
       aria-controls="my-accordion_content"
@@ -234,31 +232,30 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
       </span>
     </button>
   </dt>
-  <div
-    onTransitionEnd={[Function]}
-    style={
-      Object {
-        "MozTransition": "height 200ms ease ",
-        "OTransition": "height 200ms ease ",
-        "WebkitTransition": "height 200ms ease ",
-        "height": 0,
-        "msTransition": "height 200ms ease ",
-        "overflow": "hidden",
-        "transition": "height 200ms ease ",
-      }
-    }
+  <dd
+    aria-labelledby="my-accordion_content"
+    className="bpk-accordion__content-container"
+    id="my-accordion_content"
   >
-    <div>
-      <dd
-        aria-labelledby="my-accordion_title"
-        className="bpk-accordion__content-container"
-        id="my-accordion_content"
-        role="region"
-      >
+    <div
+      onTransitionEnd={[Function]}
+      style={
+        Object {
+          "MozTransition": "height 200ms ease ",
+          "OTransition": "height 200ms ease ",
+          "WebkitTransition": "height 200ms ease ",
+          "height": 0,
+          "msTransition": "height 200ms ease ",
+          "overflow": "hidden",
+          "transition": "height 200ms ease ",
+        }
+      }
+    >
+      <div>
         My accordion content
-      </dd>
+      </div>
     </div>
-  </div>
+  </dd>
 </div>
 `;
 
@@ -267,9 +264,9 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
   id="my-accordion"
 >
   <dt
+    aria-labelledby="my-accordion"
     aria-level="3"
     className="bpk-accordion__title"
-    role="heading"
   >
     <button
       aria-controls="my-accordion_content"
@@ -321,31 +318,30 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
       </span>
     </button>
   </dt>
-  <div
-    onTransitionEnd={[Function]}
-    style={
-      Object {
-        "MozTransition": "height 200ms ease ",
-        "OTransition": "height 200ms ease ",
-        "WebkitTransition": "height 200ms ease ",
-        "height": "auto",
-        "msTransition": "height 200ms ease ",
-        "overflow": "visible",
-        "transition": "height 200ms ease ",
-      }
-    }
+  <dd
+    aria-labelledby="my-accordion_content"
+    className="bpk-accordion__content-container"
+    id="my-accordion_content"
   >
-    <div>
-      <dd
-        aria-labelledby="my-accordion_title"
-        className="bpk-accordion__content-container"
-        id="my-accordion_content"
-        role="region"
-      >
+    <div
+      onTransitionEnd={[Function]}
+      style={
+        Object {
+          "MozTransition": "height 200ms ease ",
+          "OTransition": "height 200ms ease ",
+          "WebkitTransition": "height 200ms ease ",
+          "height": "auto",
+          "msTransition": "height 200ms ease ",
+          "overflow": "visible",
+          "transition": "height 200ms ease ",
+        }
+      }
+    >
+      <div>
         My accordion content
-      </dd>
+      </div>
     </div>
-  </div>
+  </dd>
 </div>
 `;
 
@@ -354,9 +350,9 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
   id="my-accordion"
 >
   <dt
+    aria-labelledby="my-accordion"
     aria-level="3"
     className="bpk-accordion__title"
-    role="heading"
   >
     <button
       aria-controls="my-accordion_content"
@@ -408,30 +404,29 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
       </span>
     </button>
   </dt>
-  <div
-    onTransitionEnd={[Function]}
-    style={
-      Object {
-        "MozTransition": "height 200ms ease ",
-        "OTransition": "height 200ms ease ",
-        "WebkitTransition": "height 200ms ease ",
-        "height": 0,
-        "msTransition": "height 200ms ease ",
-        "overflow": "hidden",
-        "transition": "height 200ms ease ",
-      }
-    }
+  <dd
+    aria-labelledby="my-accordion_content"
+    className="bpk-accordion__content-container"
+    id="my-accordion_content"
   >
-    <div>
-      <dd
-        aria-labelledby="my-accordion_title"
-        className="bpk-accordion__content-container"
-        id="my-accordion_content"
-        role="region"
-      >
+    <div
+      onTransitionEnd={[Function]}
+      style={
+        Object {
+          "MozTransition": "height 200ms ease ",
+          "OTransition": "height 200ms ease ",
+          "WebkitTransition": "height 200ms ease ",
+          "height": 0,
+          "msTransition": "height 200ms ease ",
+          "overflow": "hidden",
+          "transition": "height 200ms ease ",
+        }
+      }
+    >
+      <div>
         My accordion content
-      </dd>
+      </div>
     </div>
-  </div>
+  </dd>
 </div>
 `;

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -20,7 +20,7 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
         className="bpk-accordion__flex-container"
       >
         <span
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
+          className="bpk-text  bpk-accordion__title-text"
         >
           My accordion item
         </span>
@@ -106,7 +106,7 @@ exports[`BpkAccordionItem should render correctly 1`] = `
         className="bpk-accordion__flex-container"
       >
         <span
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
+          className="bpk-text  bpk-accordion__title-text"
         >
           My accordion item
         </span>
@@ -193,7 +193,7 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
         className="bpk-accordion__flex-container"
       >
         <span
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
+          className="bpk-text  bpk-accordion__title-text"
         >
           My accordion item
         </span>
@@ -279,7 +279,7 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
         className="bpk-accordion__flex-container"
       >
         <span
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
+          className="bpk-text  bpk-accordion__title-text"
         >
           My accordion item
         </span>
@@ -365,7 +365,7 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
         className="bpk-accordion__flex-container"
       >
         <h3
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
+          className="bpk-text  bpk-accordion__title-text"
         >
           My accordion item
         </h3>

--- a/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
@@ -20,7 +20,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
         className="bpk-accordion__flex-container"
       >
         <span
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
+          className="bpk-text  bpk-accordion__title-text"
         >
           My accordion item
         </span>
@@ -106,7 +106,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
         className="bpk-accordion__flex-container"
       >
         <span
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
+          className="bpk-text  bpk-accordion__title-text"
         >
           My accordion item
         </span>
@@ -192,7 +192,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
         className="bpk-accordion__flex-container"
       >
         <span
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
+          className="bpk-text  bpk-accordion__title-text"
         >
           My accordion item
         </span>

--- a/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
@@ -5,9 +5,9 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
   id="my-accordion"
 >
   <dt
+    aria-labelledby="my-accordion"
     aria-level="3"
     className="bpk-accordion__title"
-    role="heading"
   >
     <button
       aria-controls="my-accordion_content"
@@ -59,31 +59,30 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
       </span>
     </button>
   </dt>
-  <div
-    onTransitionEnd={[Function]}
-    style={
-      Object {
-        "MozTransition": "height 200ms ease ",
-        "OTransition": "height 200ms ease ",
-        "WebkitTransition": "height 200ms ease ",
-        "height": 0,
-        "msTransition": "height 200ms ease ",
-        "overflow": "hidden",
-        "transition": "height 200ms ease ",
-      }
-    }
+  <dd
+    aria-labelledby="my-accordion_content"
+    className="bpk-accordion__content-container"
+    id="my-accordion_content"
   >
-    <div>
-      <dd
-        aria-labelledby="my-accordion_title"
-        className="bpk-accordion__content-container"
-        id="my-accordion_content"
-        role="region"
-      >
+    <div
+      onTransitionEnd={[Function]}
+      style={
+        Object {
+          "MozTransition": "height 200ms ease ",
+          "OTransition": "height 200ms ease ",
+          "WebkitTransition": "height 200ms ease ",
+          "height": 0,
+          "msTransition": "height 200ms ease ",
+          "overflow": "hidden",
+          "transition": "height 200ms ease ",
+        }
+      }
+    >
+      <div>
         My accordion content
-      </dd>
+      </div>
     </div>
-  </div>
+  </dd>
 </div>
 `;
 
@@ -92,9 +91,9 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
   id="my-accordion"
 >
   <dt
+    aria-labelledby="my-accordion"
     aria-level="3"
     className="bpk-accordion__title"
-    role="heading"
   >
     <button
       aria-controls="my-accordion_content"
@@ -146,31 +145,30 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
       </span>
     </button>
   </dt>
-  <div
-    onTransitionEnd={[Function]}
-    style={
-      Object {
-        "MozTransition": "height 200ms ease ",
-        "OTransition": "height 200ms ease ",
-        "WebkitTransition": "height 200ms ease ",
-        "height": 0,
-        "msTransition": "height 200ms ease ",
-        "overflow": "hidden",
-        "transition": "height 200ms ease ",
-      }
-    }
+  <dd
+    aria-labelledby="my-accordion_content"
+    className="bpk-accordion__content-container"
+    id="my-accordion_content"
   >
-    <div>
-      <dd
-        aria-labelledby="my-accordion_title"
-        className="bpk-accordion__content-container"
-        id="my-accordion_content"
-        role="region"
-      >
+    <div
+      onTransitionEnd={[Function]}
+      style={
+        Object {
+          "MozTransition": "height 200ms ease ",
+          "OTransition": "height 200ms ease ",
+          "WebkitTransition": "height 200ms ease ",
+          "height": 0,
+          "msTransition": "height 200ms ease ",
+          "overflow": "hidden",
+          "transition": "height 200ms ease ",
+        }
+      }
+    >
+      <div>
         My accordion content
-      </dd>
+      </div>
     </div>
-  </div>
+  </dd>
 </div>
 `;
 
@@ -179,9 +177,9 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
   id="my-accordion"
 >
   <dt
+    aria-labelledby="my-accordion"
     aria-level="3"
     className="bpk-accordion__title"
-    role="heading"
   >
     <button
       aria-controls="my-accordion_content"
@@ -233,30 +231,29 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
       </span>
     </button>
   </dt>
-  <div
-    onTransitionEnd={[Function]}
-    style={
-      Object {
-        "MozTransition": "height 200ms ease ",
-        "OTransition": "height 200ms ease ",
-        "WebkitTransition": "height 200ms ease ",
-        "height": "auto",
-        "msTransition": "height 200ms ease ",
-        "overflow": "visible",
-        "transition": "height 200ms ease ",
-      }
-    }
+  <dd
+    aria-labelledby="my-accordion_content"
+    className="bpk-accordion__content-container"
+    id="my-accordion_content"
   >
-    <div>
-      <dd
-        aria-labelledby="my-accordion_title"
-        className="bpk-accordion__content-container"
-        id="my-accordion_content"
-        role="region"
-      >
+    <div
+      onTransitionEnd={[Function]}
+      style={
+        Object {
+          "MozTransition": "height 200ms ease ",
+          "OTransition": "height 200ms ease ",
+          "WebkitTransition": "height 200ms ease ",
+          "height": "auto",
+          "msTransition": "height 200ms ease ",
+          "overflow": "visible",
+          "transition": "height 200ms ease ",
+        }
+      }
+    >
+      <div>
         My accordion content
-      </dd>
+      </div>
     </div>
-  </div>
+  </dd>
 </div>
 `;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

Browser support
Please complete this list of browsers that you've checked this works in.

+ [ ] IE11
+ [ ] Edge
+ [x] Safari (iOS)
+ [x] Chrome (Android)
+ [x] Chrome (Desktop)
+ [x] Firefox (Desktop)

### No Violations

![BpkAccordionA11y](https://user-images.githubusercontent.com/2506718/66664551-aa439d80-ec44-11e9-82f2-5931d0c41b6f.gif)

### Before with Violations
![BpkAccordionOld](https://user-images.githubusercontent.com/2506718/66664552-aa439d80-ec44-11e9-96e8-0f3ba3bfce47.gif)

1) ARIA role must be appropriate for the element


2) ARIA attributes must conform to valid values


3) <dl> elements must only directly contain properly-ordered <dt> and <dd> groups, <script> or <template> elements


Also Tested on Android with Talkback, functionality is exact same. 