### PR TITLE
ATBT-2578 - Add schema markup for breadcrumbs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -170,6 +170,7 @@ iff
 isRTL
 IntersectionObserver
 JS
+JSON-LD
 keystore
 Keystore
 linter
@@ -455,6 +456,7 @@ keyup
 iconDisabled
 rel
 buttonProps
+schemaMetaData
 
 autoScrollToSelected
 calendarComponent

--- a/.spelling
+++ b/.spelling
@@ -201,6 +201,7 @@ themeable
 TTF
 UIs
 uncompiled
+url
 z-index
 
 # a11y terms

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -25,3 +25,7 @@
 #   FIXED:
 #     - bpk-component-horcrux:
 #       - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+ADDED:
+  - bpk-component-breadcrumb
+    - Added support for building schema markup to the component

--- a/decisions/structured-data.md
+++ b/decisions/structured-data.md
@@ -1,0 +1,8 @@
+# Adding structured data to components
+
+## Decision
+Use [structured data](https://developers.google.com/search/docs/guides/intro-structured-data) as an optional, non-default feature to components where there is a use case, following the [JSON-LD](https://json-ld.org/) schema
+
+## Examples
+
+* `bpk-component-breadcrumb`

--- a/packages/bpk-component-breadcrumb/README.md
+++ b/packages/bpk-component-breadcrumb/README.md
@@ -37,6 +37,8 @@ export default class App extends Component {
 | ------------------ | -------- | -------- | ------------- |
 | children           | node     | true     | -             |
 | label              | string   | true     | -             |
+| schemaMetaData     | array    | false    | null          |
+
 
 
 ### BpkBreadcrumbItem

--- a/packages/bpk-component-breadcrumb/README.md
+++ b/packages/bpk-component-breadcrumb/README.md
@@ -30,19 +30,21 @@ export default class App extends Component {
 
 ```
 
-## Schema Markup
+## Structured Data
 
-JSON-LD schema mark up can be added to improve the SEO of the component through the `schemaMetaData` property
+[JSON-LD](https://json-ld.org/) schema mark up can be used to
+add [structured data](https://developers.google.com/search/docs/guides/intro-structured-data)
+to the component to improve the SEO of the component through the `schemaMetaData` property.
 
 ## Props
 
 ### BpkBreadcrumb
 
-| Property           | PropType | Required | Default Value |
-| ------------------ | -------- | -------- | ------------- |
-| children           | node     | true     | -             |
-| label              | string   | true     | -             |
-| schemaMetaData     | array    | false    | null          |
+| Property           | PropType                             | Required | Default Value |
+| ------------------ | ------------------------------------ | -------- | ------------- |
+| children           | node                                 | true     | -             |
+| label              | string                               | true     | -             |
+| schemaMetaData     | array({url: string, label: string})  | false    | null          |
 
 
 

--- a/packages/bpk-component-breadcrumb/README.md
+++ b/packages/bpk-component-breadcrumb/README.md
@@ -29,6 +29,11 @@ export default class App extends Component {
 }
 
 ```
+
+## Schema Markup
+
+JSON-LD schema mark up can be added to improve the SEO of the component through the `schemaMetaData` property
+
 ## Props
 
 ### BpkBreadcrumb

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumb-test.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumb-test.js
@@ -62,4 +62,26 @@ describe('BpkBreadcrumb', () => {
 
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render correctly with schema meta data', () => {
+    const schemaMetaData = [
+      {
+        url: 'http://www.skyscanner.net',
+        label: 'home',
+      },
+      {
+        url: 'http://www.skyscanner.net/hotels',
+        label: 'hotels',
+      },
+    ];
+    const tree = renderer
+      .create(
+        <BpkBreadcrumb label="My breadcrumbs" schemaMetaData={schemaMetaData}>
+          <div>Anything can go in here</div>
+        </BpkBreadcrumb>,
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
@@ -37,6 +37,11 @@ export type Props = {
   label: string,
 };
 
+/*
+  The google structured data reference for the stringified output of
+  the following function is here:
+  https://developers.google.com/search/docs/data-types/breadcrumb
+*/
 const buildMetaData = (schemaMetaData: SchemaMetaDataItem[]): string => {
   const itemListElement = schemaMetaData.map((schemaMetaDataItem, index) => ({
     '@type': 'ListItem',

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
@@ -77,7 +77,7 @@ BpkBreadcrumb.propTypes = {
   children: PropTypes.node.isRequired,
   label: PropTypes.string.isRequired,
   schemaMetaData: PropTypes.arrayOf(
-    PropTypes.Shape({
+    PropTypes.shape({
       url: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,
     }),

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
@@ -59,11 +59,11 @@ const BpkBreadcrumb = (props: Props) => {
 
   return (
     <React.Fragment>
-      {schemaMetaData && (
+      {Array.isArray(schemaMetaData) && (
         <script
           type="application/ld+json"
           // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={buildMetaData(schemaMetaData)}
+          dangerouslySetInnerHTML={{ __html: buildMetaData(schemaMetaData) }}
         />
       )}
       <nav aria-label={label} {...rest}>

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
@@ -26,24 +26,66 @@ import STYLES from './BpkBreadcrumb.scss';
 
 const getClassName = cssModules(STYLES);
 
-export type Props = {
-  children: Node,
+type SchemaMetaDataItem = {
+  url: string,
   label: string,
 };
 
+export type Props = {
+  children: Node,
+  schemaMetaData: ?(SchemaMetaDataItem[]),
+  label: string,
+};
+
+const buildMetaData = (schemaMetaData: SchemaMetaDataItem[]): string => {
+  const itemListElement = schemaMetaData.map((schemaMetaDataItem, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    item: {
+      '@id': schemaMetaDataItem.url,
+      name: schemaMetaDataItem.label,
+    },
+  }));
+
+  return JSON.stringify({
+    '@context': 'http://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement,
+  });
+};
+
 const BpkBreadcrumb = (props: Props) => {
-  const { children, label, ...rest } = props;
+  const { children, label, schemaMetaData, ...rest } = props;
 
   return (
-    <nav aria-label={label} {...rest}>
-      <ol className={getClassName('bpk-breadcrumb')}>{children}</ol>
-    </nav>
+    <React.Fragment>
+      {schemaMetaData && (
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={buildMetaData(schemaMetaData)}
+        />
+      )}
+      <nav aria-label={label} {...rest}>
+        <ol className={getClassName('bpk-breadcrumb')}>{children}</ol>
+      </nav>
+    </React.Fragment>
   );
 };
 
 BpkBreadcrumb.propTypes = {
   children: PropTypes.node.isRequired,
   label: PropTypes.string.isRequired,
+  schemaMetaData: PropTypes.arrayOf(
+    PropTypes.Shape({
+      url: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    }),
+  ),
+};
+
+BpkBreadcrumb.defaultProps = {
+  schemaMetaData: null,
 };
 
 export default BpkBreadcrumb;

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
@@ -59,24 +59,38 @@ const buildMetaData = (schemaMetaData: SchemaMetaDataItem[]): string => {
   });
 };
 
-const BpkBreadcrumb = (props: Props) => {
-  const { children, label, schemaMetaData, ...rest } = props;
+class BpkBreadcrumb extends React.Component<Props> {
+  metaData: ?string;
 
-  return (
-    <React.Fragment>
-      {Array.isArray(schemaMetaData) && (
-        <script
-          type="application/ld+json"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: buildMetaData(schemaMetaData) }}
-        />
-      )}
-      <nav aria-label={label} {...rest}>
-        <ol className={getClassName('bpk-breadcrumb')}>{children}</ol>
-      </nav>
-    </React.Fragment>
-  );
-};
+  static defaultProps = {
+    schemaMetaData: null,
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.metaData = props.schemaMetaData && buildMetaData(props.schemaMetaData);
+  }
+
+  render() {
+    const { children, label, schemaMetaData, ...rest } = this.props;
+
+    return (
+      <React.Fragment>
+        {this.metaData && (
+          <script
+            type="application/ld+json"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: this.metaData }}
+          />
+        )}
+        <nav aria-label={label} {...rest}>
+          <ol className={getClassName('bpk-breadcrumb')}>{children}</ol>
+        </nav>
+      </React.Fragment>
+    );
+  }
+}
 
 BpkBreadcrumb.propTypes = {
   children: PropTypes.node.isRequired,

--- a/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumb-test.js.snap
+++ b/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumb-test.js.snap
@@ -43,3 +43,27 @@ exports[`BpkBreadcrumb should render correctly with arbitrary props 1`] = `
   </ol>
 </nav>
 `;
+
+exports[`BpkBreadcrumb should render correctly with schema meta data 1`] = `
+Array [
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "{\\"@context\\":\\"http://schema.org\\",\\"@type\\":\\"BreadcrumbList\\",\\"itemListElement\\":[{\\"@type\\":\\"ListItem\\",\\"position\\":1,\\"item\\":{\\"@id\\":\\"http://www.skyscanner.net\\",\\"name\\":\\"home\\"}},{\\"@type\\":\\"ListItem\\",\\"position\\":2,\\"item\\":{\\"@id\\":\\"http://www.skyscanner.net/hotels\\",\\"name\\":\\"hotels\\"}}]}",
+      }
+    }
+    type="application/ld+json"
+  />,
+  <nav
+    aria-label="My breadcrumbs"
+  >
+    <ol
+      className="bpk-breadcrumb"
+    >
+      <div>
+        Anything can go in here
+      </div>
+    </ol>
+  </nav>,
+]
+`;

--- a/packages/bpk-component-modal/package.json
+++ b/packages/bpk-component-modal/package.json
@@ -16,7 +16,7 @@
     "bpk-component-close-button": "^2.0.35",
     "bpk-component-icon": "^5.0.35",
     "bpk-component-link": "^2.0.34",
-    "bpk-component-navigation-bar": "^2.1.31",
+    "bpk-component-navigation-bar": "^2.1.32",
     "bpk-mixins": "^19.1.3",
     "bpk-react-utils": "^2.9.3",
     "bpk-scrim-utils": "^4.0.34",

--- a/packages/bpk-component-modal/package.json
+++ b/packages/bpk-component-modal/package.json
@@ -16,7 +16,7 @@
     "bpk-component-close-button": "^2.0.35",
     "bpk-component-icon": "^5.0.35",
     "bpk-component-link": "^2.0.34",
-    "bpk-component-navigation-bar": "^2.1.32",
+    "bpk-component-navigation-bar": "^2.1.31",
     "bpk-mixins": "^19.1.3",
     "bpk-react-utils": "^2.9.3",
     "bpk-scrim-utils": "^4.0.34",

--- a/packages/bpk-component-navigation-stack/package.json
+++ b/packages/bpk-component-navigation-stack/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "bpk-component-button": "^3.2.13",
     "bpk-component-icon": "^5.0.35",
-    "bpk-component-navigation-bar": "^2.1.32",
+    "bpk-component-navigation-bar": "^2.1.31",
     "bpk-component-rtl-toggle": "^2.0.34"
   },
   "publishConfig": {

--- a/packages/bpk-component-navigation-stack/package.json
+++ b/packages/bpk-component-navigation-stack/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "bpk-component-button": "^3.2.13",
     "bpk-component-icon": "^5.0.35",
-    "bpk-component-navigation-bar": "^2.1.31",
+    "bpk-component-navigation-bar": "^2.1.32",
     "bpk-component-rtl-toggle": "^2.0.34"
   },
   "publishConfig": {


### PR DESCRIPTION
Adds schema meta data as an optional property for breadcrumbs

More info about structured data can be found here https://developers.google.com/search/docs/guides/intro-structured-data
Breadcrumb schema specifically is here
https://developers.google.com/search/docs/data-types/breadcrumb

Remember to include the following changes:
+ [x] `UNRELEASED.yaml`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

To discuss: Do we prefer the implementation here (including dangerouslySetInnerHtml) or adding an additional dependency like: https://github.com/google/react-schemaorg