### PR TITLE
[BPK-2653] Investigate shipping CSS (#1607)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test": "npm run lint && npm run check-bpk-dependencies && npm run jest && npm run flow && npm run spellcheck",
     "check-owners": "npm whoami && ( node scripts/npm/get-owners.js | grep -E $(npm whoami) ) && node scripts/npm/check-owners.js",
     "check-pristine": "node scripts/check-pristine-state",
+    "publish:css": "node ./scripts/publish-process/transform-js-scss-css-imports.js && node ./scripts/publish-process/publish-css-tagged-packages.js && git reset --hard HEAD",
     "publish": "npm run check-pristine && npm run check-owners && npm run build && git pull --rebase && flow stop && npm run test && lerna publish",
     "publish:beta": "npm run check-pristine && npm run check-owners && npm run build && git pull --rebase && flow stop && npm run test && node scripts/publish-process/auto-publish.js",
     "release": "npm run publish",

--- a/scripts/publish-process/publish-css-tagged-packages.js
+++ b/scripts/publish-process/publish-css-tagged-packages.js
@@ -1,0 +1,54 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * How this works
+ *
+ * First of all, this scans all our packages and gets the current versions.
+ *
+ * Each package is then updated to have `-css.0` appended to the version,
+ * and then `npm publish` is used to publish each package with the `css` tag for easy installation,
+ */
+
+/* @flow */
+
+const {
+  getCurrentPackageMeta,
+  appendToPackageVersions,
+  publishPackagesToNPM,
+  verbose,
+  logVerbose,
+} = require('./util');
+
+const cli = async () => {
+  const currentPackageMeta = getCurrentPackageMeta();
+  if (verbose) {
+    logVerbose(`currentPackageMeta`);
+    logVerbose(currentPackageMeta);
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('Updating package versions...');
+  await appendToPackageVersions(currentPackageMeta, 'css.0');
+  // eslint-disable-next-line no-console
+  console.log('All good. 👍');
+
+  await publishPackagesToNPM(currentPackageMeta, 'css');
+};
+
+cli().then(null);

--- a/scripts/publish-process/transform-js-scss-css-imports.js
+++ b/scripts/publish-process/transform-js-scss-css-imports.js
@@ -1,0 +1,64 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+const updateImports = (file, findReplaces) =>
+  new Promise((resolve, reject) => {
+    fs.readFile(file, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+      }
+      let result = data;
+      findReplaces.forEach(fr => {
+        const splitFile = result.split(fr.find);
+        if (splitFile.length === 1) {
+          return;
+        }
+        result = splitFile.join(fr.replace);
+      });
+
+      fs.writeFile(file, result, 'utf8', err2 => {
+        if (err2) return reject(err2);
+        return resolve();
+      });
+    });
+  });
+
+// eslint-disable-next-line no-console
+console.log('Crunching import paths...');
+
+const findReplaces = [{ find: '.scss', replace: '.css' }];
+
+const jsFiles = execSync(
+  'find packages -name "*.js" -o -name "*.jsx" | grep -v node_modules',
+)
+  .toString()
+  .split('\n')
+  .filter(s => s !== '');
+
+const updatePromises = jsFiles.map(jF => updateImports(jF, findReplaces));
+
+Promise.all(updatePromises).then(() => {
+  // eslint-disable-next-line no-console
+  console.log('All good.  👍');
+  process.exit(0);
+});


### PR DESCRIPTION
Using tags alone to distinguish which packages ship with CSS is a bad idea. A NPM package tag is a 1-1 mapping from a tag name to a specific version. This means that every time we publish a package with the tag "css" we untag the previous css version. This means that there will be no way to distinguish between versions shipping with css and not.

Instead we should ensure that the version is updated to `X.Y.Z-css.0` and then it is published with a `CSS` tag.

<img width="913" alt="image" src="https://user-images.githubusercontent.com/30267516/67117486-b8606380-f1da-11e9-9bbf-4ae6ee76c1b9.png">

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
