### PR TITLE
[BPK-3817] Upgrade to latest Flow

### DIFF
--- a/decisions/flowfixme.md
+++ b/decisions/flowfixme.md
@@ -10,6 +10,6 @@ We decided to suppress these comments using the following comment:
 
 If you need to do this in future, add the same comment. Using this format will allow us to easily find and remove the suppression comments once a better solution is found.
 
-We should revisit this occasionally to see if we can remove the comments. The last time we attempted this was April 2020.
+We should revisit this occasionally to see if we can remove the comments. The last time we attempted this was April 2020. [This PR](https://github.com/facebook/flow/pull/7569), open as of April 8th, may fix the problem.
 
 In all other cases, you shouldn't opt out of Flow. If there's a legitimate bug in Flow and you have to opt out, add a comment to explain, linking to a GitHub issue where possible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20383,9 +20383,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.112.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.112.0.tgz",
-      "integrity": "sha512-vdcuKv0UU55vjv0e2EVh1ZxlU+TSNT19SkE+6gT1vYzTKtzYE6dLuAmBIiS3Rg2N9D9HOI6TKSyl53zPtqZLrA==",
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.122.0.tgz",
+      "integrity": "sha512-my8N5jgl/A+UVby9E7NDppHdhLgRbWgKbmFZSx2MSYMRh3d9YGnM2MM+wexpUpl0ftY1IM6ZcUwaAhrypLyvlA==",
       "dev": true
     },
     "flow-typed": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "eslint-plugin-flowtype": "^4.0.0",
     "eslint_d": "^8.0.0",
     "extract-text-webpack-plugin": "^3.0.2",
-    "flow-bin": "^0.112.0",
+    "flow-bin": "^0.122.0",
     "flow-typed": "^2.5.1",
     "globby": "^10.0.0",
     "gulp": "^4.0.2",

