### PR TITLE
Remove use of componentWillMount in withBannerAlertState

### DIFF
--- a/packages/bpk-component-banner-alert/src/withBannerAlertState.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState.js
@@ -96,7 +96,7 @@ const withBannerAlertState = (WrappedComponent: ComponentType<any>) => {
       this.hideIntervalId = null;
     }
 
-    componentWillMount() {
+    componentDidMount() {
       const { hideAfter } = this.props;
 
       if (


### PR DESCRIPTION
Replaced with componentDidMount.

There should be no visible difference to the users. The alert might be shown a couple of milliseconds later than before but should be overall positive as the defined timeout should start when the component is visible rather than when React starts processing it.

Remember to include the following changes:
+ [x] `UNRELEASED.yaml`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
