### PR TITLE
No jira/Add flow annotation to nudger

### DIFF
--- a/packages/bpk-component-nudger/index.js
+++ b/packages/bpk-component-nudger/index.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import BpkNudger from './src/BpkNudger';
 import BpkConfigurableNudger from './src/BpkConfigurableNudger';
 import themeAttributes from './src/themeAttributes';

--- a/packages/bpk-component-nudger/src/themeAttributes.js
+++ b/packages/bpk-component-nudger/src/themeAttributes.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import { secondaryThemeAttributes as themeAttributes } from 'bpk-component-button/themeAttributes';
 
 export default themeAttributes;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

I added the annotation `/* @flow strict */` to the index of BpkNudger in order to be able to use the types and avoid adding libdefs.

Remember to include the following changes:
+ [x] `UNRELEASED.yaml`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
