### PR TITLE
[ZEP-688] Allow consumers of BpkDatePicker to control isOpen from the outside

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -796,3 +796,4 @@ props.label
 semver.org
 ROUNDING_TYPES
 ROUNDING_TYPES.down
+onOpenChange

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -19,7 +19,7 @@
 
    ADDED:
      - bpk-component-datepicker:
-       - New `onClose` prop which is a callback method that will be called when the date picker is closed
+       - New `onOpenChange` prop which is a callback method that will be called when the date picker open state changes
        - The isOpen state can be updated through the isOpen prop
 
 #   FIXED:

--- a/UNRELEASED.yaml
+++ b/UNRELEASED.yaml
@@ -16,11 +16,12 @@
 #     - bpk-svgs:
 #       - Replaced `charmeleon` icon with new `charizard` icon. To upgrade, replace your references to `charmeleon` with `charizard`.
 #       - Upgraded `fire` dependency to `3.0.0`.
-#
-#   ADDED:
-#     - bpk-component-infinity-gauntlet:
-#       - New `timeStone` prop for controlling time. See <link to docs site>.
-#
+
+   ADDED:
+     - bpk-component-datepicker:
+       - New `onClose` prop which is a callback method that will be called when the date picker is closed
+       - The isOpen state can be updated through the isOpen prop
+
 #   FIXED:
 #     - bpk-component-horcrux:
 #       - Fixed issue where `BpkHorcrux` would occasionally possess the living.

--- a/packages/bpk-component-datepicker/README.md
+++ b/packages/bpk-component-datepicker/README.md
@@ -147,7 +147,7 @@ For more information on some these props, check the BpkCalendar documentation.
 | initiallyFocusedDate  | Date                  | false    | null                                |
 | renderTarget          | func                  | false    | null                                |
 | isOpen                | bool                  | false    | false                               |
-| onClose               | func                  | false    | null                                |
+| onOpenChange          | func                  | false    | null                                |
 | valid                 | bool                  | false    | null                                |
 
 > (\*) Default value is defined on child component

--- a/packages/bpk-component-datepicker/README.md
+++ b/packages/bpk-component-datepicker/README.md
@@ -147,6 +147,7 @@ For more information on some these props, check the BpkCalendar documentation.
 | initiallyFocusedDate  | Date                  | false    | null                                |
 | renderTarget          | func                  | false    | null                                |
 | isOpen                | bool                  | false    | false                               |
