### PR TITLE
[BPK-3256] Add `renderCalendar` prop to datepicker

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -456,6 +456,7 @@ rel
 buttonProps
 
 autoScrollToSelected
+calendarComponent
 leadingScrollIndicatorClassName
 trailingScrollIndicatorClassName
 bottomMargin

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -15,7 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import '@storybook/addon-a11y/register';
+
+// TODO: addon-a11y breaks the calendar example
+// import '@storybook/addon-a11y/register';
 import '@storybook/addon-actions/register';
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-viewport/register';

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -1,5 +1,16 @@
 # UNRELEASED:
 
+ADDED:
+  - bpk-component-calendar:
+    - Added export for `BpkCalendarGridWithTransition`
+
+  - bpk-component-datepicker:
+    - Added new `calendarComponent` prop
+
+BREAKING:
+  - bpk-component-datepicker:
+    - Removed invalid `DateComponent` prop.
+
 # How to write a good changelog entry:
 #
 #   1. Add 'BREAKING', 'ADDED' OR 'FIXED' depending on if the change will be major, minor or patch according to [semver.org](semver.org).

--- a/packages/bpk-component-calendar/index.js
+++ b/packages/bpk-component-calendar/index.js
@@ -21,6 +21,7 @@ import BpkCalendarContainer, {
 } from './src/BpkCalendarContainer';
 import BpkCalendarGrid, {
   propTypes as BpkCalendarGridPropTypes,
+  BpkCalendarGridWithTransition,
 } from './src/BpkCalendarGrid';
 import BpkCalendarGridHeader from './src/BpkCalendarGridHeader';
 import BpkCalendarNav from './src/BpkCalendarNav';
@@ -46,4 +47,5 @@ export {
   themeAttributes,
   BpkCalendarDatePropTypes,
   BpkCalendarGridPropTypes,
+  BpkCalendarGridWithTransition,
 };

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.js
@@ -21,8 +21,7 @@ import React, { Component } from 'react';
 import { isRTL } from 'bpk-react-utils';
 
 import BpkCalendarNav from './BpkCalendarNav';
-import BpkCalendarGrid from './BpkCalendarGrid';
-import { addCalendarGridTransition } from './BpkCalendarGridTransition';
+import { BpkCalendarGridWithTransition } from './BpkCalendarGrid';
 import BpkCalendarGridHeader from './BpkCalendarGridHeader';
 import BpkCalendarDate from './BpkCalendarDate';
 import composeCalendar from './composeCalendar';
@@ -37,8 +36,6 @@ import {
   startOfDay,
   startOfMonth,
 } from './date-utils';
