### PR TITLE
[BPK-3208] Add flow typing to RN tokens

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -1,5 +1,10 @@
 # UNRELEASED:
 
+BREAKING:
+  - bpk-tokens:
+    - Added flow typing to RN tokens.
+    - Removed wrong `secondaryColor` and `secondaryDarkColor` from RN tokens.
+
 # How to write a good changelog entry:
 #
 #   1. Add 'BREAKING', 'ADDED' OR 'FIXED' depending on if the change will be major, minor or patch according to [semver.org](semver.org).

--- a/packages/bpk-tokens/formatters/bpk.react.native.es6.js.js
+++ b/packages/bpk-tokens/formatters/bpk.react.native.es6.js.js
@@ -16,6 +16,9 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
+
 import _ from 'lodash';
 
 import sortTokens from './sort-tokens';
@@ -23,10 +26,24 @@ import adjustTypography from './adjust-typography';
 import { blockComment } from './license-header';
 import valueTemplate from './react-native-value-template';
 
+const iosRawTokens = _.memoize(() =>
+  JSON.parse(
+    fs.readFileSync(path.join(__dirname, '../tokens/base.raw.ios.json')),
+  ),
+);
+
+const androidRawTokens = _.memoize(() =>
+  JSON.parse(
+    fs.readFileSync(path.join(__dirname, '../tokens/base.raw.android.json')),
+  ),
+);
+
 const SEMANTIC_TOKEN_REGEX = /(.*)_(LIGHT|DARK)_(.*)/;
 
 const tokenTemplate = ({ name, value, type }) =>
-  `export const ${_.camelCase(name)} = ${valueTemplate(value, type)};`;
+  `export const ${_.camelCase(name)} = ${
+    value ? valueTemplate(value, type) : value
+  };`;
 
 export const categoryTemplate = (
   categoryName,
@@ -35,34 +52,77 @@ export const categoryTemplate = (
 ${_.map(props, prop => `${_.camelCase(prop.name)},`).join('\n')}
 };`;
 
-const extractSemanticTokens = allTokens =>
-  Object.keys(allTokens).reduce((semanticTokens, tokenKey) => {
-    const token = allTokens[tokenKey];
-    const match = token.name.match(SEMANTIC_TOKEN_REGEX);
-    if (match) {
-      // E.g. for backgroundLightColor this will be backgroundColor
-      const key = `${match[1]}_${match[3]}`;
-      const semanticToken = semanticTokens[key] || {
-        name: key,
-        type: 'semantic',
-        value: {},
-        category: `semantic${_.capitalize(token.category)}`,
-      };
-      // This will be light or dark
-      const variation = match[2].toLowerCase();
-      semanticToken.value[variation] = { ...token };
-      semanticTokens[key] = semanticToken; // eslint-disable-line
-    }
-    return semanticTokens;
-  }, {});
+const extractSemanticTokens = allTokens => {
+  const parsedTokens = Object.keys(allTokens).reduce(
+    (semanticTokens, tokenKey) => {
+      const token = allTokens[tokenKey];
+      const match = token.name.match(SEMANTIC_TOKEN_REGEX);
+      if (match) {
+        // E.g. for backgroundLightColor this will be backgroundColor
+        const key = `${match[1]}_${match[3]}`;
+        const semanticToken = semanticTokens[key] || {
+          name: key,
+          type: 'semantic',
+          value: {},
+          category: `semantic${_.capitalize(token.category)}`,
+        };
+        // This will be light or dark
+        const variation = match[2].toLowerCase();
+        semanticToken.value[variation] = { ...token };
+        semanticTokens[key] = semanticToken; // eslint-disable-line
+      }
+      return semanticTokens;
+    },
+    {},
+  );
 
-const bpkReactNativeEs6Js = (result, platform = 'other') => {
+  return Object.keys(parsedTokens).map(
+    parsedToken => parsedTokens[parsedToken],
+  );
+};
+
+const extractPlatformSpecifcTokens = (allTokens, platform) => {
+  const otherPlatformTokens =
+    platform === 'iosRn' ? androidRawTokens() : iosRawTokens();
+  const otherPlatformKeys = Object.keys(otherPlatformTokens.props);
+
+  const platformKeys = allTokens.props.map(token => token.name);
+
+  const missingTokens = otherPlatformKeys
+    .filter(token => platformKeys.indexOf(token) === -1)
+    .reduce(
+      (newTokens, token) => ({
+        ...newTokens,
+        [token]: {
+          name: token,
+          type: otherPlatformTokens.props[token].type,
+          value: undefined,
+          category: null,
+          nullable: true,
+        },
+      }),
+      {},
+    );
+
+  const nullableTokens = platformKeys
+    .filter(token => otherPlatformKeys.indexOf(token) === -1)
+    .reduce((acc, token) => ({ ...acc, [token]: true }), {});
+
+  return [missingTokens, nullableTokens];
+};
+
+const bpkReactNativeEs6Js = (result, platform) => {
   const baseTokens = result.toJS();
   const semanticTokens = extractSemanticTokens(baseTokens.props);
   const allTokens = {
     ...baseTokens,
-    props: { ...baseTokens.props, ...semanticTokens },
+    props: [...baseTokens.props, ...semanticTokens],
   };
+
+  const [
+    platformSpecificTokens, // Tokens that only exist in the other (not current) platform
+    nullableTokenNames, // Tokens that only exist in this platform
+  ] = extractPlatformSpecifcTokens(allTokens, platform);
 
   const { props } = sortTokens(allTokens);
 
@@ -72,7 +132,10 @@ const bpkReactNativeEs6Js = (result, platform = 'other') => {
     .value();
 
   const singleTokens = _.map(props, prop =>
-    tokenTemplate(adjustTypography(prop, platform)),
+    tokenTemplate({
+      ...adjustTypography(prop, platform),
+      nullable: nullableTokenNames[prop.name],
+    }),
   ).join('\n');
 
   const groupedTokens = categories
@@ -87,10 +150,19 @@ const bpkReactNativeEs6Js = (result, platform = 'other') => {
     )
     .join('\n');
 
-  return [blockComment, singleTokens, groupedTokens].join('\n');
-};
+  const platformSpecific = _.map(platformSpecificTokens, prop =>
+    tokenTemplate(prop),
+  ).join('\n');
 
-export default bpkReactNativeEs6Js;
+  return [
+    '// @flow',
+    blockComment,
+    singleTokens,
+    groupedTokens,
+    `// ${platform === 'iosRn' ? 'Android' : 'iOS'} only tokens`,
+    platformSpecific,
+  ].join('\n');
+};
 
 export const bpkReactNativeEs6JsAndroid = result =>
   bpkReactNativeEs6Js(result, 'androidRn');

