### PR TITLE
Add "valid" prop to BpkDatepicker

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -9,6 +9,8 @@ ADDED:
   - bpk-component-image:
   - bpk-react-utils:
     - Rename `componentWillReceiveProps` to `UNSAFE_componentWillReceiveProps`.
+  - bpk-component-datepicker:
+    - Add `valid` prop to `BpkDatepicker`.
 
 # How to write a good changelog entry:
 #

--- a/packages/bpk-component-datepicker/README.md
+++ b/packages/bpk-component-datepicker/README.md
@@ -147,6 +147,7 @@ For more information on some these props, check the BpkCalendar documentation.
 | initiallyFocusedDate  | Date                  | false    | null                                |
 | renderTarget          | func                  | false    | null                                |
 | isOpen                | bool                  | false    | false                               |
+| valid                 | bool                  | false    | null                                |
 
 > (\*) Default value is defined on child component
 

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -73,6 +73,32 @@ describe('BpkDatepicker', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should render correctly when not valid', () => {
+    const tree = renderer
+      .create(
+        <BpkDatepicker
+          valid={false}
+          id="myDatepicker"
+          closeButtonText="Close"
+          daysOfWeek={weekDays}
+          changeMonthLabel="Change month"
+          title="Departure date"
+          weekStartsOn={1}
+          getApplicationElement={() => document.createElement('div')}
+          formatDate={formatDate}
+          formatMonth={formatMonth}
+          formatDateFull={formatDateFull}
+          inputProps={inputProps}
+          minDate={new Date(2010, 1, 15)}
+          maxDate={new Date(2010, 2, 15)}
+          date={new Date(2010, 1, 15)}
+        />,
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should render correctly with datepicker open', () => {
     const datepicker = mount(
       <BpkDatepicker

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -85,6 +85,7 @@ class BpkDatepicker extends Component {
       weekStartsOn,
       initiallyFocusedDate,
       renderTarget,
+      valid,
       ...rest
     } = this.props;
 
@@ -107,6 +108,7 @@ class BpkDatepicker extends Component {
         onOpen={this.onOpen}
         isOpen={this.state.isOpen}
         readOnly
+        valid={valid}
         {...inputProps}
       />
     );
@@ -197,6 +199,7 @@ BpkDatepicker.propTypes = {
   initiallyFocusedDate: PropTypes.instanceOf(Date),
   renderTarget: PropTypes.func,
   isOpen: PropTypes.bool,
+  valid: PropTypes.bool,
 };
 
 BpkDatepicker.defaultProps = {
@@ -214,6 +217,7 @@ BpkDatepicker.defaultProps = {
   initiallyFocusedDate: null,
   renderTarget: null,
   isOpen: false,
+  valid: null,
 };
 
 export default BpkDatepicker;

--- a/packages/bpk-component-datepicker/src/__snapshots__/BpkDatepicker-test.js.snap
+++ b/packages/bpk-component-datepicker/src/__snapshots__/BpkDatepicker-test.js.snap
@@ -43,3 +43,25 @@ exports[`BpkDatepicker should render correctly 1`] = `
   value="15/02/2010"
 />
 `;
+
+exports[`BpkDatepicker should render correctly when not valid 1`] = `
+<input
+  aria-atomic="true"
+  aria-invalid={true}
+  aria-label="Monday, 15th February 2010"
+  aria-live="assertive"
+  className="bpk-input bpk-input--invalid bpk-input--large bpk-input--with-open-events bpk-datepicker__input"
+  id="myDatepicker"
+  name="myDatepicker_input"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  placeholder="placeholder"
+  readOnly={true}
+  type="text"
+  value="15/02/2010"
+/>
+`;

--- a/packages/bpk-component-datepicker/stories.js
+++ b/packages/bpk-component-datepicker/stories.js
@@ -324,4 +324,21 @@ storiesOf('bpk-component-datepicker', module)
         />
       </div>
     );
-  });
+  })
+  .add('Invalid', () => (
+    <div id="application-element">
+      <CalendarContainer
+        id="myDatepicker"
+        closeButtonText="Close"
+        daysOfWeek={weekDays}
+        weekStartsOn={1}
+        changeMonthLabel="Change month"
+        title="Departure date"
+        formatDate={formatDate}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        date={new Date()}
+        valid={false}
+      />
+    </div>
+  ));

--- a/packages/bpk-component-fieldset/package.json
+++ b/packages/bpk-component-fieldset/package.json
@@ -20,7 +20,9 @@
     "prop-types": "^15.6.2"
   },
   "devDependencies": {
+    "bpk-component-calendar": "^6.3.3",
     "bpk-component-checkbox": "^2.0.44",
+    "bpk-component-datepicker": "^11.1.21",
     "bpk-component-input": "^5.0.43",
     "bpk-component-select": "^3.0.42"
   },


### PR DESCRIPTION
`BpkDatepicker` doesn't have `valid` prop, and this makes it not work correctly with `BpkFieldset`: the label becomes red and error message is displayed, but the input border doesn't change to red nor the exclamation icon is displayed

![image](https://user-images.githubusercontent.com/7152781/78302164-8e0d2300-753a-11ea-9c88-d2a6036f6c07.png)

With this changes, the `valid` prop is send to the input field, so it behaves as expected:

![image](https://user-images.githubusercontent.com/7152781/78302421-0ffd4c00-753b-11ea-9755-e3ba17433ccb.png)


Remember to include the following changes:
+ [x] `UNRELEASED.yaml`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
