### PR TITLE
stop redundant datasource call

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -2,6 +2,8 @@
 FIXED:
   - bpk-component-accordion:
     - Added missing prop to README
+  - bpk-component-infinite-scroll:
+    - avoid redundant call to work out if data-source is exhausted
 
 # How to write a good changelog entry:
 #

--- a/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
+++ b/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
@@ -259,6 +259,93 @@ exports[`withInfiniteScroll should finish the list when data source changes to a
 </WithInfiniteScroll>
 `;
 
+exports[`withInfiniteScroll should finish the list when data source returns less than the number of elements requested 1`] = `
+<WithInfiniteScroll
+  dataSource={
+    ArrayDataSource {
+      "elements": Array [
+        "Element 0",
+        "Element 1",
+        "Element 2",
+        "Element 3",
+        "Element 4",
+      ],
+      "fetchItems": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            3,
+          ],
+          Array [
+            0,
+            3,
+          ],
+          Array [
+            3,
+            3,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+        ],
+      },
+      "listeners": Array [
+        [Function],
+      ],
+      "triggerListeners": [Function],
+    }
+  }
+  elementsPerScroll={3}
+  initiallyLoadedElements={3}
+  loaderIntersectionTrigger="full"
+  onScroll={null}
+  onScrollFinished={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "totalNumberElements": 3,
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  renderLoadingComponent={null}
+  renderSeeMoreComponent={null}
+  seeMoreAfter={null}
+>
+  <div>
+    <List
+      elements={Array []}
+    >
+      <div
+        id="list"
+      />
+    </List>
+    <div
+      className="bpk-sentinel"
+    />
+  </div>
+</WithInfiniteScroll>
+`;
+
 exports[`withInfiniteScroll should pass extra props to the decorated component 1`] = `
 <WithInfiniteScroll
   aria-label="Test"
@@ -378,9 +465,6 @@ exports[`withInfiniteScroll should refresh data when data changes 1`] = `
         </div>
       </div>
     </List>
-    <div
-      className="bpk-sentinel"
-    />
   </div>
 </WithInfiniteScroll>
 `;
@@ -461,9 +545,6 @@ exports[`withInfiniteScroll should refresh data when data changes from an empty 
         </div>
       </div>
     </List>
-    <div
-      className="bpk-sentinel"
-    />
   </div>
 </WithInfiniteScroll>
 `;
@@ -536,9 +617,6 @@ exports[`withInfiniteScroll should refresh data when data source changes from an
         </div>
       </div>
     </List>
-    <div
-      className="bpk-sentinel"
-    />
   </div>
 </WithInfiniteScroll>
 `;
@@ -611,9 +689,6 @@ exports[`withInfiniteScroll should refresh when data source changes 1`] = `
         </div>
       </div>
     </List>
-    <div
-      className="bpk-sentinel"
-    />
   </div>
 </WithInfiniteScroll>
 `;

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
@@ -394,4 +394,25 @@ describe('withInfiniteScroll', () => {
     expect(onFinished).toHaveBeenCalled();
     expect(toJson(tree)).toMatchSnapshot();
   });
+
+  it('should finish the list when data source returns less than the number of elements requested', async () => {
+    const myDs = mockDataSource(elementsArray);
+
+    const onFinished = jest.fn();
+
+    const tree = mount(
+      <InfiniteList
+        dataSource={myDs}
+        elementsPerScroll={3}
+        initiallyLoadedElements={3}
+        onScrollFinished={onFinished}
+      />,
+    );
+    await intersect();
+    await intersect();
+
+    expect(myDs.fetchItems).toHaveBeenCalledTimes(3);
+    expect(onFinished).toHaveBeenCalled();
+    expect(toJson(tree)).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -193,48 +193,6 @@ const withInfiniteScroll = <T: ExtendedProps>(
       }).then(newState => this.setStateAfterDsUpdate(newState));
     };
 
-    fetchItemsX(config): Promise<$Shape<State>> {
-      const { onScrollFinished, seeMoreAfter } = this.props;
-      const {
-        index,
-        elementsPerScroll,
-        elementsToRender,
-        computeShowSeeMore,
-      } = extend(
-        {
-          index: this.state.index,
-          elementsPerScroll: this.props.elementsPerScroll,
-          elementsToRender: this.state.elementsToRender,
-          computeShowSeeMore: true,
-        },
-        config,
-      );
-
-      return this.props.dataSource
-        .fetchItems(index, elementsPerScroll)
-        .then(nextElements => {
-          if (nextElements && nextElements.length > 0) {
-            const nextIndex = index + elementsPerScroll;
-            return {
-              index: nextIndex,
-              elementsToRender: (elementsToRender || []).concat(nextElements),
-              showSeeMore: computeShowSeeMore
-                ? seeMoreAfter === index / elementsPerScroll
-                : this.state.showSeeMore,
-              isListFinished: false,
-            };
-          }
-          if (onScrollFinished) {
-            onScrollFinished({
-              totalNumberElements: elementsToRender.length,
-            });
-          }
-          return {
-            isListFinished: true,
-          };
-        });
-    }
-
     fetchItems(config): Promise<$Shape<State>> {
       const { onScrollFinished, seeMoreAfter } = this.props;
       const {

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -168,7 +168,8 @@ const withInfiniteScroll = <T: ExtendedProps>(
     setStateAfterDsUpdate(newState: State) {
       // After a data source update (calling updateData in the data source or changing the dataSource prop)
       // all visible data is fetched again (from 0 to current index) to update the list with the new data.
-      // If after this call `isListFinished` is true, it means the new data source has no items and we need to
+      // If after this call there is no elementsToRender or index present in state
+      // it means the new data source has no items and we need to
       // reset the list, which we do by setting `elementsToRender` to `[]` and `index` to `0`
       const { elementsToRender, index } = newState;
       this.setState({

--- a/packages/bpk-component-infinite-scroll/stories.js
+++ b/packages/bpk-component-infinite-scroll/stories.js
@@ -220,4 +220,24 @@ storiesOf('bpk-component-infinite-scroll', module)
         />
       </div>
     );
-  });
+  })
+  .add(
+    'Infer datasource complete when less than request elements retruned by datasource',
+    () => {
+      const raiseLoadingAction = action('loading');
+      return (
+        <div>
+          <InfiniteList
+            dataSource={new DelayedDataSource(elementsArray)}
+            seeMoreAfter={20}
+            elementsPerScroll={7}
+            onScrollFinished={action('scroll finished')}
+            renderLoadingComponent={() => {
+              raiseLoadingAction();
+              return <div>Loading</div>;
+            }}
+          />
+        </div>
+      );
+    },
+  );


### PR DESCRIPTION
infer list has ended if less than requested elements are returned from data source

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Remember to include the following changes:
+ [] `UNRELEASED.yaml`
+ [] `README.md`
+ [x] Tests
+ [] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)