### PR TITLE
[no jira]: Update bold prop usage

### DIFF
--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.js
@@ -21,7 +21,7 @@
 import React, { type Node, type Element } from 'react';
 import PropTypes from 'prop-types';
 import { cssModules } from 'bpk-react-utils';
-import BpkText from 'bpk-component-text';
+import BpkText, { WEIGHT_STYLES } from 'bpk-component-text';
 
 import STYLES from './BpkNavigationBar.scss';
 
@@ -70,7 +70,7 @@ const BpkNavigationBar = (props: Props) => {
       {typeof title === 'string' ? (
         <BpkText
           id={titleId}
-          bold
+          weight={WEIGHT_STYLES.bold}
           className={getClassNames('bpk-navigation-bar__title')}
         >
           {title}

--- a/packages/bpk-component-popover/src/BpkPopover.js
+++ b/packages/bpk-component-popover/src/BpkPopover.js
@@ -20,7 +20,7 @@
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';
-import BpkText from 'bpk-component-text';
+import BpkText, { WEIGHT_STYLES } from 'bpk-component-text';
 import { BpkButtonLink } from 'bpk-component-link';
 import BpkCloseButton from 'bpk-component-close-button';
 import { TransitionInitialMount, cssModules } from 'bpk-react-utils';
@@ -111,7 +111,7 @@ const BpkPopover = (props: Props) => {
         />
         {labelAsTitle ? (
           <header className={getClassName('bpk-popover__header')}>
-            <BpkText tagName="h2" id={labelId} bold>
+            <BpkText tagName="h2" id={labelId} weight={WEIGHT_STYLES.bold}>
               {label}
             </BpkText>
             &nbsp;

--- a/packages/bpk-component-section-list/src/BpkSectionListSection.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListSection.js
@@ -21,7 +21,7 @@
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';
 import { cssModules } from 'bpk-react-utils';
-import BpkText from 'bpk-component-text';
+import BpkText, { WEIGHT_STYLES } from 'bpk-component-text';
 
 import STYLES from './BpkSectionListSection.scss';
 
@@ -39,7 +39,7 @@ const BpkSectionListSection = (props: Props) => {
     <section {...rest}>
       {headerText && (
         <header className={getClassName('bpk-section-list-section__header')}>
-          <BpkText bold textStyle="base">
+          <BpkText weight={WEIGHT_STYLES.bold} textStyle="base">
             {headerText}
           </BpkText>
         </header>

--- a/packages/bpk-component-text/stories.js
+++ b/packages/bpk-component-text/stories.js
@@ -88,7 +88,7 @@ storiesOf('bpk-component-text', module)
   .add('bold', () => (
     <BpkText tagName="p">
       The man jumped over the shark tank. That was very{' '}
-      <BpkText bold>bold</BpkText> indeed.
+      <BpkText weight={WEIGHT_STYLES.bold}>bold</BpkText> indeed.
     </BpkText>
   ))
   .add('with weights', () => (

--- a/packages/bpk-react-utils/src/deprecated.js
+++ b/packages/bpk-react-utils/src/deprecated.js
@@ -26,7 +26,7 @@ const deprecated = (propType: PropType, alternativeSuggestion: string) => (
   ...rest: [any]
 ) => {
   if (props[propName] != null) {
-    const message = `"${propName}" property of "${componentName}" has been deprecated. ${alternativeSuggestion}`;
+    const message = `Warning: "${propName}" property of "${componentName}" has been deprecated. ${alternativeSuggestion}`;
     // eslint-disable-next-line no-console
     console.warn(message);
   }


### PR DESCRIPTION
PR to update components that were still using deprecated `bold` prop for BpkText

Also minor update to the `deprecated` messaging as it was pointed out by @sogame danger would not see and report the warnings so add 'Warning' so that danger can parse and report back to PR 😄  see here https://github.com/sogame/danger-plugin-toolbox/blob/master/src/rules/common/fileWarnings.js#L21