### PR TITLE
Add "dismissible" prop to BpkChip

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Please include a description of the changes you are introducing and some screens
 -->
 
 Remember to include the following changes:
-+ [x] `UNRELEASED.md`
++ [x] `UNRELEASED.yaml`
 + [x] `README.md`
 + [x] Tests
 + [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,14 @@ Conventions and squad decisions are kept in the [decisions folder](/decisions). 
 
 Backpack is developed using Node, using the following versions:
 
-* `LTS/Carbon` (Node ^8.12.0)
-* `^6.4.1` (npm)
+* `LTS/Erbium` (Node ^12.13.0)
+* `^6.12.0` (npm)
 
 This is enforced using a pre-install hook that calls out to [ensure-node-env](https://github.com/Skyscanner/ensure-node-env).
 
 If you use [nvm](https://github.com/creationix/nvm) or [nave](https://github.com/isaacs/nave) to manage your Node environment, Backpack has built-in support for these. Just run `nvm use` or `nave auto` to install the correct Node version.
 
-To install npm, use `npm install --global npm@^6.4.1`.
+To install npm, use `npm install --global npm@^6.12.0`.
 
 
 ### Android, iOS and React Native
@@ -209,7 +209,7 @@ You can also run the tests in 'watch mode', which means the process will continu
 <details>
 <summary>Publish packages (Backpack squad members only)</summary>
 
-- Update the [unreleased changelog](/unreleased.yaml) with every package that has changed, separating out `BRAKING`, `ADDED` and `FIXED` changes (there are examples at the bottom of the file). If you need more details on classification please checkout the [versioning decision](/decisions/versioning-rules.md)).
+- Update the [unreleased changelog](/UNRELEASED.yaml) with every package that has changed, separating out `BRAKING`, `ADDED` and `FIXED` changes (there are examples at the bottom of the file). If you need more details on classification please checkout the [versioning decision](/decisions/versioning-rules.md)).
   - Some useful commands for determining "what's changed?":
     - `npm run lerna updated`
     - `npm run lerna diff <package-name>`

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -24,3 +24,7 @@
 #   FIXED:
 #     - bpk-component-horcrux:
 #       - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+ADDED:
+  - bpk-component-chip:
+    - New `dismissible` prop that hides the close button when `false`.

--- a/packages/bpk-component-chip/README.md
+++ b/packages/bpk-component-chip/README.md
@@ -26,9 +26,10 @@ export default () => (
 
 ## Props
 
-| Property   | PropType                | Required | Default Value |
-| ---------- | ----------------------- | -------- | ------------- |
-| children   | node                    | true     | -             |
-| onClose    | func                    | true     | -             |
-| closeLabel | oneOfType(string, func) | true     | -             |
-| className  | string                  | false    | null          |
+| Property    | PropType                | Required | Default Value |
+| ----------- | ----------------------- | -------- | ------------- |
+| children    | node                    | true     | -             |
+| onClose     | func                    | true     | -             |
+| closeLabel  | oneOfType(string, func) | true     | -             |
+| className   | string                  | false    | null          |
+| dismissible | bool                    | false    | true          |

--- a/packages/bpk-component-chip/src/BpkChip-test.js
+++ b/packages/bpk-component-chip/src/BpkChip-test.js
@@ -69,4 +69,13 @@ describe('BpkChip', () => {
     );
     expect(toJson(tree)).toMatchSnapshot();
   });
+
+  it('should render correctly when not "dismissible"', () => {
+    const tree = shallow(
+      <BpkChip onClose={() => null} closeLabel="Close" dismissible={false}>
+        This is a Chip!
+      </BpkChip>,
+    );
+    expect(toJson(tree)).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-chip/src/BpkChip.js
+++ b/packages/bpk-component-chip/src/BpkChip.js
@@ -32,11 +32,19 @@ export type Props = {
   onClose: (event: SyntheticEvent<>) => mixed,
   closeLabel: ((children: Node) => string) | string,
   className: ?string,
+  dismissible: ?boolean,
 };
 
 const BpkChip = (props: Props) => {
   const classNames = [getClassName('bpk-chip')];
-  const { children, className, onClose, closeLabel, ...rest } = props;
+  const {
+    children,
+    className,
+    onClose,
+    closeLabel,
+    dismissible,
+    ...rest
+  } = props;
 
   if (className) {
     classNames.push(className);
@@ -48,7 +56,7 @@ const BpkChip = (props: Props) => {
   return (
     <div className={classNames.join(' ')} {...rest}>
       <span className={getClassName('bpk-chip__label')}>{children}</span>
-      <BpkCloseButton label={label} onClick={onClose} />
+      {dismissible && <BpkCloseButton label={label} onClick={onClose} />}
     </div>
   );
 };
@@ -59,10 +67,12 @@ BpkChip.propTypes = {
   closeLabel: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
     .isRequired,
   className: PropTypes.string,
+  dismissible: PropTypes.bool,
 };
 
 BpkChip.defaultProps = {
   className: null,
+  dismissible: true,
 };
 
 export default BpkChip;

--- a/packages/bpk-component-chip/src/__snapshots__/BpkChip-test.js.snap
+++ b/packages/bpk-component-chip/src/__snapshots__/BpkChip-test.js.snap
@@ -18,6 +18,18 @@ exports[`BpkChip should render correctly 1`] = `
 </div>
 `;
 
+exports[`BpkChip should render correctly when not "dismissible" 1`] = `
+<div
+  className="bpk-chip"
+>
+  <span
+    className="bpk-chip__label"
+  >
+    This is a Chip!
+  </span>
+</div>
+`;
+
 exports[`BpkChip should render correctly with a "className" attribute 1`] = `
 <div
   className="bpk-chip custom-class"

--- a/packages/bpk-component-chip/stories.js
+++ b/packages/bpk-component-chip/stories.js
@@ -24,8 +24,14 @@ import { action } from '@storybook/addon-actions';
 
 import BpkChip from './index';
 
-storiesOf('bpk-component-chip', module).add('Default', () => (
-  <BpkChip onClose={action('Chip closing!')} closeLabel="Close">
-    This is a chip!
-  </BpkChip>
-));
+storiesOf('bpk-component-chip', module)
+  .add('Default', () => (
+    <BpkChip onClose={action('Chip closing!')} closeLabel="Close">
+      This is a chip!
+    </BpkChip>
+  ))
+  .add('Non-dimissible', () => (
+    <BpkChip onClose={() => null} closeLabel="Close" dismissible={false}>
+      This is a non-dismissible chip!
+    </BpkChip>
+  ));

--- a/packages/bpk-component-map/stories.js
+++ b/packages/bpk-component-map/stories.js
@@ -149,7 +149,7 @@ storiesOf('bpk-component-map', module)
   .add('With onTilesLoaded', () => (
     <StoryMap
       center={{ latitude: 55.944357, longitude: -3.1967116 }}
-      onTilesLoaded={() => console.log('Tiles loaded')}
+      onTilesLoaded={() => console.log('Tiles loaded')} // eslint-disable-line no-console
     >
       <StatefulBpkMapMarker
         large


### PR DESCRIPTION
To allow using `BpkChip` in a read-only way.
When `dismissible` is set to `false`, the close button is hidden.