### PR TITLE
ELMO-194 Datepicker - dont pass isOpen to BpkPopover

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -1,5 +1,8 @@
 # UNRELEASED:
 
+FIXED:
+  - bpk-component-datepicker:
+    - Fixed popover with isOpen overridden from datepicker's props.
 
 # How to write a good changelog entry:
 #

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -92,6 +92,7 @@ class BpkDatepicker extends Component {
 
     // The following props are not used in render
     delete rest.onDateSelect;
+    delete rest.isOpen;
 
     const inputComponent = (
       <Input


### PR DESCRIPTION
The previous PR introduced the bug where isOpen was passed to BpkPopover and overriding the state value.

Remember to include the following changes:
+ [x] `UNRELEASED.yaml`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
