### PR TITLE
Use "currentColor" as "fill" in Icon documentation

### DIFF
--- a/packages/bpk-component-icon/README.md
+++ b/packages/bpk-component-icon/README.md
@@ -30,7 +30,7 @@ export default () => (
 @import '~bpk-mixins';
 
 .abc-icon__flight {
-  fill: $bpk-color-white;
+  fill: currentColor; // see https://css-tricks.com/currentcolor/
 }
 
 .abc-icon__a11y {


### PR DESCRIPTION
Using `currentColor` for `fill` in icons is very useful, as it allows not duplicating the same color (and makes components more reusable).
`currentColor` is not know by many people, so I though it would be good to use it in the example (adding a link to some documentation).

What do you think about this? Might not be the best way to promote its usage 😅 