### PR TITLE
[no jira]: Fixing css release process to update backpack imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "npm run lint && npm run check-bpk-dependencies && npm run jest && npm run flow && npm run spellcheck",
     "check-owners": "npm whoami && ( node scripts/npm/get-owners.js | grep -E $(npm whoami) ) && node scripts/npm/check-owners.js",
     "check-pristine": "node scripts/check-pristine-state",
-    "publish:css": "node ./scripts/publish-process/transform-js-scss-css-imports.js && node ./scripts/publish-process/publish-css-tagged-packages.js && git reset --hard HEAD",
+    "publish:css": "node ./scripts/publish-process/transform-js-scss-css-imports.js && node ./scripts/publish-process/transform-bpk-imports.js && node ./scripts/publish-process/publish-css-tagged-packages.js && git reset --hard HEAD",
     "publish": "npm run check-pristine && npm run check-owners && npm run build && git pull --rebase && flow stop && npm run test && lerna publish && echo \"NOW PLEASE USE npm run publish:css\"",
     "publish:beta": "npm run check-pristine && npm run check-owners && npm run build && git pull --rebase && flow stop && npm run test && node scripts/publish-process/auto-publish.js && npm run publish:css",
     "release": "npm run publish",

--- a/scripts/publish-process/transform-bpk-imports.js
+++ b/scripts/publish-process/transform-bpk-imports.js
@@ -1,0 +1,68 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2020 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+const updateImports = (file, dirs) =>
+  new Promise((resolve, reject) => {
+    fs.readFile(file, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+      }
+      let result = data;
+
+      dirs.forEach(pkg => {
+        const split = result.split(`from '${pkg}`);
+        if (split.length === 1) {
+          return;
+        }
+        result = split.join(`from '${pkg}-css`);
+      });
+
+      fs.writeFile(file, result, 'utf8', err2 => {
+        if (err2) return reject(err2);
+        return resolve();
+      });
+    });
+  });
+
+// eslint-disable-next-line no-console
+console.log('Crunching Backpack import paths...');
+
+const dirs = execSync('ls packages | grep -v "react-version-test.js"')
+  .toString()
+  .split('\n')
+  .filter(s => s !== '');
+
+const jsFiles = execSync(
+  'find packages -name "*.js" -o -name "*.jsx" | grep -v node_modules',
+)
+  .toString()
+  .split('\n')
+  .filter(s => s !== '');
+
+const updatePromises = jsFiles.map(jF => updateImports(jF, dirs));
+
+Promise.all(updatePromises).then(() => {
+  // eslint-disable-next-line no-console
+  console.log('All good.  👍');
+  process.exit(0);
+});


### PR DESCRIPTION
This PR fixes the issue where when we release the CSS versions of the packages, the imports in the js files for Backpack components were still refering to the old package names which are not available when you install

e.g. `bpk-component-button` was being imported when it should be `bpk-component-button-css` as that is the installed version.

## Testing
To test the PR I commented out the part where it actually does the publish to npm and just ran the publish:css command manually and checked the git changes that were made to verify that the imports were correct