-
-const TransitioningBpkCalendarGrid = addCalendarGridTransition(BpkCalendarGrid);
 
 const focusedDateHasChanged = (currentProps, nextProps) => {
   const rawNextSelectedDate = nextProps.selectedDate || nextProps.date;
@@ -293,7 +290,7 @@ export default withCalendarState(
   composeCalendar(
     BpkCalendarNav,
     BpkCalendarGridHeader,
-    TransitioningBpkCalendarGrid,
+    BpkCalendarGridWithTransition,
     BpkCalendarDate,
   ),
 );

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -30,6 +30,16 @@ import {
 } from './date-utils';
 import CustomPropTypes from './custom-proptypes';
 import STYLES from './BpkCalendarGrid.scss';
+import { addCalendarGridTransition } from './BpkCalendarGridTransition';
+// This should be imported after `./BpkCalendarGrid.scss`.
+// Because of how css specificity works the class `bpk-calendar-grid-transition__grid` needs to be defined
+// after `bpk-calendar-grid` (defined by BpkCalendarGrid.scss) so it can override width and display of the calendar
+
+// This is because the calendar with transiction is expected to have a fixed width and whenever `bpk-calendar-grid-transition__grid`
+// class is applyed it should override the calendar style.
+
+// NOTE that ./Week is also importing ./BpkCalendarGrid.scss so adding this after `./Week` would also do the job but
+// for clarity we should leave it here.
 
 const getClassName = cssModules(STYLES);
 
@@ -205,4 +215,9 @@ BpkCalendarGrid.defaultProps = {
   cellClassName: null,
 };
 
+const BpkCalendarGridWithTransition = addCalendarGridTransition(
+  BpkCalendarGrid,
+);
+
 export default BpkCalendarGrid;
+export { BpkCalendarGridWithTransition };

--- a/packages/bpk-component-calendar/src/Week.js
+++ b/packages/bpk-component-calendar/src/Week.js
@@ -35,6 +35,9 @@ import {
   isWithinRange,
 } from './date-utils';
 import CustomPropTypes from './custom-proptypes';
+// TODO: Move this to `Week.scss`
+// This should be using its own css file as `BpkCalendarGrid` is also importing `BpkCalendarGrid.scss`
+// and the order of css imports can break the component.
 import STYLES from './BpkCalendarGrid.scss';
 
 const getClassName = cssModules(STYLES);

--- a/packages/bpk-component-datepicker/README.md
+++ b/packages/bpk-component-datepicker/README.md
@@ -64,6 +64,52 @@ export default class App extends Component {
 }
 ```
 
+By default `BpkCalendar` is used but the calendar component is fully configurable through the `calendarComponent` prop.
+
+```js
+import React, { Component } from 'react';
+import BpkDatepicker from 'bpk-component-datepicker';
+import {
+  BpkCalendarNav,
+  BpkCalendarGridHeader,
+  BpkCalendarGridWithTransition,
+  BpkCalendarDate,
+  withCalendarState,
+  composeCalendar,
+} from 'bpk-component-calendar';
+import { colorSagano } from 'bpk-tokens/tokens/base.es6';
+
+const ColoredCalendarDate = props =>
+  <BpkCalendarDate {...props} style={{ backgroundColor: colorSagano }} />;
+
+const CalendarWithColoredDates = withCalendarState(
+  composeCalendar(
+    BpkCalendarNav,
+    BpkCalendarGridHeader,
+    BpkCalendarGridWithTransition,
+    ColoredCalendarDate,
+  ),
+);
+
+const CustomPicker = () => (
+  <BpkDatepicker
+    id="datepicker"
+    calendarComponent={CalendarWithColoredDates}
+    daysOfWeek={daysOfWeek}
+    weekStartsOn={1}
+    changeMonthLabel="Change month"
+    closeButtonText="Close"
+    title="Departure date"
+    getApplicationElement={() => document.getElementById('pagewrap')}
+    formatDate={formatDate}
+    formatMonth={formatMonth}
+    formatDateFull={formatDateFull}
+    onDateSelect={this.handleDateSelect}
+    date={this.state.selectedDate}
+  />
+);
+```
+
 > **Theming:** In order to theme the modal, a `renderTarget` needs to be supplied as a function which returns a DOM node
 > in the scope of a `BpkThemeProvider`.
 
@@ -76,30 +122,30 @@ For more information on some these props, check the BpkCalendar documentation.
 > `getApplicationElement` prop (see the example above) - this is to "hide" your application from
 > screen readers whilst the datepicker is open. The `pagewrap` element id is a convention we use internally at Skyscanner. In most cases it should "just work".
 
-| Property              | PropType        | Required | Default Value         |
-| --------------------- | --------------- | -------- | --------------------- |
-| changeMonthLabel      | string          | true     | -                     |
-| closeButtonText       | string          | true     | -                     |
-| title                 | string          | true     | -                     |
-| id                    | string          | true     | -                     |
-| getApplicationElement | func            | true     | -                     |
-| daysOfWeek            | arrayOf(object) | true     | -                     |
-| weekStartsOn          | number          | true     | -                     |
-| formatDate            | func            | true     | -                     |
-| formatDateFull        | func            | true     | -                     |
-| formatMonth           | func            | true     | -                     |
-| date                  | Date            | false    | null                  |
-| DateComponent         | func            | false    | BpkCalendarDate (\*)  |
-| dateModifiers         | object          | false    | {} (\*)               |
-| inputProps            | object          | false    | {}                    |
-| markOutsideDays       | bool            | false    | true (\*)             |
-| markToday             | bool            | false    | true (\*)             |
-| maxDate               | Date            | false    | new Date() + 1 year (\*) |
-| minDate               | Date            | false    | new Date() (\*)       |
-| onDateSelect          | func            | false    | null                  |
-| showWeekendSeparator  | bool            | false    | true (\*)             |
-| initiallyFocusedDate  | Date            | false    | null                  |
-| renderTarget          | func            | false    | null                  |
+| Property              | PropType              | Required | Default Value                       |
+| --------------------- | --------------------- | -------- | ----------------------------------- |
+| changeMonthLabel      | string                | true     | -                                   |
+| closeButtonText       | string                | true     | -                                   |
+| title                 | string                | true     | -                                   |
+| id                    | string                | true     | -                                   |
+| getApplicationElement | func                  | true     | -                                   |
+| daysOfWeek            | arrayOf(object)       | true     | -                                   |
+| weekStartsOn          | number                | true     | -                                   |
+| formatDate            | func                  | true     | -                                   |
+| formatDateFull        | func                  | true     | -                                   |
+| formatMonth           | func                  | true     | -                                   |
+| calendarComponent     | oneOfType(func, node) | false    | BpkCalendar                         |
+| date                  | Date                  | false    | null                                |
+| dateModifiers         | object                | false    | {} (\*)                             |
+| inputProps            | object                | false    | {}                                  |
+| markOutsideDays       | bool                  | false    | true (\*)                           |
+| markToday             | bool                  | false    | true (\*)                           |
+| maxDate               | Date                  | false    | new Date() + 1 year (\*)            |
+| minDate               | Date                  | false    | new Date() (\*)                     |
+| onDateSelect          | func                  | false    | null                                |
+| showWeekendSeparator  | bool                  | false    | true (\*)                           |
+| initiallyFocusedDate  | Date                  | false    | null                                |
+| renderTarget          | func                  | false    | null                                |
 
 > (\*) Default value is defined on child component
 

--- a/packages/bpk-component-datepicker/package.json
+++ b/packages/bpk-component-datepicker/package.json
@@ -22,6 +22,9 @@
     "bpk-react-utils": "^2.8.3",
     "prop-types": "^15.6.2"
   },
+  "devDependencies": {
+    "bpk-tokens": "^29.4.0"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -23,10 +23,7 @@ import { cssModules } from 'bpk-react-utils';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import BpkBreakpoint, { BREAKPOINTS } from 'bpk-component-breakpoint';
-import BpkCalendar, {
-  CustomPropTypes,
-  BpkCalendarDate,
-} from 'bpk-component-calendar';
+import BpkCalendar, { CustomPropTypes } from 'bpk-component-calendar';
 
 import STYLES from './BpkDatepicker.scss';
 
@@ -67,9 +64,9 @@ class BpkDatepicker extends Component {
   render() {
     const {
       changeMonthLabel,
+      calendarComponent: Calendar,
       closeButtonText,
       date,
-      DateComponent,
       dateModifiers,
       daysOfWeek,
       formatDate,
@@ -113,28 +110,27 @@ class BpkDatepicker extends Component {
       />
     );
 
-    const calendarComponent = (
-      <BpkCalendar
-        className={getClassName('bpk-datepicker__calendar')}
-        changeMonthLabel={changeMonthLabel}
-        date={date}
-        DateComponent={DateComponent}
-        dateModifiers={dateModifiers}
-        daysOfWeek={daysOfWeek}
-        formatDateFull={formatDateFull}
-        formatMonth={formatMonth}
-        id={`${id}-calendar`}
-        markOutsideDays={markOutsideDays}
-        markToday={markToday}
-        maxDate={maxDate}
-        minDate={minDate}
-        onDateSelect={this.handleDateSelect}
-        onMonthChange={onMonthChange}
-        showWeekendSeparator={showWeekendSeparator}
-        weekStartsOn={weekStartsOn}
-        initiallyFocusedDate={initiallyFocusedDate}
-      />
-    );
+    const calendarProps = {
+      id: `${id}-calendar`,
+      className: getClassName('bpk-datepicker__calendar'),
+      changeMonthLabel,
+      date,
+      dateModifiers,
+      daysOfWeek,
+      formatDateFull,
+      formatMonth,
+      markOutsideDays,
+      markToday,
+      maxDate,
+      minDate,
+      onDateSelect: this.handleDateSelect,
+      onMonthChange,
+      showWeekendSeparator,
+      weekStartsOn,
+      initiallyFocusedDate,
+    };
+
+    const calendar = <Calendar {...calendarProps} />;
 
     return (
       <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
@@ -150,7 +146,7 @@ class BpkDatepicker extends Component {
               closeLabel={closeButtonText}
               getApplicationElement={getApplicationElement}
             >
-              {calendarComponent}
+              {calendar}
             </BpkModal>
           ) : (
             <BpkPopover
@@ -164,7 +160,7 @@ class BpkDatepicker extends Component {
               tabIndex={0}
               {...rest}
             >
-              {calendarComponent}
+              {calendar}
             </BpkPopover>
           )
         }
@@ -186,8 +182,8 @@ BpkDatepicker.propTypes = {
   getApplicationElement: PropTypes.func.isRequired,
   weekStartsOn: PropTypes.number.isRequired,
   // Optional
+  calendarComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   date: PropTypes.instanceOf(Date),
-  DateComponent: PropTypes.func,
   dateModifiers: CustomPropTypes.DateModifiers,
   inputProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   markOutsideDays: PropTypes.bool,
@@ -202,8 +198,8 @@ BpkDatepicker.propTypes = {
 };
 
 BpkDatepicker.defaultProps = {
+  calendarComponent: BpkCalendar,
   date: null,
-  DateComponent: BpkCalendarDate,
   dateModifiers: BpkCalendar.defaultProps.dateModifiers,
   inputProps: {},
   markOutsideDays: BpkCalendar.defaultProps.markOutsideDays,

--- a/packages/bpk-component-datepicker/stories.js
+++ b/packages/bpk-component-datepicker/stories.js
@@ -18,8 +18,15 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { memoize } from 'lodash';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import {
+  colorSagano,
+  colorBagan,
+  colorPetra,
+  colorSkyGray,
+} from 'bpk-tokens/tokens/base.es6';
 import {
   weekDays,
   formatMonth,
@@ -32,6 +39,14 @@ import {
   addDays,
   startOfDay,
 } from 'bpk-component-calendar/src/date-utils';
+import {
+  BpkCalendarNav,
+  BpkCalendarGridHeader,
+  BpkCalendarGridWithTransition,
+  BpkCalendarDate,
+  withCalendarState,
+  composeCalendar,
+} from 'bpk-component-calendar';
 
 import BpkDatepicker from './index';
 
@@ -95,6 +110,30 @@ CalendarContainer.propTypes = {
 
 CalendarContainer.defaultProps = {
   date: null,
+};
+
+const getBackgroundForDate = memoize(
+  () => [colorSagano, colorBagan, colorPetra][parseInt(Math.random() * 3, 10)],
+);
+
+const ColoredCalendarDate = props => {
+  let style = {};
+
+  if (!props.isFocused && !props.isOutside && !props.isBlocked) {
+    style = {
+      backgroundColor: getBackgroundForDate(props.date.getTime()), // stylelint-disable
+      color: colorSkyGray,
+    };
+  }
+
+  return <BpkCalendarDate {...props} style={style} />;
+};
+
+ColoredCalendarDate.propTypes = {
+  isFocused: PropTypes.bool.isRequired,
+  isOutside: PropTypes.bool.isRequired,
+  isBlocked: PropTypes.bool.isRequired,
+  date: PropTypes.object.isRequired, // eslint-disable-line
 };
 
 class ReturnDatepicker extends Component {
@@ -243,4 +282,31 @@ storiesOf('bpk-component-datepicker', module)
       />
     </div>
   ))
-  .add('Depart & Return', () => <ReturnDatepicker />);
+  .add('Depart & Return', () => <ReturnDatepicker />)
+  .add('Custon calendar component', () => {
+    const CalendarWithColoredDates = withCalendarState(
+      composeCalendar(
+        BpkCalendarNav,
+        BpkCalendarGridHeader,
+        BpkCalendarGridWithTransition,
+        ColoredCalendarDate,
+      ),
+    );
+
+    return (
+      <div id="application-element">
+        <CalendarContainer
+          id="myDatepicker"
+          closeButtonText="Close"
+          daysOfWeek={weekDays}
+          weekStartsOn={1}
+          changeMonthLabel="Change month"
+          title="Departure date"
+          formatDate={formatDate}
+          formatMonth={formatMonth}
+          formatDateFull={formatDateFull}
+          calendarComponent={CalendarWithColoredDates}
+        />
+      </div>
+    );
+  });


### PR DESCRIPTION

<img width="540" alt="Screenshot 2019-11-18 at 18 17 10" src="https://user-images.githubusercontent.com/1457263/69078397-b8e55780-0a2f-11ea-86ec-24f4c6d740e1.png">


Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
