### PR TITLE
[No Jira] Reinstate icons.js file, needed for docs site icon downloads

### DIFF
--- a/packages/bpk-svgs/src/icons/icons-test.js
+++ b/packages/bpk-svgs/src/icons/icons-test.js
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+
+// In order for the docs site to serve a zip-file containing all icon SVGs, the `zip-it-loader` loader
+// must be provided with an empty file within the icons directory.
+// If icons.js is not empty, then it will be served instead of the SVGs
+describe('icons.js', () => {
+  it('icons.js file should be empty', () => {
+    const iconsFile = path.join(__dirname, 'icons.js');
+    const iconsJsFileContents = fs.readFileSync(iconsFile);
+
+    expect(iconsJsFileContents.toString()).toEqual('');
+  });
+});


### PR DESCRIPTION
When the last PR was merged, it broke the docs site. Turns out, that blank `icons.js` file in `bpk-svgs` actually has a purpose! It's used in the docs site as something to latch onto for downloading a zip file of all the icons. So, I reinstated it.

I tested this locally on a copy of the docs site and it works fine.