### PR TITLE
[No Jira] Remove unused 'chalk' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "babel-jest": "^24.8.0",
     "babel-loader": "^8.0.0",
     "backpack-node-sass": "^0.3.2",
-    "chalk": "^2.4.2",
     "cli-progress": "^3.0.0",
     "colors": "^1.3.3",
     "copy-webpack-plugin": "^5.0.4",


### PR DESCRIPTION
Removes the need for https://github.com/Skyscanner/backpack/pull/1717 as `chalk` isn't actually being used (probably a holdover from `backpack-docs`).