### PR TITLE
[No Jira] Fix warning Danger keeps reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
       "^.+\\.scss$": "<rootDir>/scripts/stubs/styleStub.js",
       "^.+\\.svg$": "<rootDir>/scripts/stubs/fileStub.js"
     },
+    "coverageReporters": ["text"],
     "coverageThreshold": {
       "global": {
         "statements": 75,


### PR DESCRIPTION
Lately, Danger keeps reporting build log warnings in every PR — like this: https://github.com/Skyscanner/backpack/pull/1995#issuecomment-707092530.

I looked into it and it's a warning from `handlebars`. We don't use this, but it's a dependency of `jest`. Apparently they messed something up in a release and it was causing errors when `jest --coverage` is run.

I followed https://github.com/facebook/jest/issues/9396#issuecomment-573328488 to fix it, by making the coverage reports just print in text (which is how we were using it before, so nothing should change).

If it's worked, Danger shouldn't report any build log warnings on this PR.