### PR TITLE
WIP - Excluding bpk-mixins from css process

### DIFF
--- a/scripts/publish-process/transform-bpk-imports.js
+++ b/scripts/publish-process/transform-bpk-imports.js
@@ -47,7 +47,9 @@ const updateImports = (file, dirs) =>
 // eslint-disable-next-line no-console
 console.log('Crunching Backpack import paths...');
 
-const dirs = execSync('ls packages | grep -v "react-version-test.js"')
+const dirs = execSync(
+  'ls packages | grep -v "react-version-test.js" | grep -v "bpk-mixins"',
+)
   .toString()
   .split('\n')
   .filter(s => s !== '');

--- a/scripts/publish-process/util.js
+++ b/scripts/publish-process/util.js
@@ -417,7 +417,7 @@ const updateDependencies = dependencies => {
 
   Object.keys(dependencies).forEach(depName => {
     const depValue = dependencies[depName];
-    if (depName.match('bpk-*')) {
+    if (depName.match('bpk-*') && !depName.match('bpk-mixins')) {
       const newName = `${depName}-css`;
       dependencyList[newName] = depValue;
     } else {
@@ -431,6 +431,7 @@ const updateDependencies = dependencies => {
 
 const appendToPackageName = (c, text) =>
   new Promise(resolve => {
+    if (c.name.match('bpk-mixins')) resolve();
     const packageJsonFilePath = path.join(c.path, 'package.json');
     const appendedName = `${c.name}-${text}`;
     const packageJsonData = JSON.parse(


### PR DESCRIPTION
This fix excludes bpk-mixins from being changed to CSS as they are focused on SASS they shouldn't be published as a css package as they don't contain any .css files