+| onClose               | func                  | false    | null                                |
 | valid                 | bool                  | false    | null                                |
 
 > (\*) Default value is defined on child component

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -233,7 +233,7 @@ describe('BpkDatepicker', () => {
   });
 
   it('should update state when a date is selected', () => {
-    const onCloseHook = jest.fn();
+    const onOpenChangeHook = jest.fn();
 
     const datepicker = mount(
       <BpkDatepicker
@@ -251,21 +251,22 @@ describe('BpkDatepicker', () => {
         minDate={new Date(2010, 1, 15)}
         maxDate={new Date(2010, 2, 15)}
         date={new Date(2010, 1, 15)}
-        onClose={onCloseHook}
+        onOpenChange={onOpenChangeHook}
       />,
     );
 
     datepicker.find('BpkInput').simulate('click');
     expect(datepicker.state('isOpen')).toEqual(true);
+    expect(onOpenChangeHook).toHaveBeenCalledWith(true);
 
     const date = new Date(2010, 1, 15);
     datepicker.instance().handleDateSelect(date);
     expect(datepicker.state('isOpen')).toEqual(false);
-    expect(onCloseHook).toHaveBeenCalledTimes(1);
+    expect(onOpenChangeHook).toHaveBeenCalledWith(false);
   });
 
   it('should close when `onClose` is called', () => {
-    const onCloseHook = jest.fn();
+    const onOpenChangeHook = jest.fn();
 
     const datepicker = mount(
       <BpkDatepicker
@@ -283,15 +284,16 @@ describe('BpkDatepicker', () => {
         minDate={new Date(2010, 1, 15)}
         maxDate={new Date(2010, 2, 15)}
         date={new Date(2010, 1, 15)}
-        onClose={onCloseHook}
+        onOpenChange={onOpenChangeHook}
       />,
     );
 
     datepicker.find('BpkInput').simulate('click');
     expect(datepicker.state('isOpen')).toEqual(true);
+    expect(onOpenChangeHook).toHaveBeenCalledWith(true);
 
     datepicker.instance().onClose();
     expect(datepicker.state('isOpen')).toEqual(false);
-    expect(onCloseHook).toHaveBeenCalledTimes(1);
+    expect(onOpenChangeHook).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -233,6 +233,8 @@ describe('BpkDatepicker', () => {
   });
 
   it('should update state when a date is selected', () => {
+    const onCloseHook = jest.fn();
+
     const datepicker = mount(
       <BpkDatepicker
         id="myDatepicker"
@@ -249,6 +251,7 @@ describe('BpkDatepicker', () => {
         minDate={new Date(2010, 1, 15)}
         maxDate={new Date(2010, 2, 15)}
         date={new Date(2010, 1, 15)}
+        onClose={onCloseHook}
       />,
     );
 
@@ -258,9 +261,12 @@ describe('BpkDatepicker', () => {
     const date = new Date(2010, 1, 15);
     datepicker.instance().handleDateSelect(date);
     expect(datepicker.state('isOpen')).toEqual(false);
+    expect(onCloseHook).toHaveBeenCalledTimes(1);
   });
 
   it('should close when `onClose` is called', () => {
+    const onCloseHook = jest.fn();
+
     const datepicker = mount(
       <BpkDatepicker
         id="myDatepicker"
@@ -277,6 +283,7 @@ describe('BpkDatepicker', () => {
         minDate={new Date(2010, 1, 15)}
         maxDate={new Date(2010, 2, 15)}
         date={new Date(2010, 1, 15)}
+        onClose={onCloseHook}
       />,
     );
 
@@ -285,5 +292,6 @@ describe('BpkDatepicker', () => {
 
     datepicker.instance().onClose();
     expect(datepicker.state('isOpen')).toEqual(false);
+    expect(onCloseHook).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -204,6 +204,34 @@ describe('BpkDatepicker', () => {
     expect(datepicker.state('isOpen')).toEqual(true);
   });
 
+  it('should open when the isOpen prop is changed from the outside', () => {
+    const datepicker = mount(
+      <BpkDatepicker
+        id="myDatepicker"
+        closeButtonText="Close"
+        daysOfWeek={weekDays}
+        changeMonthLabel="Change month"
+        title="Departure date"
+        getApplicationElement={() => document.createElement('div')}
+        formatDate={formatDate}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        inputProps={inputProps}
+        minDate={new Date(2010, 1, 15)}
+        maxDate={new Date(2010, 2, 15)}
+        date={new Date(2010, 1, 15)}
+        weekStartsOn={1}
+        isOpen={false}
+      />,
+    );
+
+    expect(datepicker.state('isOpen')).toBeFalsy();
+
+    datepicker.setProps({ isOpen: true });
+
+    expect(datepicker.state('isOpen')).toBeTruthy();
+  });
+
   it('should update state when a date is selected', () => {
     const datepicker = mount(
       <BpkDatepicker

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -233,7 +233,7 @@ describe('BpkDatepicker', () => {
   });
 
   it('should update state when a date is selected', () => {
-    const onOpenChangeHook = jest.fn();
+    const onOpenChangeMock = jest.fn();
 
     const datepicker = mount(
       <BpkDatepicker
@@ -251,22 +251,22 @@ describe('BpkDatepicker', () => {
         minDate={new Date(2010, 1, 15)}
         maxDate={new Date(2010, 2, 15)}
         date={new Date(2010, 1, 15)}
-        onOpenChange={onOpenChangeHook}
+        onOpenChange={onOpenChangeMock}
       />,
     );
 
     datepicker.find('BpkInput').simulate('click');
     expect(datepicker.state('isOpen')).toEqual(true);
-    expect(onOpenChangeHook).toHaveBeenCalledWith(true);
+    expect(onOpenChangeMock).toHaveBeenCalledWith(true);
 
     const date = new Date(2010, 1, 15);
     datepicker.instance().handleDateSelect(date);
     expect(datepicker.state('isOpen')).toEqual(false);
-    expect(onOpenChangeHook).toHaveBeenCalledWith(false);
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false);
   });
 
   it('should close when `onClose` is called', () => {
-    const onOpenChangeHook = jest.fn();
+    const onOpenChangeMock = jest.fn();
 
     const datepicker = mount(
       <BpkDatepicker
@@ -284,16 +284,16 @@ describe('BpkDatepicker', () => {
         minDate={new Date(2010, 1, 15)}
         maxDate={new Date(2010, 2, 15)}
         date={new Date(2010, 1, 15)}
-        onOpenChange={onOpenChangeHook}
+        onOpenChange={onOpenChangeMock}
       />,
     );
 
     datepicker.find('BpkInput').simulate('click');
     expect(datepicker.state('isOpen')).toEqual(true);
-    expect(onOpenChangeHook).toHaveBeenCalledWith(true);
+    expect(onOpenChangeMock).toHaveBeenCalledWith(true);
 
     datepicker.instance().onClose();
     expect(datepicker.state('isOpen')).toEqual(false);
-    expect(onOpenChangeHook).toHaveBeenCalledWith(false);
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -61,6 +61,9 @@ class BpkDatepicker extends Component {
     this.setState({
       isOpen: false,
     });
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
   };
 
   handleDateSelect = dateObj => {
@@ -69,6 +72,9 @@ class BpkDatepicker extends Component {
     });
     if (this.props.onDateSelect) {
       this.props.onDateSelect(dateObj);
+    }
+    if (this.props.onClose) {
+      this.props.onClose();
     }
   };
 
@@ -97,14 +103,15 @@ class BpkDatepicker extends Component {
       initiallyFocusedDate,
       renderTarget,
       valid,
+      // onDateSelect, onClose and isOpen are decomposed here so they don't end
+      // up in the rest object
+      onDateSelect,
+      onClose,
+      isOpen,
       ...rest
     } = this.props;
 
     const dateLabel = date ? formatDateFull(date) : '';
-
-    // The following props are not used in render
-    delete rest.onDateSelect;
-    delete rest.isOpen;
 
     const inputComponent = (
       <Input
@@ -205,6 +212,7 @@ BpkDatepicker.propTypes = {
   maxDate: PropTypes.instanceOf(Date),
   minDate: PropTypes.instanceOf(Date),
   onDateSelect: PropTypes.func,
+  onClose: PropTypes.func,
   onMonthChange: PropTypes.func,
   showWeekendSeparator: PropTypes.bool,
   initiallyFocusedDate: PropTypes.instanceOf(Date),
@@ -223,6 +231,7 @@ BpkDatepicker.defaultProps = {
   maxDate: BpkCalendar.defaultProps.maxDate,
   minDate: BpkCalendar.defaultProps.minDate,
   onDateSelect: null,
+  onClose: null,
   onMonthChange: null,
   showWeekendSeparator: BpkCalendar.defaultProps.showWeekendSeparator,
   initiallyFocusedDate: null,

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -40,6 +40,17 @@ class BpkDatepicker extends Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    const { isOpen } = this.props;
+
+    if (prevProps.isOpen !== isOpen) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({
+        isOpen,
+      });
+    }
+  }
+
   onOpen = () => {
     this.setState({
       isOpen: true,

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -40,14 +40,15 @@ class BpkDatepicker extends Component {
     };
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const { isOpen } = this.props;
 
-    if (prevProps.isOpen !== isOpen) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        isOpen,
-      });
+    if (prevProps.isOpen !== isOpen && prevState.isOpen !== isOpen) {
+      if (isOpen) {
+        this.onOpen();
+      } else {
+        this.onClose();
+      }
     }
   }
 
@@ -55,26 +56,24 @@ class BpkDatepicker extends Component {
     this.setState({
       isOpen: true,
     });
+    if (this.props.onOpenChange) {
+      this.props.onOpenChange(true);
+    }
   };
 
   onClose = () => {
     this.setState({
       isOpen: false,
     });
-    if (this.props.onClose) {
-      this.props.onClose();
+    if (this.props.onOpenChange) {
+      this.props.onOpenChange(false);
     }
   };
 
   handleDateSelect = dateObj => {
-    this.setState({
-      isOpen: false,
-    });
+    this.onClose();
     if (this.props.onDateSelect) {
       this.props.onDateSelect(dateObj);
-    }
-    if (this.props.onClose) {
-      this.props.onClose();
     }
   };
 
@@ -103,15 +102,15 @@ class BpkDatepicker extends Component {
       initiallyFocusedDate,
       renderTarget,
       valid,
-      // onDateSelect, onClose and isOpen are decomposed here so they don't end
-      // up in the rest object
-      onDateSelect,
-      onClose,
-      isOpen,
       ...rest
     } = this.props;
 
     const dateLabel = date ? formatDateFull(date) : '';
+
+    // The following props are not used in render
+    delete rest.onDateSelect;
+    delete rest.onOpenChange;
+    delete rest.isOpen;
 
     const inputComponent = (
       <Input
@@ -212,7 +211,7 @@ BpkDatepicker.propTypes = {
   maxDate: PropTypes.instanceOf(Date),
   minDate: PropTypes.instanceOf(Date),
   onDateSelect: PropTypes.func,
-  onClose: PropTypes.func,
+  onOpenChange: PropTypes.func,
   onMonthChange: PropTypes.func,
   showWeekendSeparator: PropTypes.bool,
   initiallyFocusedDate: PropTypes.instanceOf(Date),
@@ -231,7 +230,7 @@ BpkDatepicker.defaultProps = {
   maxDate: BpkCalendar.defaultProps.maxDate,
   minDate: BpkCalendar.defaultProps.minDate,
   onDateSelect: null,
-  onClose: null,
+  onOpenChange: null,
   onMonthChange: null,
   showWeekendSeparator: BpkCalendar.defaultProps.showWeekendSeparator,
   initiallyFocusedDate: null,

--- a/packages/bpk-component-datepicker/stories.js
+++ b/packages/bpk-component-datepicker/stories.js
@@ -209,9 +209,9 @@ class ReturnDatepicker extends Component {
               }));
               action('Selected return date')(returnDate);
             }}
-            onClose={() => {
+            onOpenChange={isOpen => {
               this.setState({
-                isReturnPickerOpen: false,
+                isReturnPickerOpen: isOpen,
               });
             }}
             onMonthChange={action('Changed month')}

--- a/packages/bpk-component-datepicker/stories.js
+++ b/packages/bpk-component-datepicker/stories.js
@@ -144,6 +144,7 @@ class ReturnDatepicker extends Component {
     this.state = {
       departDate: startOfDay(addDays(new Date(), 1)),
       returnDate: startOfDay(addDays(new Date(), 4)),
+      isReturnPickerOpen: false,
     };
   }
 
@@ -175,6 +176,7 @@ class ReturnDatepicker extends Component {
                   departDate,
                   this.maxDate,
                 ),
+                isReturnPickerOpen: true,
               }));
               action('Selected departure date')(departDate);
             }}
@@ -207,7 +209,13 @@ class ReturnDatepicker extends Component {
               }));
               action('Selected return date')(returnDate);
             }}
+            onClose={() => {
+              this.setState({
+                isReturnPickerOpen: false,
+              });
+            }}
             onMonthChange={action('Changed month')}
+            isOpen={this.state.isReturnPickerOpen}
           />
         </div>
       </div>


### PR DESCRIPTION
At the moment the isOpen state from the BpkDatePicker can be only initialised as opened or closed through a prop but the component doesn't re-render when the prop changes. To fix that I added a check in componentDidUpdate to update the state when the prop changes.

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Remember to include the following changes:

- [x] `UNRELEASED.yaml`
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

React 16.4 compatibility:

- [x] I haven't used Hooks in any code that we ship to consumers.
