### PR TITLE
Fixed rating component warnings

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -355,8 +355,8 @@ ratingLabel
 RATING_SIZES
 RATING_SIZES.base
 RATING_TYPES
-RATING_TYPES.DEFAULT
-RATING_TYPES.PILL
+RATING_TYPES.default
+RATING_TYPES.pill
 renderFlag
 renderTarget
 selectedDates

--- a/packages/bpk-component-rating/README.md
+++ b/packages/bpk-component-rating/README.md
@@ -33,7 +33,7 @@ export default () => (
 | className | string                | false    | null              |
 | size      | oneOf(RATING_SIZES)   | false    | RATING_SIZES.base |
 | subtitle  | string                | false    | null              |
-| type      | oneOf(RATING_TYPES)   | false    | RATING_TYPES.DEFAULT |
+| type      | oneOf(RATING_TYPES)   | false    | RATING_TYPES.default |
 | vertical  | boolean               | false    | false             |
 
 ## Theme props

--- a/packages/bpk-component-rating/src/BpkRating-test.js
+++ b/packages/bpk-component-rating/src/BpkRating-test.js
@@ -189,7 +189,7 @@ describe('BpkRating', () => {
           ariaLabel="6.7 Average might recommend"
           title="Average"
           subtitle="Might recommend"
-          type={RATING_TYPES.PILL}
+          type={RATING_TYPES.pill}
           value={6.7}
         />,
       )
@@ -203,7 +203,7 @@ describe('BpkRating', () => {
         <BpkRating
           ariaLabel="6.7 Average might recommend"
           title="Average"
-          type={RATING_TYPES.PILL}
+          type={RATING_TYPES.pill}
           value={6.7}
         />,
       )

--- a/packages/bpk-component-rating/src/BpkRating.js
+++ b/packages/bpk-component-rating/src/BpkRating.js
@@ -60,7 +60,7 @@ const BpkRating = (props: Props) => {
     getClassName(
       'bpk-rating__component',
       `bpk-rating--${size}-rating`,
-      type === RATING_TYPES.PILL && `bpk-rating--${size}-pill`,
+      type === RATING_TYPES.pill && `bpk-rating--${size}-pill`,
     ),
   ];
   const textWrapperStyles = [getClassName('bpk-rating__text-wrapper')];
@@ -120,9 +120,9 @@ const BpkRating = (props: Props) => {
           aria-hidden="true"
         >
           <strong>{title}</strong>{' '}
-          {subtitle && type === RATING_TYPES.PILL && <span>{subtitle}</span>}
+          {subtitle && type === RATING_TYPES.pill && <span>{subtitle}</span>}
         </BpkText>
-        {subtitle && type !== RATING_TYPES.PILL && (
+        {subtitle && type !== RATING_TYPES.pill && (
           <BpkText
             className={textStyles.join(' ')}
             textStyle={size === RATING_SIZES.lg ? 'sm' : 'xs'}
@@ -144,7 +144,7 @@ BpkRating.propTypes = {
   className: PropTypes.string,
   size: PropTypes.oneOf(Object.keys(RATING_SIZES)),
   subtitle: PropTypes.string,
-  type: PropTypes.oneOf(Object.keys(RATING_TYPES)),
+  type: PropTypes.oneOf([RATING_TYPES.default, RATING_TYPES.pill]),
   vertical: PropTypes.bool,
 };
 
@@ -152,7 +152,7 @@ BpkRating.defaultProps = {
   className: null,
   size: RATING_SIZES.base,
   subtitle: null,
-  type: RATING_TYPES.DEFAULT,
+  type: RATING_TYPES.default,
   vertical: false,
 };
 

--- a/packages/bpk-component-rating/src/common-types.js
+++ b/packages/bpk-component-rating/src/common-types.js
@@ -21,6 +21,6 @@
 export const RATING_SIZES = { sm: 'sm', base: 'base', lg: 'lg' };
 
 export const RATING_TYPES = {
-  DEFAULT: 'default',
-  PILL: 'pill',
+  default: 'default',
+  pill: 'pill',
 };

--- a/packages/bpk-component-rating/stories.js
+++ b/packages/bpk-component-rating/stories.js
@@ -259,7 +259,7 @@ storiesOf('bpk-component-rating', module)
         subtitle="(4,000 reviews)"
         value={9}
         size={RATING_SIZES.sm}
-        type={RATING_TYPES.PILL}
+        type={RATING_TYPES.pill}
       />
       <br />
       <BpkRating
@@ -267,7 +267,7 @@ storiesOf('bpk-component-rating', module)
         title="Average"
         subtitle="(50 reviews)"
         value={6.7}
-        type={RATING_TYPES.PILL}
+        type={RATING_TYPES.pill}
       />
       <br />
       <BpkRating
@@ -276,7 +276,7 @@ storiesOf('bpk-component-rating', module)
         subtitle="(1,000 reviews)"
         value={2.3}
         size={RATING_SIZES.lg}
-        type={RATING_TYPES.PILL}
+        type={RATING_TYPES.pill}
       />
       <br />
     </div>
@@ -288,14 +288,14 @@ storiesOf('bpk-component-rating', module)
         title="Excellent"
         value={9}
         size={RATING_SIZES.sm}
-        type={RATING_TYPES.PILL}
+        type={RATING_TYPES.pill}
       />
       <br />
       <BpkRating
         ariaLabel="6.7 Average might recommend"
         title="Average"
         value={6.7}
-        type={RATING_TYPES.PILL}
+        type={RATING_TYPES.pill}
       />
       <br />
       <BpkRating
@@ -303,7 +303,7 @@ storiesOf('bpk-component-rating', module)
         title="Bad"
         value={2.3}
         size={RATING_SIZES.lg}
-        type={RATING_TYPES.PILL}
+        type={RATING_TYPES.pill}
       />
       <br />
     </div>


### PR DESCRIPTION
Fix for prop warnings that were being thrown by the component.

See here for example:
https://github.com/Skyscanner/backpack/pull/1935#issuecomment-665142697