--- a/packages/bpk-component-badge/src/BpkBadge.js
+++ b/packages/bpk-component-badge/src/BpkBadge.js
@@ -69,11 +69,8 @@ const BpkBadge = (props: Props) => {
   }
 
   return (
-    <span
-      className={classNames.join(' ')}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    />
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <span className={classNames.join(' ')} {...rest} />
   );
 };
 

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertDismissable.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertDismissable.js
@@ -35,11 +35,8 @@ type Props = {
 };
 
 const BpkBannerAlertDismissable = (props: Props) => (
-  <BpkBannerAlertInner
-    configuration={CONFIGURATION.DISMISSABLE}
-    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-    {...props}
-  />
+  // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+  <BpkBannerAlertInner configuration={CONFIGURATION.DISMISSABLE} {...props} />
 );
 
 BpkBannerAlertDismissable.propTypes = {

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertExpandable.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertExpandable.js
@@ -39,11 +39,8 @@ type Props = {
 const BpkBannerAlertExpandable = (props: Props) => {
   const { children, ...rest } = props;
   return (
-    <BpkBannerAlertInner
-      configuration={CONFIGURATION.EXPANDABLE}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <BpkBannerAlertInner configuration={CONFIGURATION.EXPANDABLE} {...rest}>
       {children}
     </BpkBannerAlertInner>
   );

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
@@ -173,11 +173,11 @@ const BpkBannerAlertInner = (props: Props) => {
   // Disabling 'click-events-have-key-events and interactive-supports-focus' because header element is not focusable.
   // ToggleButton is focusable and works for this.
   return (
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     <AnimateAndFade
       animateOnEnter={animateOnEnter}
       animateOnLeave={dismissable || animateOnLeave}
       show={show}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       {...rest}
     >
       <section className={sectionClassNames.join(' ')}>

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState.js
@@ -158,13 +158,13 @@ const withBannerAlertState = (WrappedComponent: ComponentType<any>) => {
       } = this.props;
 
       return (
+        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         <WrappedComponent
           expanded={this.state.expanded}
           onExpandToggle={this.onExpandToggle}
           onDismiss={this.onDismiss}
           show={this.state.show}
           animateOnLeave={(hideAfter && hideAfter > 0) || animateOnLeave}
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
           {...rest}
         >
           {children}

--- a/packages/bpk-component-boilerplate/src/BpkBoilerplate.js
+++ b/packages/bpk-component-boilerplate/src/BpkBoilerplate.js
@@ -33,11 +33,8 @@ const BpkBoilerplate = (props: Props) => {
   const classNames = getClassName('bpk-boilerplate', className);
 
   return (
-    <div
-      className={classNames}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <div className={classNames} {...rest}>
       I am an example component.
     </div>
   );

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumb.js
@@ -84,11 +84,8 @@ class BpkBreadcrumb extends React.Component<Props> {
             dangerouslySetInnerHTML={{ __html: this.metaData }}
           />
         )}
-        <nav
-          aria-label={label}
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-          {...rest}
-        >
+        {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
+        <nav aria-label={label} {...rest}>
           <ol className={getClassName('bpk-breadcrumb')}>{children}</ol>
         </nav>
       </React.Fragment>

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
@@ -44,25 +44,22 @@ const BpkBreadcrumbItem = (props: Props) => {
   const { children, className, active, href, linkProps, ...rest } = props;
 
   return (
-    <li
-      className={getClassName('bpk-breadcrumb-item', className)}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <li className={getClassName('bpk-breadcrumb-item', className)} {...rest}>
       {active ? (
+        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         <BpkText
           className={getClassName('bpk-breadcrumb-item__active-item')}
           aria-current="page"
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
           {...linkProps}
         >
           {children}
         </BpkText>
       ) : (
+        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         <BpkLink
           href={href}
           className={getClassName('bpk-breadcrumb-item__link')}
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
           {...linkProps}
         >
           {children}

--- a/packages/bpk-component-button/src/BpkButtonBase.js
+++ b/packages/bpk-component-button/src/BpkButtonBase.js
@@ -71,13 +71,13 @@ const BpkButton = (props: Props) => {
 
   if (!disabled && href) {
     return (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <a
         href={href}
         className={classNameFinal}
         onClick={onClick}
         target={target}
         rel={rel}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         {children}
@@ -99,12 +99,12 @@ const BpkButton = (props: Props) => {
 
   /* eslint-disable react/button-has-type */
   return (
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     <button
       type={buttonType}
       disabled={disabled}
       className={classNameFinal}
       onClick={onClickWrapper}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       {...rest}
     >
       {children}

--- a/packages/bpk-component-button/src/BpkButtonDestructive.js
+++ b/packages/bpk-component-button/src/BpkButtonDestructive.js
@@ -37,11 +37,8 @@ const BpkButtonDestructive = (props: Props) => {
   const classNamesFinal = classNames.join(' ');
 
   return (
-    <BpkButtonBase
-      className={classNamesFinal}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    />
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <BpkButtonBase className={classNamesFinal} {...rest} />
   );
 };
 

--- a/packages/bpk-component-button/src/BpkButtonFeatured.js
+++ b/packages/bpk-component-button/src/BpkButtonFeatured.js
@@ -37,11 +37,8 @@ const BpkButtonFeatured = (props: Props) => {
   const classNamesFinal = classNames.join(' ');
 
   return (
-    <BpkButtonBase
-      className={classNamesFinal}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    />
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <BpkButtonBase className={classNamesFinal} {...rest} />
   );
 };
 

--- a/packages/bpk-component-button/src/BpkButtonLink.js
+++ b/packages/bpk-component-button/src/BpkButtonLink.js
@@ -37,11 +37,8 @@ const BpkButtonLink = (props: Props) => {
   const classNamesFinal = classNames.join(' ');
 
   return (
-    <BpkButtonBase
-      className={classNamesFinal}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    />
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <BpkButtonBase className={classNamesFinal} {...rest} />
   );
 };
 

--- a/packages/bpk-component-button/src/BpkButtonOutline.js
+++ b/packages/bpk-component-button/src/BpkButtonOutline.js
@@ -37,11 +37,8 @@ const BpkButtonOutline = (props: Props) => {
   const classNamesFinal = classNames.join(' ');
 
   return (
-    <BpkButtonBase
-      className={classNamesFinal}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    />
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <BpkButtonBase className={classNamesFinal} {...rest} />
   );
 };
 

--- a/packages/bpk-component-button/src/BpkButtonSecondary.js
+++ b/packages/bpk-component-button/src/BpkButtonSecondary.js
@@ -37,11 +37,8 @@ const BpkButtonSecondary = (props: Props) => {
   const classNamesFinal = classNames.join(' ');
 
   return (
-    <BpkButtonBase
-      className={classNamesFinal}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    />
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <BpkButtonBase className={classNamesFinal} {...rest} />
   );
 };
 

--- a/packages/bpk-component-button/stories.js
+++ b/packages/bpk-component-button/stories.js
@@ -69,56 +69,41 @@ const ButtonStory = ({
       )}
     >
       &nbsp;
-      <Wrapped
-        onClick={action('button clicked')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-        {...rest}
-      >
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
+      <Wrapped onClick={action('button clicked')} {...rest}>
         Button
       </Wrapped>
       &nbsp;
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
+      <Wrapped disabled onClick={action('THIS SHOULD NOT HAPPEN')} {...rest}>
+        Disabled
+      </Wrapped>
+      &nbsp;
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
+      <Wrapped large onClick={action('large button clicked')} {...rest}>
+        Button
+      </Wrapped>
+      &nbsp;
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
       <Wrapped
+        large
         disabled
         onClick={action('THIS SHOULD NOT HAPPEN')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         Disabled
       </Wrapped>
       &nbsp;
-      <Wrapped
-        large
-        onClick={action('large button clicked')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-        {...rest}
-      >
-        Button
-      </Wrapped>
-      &nbsp;
-      <Wrapped
-        large
-        disabled
-        onClick={action('THIS SHOULD NOT HAPPEN')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-        {...rest}
-      >
-        Disabled
-      </Wrapped>
-      &nbsp;
-      <Wrapped
-        iconOnly
-        onClick={action('iconOnly button clicked')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-        {...rest}
-      >
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
+      <Wrapped iconOnly onClick={action('iconOnly button clicked')} {...rest}>
         <AlignedSmallLongArrowRightIcon />
       </Wrapped>
       &nbsp;
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
       <Wrapped
         iconOnly
         large
         onClick={action('large iconOnly button clicked')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         <AlignedLargeLongArrowRightIcon />

--- a/packages/bpk-component-carousel/src/BpkCarousel.js
+++ b/packages/bpk-component-carousel/src/BpkCarousel.js
@@ -136,11 +136,11 @@ class BpkCarousel extends Component<Props, State> {
     const classNames = getClassName('bpk-carousel', className);
 
     return (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <Swipeable
         onSwipedLeft={this.nextSlide}
         onSwipedRight={this.prevSlide}
         className={classNames}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         <div>

--- a/packages/bpk-component-chip/src/BpkChip.js
+++ b/packages/bpk-component-chip/src/BpkChip.js
@@ -54,11 +54,8 @@ const BpkChip = (props: Props) => {
     typeof closeLabel === 'function' ? closeLabel(children) : closeLabel;
 
   return (
-    <div
-      className={classNames.join(' ')}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <div className={classNames.join(' ')} {...rest}>
       <span className={getClassName('bpk-chip__label')}>{children}</span>
       {dismissible && <BpkCloseButton label={label} onClick={onClose} />}
     </div>

--- a/packages/bpk-component-code/src/BpkCode.js
+++ b/packages/bpk-component-code/src/BpkCode.js
@@ -43,11 +43,8 @@ const BpkCode = (props: Props) => {
   }
 
   return (
-    <code
-      className={classNames.join(' ')}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <code className={classNames.join(' ')} {...rest}>
       {children}
     </code>
   );

--- a/packages/bpk-component-code/src/BpkCodeBlock.js
+++ b/packages/bpk-component-code/src/BpkCodeBlock.js
@@ -44,11 +44,8 @@ const BpkCodeBlock = (props: Props) => {
   }
 
   return (
-    <pre
-      className={preClassNames.join(' ')}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <pre className={preClassNames.join(' ')} {...rest}>
       <code className={codeClassNames.join(' ')}>{children}</code>
     </pre>
   );

--- a/packages/bpk-component-dialog/stories.js
+++ b/packages/bpk-component-dialog/stories.js
@@ -82,6 +82,7 @@ class DialogContainer extends Component<Props, State> {
         <div id="pagewrap">
           <BpkButton onClick={this.onOpen}>Open dialog</BpkButton>
         </div>
+        {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
         <BpkDialog
           closeLabel="Close dialog"
           id="my-dialog"
@@ -90,7 +91,6 @@ class DialogContainer extends Component<Props, State> {
           onClose={this.onClose}
           getApplicationElement={() => document.getElementById('pagewrap')}
           renderTarget={() => document.getElementById('dialog-container')}
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
           {...this.props}
         >
           {this.props.children}

--- a/packages/bpk-component-fieldset/src/BpkFieldset.js
+++ b/packages/bpk-component-fieldset/src/BpkFieldset.js
@@ -62,8 +62,9 @@ const BpkFieldset = (props: Props) => {
 
   let childId: string = children.props.id;
   if (
-    // $FlowFixMe
+    // $FlowFixMe Flow is being dumb here and doesn't let us do this check, even though it's perfectly safe!
     children.props.inputProps &&
+    // $FlowFixMe
     children.props.inputProps.id &&
     typeof children.props.inputProps.id === 'string'
   ) {
@@ -107,11 +108,8 @@ const BpkFieldset = (props: Props) => {
   }
 
   return (
-    <fieldset
-      className={classNames.join(' ')}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <fieldset className={classNames.join(' ')} {...rest}>
       {!isCheckbox && (
         <BpkLabel
           htmlFor={childId}
@@ -132,11 +130,11 @@ const BpkFieldset = (props: Props) => {
         </span>
       )}
       {!disabled && validationMessage && (
+        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         <BpkFormValidation
           id={validationMessageId}
           expanded={isInvalid}
           isCheckbox={isCheckbox}
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
           {...validationProps}
         >
           {validationMessage}

--- a/packages/bpk-component-fieldset/stories.js
+++ b/packages/bpk-component-fieldset/stories.js
@@ -116,12 +116,8 @@ class FieldsetContainer extends Component<Props, State> {
     });
 
     return (
-      <BpkFieldset
-        isCheckbox={isCheckbox}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-        {...rest}
-        {...dynamicFieldsetProps}
-      >
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+      <BpkFieldset isCheckbox={isCheckbox} {...rest} {...dynamicFieldsetProps}>
         {clonedChildren}
       </BpkFieldset>
     );

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -168,6 +168,7 @@ class BpkHorizontalNav extends Component<Props> {
     }
 
     return (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <BpkMobileScrollContainer
         innerContainerTagName="nav"
         className={classNames.join(' ')}
@@ -176,7 +177,6 @@ class BpkHorizontalNav extends Component<Props> {
         scrollerRef={ref => {
           this.scrollRef = ref;
         }}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         <ul className={getClassName('bpk-horizontal-nav__list')}>{children}</ul>

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -78,21 +78,21 @@ class BpkHorizontalNavItem extends Component<Props> {
     );
 
     const clickableElement = href ? (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <a
         href={href}
         className={innerClassNames}
         aria-disabled={selected || disabled}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         {children}
       </a>
     ) : (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <button
         type="button"
         className={innerClassNames}
         disabled={selected || disabled}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         {children}

--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -89,12 +89,12 @@ class Image extends Component<ImageProps> {
     }
 
     return (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <img
         className={imgClassNames.join(' ')}
         alt={altText}
         onLoad={onImageLoad}
         ref={this.setImgRef}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       />
     );
@@ -168,11 +168,11 @@ class BpkImage extends Component<BpkImageProps> {
             which seems to be enough to fix it.
           */}
           {inView && (
+            // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
             <Image // eslint-disable-line backpack/use-components
               hidden={loading}
               altText={altText}
               onImageLoad={this.onImageLoad}
-              // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
               {...rest}
             />
           )}
@@ -191,10 +191,10 @@ class BpkImage extends Component<BpkImageProps> {
           )}
           {typeof window === 'undefined' && (!inView || loading) && (
             <noscript>
+              {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
               <Image // eslint-disable-line backpack/use-components
                 altText={altText}
                 onImageLoad={this.onImageLoad}
-                // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
                 {...rest}
               />
             </noscript>

--- a/packages/bpk-component-image/src/withLazyLoading.js
+++ b/packages/bpk-component-image/src/withLazyLoading.js
@@ -161,11 +161,8 @@ export default function withLazyLoading(
           style={style}
           className={className}
         >
-          <Component
-            inView={this.state.inView}
-            // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-            {...rest}
-          />
+          {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
+          <Component inView={this.state.inView} {...rest} />
         </div>
       );
     }

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.flow.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.flow.js
@@ -46,11 +46,8 @@ class List extends Component<ListProps> {
   render() {
     const { elements, ...rest } = this.props;
     return (
-      <div
-        id="list"
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-        {...rest}
-      >
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+      <div id="list" {...rest}>
         {elements.forEach(element => (
           <div key={element}>{element}</div>
         ))}

--- a/packages/bpk-component-input/src/BpkClearButton.js
+++ b/packages/bpk-component-input/src/BpkClearButton.js
@@ -44,13 +44,13 @@ const BpkClearButton = (props: Props) => {
   }
 
   return (
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     <button
       type="button"
       title={label}
       onClick={onClick}
       aria-label={label}
       className={classNames.join(' ')}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       {...rest}
     >
       <ClearButtonIcon

--- a/packages/bpk-component-input/src/BpkInput.js
+++ b/packages/bpk-component-input/src/BpkInput.js
@@ -124,6 +124,7 @@ class BpkInput extends Component<Props, State> {
     }
 
     const renderedInput = (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <input
         className={classNames.join(' ')}
         ref={input => {
@@ -135,7 +136,6 @@ class BpkInput extends Component<Props, State> {
         aria-invalid={isInvalid}
         value={value}
         name={name}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       />
     );

--- a/packages/bpk-component-label/src/BpkLabel.js
+++ b/packages/bpk-component-label/src/BpkLabel.js
@@ -61,11 +61,8 @@ const BpkLabel = (props: Props) => {
   }
 
   return (
-    <label
-      className={classNames.join(' ')}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <label className={classNames.join(' ')} {...rest}>
       {children}
       {required && (
         <span className={getClassName('bpk-label__asterisk')}>*</span>

--- a/packages/bpk-component-map/src/BpkBasicMapMarker.js
+++ b/packages/bpk-component-map/src/BpkBasicMapMarker.js
@@ -38,10 +38,10 @@ const BpkBasicMapMarker = (props: Props) => {
   const { children, position, ...rest } = props;
 
   return (
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     <BpkOverlayView
       position={position}
       getPixelPositionOffset={getPixelPositionOffset}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       {...rest}
     >
       {children}

--- a/packages/bpk-component-map/src/BpkMapMarker.js
+++ b/packages/bpk-component-map/src/BpkMapMarker.js
@@ -79,16 +79,13 @@ const BpkMapMarker = (props: Props) => {
   );
 
   return (
-    <BpkBasicMapMarker
-      position={position}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <BpkBasicMapMarker position={position} {...rest}>
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
       <button
         type="button"
         className={getClassName('bpk-map-marker__wrapper')}
         onClick={onClick}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...buttonProps}
       >
         <div className={classNames}>{icon}</div>

--- a/packages/bpk-component-map/src/BpkOverlayView.js
+++ b/packages/bpk-component-map/src/BpkOverlayView.js
@@ -32,10 +32,10 @@ type Props = {
 const BpkOverlayView = (props: Props) => {
   const { children, position, ...rest } = props;
   return (
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     <OverlayView
       mapPaneName="overlayMouseTarget"
       position={{ lat: position.latitude, lng: position.longitude }}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       {...rest}
     >
       {children}

--- a/packages/bpk-component-map/stories.js
+++ b/packages/bpk-component-map/stories.js
@@ -98,12 +98,12 @@ class StatefulBpkMapMarker extends React.Component<Props, State> {
     const { onClick, ...rest } = this.props;
 
     return (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <BpkMapMarker
         selected={this.state.selected}
         onClick={() => {
           this.onClick();
         }}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       />
     );

--- a/packages/bpk-component-modal/src/BpkModal.js
+++ b/packages/bpk-component-modal/src/BpkModal.js
@@ -85,6 +85,7 @@ const BpkModal = (props: Props) => {
       renderTarget={renderTarget}
       closeOnEscPressed={closeOnEscPressed}
     >
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
       <ScrimBpkModalDialog
         onClose={onClose}
         fullScreenOnMobile={fullScreenOnMobile}
@@ -92,7 +93,6 @@ const BpkModal = (props: Props) => {
         closeOnScrimClick={closeOnScrimClick}
         containerClassName={containerClass.join(' ')}
         isIphone={isIphone}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       />
     </Portal>

--- a/packages/bpk-component-modal/stories.js
+++ b/packages/bpk-component-modal/stories.js
@@ -157,6 +157,7 @@ class ModalContainer extends Component<
           <BpkButton onClick={this.onOpen}>
             {buttonLabel || 'Open modal'}
           </BpkButton>
+          {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
           <BpkModal
             id="my-modal"
             className="my-classname"
@@ -165,7 +166,6 @@ class ModalContainer extends Component<
             getApplicationElement={() => document.getElementById('pagewrap')}
             renderTarget={() => document.getElementById('modal-container')}
             accessoryView={accessoryView}
-            // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
             {...rest}
           >
             {children}

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.js
@@ -55,6 +55,7 @@ const BpkNavigationBar = (props: Props) => {
   const titleId = `${id}-bpk-navigation-bar-title`;
 
   return (
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     <nav
       aria-labelledby={titleId}
       className={getClassNames(
@@ -62,7 +63,6 @@ const BpkNavigationBar = (props: Props) => {
         sticky && 'bpk-navigation-bar__sticky',
         className,
       )}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       {...rest}
     >
       {leadingButton &&

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.js
@@ -39,9 +39,9 @@ const BpkNavigationBarButtonLink = ({
   children,
   ...rest
 }: Props) => (
+  // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
   <BpkButtonLink
     className={getClassName('bpk-navigation-bar-button-link', className)}
-    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     {...rest}
   >
     {children}

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.js
@@ -36,10 +36,10 @@ export type Props = {
 };
 
 const BpkNavigationBarIconButton = ({ icon, className, ...rest }: Props) => (
+  // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
   <BpkIconButton
     customIcon={icon}
     className={getClassName('bpk-navigation-bar-icon-button', className)}
-    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     {...rest}
   />
 );

--- a/packages/bpk-component-navigation-stack/src/BpkNavigationStack.js
+++ b/packages/bpk-component-navigation-stack/src/BpkNavigationStack.js
@@ -78,9 +78,9 @@ class BpkNavigationStack extends React.Component<Props, State> {
     const lastIndex = (views || []).length - 1;
 
     return (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <div
         className={getClassName('bpk-navigation-stack', className)}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         <TransitionGroup

--- a/packages/bpk-component-navigation-stack/src/withNavigationStackState-test.js
+++ b/packages/bpk-component-navigation-stack/src/withNavigationStackState-test.js
@@ -28,11 +28,8 @@ describe('withNavigationStackState', () => {
   const View = () => <div />;
 
   const Stack = ({ views, ...rest }: { views: Array<Element<any>> }) => (
-    <div
-      className="parent"
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <div className="parent" {...rest}>
       {views}
     </div>
   );

--- a/packages/bpk-component-navigation-stack/src/withNavigationStackState.js
+++ b/packages/bpk-component-navigation-stack/src/withNavigationStackState.js
@@ -94,12 +94,8 @@ export default (
         : [this.state.views, callbacks];
 
       return (
-        <Stack
-          views={views}
-          {...optionalCallbacks}
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-          {...rest}
-        />
+        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+        <Stack views={views} {...optionalCallbacks} {...rest} />
       );
     }
   }

--- a/packages/bpk-component-navigation-stack/stories-components.js
+++ b/packages/bpk-component-navigation-stack/stories-components.js
@@ -63,6 +63,7 @@ export const View = ({
   noNavBar: boolean,
   centered: boolean,
 }) => (
+  // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
   <section
     className={getClassName(
       'bpk-navigation-stack-view',
@@ -71,7 +72,6 @@ export const View = ({
       centered && 'bpk-navigation-stack-view--centered',
       className,
     )}
-    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     {...rest}
   >
     {children({ index, pushView, popView })}

--- a/packages/bpk-component-nudger/src/BpkNudger.js
+++ b/packages/bpk-component-nudger/src/BpkNudger.js
@@ -44,13 +44,13 @@ const BpkNudger = (props: Props) => {
   const { ...rest } = props;
 
   return (
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     <BpkConfigurableNudger
       inputClassName={getClassName('bpk-nudger__input--numeric')}
       compareValues={compareValues}
       incrementValue={incrementValue}
       decrementValue={decrementValue}
       formatValue={formatValue}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       {...rest}
     />
   );

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput.js
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput.js
@@ -163,8 +163,8 @@ const BpkPhoneInput = (props: Props) => {
       >
         {dialingCodeProps.label}
       </BpkLabel>
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
       <BpkSelect
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...commonProps}
         {...dialingCodeProps}
         className={getClassName(
@@ -179,12 +179,8 @@ const BpkPhoneInput = (props: Props) => {
         }}
       >
         {dialingCodes.map(({ code, description, ...extraDialingProps }) => (
-          <option
-            key={code}
-            value={code}
-            // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-            {...extraDialingProps}
-          >
+          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+          <option key={code} value={code} {...extraDialingProps}>
             {description}
           </option>
         ))}
@@ -196,9 +192,9 @@ const BpkPhoneInput = (props: Props) => {
       >
         {label}
       </BpkLabel>
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
       <BpkInput
         {...commonProps}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
         id={id}
         name={name}

--- a/packages/bpk-component-popover/src/BpkPopover.js
+++ b/packages/bpk-component-popover/src/BpkPopover.js
@@ -95,13 +95,13 @@ const BpkPopover = (props: Props) => {
       appearActiveClassName={getClassName('bpk-popover--appear-active')}
       transitionTimeout={200}
     >
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
       <section
         id={id}
         tabIndex="-1"
         role="dialog"
         aria-labelledby={labelId}
         className={classNames.join(' ')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         <span

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -174,11 +174,8 @@ class BpkPopoverPortal extends Component<Props> {
         renderTarget={renderTarget}
         target={target}
       >
-        <BpkPopover
-          onClose={onClose}
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-          {...rest}
-        />
+        {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
+        <BpkPopover onClose={onClose} {...rest} />
       </Portal>
     );
   }

--- a/packages/bpk-component-popover/stories.js
+++ b/packages/bpk-component-popover/stories.js
@@ -135,6 +135,7 @@ class PopoverContainer extends Component<Props, State> {
     return (
       <div id="popover-container">
         {openButton}
+        {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
         <BpkPopover
           closeButtonText="Close"
           id={`my-popover-${id}`}
@@ -143,7 +144,6 @@ class PopoverContainer extends Component<Props, State> {
           onClose={this.closePopover}
           renderTarget={renderTarget}
           target={target}
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
           {...rest}
         >
           <BpkContentContainer>

--- a/packages/bpk-component-rating/src/BpkRating.js
+++ b/packages/bpk-component-rating/src/BpkRating.js
@@ -94,12 +94,8 @@ const BpkRating = (props: Props) => {
   }
 
   return (
-    <div
-      className={classNames.join(' ')}
-      aria-label={ariaLabel}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <div className={classNames.join(' ')} aria-label={ariaLabel} {...rest}>
       <BpkText
         textStyle={textSize}
         tagName="span"

--- a/packages/bpk-component-section-list/src/BpkSectionListItem.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListItem.js
@@ -53,12 +53,12 @@ const BpkSectionListItem = (props: Props) => {
   if (href) {
     const target = blank ? '_blank' : null;
     return (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <a
         href={href}
         target={target}
         onClick={onClick}
         className={classNames.join(' ')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         {children}
@@ -71,11 +71,11 @@ const BpkSectionListItem = (props: Props) => {
 
   if (onClick) {
     return (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <button
         type="button"
         onClick={onClick}
         className={classNames.join(' ')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         {children}
@@ -87,11 +87,8 @@ const BpkSectionListItem = (props: Props) => {
   }
 
   return (
-    <div
-      className={classNames.join(' ')}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <div className={classNames.join(' ')} {...rest}>
       {children}
     </div>
   );

--- a/packages/bpk-component-select/src/BpkSelect.js
+++ b/packages/bpk-component-select/src/BpkSelect.js
@@ -61,6 +61,7 @@ const BpkSelect = (props: Props) => {
   const isInvalid = valid === false;
 
   const select = (
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
     <select
       className={getClassName(
         'bpk-select',
@@ -76,7 +77,6 @@ const BpkSelect = (props: Props) => {
       )}
       disabled={disabled}
       aria-invalid={isInvalid}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       {...rest}
     />
   );

--- a/packages/bpk-component-text/src/BpkText.js
+++ b/packages/bpk-component-text/src/BpkText.js
@@ -73,11 +73,8 @@ const BpkText = (props: Props) => {
   );
 
   return (
-    <TagName
-      className={classNames}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <TagName className={classNames} {...rest}>
       {children}
     </TagName>
   );

--- a/packages/bpk-component-ticket/src/BpkTicket.js
+++ b/packages/bpk-component-ticket/src/BpkTicket.js
@@ -151,24 +151,16 @@ const BpkTicket = (props: Props) => {
 
   if (href) {
     return (
-      <a
-        href={href}
-        className={classNames}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-        {...rest}
-      >
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+      <a href={href} className={classNames} {...rest}>
         {contents}
       </a>
     );
   }
 
   return (
-    <div
-      role="button"
-      className={classNames}
-      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-      {...rest}
-    >
+    // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
+    <div role="button" className={classNames} {...rest}>
       {contents}
     </div>
   );

--- a/packages/bpk-component-tooltip/src/BpkTooltip.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltip.js
@@ -57,12 +57,12 @@ const BpkTooltip = (props: TooltipProps) => {
       appearActiveClassName={getClassName('bpk-tooltip--appear-active')}
       transitionTimeout={200}
     >
+      {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
       <section
         id={id}
         tabIndex="-1"
         role="dialog"
         className={classNames}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...rest}
       >
         <span id={ARROW_ID} className={arrowClassNames} role="presentation" />

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -186,11 +186,8 @@ class BpkTooltipPortal extends Component<Props, State> {
         renderTarget={renderTarget}
         className={classNames.join(' ')}
       >
-        <BpkTooltip
-          padded={padded}
-          // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-          {...rest}
-        >
+        {/* $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'. */}
+        <BpkTooltip padded={padded} {...rest}>
           {children}
         </BpkTooltip>
       </Portal>

--- a/packages/bpk-react-utils/src/withDefaultProps.js
+++ b/packages/bpk-react-utils/src/withDefaultProps.js
@@ -49,9 +49,9 @@ const withDefaultProps = (
     }
 
     return (
+      // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
       <WrappedComponent
         className={classNames.join(' ')}
-        // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
         {...defaultRest}
         {...rest}
       >


### PR DESCRIPTION
This PR means we're on the latest version once again! 🎉 

I had to move the suppression comments for object spreads to a higher level due [a change in 0.122](https://github.com/facebook/flow/blob/master/Changelog.md#01220):

> Improved object spread-related error messages, which may cause suppressed errors to become unsuppressed because they moved to better locations