### PR TITLE
[NO-JIRA] Remove scrollable calendar resize listeners on unmount

### DIFF
--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -4,6 +4,9 @@ FIXED:
   - bpk-component-badge:
     - Tweaked design of badges.
 
+  - bpk-component-scrollable-calendar:
+    - Remove resize event listeners when the component is unmounted.
+
 # How to write a good changelog entry:
 #
 #   1. Add 'BREAKING', 'ADDED' OR 'FIXED' depending on if the change will be major, minor or patch according to [semver.org](semver.org).

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
@@ -80,6 +80,17 @@ class BpkScrollableCalendarGridList extends React.Component {
     }
   };
 
+  componentWillUnmount = () => {
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('resize', this.setComponentHeight);
+      document.removeEventListener(
+        'orientationchange',
+        this.setComponentHeight,
+      );
+      document.removeEventListener('fullscreenchange', this.setComponentHeight);
+    }
+  };
+
   getHtmlElement = () =>
     typeof document !== 'undefined' ? document.querySelector('html') : {};
 


### PR DESCRIPTION
Remove the resize listeners otherwise we end up causing memory leaks when the component is mounted/unmounted multiple times.

Remember to include the following changes:
+ [x] `UNRELEASED.yaml`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
