### PR TITLE
Upgrading flow to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19801,9 +19801,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.98.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.98.0.tgz",
-      "integrity": "sha512-vuiYjBVt82eYF+dEk9Zqa8hTSDvbhl/czxzFRLZm9/XHbJnYNMTwFoNFYAQT9IQ6ACNBIbwSTIfxroieuKja7g==",
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.111.0.tgz",
+      "integrity": "sha512-RQQMJ23r9zdGJjmYDoAoKqFy3TAudqbf/QGpsgsZvzMPg/qgIPK6e0hDLJe4aARR6B1+Gs0xBbVRBcFEFK8jyg==",
       "dev": true
     },
     "flow-typed": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "eslint-plugin-flowtype": "^4.0.0",
     "eslint_d": "^8.0.0",
     "extract-text-webpack-plugin": "^3.0.2",
-    "flow-bin": "^0.98.0",
+    "flow-bin": "^0.111.0",
     "flow-typed": "^2.5.1",
     "globby": "^10.0.0",
     "gulp": "^4.0.2",

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -124,7 +124,6 @@ class BpkHorizontalNav extends Component<Props> {
       typeof this.scrollRef.scroll === 'function' &&
       useSmoothScroll
     ) {
-      // $FlowFixMe - we've already checked that `this.scrollRef.scroll` is a function
       this.scrollRef.scroll({
         left: scrollAdjustment,
         behavior: 'smooth',

--- a/packages/bpk-component-image/src/BpkBackgroundImage.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.js
@@ -38,7 +38,9 @@ type BpkBackgroundImageProps = {
   className: ?string,
   onLoad: ?() => mixed,
   style: ?{}, // eslint-disable-line react/forbid-prop-types
-  imageStyle: ?{}, // eslint-disable-line react/forbid-prop-types
+  imageStyle: ?{
+    backgroundImage: string,
+  }, // eslint-disable-line react/forbid-prop-types
 };
 
 class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {

--- a/packages/bpk-component-image/src/withLazyLoading.js
+++ b/packages/bpk-component-image/src/withLazyLoading.js
@@ -67,7 +67,6 @@ export default function withLazyLoading(
 
     componentDidMount(): void {
       documentRef.addEventListener('scroll', this.checkInView, {
-        capture: true,
         ...this.getPassiveArgs(),
       });
       documentRef.addEventListener('resize', this.checkInView);
@@ -89,13 +88,14 @@ export default function withLazyLoading(
       this.removeEventListeners();
     };
 
-    getPassiveArgs(): {} {
-      return this.supportsPassiveEvents() ? { passive: true } : {};
+    getPassiveArgs(): { capture: boolean } {
+      return this.supportsPassiveEvents()
+        ? { capture: true, passive: true }
+        : { capture: true };
     }
 
     removeEventListeners = (): void => {
       documentRef.removeEventListener('scroll', this.checkInView, {
-        capture: true,
         ...this.getPassiveArgs(),
       });
       documentRef.removeEventListener('resize', this.checkInView);
@@ -115,7 +115,6 @@ export default function withLazyLoading(
     supportsPassiveEvents = (): boolean => {
       let supportsPassiveOption = false;
       try {
-        // $FlowFixMe
         const opts = Object.defineProperty({}, 'passive', {
           // eslint-disable-next-line getter-return
           get() {

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.flow.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.flow.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import React from 'react';
+import React, { Component } from 'react';
 
 import withInfiniteScroll from './withInfiniteScroll';
 import { ArrayDataSource } from './DataSource';
@@ -35,13 +35,25 @@ type ListProps = {
   onClick?: ?() => void,
 };
 
-const List = ({ elements, ...rest }: ListProps) => (
-  <div id="list" {...rest}>
-    {elements.forEach(element => (
-      <div key={element}>{element}</div>
-    ))}
-  </div>
-);
+// We have to turn this into a function as the HOC ignores the props of a function
+// another approach could be to put these props in the HOC as they aren't passed through.
+/* eslint-disable react/prefer-stateless-function */
+class List extends Component<ListProps> {
+  static defaultProps: {
+    onClick: null,
+  };
+
+  render() {
+    const { elements, ...rest } = this.props;
+    return (
+      <div id="list" {...rest}>
+        {elements.forEach(element => (
+          <div key={element}>{element}</div>
+        ))}
+      </div>
+    );
+  }
+}
 
 List.defaultProps = {
   onClick: null,

--- a/packages/bpk-component-popover/index.js
+++ b/packages/bpk-component-popover/index.js
@@ -18,9 +18,17 @@
 
 /* @flow strict */
 
-import BpkPopoverPortal, { type Props } from './src/BpkPopoverPortal';
+import BpkPopoverPortal, {
+  propTypes as bpkPopoverPortalPropTypes,
+  defaultProps as bpkPopoverPortalDefaultProps,
+  type Props,
+} from './src/BpkPopoverPortal';
 import themeAttributes from './src/themeAttributes';
 
 export type BpkPopoverProps = Props;
-export { themeAttributes };
+export {
+  themeAttributes,
+  bpkPopoverPortalPropTypes,
+  bpkPopoverPortalDefaultProps,
+};
 export default BpkPopoverPortal;

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -46,31 +46,35 @@ export type Props = {
   popperModifiers: ?Object,
 };
 
+export const propTypes = {
+  ...popoverPropTypes,
+  target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  portalStyle: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  portalClassName: PropTypes.string,
+  renderTarget: PropTypes.func,
+  popperModifiers: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+};
+
+export const defaultProps = {
+  ...popoverDefaultProps,
+  placement: 'bottom',
+  portalStyle: null,
+  portalClassName: null,
+  renderTarget: null,
+  popperModifiers: null,
+};
+
 class BpkPopoverPortal extends Component<Props> {
   popper: ?Popper;
 
   previousTargetElement: ?HTMLElement;
 
-  static propTypes = {
-    ...popoverPropTypes,
-    target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
-    isOpen: PropTypes.bool.isRequired,
-    onClose: PropTypes.func.isRequired,
-    placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
-    portalStyle: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-    portalClassName: PropTypes.string,
-    renderTarget: PropTypes.func,
-    popperModifiers: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  };
+  static propTypes = propTypes;
 
-  static defaultProps = {
-    ...popoverDefaultProps,
-    placement: 'bottom',
-    portalStyle: null,
-    portalClassName: null,
-    renderTarget: null,
-    popperModifiers: null,
-  };
+  static defaultProps = defaultProps;
 
   constructor() {
     super();

--- a/packages/bpk-component-popover/stories.js
+++ b/packages/bpk-component-popover/stories.js
@@ -28,7 +28,11 @@ import BpkContentContainer from 'bpk-component-content-container';
 
 import STYLES from './stories.scss';
 
-import BpkPopover, { type BpkPopoverProps as PopoverProps } from './index';
+import BpkPopover, {
+  bpkPopoverPortalPropTypes,
+  bpkPopoverPortalDefaultProps,
+  type BpkPopoverProps as PopoverProps,
+} from './index';
 
 const getClassName = cssModules(STYLES);
 
@@ -38,8 +42,17 @@ const Paragraph = withDefaultProps(BpkText, {
   className: getClassName('bpk-popover-paragraph'),
 });
 
+type IgnoredPopoverProps = {
+  children: Node,
+  closeButtonText: string,
+  isOpen: boolean,
+  label: string,
+  onClose: (event: SyntheticEvent<>, props: { source: string }) => mixed,
+  target: (() => ?HTMLElement) | Node,
+};
+
 type Props = {
-  ...$Diff<PopoverProps, { children: Node }>,
+  ...$Diff<PopoverProps, IgnoredPopoverProps>,
   id: string,
   changeProps: boolean,
   targetFunction: ?() => ?HTMLElement,
@@ -53,12 +66,16 @@ type State = {
 
 class PopoverContainer extends Component<Props, State> {
   static propTypes = {
+    ...bpkPopoverPortalPropTypes,
+    className: PropTypes.string,
     id: PropTypes.string.isRequired,
     changeProps: PropTypes.bool,
     targetFunction: PropTypes.func,
   };
 
   static defaultProps = {
+    ...bpkPopoverPortalDefaultProps,
+    className: null,
     changeProps: false,
     targetFunction: null,
   };

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -46,7 +46,6 @@ export type Props = {
   children: Node,
   placement: 'top' | 'right' | 'bottom' | 'left' | 'auto',
   hideOnTouchDevices: boolean,
-  padded: boolean,
   portalStyle: ?Object, // eslint-disable-line react/forbid-prop-types
   portalClassName: ?string,
   renderTarget: ?() => HTMLElement,
@@ -68,7 +67,6 @@ class BpkTooltipPortal extends Component<Props, State> {
     children: PropTypes.node.isRequired,
     placement: PropTypes.oneOf(Popper.placements),
     hideOnTouchDevices: PropTypes.bool,
-    padded: PropTypes.bool,
     portalStyle: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     portalClassName: PropTypes.string,
     renderTarget: PropTypes.func,
@@ -79,7 +77,6 @@ class BpkTooltipPortal extends Component<Props, State> {
     ...tooltipDefaultProps,
     placement: 'bottom',
     hideOnTouchDevices: true,
-    padded: true,
     portalStyle: null,
     portalClassName: null,
     renderTarget: null,


### PR DESCRIPTION
This upgrades flow to `0.111.0`

The current version is `0.112.0` but due to a bug with types and exact types we can't upgrade to the latest without removing `...rest` spreading from all our components.

More detail here: https://github.com/facebook/flow/issues/8192 