--- a/packages/bpk-tokens/formatters/bpk.react.native.es6.js.js
+++ b/packages/bpk-tokens/formatters/bpk.react.native.es6.js.js
@@ -26,6 +26,10 @@ import adjustTypography from './adjust-typography';
 import { blockComment } from './license-header';
 import valueTemplate from './react-native-value-template';
 
+// The raw tokens are guaranteed to be generated at this point, we make sure they are done first in the gulpfile.
+// We do this because I could not find any way to make Theo provide both the Android and iOS tokens as arguments to this function, because Theo
+// merges all tokens we provide as input, and that will result in the function being always called with all tokens (iOS and Android),
+// which is no good for us here, we need to know which tokens are Android and iOS to add the proper flow annotations.
 const iosRawTokens = _.memoize(() =>
   JSON.parse(
     fs.readFileSync(path.join(__dirname, '../tokens/base.raw.ios.json')),

--- a/packages/bpk-tokens/formatters/react-native-value-template.js
+++ b/packages/bpk-tokens/formatters/react-native-value-template.js
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2020 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import tinycolor from 'tinycolor2';
 
 export default function formatValue(value, type) {

--- a/packages/bpk-tokens/src/android/base/colors.json
+++ b/packages/bpk-tokens/src/android/base/colors.json
@@ -17,9 +17,6 @@
     "PRIMARY_DARK_COLOR": {
       "value": "{!SKY_BLUE_TINT_01}"
     },
-    "SECONDARY_DARK_COLOR": {
-      "value": "{!SKY_BLUE_TINT_01}"
-    },
     "BACKGROUND_LIGHT_COLOR": {
       "value": "{!WHITE}"
     },

--- a/packages/bpk-tokens/src/ios/base/colors.json
+++ b/packages/bpk-tokens/src/ios/base/colors.json
@@ -17,9 +17,6 @@
     "PRIMARY_DARK_COLOR": {
       "value": "{!SKY_BLUE_TINT_01}"
     },
-    "SECONDARY_DARK_COLOR": {
-      "value": "{!SKY_BLUE_TINT_01}"
-    },
     "BACKGROUND_LIGHT_COLOR": {
       "value": "{!WHITE}"
     },

--- a/packages/bpk-tokens/src/transformDarkValues.js
+++ b/packages/bpk-tokens/src/transformDarkValues.js
@@ -71,7 +71,7 @@ const performMerge = (key, mergeDefinition) => {
     return null;
   }
 
-  const newObj = JSON.parse(JSON.stringify(mergeDefinition.light));
+  const newObj = { ...mergeDefinition.light };
   newObj.name = key;
   newObj.darkValue = mergeDefinition.dark.value;
   newObj.originalDarkValue = mergeDefinition.dark.originalValue;

--- a/packages/bpk-tokens/tokens/android/base.react.native.common.js
+++ b/packages/bpk-tokens/tokens/android/base.react.native.common.js
@@ -128,7 +128,6 @@ module.exports = {
   lineLightColor: "rgb(205, 205, 215)",
   primaryDarkColor: "rgb(109, 159, 235)",
   primaryLightColor: "rgb(7, 112, 227)",
-  secondaryDarkColor: "rgb(109, 159, 235)",
   spacingBase: 16,
   spacingLg: 24,
   spacingMd: 8,

--- a/packages/bpk-tokens/tokens/android/base.react.native.es6.js
+++ b/packages/bpk-tokens/tokens/android/base.react.native.es6.js
@@ -1,3 +1,4 @@
+// @flow
 /*
  * 
  * Backpack - Skyscanner's Design System
@@ -166,10 +167,6 @@ export const primaryColor = {
 };
 export const primaryDarkColor = "rgb(109, 159, 235)";
 export const primaryLightColor = "rgb(7, 112, 227)";
-export const secondaryColor = {
- dark: "rgb(109, 159, 235)",
-};
-export const secondaryDarkColor = "rgb(109, 159, 235)";
 export const spacingBase = 16;
 export const spacingLg = 24;
 export const spacingMd = 8;
@@ -297,7 +294,6 @@ lineDarkColor,
 lineLightColor,
 primaryDarkColor,
 primaryLightColor,
-secondaryDarkColor,
 };
 export const elevation = {
 elevationBase,
@@ -359,7 +355,6 @@ backgroundSecondaryColor,
 backgroundTertiaryColor,
 lineColor,
 primaryColor,
-secondaryColor,
 };
 export const semanticTextColors = {
 backgroundElevation01Color,
@@ -419,3 +414,18 @@ lineHeightXl,
 lineHeightXs,
 lineHeightXxl,
 };
+// iOS only tokens
+export const shadowLgColor = undefined;
+export const shadowLgOffsetHeight = undefined;
+export const shadowLgOffsetWidth = undefined;
+export const shadowLgOpacity = undefined;
+export const shadowLgRadius = undefined;
+export const shadowSmColor = undefined;
+export const shadowSmOffsetHeight = undefined;
+export const shadowSmOffsetWidth = undefined;
+export const shadowSmOpacity = undefined;
+export const shadowSmRadius = undefined;
+export const textHeavyFontWeight = undefined;
+export const touchableOverlayColor = undefined;
+export const touchableOverlayOpacity = undefined;
+export const underlayOpacity = undefined;

--- a/packages/bpk-tokens/tokens/base.android.xml
+++ b/packages/bpk-tokens/tokens/base.android.xml
@@ -129,7 +129,6 @@
   <color name="LINE_LIGHT_COLOR" category="colors">#ffcdcdd7</color>
   <color name="PRIMARY_DARK_COLOR" category="colors">#ff6d9feb</color>
   <color name="PRIMARY_LIGHT_COLOR" category="colors">#ff0770e3</color>
-  <color name="SECONDARY_DARK_COLOR" category="colors">#ff6d9feb</color>
   <property name="SPACING_BASE" category="spacings">16dp</property>
   <property name="SPACING_LG" category="spacings">24dp</property>
   <property name="SPACING_MD" category="spacings">8dp</property>

--- a/packages/bpk-tokens/tokens/base.ios.json
+++ b/packages/bpk-tokens/tokens/base.ios.json
@@ -708,13 +708,6 @@
       "name": "primaryLightColor"
     },
     {
-      "type": "color",
-      "category": "colors",
-      "value": "#6d9febff",
-      "originalValue": "{!SKY_BLUE_TINT_01}",
-      "name": "secondaryDarkColor"
-    },
-    {
       "value": "#111236ff",
       "type": "color",
       "category": "box-shadows",

--- a/packages/bpk-tokens/tokens/base.raw.android.json
+++ b/packages/bpk-tokens/tokens/base.raw.android.json
@@ -1038,13 +1038,6 @@
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_LIGHT_COLOR"
     },
-    "SECONDARY_DARK_COLOR": {
-      "type": "color",
-      "category": "colors",
-      "value": "#6d9febff",
-      "originalValue": "{!SKY_BLUE_TINT_01}",
-      "name": "SECONDARY_DARK_COLOR"
-    },
     "SPACING_BASE": {
       "type": "size",
       "category": "spacings",
@@ -1562,7 +1555,6 @@
     "LINE_LIGHT_COLOR",
     "PRIMARY_DARK_COLOR",
     "PRIMARY_LIGHT_COLOR",
-    "SECONDARY_DARK_COLOR",
     "SPACING_BASE",
     "SPACING_LG",
     "SPACING_MD",

--- a/packages/bpk-tokens/tokens/base.raw.ios.json
+++ b/packages/bpk-tokens/tokens/base.raw.ios.json
@@ -961,13 +961,6 @@
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_LIGHT_COLOR"
     },
-    "SECONDARY_DARK_COLOR": {
-      "type": "color",
-      "category": "colors",
-      "value": "#6d9febff",
-      "originalValue": "{!SKY_BLUE_TINT_01}",
-      "name": "SECONDARY_DARK_COLOR"
-    },
     "SHADOW_LG_COLOR": {
       "value": "#111236ff",
       "type": "color",
@@ -1576,7 +1569,6 @@
     "LINE_LIGHT_COLOR",
     "PRIMARY_DARK_COLOR",
     "PRIMARY_LIGHT_COLOR",
-    "SECONDARY_DARK_COLOR",
     "SHADOW_LG_COLOR",
     "SHADOW_LG_OFFSET_HEIGHT",
     "SHADOW_LG_OFFSET_WIDTH",

--- a/packages/bpk-tokens/tokens/base.react.native.android.js
+++ b/packages/bpk-tokens/tokens/base.react.native.android.js
@@ -1,3 +1,4 @@
+// @flow
 /*
  * 
  * Backpack - Skyscanner's Design System
@@ -166,10 +167,6 @@ export const primaryColor = {
 };
 export const primaryDarkColor = "rgb(109, 159, 235)";
 export const primaryLightColor = "rgb(7, 112, 227)";
-export const secondaryColor = {
- dark: "rgb(109, 159, 235)",
-};
-export const secondaryDarkColor = "rgb(109, 159, 235)";
 export const spacingBase = 16;
 export const spacingLg = 24;
 export const spacingMd = 8;
@@ -297,7 +294,6 @@ lineDarkColor,
 lineLightColor,
 primaryDarkColor,
 primaryLightColor,
-secondaryDarkColor,
 };
 export const elevation = {
 elevationBase,
@@ -359,7 +355,6 @@ backgroundSecondaryColor,
 backgroundTertiaryColor,
 lineColor,
 primaryColor,
-secondaryColor,
 };
 export const semanticTextColors = {
 backgroundElevation01Color,
@@ -419,3 +414,18 @@ lineHeightXl,
 lineHeightXs,
 lineHeightXxl,
 };
+// iOS only tokens
+export const shadowLgColor = undefined;
+export const shadowLgOffsetHeight = undefined;
+export const shadowLgOffsetWidth = undefined;
+export const shadowLgOpacity = undefined;
+export const shadowLgRadius = undefined;
+export const shadowSmColor = undefined;
+export const shadowSmOffsetHeight = undefined;
+export const shadowSmOffsetWidth = undefined;
+export const shadowSmOpacity = undefined;
+export const shadowSmRadius = undefined;
+export const textHeavyFontWeight = undefined;
+export const touchableOverlayColor = undefined;
+export const touchableOverlayOpacity = undefined;
+export const underlayOpacity = undefined;

--- a/packages/bpk-tokens/tokens/base.react.native.ios.js
+++ b/packages/bpk-tokens/tokens/base.react.native.ios.js
@@ -1,3 +1,4 @@
+// @flow
 /*
  * 
  * Backpack - Skyscanner's Design System
@@ -158,10 +159,6 @@ export const primaryColor = {
 };
 export const primaryDarkColor = "rgb(109, 159, 235)";
 export const primaryLightColor = "rgb(7, 112, 227)";
-export const secondaryColor = {
- dark: "rgb(109, 159, 235)",
-};
-export const secondaryDarkColor = "rgb(109, 159, 235)";
 export const shadowLgColor = "rgb(17, 18, 54)";
 export const shadowLgOffsetHeight = 4;
 export const shadowLgOffsetWidth = 0;
@@ -315,7 +312,6 @@ lineDarkColor,
 lineLightColor,
 primaryDarkColor,
 primaryLightColor,
-secondaryDarkColor,
 };
 export const fontSizes = {
 textBaseFontSize,
@@ -370,7 +366,6 @@ backgroundSecondaryColor,
 backgroundTertiaryColor,
 lineColor,
 primaryColor,
-secondaryColor,
 };
 export const semanticTextColors = {
 backgroundElevation01Color,
@@ -433,3 +428,12 @@ lineHeightXl,
 lineHeightXs,
 lineHeightXxl,
 };
+// Android only tokens
+export const elevationBase = undefined;
+export const elevationLg = undefined;
+export const elevationSm = undefined;
+export const elevationXl = undefined;
+export const elevationXs = undefined;
+export const elevationXxl = undefined;
+export const fontFamilyEmphasize = undefined;
+export const fontFamilyHeavy = undefined;

--- a/packages/bpk-tokens/tokens/ios/base.react.native.common.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.common.js
@@ -120,7 +120,6 @@ module.exports = {
   lineLightColor: "rgb(205, 205, 215)",
   primaryDarkColor: "rgb(109, 159, 235)",
   primaryLightColor: "rgb(7, 112, 227)",
-  secondaryDarkColor: "rgb(109, 159, 235)",
   shadowLgColor: "rgb(17, 18, 54)",
   shadowLgOffsetHeight: 4,
   shadowLgOffsetWidth: 0,

--- a/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
+++ b/packages/bpk-tokens/tokens/ios/base.react.native.es6.js
@@ -1,3 +1,4 @@
+// @flow
 /*
  * 
  * Backpack - Skyscanner's Design System
@@ -158,10 +159,6 @@ export const primaryColor = {
 };
 export const primaryDarkColor = "rgb(109, 159, 235)";
 export const primaryLightColor = "rgb(7, 112, 227)";
-export const secondaryColor = {
- dark: "rgb(109, 159, 235)",
-};
-export const secondaryDarkColor = "rgb(109, 159, 235)";
 export const shadowLgColor = "rgb(17, 18, 54)";
 export const shadowLgOffsetHeight = 4;
 export const shadowLgOffsetWidth = 0;
@@ -315,7 +312,6 @@ lineDarkColor,
 lineLightColor,
 primaryDarkColor,
 primaryLightColor,
-secondaryDarkColor,
 };
 export const fontSizes = {
 textBaseFontSize,
@@ -370,7 +366,6 @@ backgroundSecondaryColor,
 backgroundTertiaryColor,
 lineColor,
 primaryColor,
-secondaryColor,
 };
 export const semanticTextColors = {
 backgroundElevation01Color,
@@ -433,3 +428,12 @@ lineHeightXl,
 lineHeightXs,
 lineHeightXxl,
 };
+// Android only tokens
+export const elevationBase = undefined;
+export const elevationLg = undefined;
+export const elevationSm = undefined;
+export const elevationXl = undefined;
+export const elevationXs = undefined;
+export const elevationXxl = undefined;
+export const fontFamilyEmphasize = undefined;
+export const fontFamilyHeavy = undefined;


### PR DESCRIPTION
This makes both iOS and Android tokens file the same, the tokens that are not valid for one platform are exported with `undefined` (which is a valid value for all stylesheet props) so flow is happy when people import a platform specific token in a "general" file (no ios or android extension).

It also removes `secondaryColor` from RN tokens which was wrong.

Remember to include the following changes:
+ [x] `UNRELEASED.yaml`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
