### PR TITLE
ELMO-194 Add iOpen prop to datepicker

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -3,6 +3,8 @@
 ADDED:
   - bpk-component-carousel:
     - Added swipe support. Users of touchscreens can now swipe the carousel to scroll it.
+  - bpk-component-datepicker:
+    - New `isOpen` prop for controlling whether the date picker should be open on its first render.
 
 # How to write a good changelog entry:
 #

--- a/packages/bpk-component-datepicker/README.md
+++ b/packages/bpk-component-datepicker/README.md
@@ -146,6 +146,7 @@ For more information on some these props, check the BpkCalendar documentation.
 | showWeekendSeparator  | bool                  | false    | true (\*)                           |
 | initiallyFocusedDate  | Date                  | false    | null                                |
 | renderTarget          | func                  | false    | null                                |
+| isOpen                | bool                  | false    | false                               |
 
 > (\*) Default value is defined on child component
 

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -73,6 +73,33 @@ describe('BpkDatepicker', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should render correctly with datepicker open', () => {
+    const datepicker = mount(
+      <BpkDatepicker
+        id="myDatepicker"
+        closeButtonText="Close"
+        daysOfWeek={weekDays}
+        changeMonthLabel="Change month"
+        title="Departure date"
+        weekStartsOn={1}
+        getApplicationElement={() => document.createElement('div')}
+        formatDate={formatDate}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        inputProps={inputProps}
+        minDate={new Date(2010, 1, 15)}
+        maxDate={new Date(2010, 2, 15)}
+        date={new Date(2010, 1, 15)}
+        isOpen
+      />,
+    );
+
+    expect(datepicker.state('isOpen')).toEqual(true);
+
+    datepicker.instance().onClose();
+    expect(datepicker.state('isOpen')).toEqual(false);
+  });
+
   it('"readOnly" can be overriden in "inputProps"', () => {
     const noReadOnlyInputProps = Object.assign({}, inputProps, {
       readOnly: false,

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -36,7 +36,7 @@ class BpkDatepicker extends Component {
     super(props);
 
     this.state = {
-      isOpen: false,
+      isOpen: props.isOpen,
     };
   }
 
@@ -195,6 +195,7 @@ BpkDatepicker.propTypes = {
   showWeekendSeparator: PropTypes.bool,
   initiallyFocusedDate: PropTypes.instanceOf(Date),
   renderTarget: PropTypes.func,
+  isOpen: PropTypes.bool,
 };
 
 BpkDatepicker.defaultProps = {
@@ -211,6 +212,7 @@ BpkDatepicker.defaultProps = {
   showWeekendSeparator: BpkCalendar.defaultProps.showWeekendSeparator,
   initiallyFocusedDate: null,
   renderTarget: null,
+  isOpen: false,
 };
 
 export default BpkDatepicker;

--- a/packages/bpk-component-datepicker/stories.js
+++ b/packages/bpk-component-datepicker/stories.js
@@ -234,6 +234,23 @@ storiesOf('bpk-component-datepicker', module)
       />
     </div>
   ))
+  .add('Open on first render', () => (
+    <div id="application-element">
+      <CalendarContainer
+        id="myDatepicker"
+        closeButtonText="Close"
+        daysOfWeek={weekDays}
+        weekStartsOn={1}
+        changeMonthLabel="Change month"
+        title="Departure date"
+        formatDate={formatDate}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        date={new Date()}
+        isOpen
+      />
+    </div>
+  ))
   .add('Min date in the past', () => (
     <div id="application-element">
       <CalendarContainer


### PR DESCRIPTION
Datepicker was always closed by default on the first render. I changed it to configurable by a new prop.

Remember to include the following changes:
+ [x] `UNRELEASED.yaml`
+ [x] `README.md`
+ [ ] Tests (As it's a minor change i didn't include tests. In fact, a snapshot test wouldn't really help here)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
