### PR TITLE
[BPK-2118] Add Flow types to some of `bpk-react-utils`

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,4 @@
 [ignore]
-<PROJECT_ROOT>/backpack-react-native/.*
 .*/node_modules/jsonlint/.*
 .*/node_modules/config-chain/test/broken.json
 

--- a/packages/bpk-component-code/src/BpkCodeBlock.js
+++ b/packages/bpk-component-code/src/BpkCodeBlock.js
@@ -34,7 +34,7 @@ const BpkCodeBlock = (props: Props) => {
   const { children, alternate, className, ...rest } = props;
   const preClassNames = getClassName(
     'bpk-code__pre',
-    alternate && 'bpk-code__pre-alternate',
+    alternate && 'bpk-code__pre--alternate',
     className,
   );
 

--- a/packages/bpk-component-code/src/BpkCodeBlock.js
+++ b/packages/bpk-component-code/src/BpkCodeBlock.js
@@ -32,21 +32,18 @@ type Props = {
 };
 const BpkCodeBlock = (props: Props) => {
   const { children, alternate, className, ...rest } = props;
-  const preClassNames = [getClassName('bpk-code__pre')];
-  const codeClassNames = ['bpk-code', 'bpk-code--block'].map(getClassName);
+  const preClassNames = getClassName(
+    'bpk-code__pre',
+    alternate && 'bpk-code__pre-alternate',
+    className,
+  );
 
-  if (alternate) {
-    preClassNames.push(getClassName('bpk-code__pre--alternate'));
-  }
-
-  if (className) {
-    preClassNames.push(className);
-  }
+  const codeClassNames = getClassName('bpk-code', 'bpk-code--block');
 
   return (
     // $FlowFixMe - inexact rest. See 'decisions/flowfixme.md'.
-    <pre className={preClassNames.join(' ')} {...rest}>
-      <code className={codeClassNames.join(' ')}>{children}</code>
+    <pre className={preClassNames} {...rest}>
+      <code className={codeClassNames}>{children}</code>
     </pre>
   );
 };

--- a/packages/bpk-react-utils/index.js
+++ b/packages/bpk-react-utils/index.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import wrapDisplayName from 'recompose/wrapDisplayName';
 
 import Portal from './src/Portal';

--- a/packages/bpk-react-utils/src/TransitionInitialMount-test.js
+++ b/packages/bpk-react-utils/src/TransitionInitialMount-test.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';

--- a/packages/bpk-react-utils/src/TransitionInitialMount.js
+++ b/packages/bpk-react-utils/src/TransitionInitialMount.js
@@ -16,21 +16,30 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import assign from 'object-assign';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type Node } from 'react';
 import CSSTransition from 'react-transition-group/CSSTransition';
 
 // Object.assign() is used unpolyfilled in react-transition-group.
 // It will use the native implementation if it's present and isn't buggy.
 Object.assign = assign;
 
+type Props = {
+  appearClassName: string,
+  appearActiveClassName: string,
+  transitionTimeout: number,
+  children: Node,
+};
+
 const TransitionInitialMount = ({
   appearClassName,
   appearActiveClassName,
   transitionTimeout,
   children,
-}) => (
+}: Props) => (
   <CSSTransition
     classNames={{
       appear: appearClassName,


### PR DESCRIPTION
I tried adding Flow to `Portal.js` but it's an absolute BEAST and a lot of what it's doing is strictly against Flow, even though we know it's ok because it works. So many of the errors are interlinked where fixing one opens up ten more in other areas too.

To fix it, we'd either need to totally refactor it or use a lot of undesirable types like `any` to make the errors go away.

In this case I've left it alone and added Flow to the rest of the module, so there's at least _some_ value.