### PR TITLE
[BPK-3438]: Support bold in accordion

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -97,6 +97,8 @@ BpkInteractiveStar
 BpkInteractiveStarRating
 withInteractiveStarRatingState
 
+BpkText
+
 BpkThemeProvider
 
 BpkTicket

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -1,5 +1,9 @@
 # UNRELEASED:
 
+ADDED:
+  - bpk-component-accordion:
+    - Added new `weight` prop to allow titles to support `bold` and `heavy` font weight.
+
 # How to write a good changelog entry:
 #
 #   1. Add 'BREAKING', 'ADDED' OR 'FIXED' depending on if the change will be major, minor or patch according to [semver.org](semver.org).

--- a/packages/bpk-component-accordion/README.md
+++ b/packages/bpk-component-accordion/README.md
@@ -97,7 +97,7 @@ const AlignedStopsIcon = withAlignment(StopsIcon, lineHeightBase, iconSizeSm);
 | children  | node     | true     | -             |
 | id        | string   | true     | -             |
 | title     | string   | true     | -             |
-| weight    | See [`BpkText`](https://backpack.github.io/components/text?platform=web#readme) for valid options     | false    | WEIGHT_STYLES.regular         |
+| weight    | See prop details     | false    | WEIGHT_STYLES.regular         |
 | expanded  | bool     | false    | false         |
 | icon      | node     | false    | null          |
 | onClick   | func     | false    | () => null    |
@@ -115,6 +115,12 @@ const AlignedStopsIcon = withAlignment(StopsIcon, lineHeightBase, iconSizeSm);
 | Property                       | PropType | Required | Default Value |
 | ------------------------------ | -------- | -------- | ------------- |
 | ~~expanded~~ initiallyExpanded | bool     | false    | false         |
+
+## Prop Details
+
+#### weight
+
+This prop takes `WEIGHT_STYLES` that has been re-exported from `BpkText`. For valid options please refer to the [BpkText](https://backpack.github.io/components/text?platform=web#readme) docs.
 
 ## Theme Props
 

--- a/packages/bpk-component-accordion/README.md
+++ b/packages/bpk-component-accordion/README.md
@@ -97,6 +97,7 @@ const AlignedStopsIcon = withAlignment(StopsIcon, lineHeightBase, iconSizeSm);
 | children  | node     | true     | -             |
 | id        | string   | true     | -             |
 | title     | string   | true     | -             |
+| weight    | See [`BpkText`](https://backpack.github.io/components/text?platform=web#readme) for valid options     | false    | WEIGHT_STYLES.regular         |
 | expanded  | bool     | false    | false         |
 | icon      | node     | false    | null          |
 | onClick   | func     | false    | () => null    |

--- a/packages/bpk-component-accordion/index.js
+++ b/packages/bpk-component-accordion/index.js
@@ -19,7 +19,7 @@
 /* @flow strict */
 
 import BpkAccordion from './src/BpkAccordion';
-import BpkAccordionItem from './src/BpkAccordionItem';
+import BpkAccordionItem, { WEIGHT_STYLES } from './src/BpkAccordionItem';
 import withSingleItemAccordionState from './src/withSingleItemAccordionState';
 import withAccordionItemState from './src/withAccordionItemState';
 import themeAttributes from './src/themeAttributes';
@@ -30,4 +30,5 @@ export {
   withSingleItemAccordionState,
   withAccordionItemState,
   themeAttributes,
+  WEIGHT_STYLES,
 };

--- a/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
@@ -21,9 +21,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import StopsIcon from 'bpk-component-icon/sm/stops';
-import { WEIGHT_STYLES } from 'bpk-component-text';
 
-import BpkAccordionItem from './BpkAccordionItem';
+import BpkAccordionItem, { WEIGHT_STYLES } from './BpkAccordionItem';
 
 describe('BpkAccordionItem', () => {
   it('should render correctly', () => {

--- a/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
@@ -84,7 +84,7 @@ describe('BpkAccordionItem', () => {
         <BpkAccordionItem
           id="my-accordion"
           title="My accordion item"
-          weight={WEIGHT_STYLES.heavy}
+          weight={WEIGHT_STYLES.bold}
         >
           My accordion content
         </BpkAccordionItem>,

--- a/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
@@ -21,6 +21,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import StopsIcon from 'bpk-component-icon/sm/stops';
+import { WEIGHT_STYLES } from 'bpk-component-text';
 
 import BpkAccordionItem from './BpkAccordionItem';
 
@@ -77,10 +78,14 @@ describe('BpkAccordionItem', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('should render correctly with "bold" prop set', () => {
+  it('should render correctly with "weight" prop set to bold', () => {
     const tree = renderer
       .create(
-        <BpkAccordionItem id="my-accordion" title="My accordion item" bold>
+        <BpkAccordionItem
+          id="my-accordion"
+          title="My accordion item"
+          weight={WEIGHT_STYLES.heavy}
+        >
           My accordion content
         </BpkAccordionItem>,
       )

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -23,7 +23,7 @@ import React, { type Node, type Element } from 'react';
 import AnimateHeight from 'bpk-animate-height';
 import { withButtonAlignment } from 'bpk-component-icon';
 import ChevronDownIcon from 'bpk-component-icon/sm/chevron-down';
-import BpkText, { TEXT_STYLES } from 'bpk-component-text';
+import BpkText, { TEXT_STYLES, WEIGHT_STYLES } from 'bpk-component-text';
 import { cssModules } from 'bpk-react-utils';
 
 import STYLES from './BpkAccordionItem.scss';
@@ -36,6 +36,7 @@ type Props = {
   children: Node,
   id: string,
   title: string,
+  weight: $Keys<typeof WEIGHT_STYLES>,
   expanded: boolean,
   icon: ?Element<any>,
   onClick: () => mixed,
@@ -49,6 +50,7 @@ const BpkAccordionItem = (props: Props) => {
     id,
     title,
     children,
+    weight,
     expanded,
     icon,
     onClick,
@@ -96,6 +98,7 @@ const BpkAccordionItem = (props: Props) => {
               textStyle={textStyle}
               tagName={tagName}
               className={getClassName('bpk-accordion__title-text')}
+              weight={weight}
             >
               {clonedIcon}
               {title}
@@ -123,6 +126,7 @@ BpkAccordionItem.propTypes = {
   children: PropTypes.node.isRequired,
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  weight: PropTypes.string,
   expanded: PropTypes.bool,
   icon: PropTypes.node,
   onClick: PropTypes.func,
@@ -131,6 +135,7 @@ BpkAccordionItem.propTypes = {
 };
 
 BpkAccordionItem.defaultProps = {
+  weight: WEIGHT_STYLES.regular,
   expanded: false,
   icon: null,
   onClick: () => null,

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -23,7 +23,10 @@ import React, { type Node, type Element } from 'react';
 import AnimateHeight from 'bpk-animate-height';
 import { withButtonAlignment } from 'bpk-component-icon';
 import ChevronDownIcon from 'bpk-component-icon/sm/chevron-down';
-import BpkText, { TEXT_STYLES, WEIGHT_STYLES } from 'bpk-component-text';
+import BpkText, {
+  TEXT_STYLES,
+  WEIGHT_STYLES as weights,
+} from 'bpk-component-text';
 import { cssModules } from 'bpk-react-utils';
 
 import STYLES from './BpkAccordionItem.scss';
@@ -31,6 +34,8 @@ import STYLES from './BpkAccordionItem.scss';
 const getClassName = cssModules(STYLES);
 
 const ExpandIcon = withButtonAlignment(ChevronDownIcon);
+
+export const WEIGHT_STYLES = weights;
 
 type Props = {
   children: Node,

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -543,7 +543,7 @@ exports[`BpkAccordionItem should render correctly with "weight" prop set to bold
         className="bpk-accordion__flex-container"
       >
         <span
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
+          className="bpk-text bpk-text--base bpk-text--bold bpk-accordion__title-text"
         >
           My accordion item
         </span>

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -174,94 +174,6 @@ exports[`BpkAccordionItem should render correctly 1`] = `
 </div>
 `;
 
-exports[`BpkAccordionItem should render correctly with "bold" prop set 1`] = `
-<div
-  bold={true}
-  id="my-accordion"
->
-  <dt
-    aria-labelledby="my-accordion"
-    aria-level="3"
-    className="bpk-accordion__title"
-  >
-    <button
-      aria-controls="my-accordion_content"
-      aria-expanded={false}
-      className="bpk-accordion__toggle-button"
-      onClick={[Function]}
-      type="button"
-    >
-      <span
-        className="bpk-accordion__flex-container"
-      >
-        <span
-          className="bpk-text bpk-text--base bpk-accordion__title-text"
-        >
-          My accordion item
-        </span>
-        <span
-          className="bpk-accordion__icon-wrapper"
-        >
-          <span
-            style={
-              Object {
-                "display": "inline-block",
-                "lineHeight": "1.125rem",
-                "marginTop": "0.1875rem",
-                "verticalAlign": "top",
-              }
-            }
-          >
-            <svg
-              className="bpk-accordion__item-expand-icon"
-              height="18"
-              style={
-                Object {
-                  "height": "1.125rem",
-                  "width": "1.125rem",
-                }
-              }
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M19.113 8.095a1.496 1.496 0 0 1 0 2.008l-6.397 5.948a1 1 0 0 1-1.358.003l-6.532-6.01a1.427 1.427 0 0 1 .138-1.949 1.572 1.572 0 0 1 1.997-.103l5.078 4.638 4.97-4.535a1.72 1.72 0 0 1 2.104 0z"
-                fillRule="evenodd"
-              />
-            </svg>
-          </span>
-        </span>
-      </span>
-    </button>
-  </dt>
-  <dd
-    aria-labelledby="my-accordion_content"
-    className="bpk-accordion__content-container"
-    id="my-accordion_content"
-  >
-    <div
-      onTransitionEnd={[Function]}
-      style={
-        Object {
-          "MozTransition": "height 200ms ease ",
-          "OTransition": "height 200ms ease ",
-          "WebkitTransition": "height 200ms ease ",
-          "height": 0,
-          "msTransition": "height 200ms ease ",
-          "overflow": "hidden",
-          "transition": "height 200ms ease ",
-        }
-      }
-    >
-      <div>
-        My accordion content
-      </div>
-    </div>
-  </dd>
-</div>
-`;
-
 exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
 <div
   className="my-custom-class"
@@ -545,6 +457,93 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
       >
         <span
           className="bpk-text bpk-text--xl bpk-accordion__title-text"
+        >
+          My accordion item
+        </span>
+        <span
+          className="bpk-accordion__icon-wrapper"
+        >
+          <span
+            style={
+              Object {
+                "display": "inline-block",
+                "lineHeight": "1.125rem",
+                "marginTop": "0.1875rem",
+                "verticalAlign": "top",
+              }
+            }
+          >
+            <svg
+              className="bpk-accordion__item-expand-icon"
+              height="18"
+              style={
+                Object {
+                  "height": "1.125rem",
+                  "width": "1.125rem",
+                }
+              }
+              viewBox="0 0 24 24"
+              width="18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19.113 8.095a1.496 1.496 0 0 1 0 2.008l-6.397 5.948a1 1 0 0 1-1.358.003l-6.532-6.01a1.427 1.427 0 0 1 .138-1.949 1.572 1.572 0 0 1 1.997-.103l5.078 4.638 4.97-4.535a1.72 1.72 0 0 1 2.104 0z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </span>
+        </span>
+      </span>
+    </button>
+  </dt>
+  <dd
+    aria-labelledby="my-accordion_content"
+    className="bpk-accordion__content-container"
+    id="my-accordion_content"
+  >
+    <div
+      onTransitionEnd={[Function]}
+      style={
+        Object {
+          "MozTransition": "height 200ms ease ",
+          "OTransition": "height 200ms ease ",
+          "WebkitTransition": "height 200ms ease ",
+          "height": 0,
+          "msTransition": "height 200ms ease ",
+          "overflow": "hidden",
+          "transition": "height 200ms ease ",
+        }
+      }
+    >
+      <div>
+        My accordion content
+      </div>
+    </div>
+  </dd>
+</div>
+`;
+
+exports[`BpkAccordionItem should render correctly with "weight" prop set to bold 1`] = `
+<div
+  id="my-accordion"
+>
+  <dt
+    aria-labelledby="my-accordion"
+    aria-level="3"
+    className="bpk-accordion__title"
+  >
+    <button
+      aria-controls="my-accordion_content"
+      aria-expanded={false}
+      className="bpk-accordion__toggle-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="bpk-accordion__flex-container"
+      >
+        <span
+          className="bpk-text bpk-text--base bpk-accordion__title-text"
         >
           My accordion item
         </span>

--- a/packages/bpk-component-accordion/stories.js
+++ b/packages/bpk-component-accordion/stories.js
@@ -31,6 +31,7 @@ import {
   lineHeightBase,
   spacingSm,
 } from 'bpk-tokens/tokens/base.es6';
+import { WEIGHT_STYLES } from 'bpk-component-text';
 
 import {
   BpkAccordion,
@@ -289,4 +290,32 @@ storiesOf('bpk-component-accordion', module)
         <AirportsContent />
       </BpkAccordionItem>
     </BpkAccordion>
+  ))
+  .add('With bold titles', () => (
+    <SingleItemAccordion>
+      <BpkAccordionItem
+        id="stops"
+        title="Stops"
+        initiallyExpanded
+        weight={WEIGHT_STYLES.bold}
+      >
+        <StopsContent />
+      </BpkAccordionItem>
+      <BpkAccordionItem
+        id="airlines"
+        title="Airlines"
+        textStyle="lg"
+        weight={WEIGHT_STYLES.bold}
+      >
+        <AirlinesContent />
+      </BpkAccordionItem>
+      <BpkAccordionItem
+        id="airports"
+        title="Airports"
+        textStyle="xl"
+        weight={WEIGHT_STYLES.bold}
+      >
+        <AirportsContent />
+      </BpkAccordionItem>
+    </SingleItemAccordion>
   ));

--- a/packages/bpk-component-accordion/stories.js
+++ b/packages/bpk-component-accordion/stories.js
@@ -31,13 +31,13 @@ import {
   lineHeightBase,
   spacingSm,
 } from 'bpk-tokens/tokens/base.es6';
-import { WEIGHT_STYLES } from 'bpk-component-text';
 
 import {
   BpkAccordion,
   withSingleItemAccordionState,
   BpkAccordionItem,
   withAccordionItemState,
+  WEIGHT_STYLES,
 } from './index';
 
 const SingleItemAccordion = withSingleItemAccordionState(BpkAccordion);


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

The following PR allows the support of a `weight` prop that can be passed to `BpkAccordionItem` to style the title of the accordion.

Remember to include the following changes:

- [x] `UNRELEASED.yaml`
- [x] `README.md`
- [x] Tests

React 16.4 compatibility:

- [x] I haven't used Hooks in any code that we ship to consumers.


Screenshot:

<img width="904" alt="Screenshot 2020-09-14 at 12 45 58" src="https://user-images.githubusercontent.com/8831547/93082123-4281a800-f688-11ea-8673-54aa0abaab28.png">