### PR TITLE
BpkText readme update

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -551,6 +551,8 @@ lg
 xl
 xxl
 xxxl
+xxxxl
+xxxxxl
 
 # Package names
 

--- a/packages/bpk-component-text/README.md
+++ b/packages/bpk-component-text/README.md
@@ -60,7 +60,7 @@ export default () => (
 | Property  | PropType                                 | Required | Default Value |
 | --------- | ---------------------------------------- | -------- | ------------- |
 | children  | -                                        | true     | -             |
-| textStyle | 'xs', 'sm', 'base', 'lg', 'xl', 'xxl'    | false    | 'base'        |
+| textStyle | 'xs', 'sm', 'base', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxl', 'xxxxxl'    | false    | 'base'        |
 | tagName   | 'span', 'p', 'text', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' | false    | 'span'        |
 | className | string                                   | false    | null          |
 | bold      | bool                                     | false    | false         |

--- a/packages/bpk-component-text/src/BpkText.js
+++ b/packages/bpk-component-text/src/BpkText.js
@@ -38,11 +38,6 @@ const TEXT_STYLES = [
   'xxxxxl',
 ];
 
-const classes = {};
-TEXT_STYLES.forEach(textStyle => {
-  classes[textStyle] = getClassName(`bpk-text--${textStyle}`);
-});
-
 type Props = {
   children: Node,
   // eslint-disable-next-line flowtype/space-after-type-colon
@@ -70,17 +65,15 @@ const BpkText = (props: Props) => {
     textStyle,
     ...rest
   } = props;
-  const classNames = [getClassName('bpk-text'), classes[props.textStyle]];
-
-  if (bold) {
-    classNames.push(getClassName('bpk-text--bold'));
-  }
-  if (className) {
-    classNames.push(className);
-  }
+  const classNames = getClassName(
+    'bpk-text',
+    `bpk-text--${textStyle}`,
+    bold && 'bpk-text--bold',
+    className,
+  );
 
   return (
-    <TagName className={classNames.join(' ')} {...rest}>
+    <TagName className={classNames} {...rest}>
       {children}
     </TagName>
   );


### PR DESCRIPTION
* Readme for `BpkText` is missing the new `textStyle` values.
* Changed a bit the code that generates `className` in `BpkText` component, making use of `cssModules` capabilities.