### PR TITLE
[BPK-4053]: Horizontal Nav A11y fix

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -17,7 +17,7 @@
  */
 
 // TODO: addon-a11y breaks the calendar example
-// import '@storybook/addon-a11y/register';
+import '@storybook/addon-a11y/register';
 import '@storybook/addon-actions/register';
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-viewport/register';

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -2,7 +2,7 @@
 
 FIXED:
   - bpk-component-horizontal-nav:
-    - Added `tablist` role to `BpkHorizontalNav` component for Accessibility
+    - Added `tablist` role to `BpkHorizontalNav` component for accessibility.
 
 # How to write a good changelog entry:
 #

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -1,5 +1,9 @@
 # UNRELEASED:
 
+FIXED:
+  - bpk-component-horizontal-nav:
+    - Added `tablist` role to `BpkHorizontalNav` component for Accessibility
+
 # How to write a good changelog entry:
 #
 #   1. Add 'BREAKING', 'ADDED' OR 'FIXED' depending on if the change will be major, minor or patch according to [semver.org](semver.org).

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -179,7 +179,9 @@ class BpkHorizontalNav extends Component<Props> {
         }}
         {...rest}
       >
-        <ul className={getClassName('bpk-horizontal-nav__list')}>{children}</ul>
+        <ul className={getClassName('bpk-horizontal-nav__list')} role="tablist">
+          {children}
+        </ul>
       </BpkMobileScrollContainer>
     );
   }

--- a/packages/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNav-test.js.snap
+++ b/packages/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNav-test.js.snap
@@ -18,6 +18,7 @@ exports[`BpkHorizontalNav should render correctly 1`] = `
     >
       <ul
         className="bpk-horizontal-nav__list"
+        role="tablist"
       >
         My nav content.
       </ul>
@@ -46,6 +47,7 @@ exports[`BpkHorizontalNav should render correctly with arbitrary props 1`] = `
     >
       <ul
         className="bpk-horizontal-nav__list"
+        role="tablist"
       >
         My nav content.
       </ul>
@@ -72,6 +74,7 @@ exports[`BpkHorizontalNav should render correctly with custom "className" prop 1
     >
       <ul
         className="bpk-horizontal-nav__list"
+        role="tablist"
       >
         My nav content.
       </ul>
@@ -98,6 +101,7 @@ exports[`BpkHorizontalNav should render correctly with custom "leadingScrollIndi
     >
       <ul
         className="bpk-horizontal-nav__list"
+        role="tablist"
       >
         My nav content.
       </ul>
@@ -124,6 +128,7 @@ exports[`BpkHorizontalNav should render correctly with custom "trailingScrollInd
     >
       <ul
         className="bpk-horizontal-nav__list"
+        role="tablist"
       >
         My nav content.
       </ul>


### PR DESCRIPTION
This is a fix to add `role="tablist"` to `BpkNavigation` 