### PR TITLE
[no jira]: Add format-package dep and format package files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4097,6 +4097,45 @@
         }
       }
     },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+      "dev": true
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
+    "@hapi/hoek": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+      "dev": true
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
@@ -19889,6 +19928,12 @@
         "upper-case": "^1.1.1"
       }
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
@@ -20527,6 +20572,92 @@
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
         "tiny-emitter": "^2.0.0"
+      }
+    },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
       }
     },
     "clone": {
@@ -21606,6 +21737,12 @@
           "dev": true
         }
       }
+    },
+    "convert-hrtime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
+      "integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -28042,6 +28179,446 @@
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
       "dev": true
+    },
+    "format-package": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/format-package/-/format-package-6.1.0.tgz",
+      "integrity": "sha512-Mg4Zna29hXD3lfep5c1pgevZoA2k8mXw9F9mx22fkanGjemjrnPnU+FbvmknRAyKjfR0qYiwGWmNjuSbvowwSg==",
+      "dev": true,
+      "requires": {
+        "@hapi/joi": "^15.1.1",
+        "chalk": "^4.1.0",
+        "convert-hrtime": "^3.0.0",
+        "cosmiconfig": "^5.2.1",
+        "fs-extra": "^9.0.1",
+        "globby": "^11.0.1",
+        "json5": "^2.1.3",
+        "resolve-from": "^5.0.0",
+        "sort-scripts": "^1.0.1",
+        "yargs": "^15.4.1"
+      },
+      "dependencies": {
+        "@nodelib/fs.scandir": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+          "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "2.0.3",
+            "run-parallel": "^1.1.9"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
+        },
+        "@nodelib/fs.walk": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+          "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.scandir": "2.1.3",
+            "fastq": "^1.6.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "merge2": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "forwarded": {
       "version": "0.1.2",
@@ -48069,6 +48646,12 @@
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
+    },
+    "sort-scripts": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sort-scripts/-/sort-scripts-1.0.1.tgz",
+      "integrity": "sha512-58eys3wXg05rI51Gg/90Uvc0id0aboGLSzHm4nFvuD0MofSg/y8cyJ7ZqYuZ1eyj6AA8XwFTGaXA+6tApsMv4w==",
+      "dev": true
     },
     "source-list-map": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,55 +1,65 @@
 {
   "name": "backpack",
   "version": "0.0.1",
+  "license": "Apache-2.0",
   "private": true,
   "engines": {
     "node": "^12.13.0",
     "npm": "^6.12.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
-    "preinstall": "npx ensure-node-env",
-    "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap --no-ci",
-    "lerna": "lerna",
+    "build": "npm run build:tokens && npm run build:svgs && npm run build:sass && lerna run build",
+    "build:sass": "backpack-node-sass && rm packages/bpk-stylesheets/index.css",
+    "build:stylesheets": "lerna run build --scope bpk-stylesheets",
+    "build:svgs": "lerna run svgs --scope bpk-svgs",
+    "build:tokens": "lerna run tokens --scope bpk-tokens",
+    "check-bpk-dependencies": "node scripts/npm/check-bpk-dependencies.js",
+    "check-owners": "npm whoami && ( node scripts/npm/get-owners.js | grep -E $(npm whoami) ) && node scripts/npm/check-owners.js",
+    "check-pristine": "node scripts/check-pristine-state",
+    "clean": "npm run clean:dist && npm run clean:lerna && npm run clean:node_modules",
     "clean:dist": "rm -rf dist",
     "clean:lerna": "lerna clean --yes",
     "clean:node_modules": "rm -rf node_modules",
-    "clean": "npm run clean:dist && npm run clean:lerna && npm run clean:node_modules",
-    "lint:scss": "stylelint 'packages/**/*.scss' --syntax scss",
-    "lint:scss:fix": "stylelint 'packages/**/*.scss' --syntax scss --fix",
-    "lint:js": "eslint . .storybook --ext .js,.jsx",
-    "lint:js:fix": "eslint . .storybook --ext .js,.jsx --fix",
-    "lint": "npm run lint:js && npm run lint:scss",
-    "jest:update": "TZ=Etc/UTC jest --updateSnapshot",
-    "jest:watch": "TZ=Etc/UTC jest --watch",
-    "jest": "TZ=Etc/UTC jest --coverage",
+    "create-component": "node scripts/npm/create-component.js",
+    "danger": "danger ci",
+    "fix-bpk-dependencies": "node scripts/npm/check-bpk-dependencies.js --fix",
     "flow": "flow --max-warnings 0",
     "flow-typed": "flow-typed",
-    "build:stylesheets": "lerna run build --scope bpk-stylesheets",
-    "build:tokens": "lerna run tokens --scope bpk-tokens",
-    "build:svgs": "lerna run svgs --scope bpk-svgs",
-    "build:sass": "backpack-node-sass && rm packages/bpk-stylesheets/index.css",
-    "build": "npm run build:tokens && npm run build:svgs && npm run build:sass && lerna run build",
-    "storybook:dist": "build-storybook -c .storybook -o dist-storybook",
-    "storybook": "start-storybook -p 9001",
+    "format:packagejson": "format-package -w",
+    "generate-changelogs": "node scripts/publish-process/generate-changelogs.js",
+    "jest": "TZ=Etc/UTC jest --coverage",
+    "jest:update": "TZ=Etc/UTC jest --updateSnapshot",
+    "jest:watch": "TZ=Etc/UTC jest --watch",
+    "lerna": "lerna",
+    "lint": "npm run lint:js && npm run lint:scss",
+    "lint:js": "eslint . .storybook --ext .js,.jsx",
+    "lint:js:fix": "eslint . .storybook --ext .js,.jsx --fix",
+    "lint:scss": "stylelint 'packages/**/*.scss' --syntax scss",
+    "lint:scss:fix": "stylelint 'packages/**/*.scss' --syntax scss --fix",
+    "postinstall": "npm run bootstrap",
+    "preinstall": "npx ensure-node-env",
+    "prettier": "prettier --config .prettierrc --write \"**/*.js\"",
+    "publish": "npm run check-pristine && npm run check-owners && npm run build && git pull --rebase && flow stop && npm run test && lerna publish && npm run publish:css",
+    "publish:css": "node ./scripts/publish-process/transform-js-scss-css-imports.js && node ./scripts/publish-process/transform-bpk-imports.js && node ./scripts/publish-process/publish-css-tagged-packages.js && git reset --hard HEAD",
+    "release": "npm run publish",
     "sassdoc": "sassdoc {packages/bpk-mixins/src/**/*,packages/bpk-svgs/dist/*,packages/bpk-tokens/tokens/base.default}.scss -d dist-sassdoc -v --strict",
+    "spellcheck": "mdspell -r --en-gb --ignore-acronyms --ignore-numbers --no-suggestions 'UNRELEASED.yaml' '*.md' '**/*.md' '!**/node_modules/**/*.md'",
+    "spellcheck:interactive": "mdspell --en-gb --ignore-acronyms --no-suggestions --ignore-numbers 'UNRELEASED.yaml' '*.md' '**/*.md' '!**/node_modules/**/*.md'",
     "start": "npm run build && npm run storybook",
     "start:sass": "backpack-node-sass --watch",
-    "generate-changelogs": "node scripts/publish-process/generate-changelogs.js",
-    "upcoming-changes": "node scripts/publish-process/upcoming-changes.js",
-    "check-bpk-dependencies": "node scripts/npm/check-bpk-dependencies.js",
-    "fix-bpk-dependencies": "node scripts/npm/check-bpk-dependencies.js --fix",
+    "storybook": "start-storybook -p 9001",
+    "storybook:dist": "build-storybook -c .storybook -o dist-storybook",
     "test": "npm run lint && npm run check-bpk-dependencies && npm run jest && npm run flow && npm run spellcheck",
-    "check-owners": "npm whoami && ( node scripts/npm/get-owners.js | grep -E $(npm whoami) ) && node scripts/npm/check-owners.js",
-    "check-pristine": "node scripts/check-pristine-state",
-    "publish:css": "node ./scripts/publish-process/transform-js-scss-css-imports.js && node ./scripts/publish-process/transform-bpk-imports.js && node ./scripts/publish-process/publish-css-tagged-packages.js && git reset --hard HEAD",
-    "publish": "npm run check-pristine && npm run check-owners && npm run build && git pull --rebase && flow stop && npm run test && lerna publish && npm run publish:css",
-    "release": "npm run publish",
-    "danger": "danger ci",
-    "prettier": "prettier --config .prettierrc --write \"**/*.js\"",
-    "create-component": "node scripts/npm/create-component.js",
-    "spellcheck": "mdspell -r --en-gb --ignore-acronyms --ignore-numbers --no-suggestions 'UNRELEASED.yaml' '*.md' '**/*.md' '!**/node_modules/**/*.md'",
-    "spellcheck:interactive": "mdspell --en-gb --ignore-acronyms --no-suggestions --ignore-numbers 'UNRELEASED.yaml' '*.md' '**/*.md' '!**/node_modules/**/*.md'"
+    "upcoming-changes": "node scripts/publish-process/upcoming-changes.js"
   },
   "husky": {
     "hooks": {
@@ -60,20 +70,43 @@
     "*.js": [
       "eslint --fix"
     ],
+    "*.md": [
+      "mdspell -r --en-gb --ignore-acronyms --ignore-numbers --no-suggestions"
+    ],
     "*.scss": [
       "stylelint --syntax scss --fix",
       "stylelint --syntax scss"
-    ],
-    "*.md": [
-      "mdspell -r --en-gb --ignore-acronyms --ignore-numbers --no-suggestions"
     ]
   },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:Skyscanner/backpack.git"
+  "jest": {
+    "coverageReporters": [
+      "text"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 75,
+        "lines": 75,
+        "statements": 75
+      }
+    },
+    "moduleNameMapper": {
+      "^.+\\.scss$": "<rootDir>/scripts/stubs/styleStub.js",
+      "^.+\\.svg$": "<rootDir>/scripts/stubs/fileStub.js",
+      "react-transition-group/CSSTransition": "<rootDir>/scripts/stubs/cssTransitionStub.js"
+    },
+    "setupFiles": [
+      "<rootDir>/scripts/jest/setup.js"
+    ],
+    "testPathIgnorePatterns": [
+      "backpack-react-native/"
+    ],
+    "testRegex": "packages/.*-test\\.js$",
+    "transformIgnorePatterns": [
+      "node_modules/(?!bpk)"
+    ],
+    "verbose": true
   },
-  "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -110,6 +143,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "flow-bin": "^0.132.0",
     "flow-typed": "^2.5.1",
+    "format-package": "^6.1.0",
     "globby": "^10.0.0",
     "gulp": "^4.0.2",
     "gulp-chmod": "^3.0.0",
@@ -157,37 +191,5 @@
     "webpack-dev-server": "^3.3.1",
     "wrapper-webpack-plugin": "^1.0.0",
     "yaml": "^1.6.0"
-  },
-  "jest": {
-    "verbose": true,
-    "setupFiles": [
-      "<rootDir>/scripts/jest/setup.js"
-    ],
-    "testRegex": "packages/.*-test\\.js$",
-    "transformIgnorePatterns": [
-      "node_modules/(?!bpk)"
-    ],
-    "testPathIgnorePatterns": [
-      "backpack-react-native/"
-    ],
-    "moduleNameMapper": {
-      "react-transition-group/CSSTransition": "<rootDir>/scripts/stubs/cssTransitionStub.js",
-      "^.+\\.scss$": "<rootDir>/scripts/stubs/styleStub.js",
-      "^.+\\.svg$": "<rootDir>/scripts/stubs/fileStub.js"
-    },
-    "coverageReporters": [
-      "text"
-    ],
-    "coverageThreshold": {
-      "global": {
-        "statements": 75,
-        "branches": 70,
-        "functions": 75,
-        "lines": 75
-      }
-    }
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/bpk-animate-height/package.json
+++ b/packages/bpk-animate-height/package.json
@@ -2,25 +2,25 @@
   "name": "bpk-animate-height",
   "version": "3.0.41",
   "description": "Animate height using CSS transitions.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "prop-types": "^15.6.2"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-accordion/package.json
+++ b/packages/bpk-component-accordion/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-accordion",
   "version": "2.2.4",
   "description": "Backpack accordion component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-animate-height": "^3.0.41",
     "bpk-component-icon": "^8.2.23",
@@ -20,12 +21,11 @@
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-checkbox": "^2.2.14",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-autosuggest/package.json
+++ b/packages/bpk-component-autosuggest/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-autosuggest",
   "version": "4.1.13",
   "description": "Backpack autosuggest component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-input": "^5.0.85",
     "bpk-mixins": "^20.1.1",
@@ -19,11 +20,10 @@
     "prop-types": "^15.6.2",
     "react-autosuggest": "^10.0.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-icon": "^8.2.23"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-badge/package.json
+++ b/packages/bpk-component-badge/package.json
@@ -2,27 +2,27 @@
   "name": "bpk-component-badge",
   "version": "2.0.85",
   "description": "Backpack badge component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-banner-alert/package.json
+++ b/packages/bpk-component-banner-alert/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-banner-alert",
   "version": "4.2.33",
   "description": "Backpack banner alert component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-animate-height": "^3.0.41",
     "bpk-component-close-button": "^2.0.85",
@@ -22,8 +23,7 @@
     "prop-types": "^15.6.2",
     "react-transition-group": "^2.5.3"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-barchart/package.json
+++ b/packages/bpk-component-barchart/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-barchart",
   "version": "3.1.8",
   "description": "Backpack bar chart component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-mobile-scroll-container": "^2.0.85",
     "bpk-mixins": "^20.1.1",
@@ -22,14 +23,13 @@
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-breakpoint": "^2.0.85",
     "bpk-component-content-container": "^2.0.84",
     "bpk-component-rtl-toggle": "^2.0.85",
     "bpk-component-text": "^3.1.19"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-blockquote/package.json
+++ b/packages/bpk-component-blockquote/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-blockquote",
   "version": "2.0.84",
   "description": "Backpack blockquote component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-boilerplate/package.json
+++ b/packages/bpk-component-boilerplate/package.json
@@ -1,24 +1,24 @@
 {
   "name": "bpk-component-boilerplate",
-  "private": true,
   "version": "0.0.88",
   "description": "Backpack boilerplate component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.5.8"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+  "peerDependencies": {
+    "react": "^16.0.0"
   }
 }

--- a/packages/bpk-component-breadcrumb/package.json
+++ b/packages/bpk-component-breadcrumb/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-breadcrumb",
   "version": "2.1.50",
   "description": "Backpack breadcrumb component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-component-link": "^2.1.13",
@@ -20,8 +21,7 @@
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-breakpoint/package.json
+++ b/packages/bpk-component-breakpoint/package.json
@@ -2,26 +2,26 @@
   "name": "bpk-component-breakpoint",
   "version": "2.0.85",
   "description": "Backpack breakpoint component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "prop-types": "^15.6.2",
     "react-responsive": "^5.0.0"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-button/package.json
+++ b/packages/bpk-component-button/package.json
@@ -2,22 +2,22 @@
   "name": "bpk-component-button",
   "version": "3.2.63",
   "description": "Backpack button component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-calendar/package.json
+++ b/packages/bpk-component-calendar/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-calendar",
   "version": "7.0.41",
   "description": "Backpack calendar component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-component-select": "^3.0.84",
@@ -21,12 +22,11 @@
     "date-fns": "^1.29.0",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-text": "^3.1.19"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-card/package.json
+++ b/packages/bpk-component-card/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-card",
   "version": "2.1.13",
   "description": "Backpack card component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-checkbox/package.json
+++ b/packages/bpk-component-checkbox/package.json
@@ -2,27 +2,27 @@
   "name": "bpk-component-checkbox",
   "version": "2.2.14",
   "description": "Backpack checkbox component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-chip/package.json
+++ b/packages/bpk-component-chip/package.json
@@ -2,27 +2,27 @@
   "name": "bpk-component-chip",
   "version": "4.0.14",
   "description": "Backpack chip component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-text": "^3.1.19"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-close-button/package.json
+++ b/packages/bpk-component-close-button/package.json
@@ -2,24 +2,24 @@
   "name": "bpk-component-close-button",
   "version": "2.0.85",
   "description": "Backpack close button component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-code/package.json
+++ b/packages/bpk-component-code/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-code",
   "version": "2.0.84",
   "description": "Backpack code component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-content-container/package.json
+++ b/packages/bpk-component-content-container/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-content-container",
   "version": "2.0.84",
   "description": "Backpack content container component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-datatable/package.json
+++ b/packages/bpk-component-datatable/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-datatable",
   "version": "2.0.41",
   "description": "Backpack datatable component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-mixins": "^20.1.1",
@@ -20,11 +21,10 @@
     "prop-types": "^15.6.2",
     "react-virtualized": "^9.20.1"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-datepicker/package.json
+++ b/packages/bpk-component-datepicker/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-datepicker",
   "version": "11.3.5",
   "description": "Backpack datepicker component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "f5452c0331ac90041e38557c771c744d4f5fab66",
   "dependencies": {
     "bpk-component-breakpoint": "^2.0.85",
     "bpk-component-calendar": "^7.0.41",
@@ -22,11 +23,10 @@
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "f5452c0331ac90041e38557c771c744d4f5fab66"
+  }
 }

--- a/packages/bpk-component-description-list/package.json
+++ b/packages/bpk-component-description-list/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-description-list",
   "version": "2.0.84",
   "description": "Backpack description list component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-dialog/package.json
+++ b/packages/bpk-component-dialog/package.json
@@ -2,20 +2,24 @@
   "name": "bpk-component-dialog",
   "version": "2.2.1",
   "description": "Backpack dialog component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-flare": "^1.0.86",
     "bpk-component-modal": "^2.1.85",
     "prop-types": "^15.6.2"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
@@ -24,9 +28,5 @@
     "bpk-component-text": "^3.1.19",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-drawer/package.json
+++ b/packages/bpk-component-drawer/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-drawer",
   "version": "3.0.42",
   "description": "Backpack drawer component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-close-button": "^2.0.85",
     "bpk-component-icon": "^8.2.23",
@@ -23,12 +24,11 @@
     "prop-types": "^15.6.2",
     "react-transition-group": "^2.5.3"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-text": "^3.1.19"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-fieldset/package.json
+++ b/packages/bpk-component-fieldset/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-fieldset",
   "version": "2.0.92",
   "description": "Backpack fieldset component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "f5452c0331ac90041e38557c771c744d4f5fab66",
   "dependencies": {
     "bpk-component-form-validation": "^3.0.86",
     "bpk-component-label": "^4.0.85",
@@ -19,15 +20,14 @@
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-calendar": "^7.0.41",
     "bpk-component-checkbox": "^2.2.14",
     "bpk-component-datepicker": "^11.3.5",
     "bpk-component-input": "^5.0.85",
     "bpk-component-select": "^3.0.84"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "f5452c0331ac90041e38557c771c744d4f5fab66"
+  }
 }

--- a/packages/bpk-component-flare/package.json
+++ b/packages/bpk-component-flare/package.json
@@ -2,19 +2,20 @@
   "name": "bpk-component-flare",
   "version": "1.0.86",
   "description": "Backpack FlareBar and ContentBubble component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "build": "gulp"
   },
-  "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
-  },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-label": "^4.0.85",
     "bpk-component-text": "^3.1.19",
@@ -22,8 +23,7 @@
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-form-validation/package.json
+++ b/packages/bpk-component-form-validation/package.json
@@ -2,29 +2,29 @@
   "name": "bpk-component-form-validation",
   "version": "3.0.86",
   "description": "Backpack form-validation component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-animate-height": "^3.0.41",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-icon": "^8.2.23",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-grid-toggle/package.json
+++ b/packages/bpk-component-grid-toggle/package.json
@@ -2,24 +2,24 @@
   "name": "bpk-component-grid-toggle",
   "version": "2.0.85",
   "description": "Backpack vertical grid toggle component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-link": "^2.1.13",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-grid/package.json
+++ b/packages/bpk-component-grid/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-grid",
   "version": "2.0.84",
   "description": "Backpack grid components.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-heading/package.json
+++ b/packages/bpk-component-heading/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-heading",
   "version": "3.1.13",
   "description": "Backpack heading component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-horizontal-nav/package.json
+++ b/packages/bpk-component-horizontal-nav/package.json
@@ -2,28 +2,28 @@
   "name": "bpk-component-horizontal-nav",
   "version": "3.2.25",
   "description": "Backpack horizontal nav component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-mobile-scroll-container": "^2.0.85",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-text": "^3.1.19",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-icon/package.json
+++ b/packages/bpk-component-icon/package.json
@@ -2,19 +2,20 @@
   "name": "bpk-component-icon",
   "version": "8.2.23",
   "description": "Backpack icon components.",
-  "main": "index.js",
-  "scripts": {
-    "build": "gulp clean && gulp"
-  },
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "scripts": {
+    "build": "gulp clean && gulp"
+  },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
@@ -22,8 +23,7 @@
     "bpk-tokens": "^34.2.0",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-image/package.json
+++ b/packages/bpk-component-image/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-image",
   "version": "4.0.42",
   "description": "Backpack image component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-spinner": "^3.1.13",
     "bpk-mixins": "^20.1.1",
@@ -19,13 +20,12 @@
     "prop-types": "^15.6.2",
     "react-transition-group": "^2.5.3"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-mobile-scroll-container": "^2.0.85",
     "bpk-component-text": "^3.1.19",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-infinite-scroll/package.json
+++ b/packages/bpk-component-infinite-scroll/package.json
@@ -2,29 +2,29 @@
   "name": "bpk-component-infinite-scroll",
   "version": "3.0.87",
   "description": "Backpack infinite scroll component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "intersection-observer": "^0.7.0",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-card": "^2.1.13",
     "bpk-component-spinner": "^3.1.13"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-input/package.json
+++ b/packages/bpk-component-input/package.json
@@ -2,27 +2,27 @@
   "name": "bpk-component-input",
   "version": "5.0.85",
   "description": "Backpack input component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-text": "^3.1.19"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-label/package.json
+++ b/packages/bpk-component-label/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-label",
   "version": "4.0.85",
   "description": "Backpack label component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-link/package.json
+++ b/packages/bpk-component-link/package.json
@@ -2,26 +2,26 @@
   "name": "bpk-component-link",
   "version": "2.1.13",
   "description": "Backpack link component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-list/package.json
+++ b/packages/bpk-component-list/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-list",
   "version": "2.0.84",
   "description": "Backpack list component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-loading-button/package.json
+++ b/packages/bpk-component-loading-button/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-loading-button",
   "version": "3.2.13",
   "description": "Backpack loading button component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-icon": "^8.2.23",
@@ -20,8 +21,7 @@
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-map/package.json
+++ b/packages/bpk-component-map/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-map",
   "version": "4.0.4",
   "description": "Backpack map component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-spinner": "^3.1.13",
     "bpk-mixins": "^20.1.1",
@@ -19,13 +20,12 @@
     "prop-types": "^15.5.8",
     "react-google-maps": "^9.4.5"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-component-text": "^3.1.19",
     "prop-types": "^15.5.8"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-mobile-scroll-container/package.json
+++ b/packages/bpk-component-mobile-scroll-container/package.json
@@ -2,29 +2,29 @@
   "name": "bpk-component-mobile-scroll-container",
   "version": "2.0.85",
   "description": "Backpack mobile scroll container component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-table": "^2.0.84",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-modal/package.json
+++ b/packages/bpk-component-modal/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-modal",
   "version": "2.1.85",
   "description": "Backpack modal component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-close-button": "^2.0.85",
     "bpk-component-icon": "^8.2.23",
@@ -22,12 +23,11 @@
     "bpk-scrim-utils": "^4.0.84",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-text": "^3.1.19"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-navigation-bar/package.json
+++ b/packages/bpk-component-navigation-bar/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-navigation-bar",
   "version": "2.2.46",
   "description": "Backpack nativation bar component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-close-button": "^2.0.85",
     "bpk-component-link": "^2.1.13",
@@ -20,12 +21,11 @@
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-navigation-stack/package.json
+++ b/packages/bpk-component-navigation-stack/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-navigation-stack",
   "version": "2.0.88",
   "description": "Backpack navigation stack component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
@@ -19,14 +20,13 @@
     "prop-types": "^15.6.2",
     "react-transition-group": "^2.5.3"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-icon": "^8.2.23",
     "bpk-component-navigation-bar": "^2.2.46",
     "bpk-component-rtl-toggle": "^2.0.85"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-nudger/package.json
+++ b/packages/bpk-component-nudger/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-nudger",
   "version": "2.0.87",
   "description": "Backpack nudger component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-icon": "^8.2.23",
@@ -21,11 +22,10 @@
     "lodash.clamp": "^4.0.3",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-label": "^4.0.85"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-overlay/package.json
+++ b/packages/bpk-component-overlay/package.json
@@ -2,26 +2,26 @@
   "name": "bpk-component-overlay",
   "version": "0.0.87",
   "description": "Backpack overlay component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.5.8"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-image": "^4.0.42",
     "bpk-component-text": "^3.1.19"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/bpk-component-pagination/package.json
+++ b/packages/bpk-component-pagination/package.json
@@ -2,27 +2,27 @@
   "name": "bpk-component-pagination",
   "version": "2.0.86",
   "description": "Backpack pagination component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-icon": "^8.2.23"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-panel/package.json
+++ b/packages/bpk-component-panel/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-panel",
   "version": "2.0.84",
   "description": "Backpack panel component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-paragraph/package.json
+++ b/packages/bpk-component-paragraph/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-paragraph",
   "version": "2.0.84",
   "description": "Backpack paragraph component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-phone-input/package.json
+++ b/packages/bpk-component-phone-input/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-phone-input",
   "version": "4.1.75",
   "description": "Backpack phone input component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "f5452c0331ac90041e38557c771c744d4f5fab66",
   "dependencies": {
     "bpk-component-input": "^5.0.85",
     "bpk-component-label": "^4.0.85",
@@ -22,12 +23,11 @@
     "bpk-tokens": "^34.2.0",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-fieldset": "^2.0.92",
     "bpk-component-image": "^4.0.42"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "f5452c0331ac90041e38557c771c744d4f5fab66"
+  }
 }

--- a/packages/bpk-component-popover/package.json
+++ b/packages/bpk-component-popover/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-popover",
   "version": "3.0.87",
   "description": "Backpack popover component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "@skyscanner/popper.js": "^1.12.9-beta.1",
     "a11y-focus-scope": "^1.1.3",
@@ -23,12 +24,11 @@
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.7.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-content-container": "^2.0.84"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-progress/package.json
+++ b/packages/bpk-component-progress/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-progress",
   "version": "2.0.85",
   "description": "Backpack progress bar component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
@@ -19,11 +20,10 @@
     "lodash.clamp": "^4.0.3",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-radio/package.json
+++ b/packages/bpk-component-radio/package.json
@@ -2,26 +2,26 @@
   "name": "bpk-component-radio",
   "version": "2.0.84",
   "description": "Backpack radio button component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-rating/package.json
+++ b/packages/bpk-component-rating/package.json
@@ -2,28 +2,28 @@
   "name": "bpk-component-rating",
   "version": "2.1.15",
   "description": "Backpack rating component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "lodash.clamp": "^4.0.3",
     "prop-types": "^15.5.8"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-text": "^3.1.19",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-router-link/package.json
+++ b/packages/bpk-component-router-link/package.json
@@ -2,24 +2,24 @@
   "name": "bpk-component-router-link",
   "version": "3.0.84",
   "description": "Backpack link component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0",
-    "react-router-dom": "^4.3.1"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-router-dom": "^4.3.1"
+  }
 }

--- a/packages/bpk-component-rtl-toggle/package.json
+++ b/packages/bpk-component-rtl-toggle/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-rtl-toggle",
   "version": "2.0.85",
   "description": "Backpack RTL toggle component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-link": "^2.1.13",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-scrollable-calendar/package.json
+++ b/packages/bpk-component-scrollable-calendar/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-scrollable-calendar",
   "version": "2.0.87",
   "description": "Backpack scrollable calendar component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-calendar": "^7.0.41",
     "bpk-component-text": "^3.1.19",
@@ -21,8 +22,7 @@
     "prop-types": "^15.5.8",
     "react-window": "^1.5.0"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-section-list/package.json
+++ b/packages/bpk-component-section-list/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-section-list",
   "version": "2.0.85",
   "description": "Backpack section list component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-component-text": "^3.1.19",
@@ -20,8 +21,7 @@
     "bpk-tokens": "^34.2.0",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-select/package.json
+++ b/packages/bpk-component-select/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-select",
   "version": "3.0.84",
   "description": "Backpack select component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-slider/package.json
+++ b/packages/bpk-component-slider/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-slider",
   "version": "2.0.86",
   "description": "Backpack slider component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
@@ -19,12 +20,11 @@
     "prop-types": "^15.6.2",
     "react-slider": "^1.0.1"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-rtl-toggle": "^2.0.85",
     "create-react-class": "^15.6.3"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-spinner/package.json
+++ b/packages/bpk-component-spinner/package.json
@@ -2,24 +2,24 @@
   "name": "bpk-component-spinner",
   "version": "3.1.13",
   "description": "Backpack spinner components.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "bpk-svgs": "^12.1.13",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-star-rating/package.json
+++ b/packages/bpk-component-star-rating/package.json
@@ -2,27 +2,27 @@
   "name": "bpk-component-star-rating",
   "version": "2.1.82",
   "description": "Backpack rating star component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-table": "^2.0.84"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-switch/package.json
+++ b/packages/bpk-component-switch/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-switch",
   "version": "1.1.33",
   "description": "Backpack switch component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.5.8"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-table/package.json
+++ b/packages/bpk-component-table/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-table",
   "version": "2.0.84",
   "description": "Backpack table component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-text/package.json
+++ b/packages/bpk-component-text/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-text",
   "version": "3.1.19",
   "description": "Backpack text component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-textarea/package.json
+++ b/packages/bpk-component-textarea/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-component-textarea",
   "version": "2.0.84",
   "description": "Backpack textarea component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-theme-toggle/package.json
+++ b/packages/bpk-component-theme-toggle/package.json
@@ -2,16 +2,17 @@
   "name": "bpk-component-theme-toggle",
   "version": "2.0.89",
   "description": "Backpack theme toggle component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-component-label": "^4.0.85",
     "bpk-component-select": "^3.0.84",
@@ -21,8 +22,7 @@
     "konami": "^1.6.2",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-component-ticket/package.json
+++ b/packages/bpk-component-ticket/package.json
@@ -2,27 +2,27 @@
   "name": "bpk-component-ticket",
   "version": "3.0.86",
   "description": "Backpack ticket component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-button": "^3.2.63",
     "bpk-component-icon": "^8.2.23"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-component-tile/package.json
+++ b/packages/bpk-component-tile/package.json
@@ -1,27 +1,27 @@
 {
-  "private": true,
   "name": "bpk-component-tile",
   "version": "0.0.223",
   "description": "Backpack card component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "bpk-component-icon": "^8.2.23",
     "bpk-mixins": "^20.1.1",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-react-utils": "^3.0.6"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/bpk-component-tooltip/package.json
+++ b/packages/bpk-component-tooltip/package.json
@@ -2,28 +2,28 @@
   "name": "bpk-component-tooltip",
   "version": "4.1.40",
   "description": "Backpack tooltip component.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "@skyscanner/popper.js": "^1.12.9-beta.1",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6",
     "prop-types": "^15.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "bpk-component-text": "^3.1.19",
     "bpk-tokens": "^34.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-mixins/package.json
+++ b/packages/bpk-mixins/package.json
@@ -2,25 +2,25 @@
   "name": "bpk-mixins",
   "version": "20.1.1",
   "description": "Sass mixins and variables for Backpack.",
-  "main": "_index.scss",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
+  "main": "_index.scss",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-svgs": "^12.1.13",
     "bpk-tokens": "^34.2.0"
   },
-  "devDependencies": {
-    "bpk-react-utils": "^3.0.6"
-  },
   "peerDependencies": {
     "node-sass": "^4.12.0"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "devDependencies": {
+    "bpk-react-utils": "^3.0.6"
+  }
 }

--- a/packages/bpk-react-utils/package.json
+++ b/packages/bpk-react-utils/package.json
@@ -2,25 +2,25 @@
   "name": "bpk-react-utils",
   "version": "3.0.6",
   "description": "Utilities for Backpack's React components.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "136d3706ec2f6823e38a2b1e25715b1a280890b5",
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
     "react-transition-group": "^2.5.3",
     "recompose": "^0.30.0"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "136d3706ec2f6823e38a2b1e25715b1a280890b5"
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  }
 }

--- a/packages/bpk-scrim-utils/package.json
+++ b/packages/bpk-scrim-utils/package.json
@@ -2,21 +2,21 @@
   "name": "bpk-scrim-utils",
   "version": "4.0.84",
   "description": "Higher order component that adds an overlay behind components and manages scroll states.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "a11y-focus-scope": "^1.1.3",
     "a11y-focus-store": "^1.0.0",
     "bpk-mixins": "^20.1.1",
     "bpk-react-utils": "^3.0.6"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-stylesheets/package.json
+++ b/packages/bpk-stylesheets/package.json
@@ -2,23 +2,23 @@
   "name": "bpk-stylesheets",
   "version": "6.0.51",
   "description": "Backpack's stylesheets.",
-  "main": "index.js",
-  "scripts": {
-    "build": "node build"
-  },
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "build": "node build"
+  },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-mixins": "^20.1.1",
     "bpk-tokens": "^34.2.0",
     "normalize.css": "4.2.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  }
 }

--- a/packages/bpk-svgs/package.json
+++ b/packages/bpk-svgs/package.json
@@ -2,21 +2,21 @@
   "name": "bpk-svgs",
   "version": "12.1.13",
   "description": "Backpack's library of SVG's.",
-  "main": "_index.scss",
-  "scripts": {
-    "svgs": "gulp clean && gulp"
-  },
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "devDependencies": {
-    "bpk-tokens": "^34.2.0"
-  },
+  "main": "_index.scss",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "scripts": {
+    "svgs": "gulp clean && gulp"
+  },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
+  "devDependencies": {
+    "bpk-tokens": "^34.2.0"
+  }
 }

--- a/packages/bpk-tether/package.json
+++ b/packages/bpk-tether/package.json
@@ -2,18 +2,18 @@
   "name": "bpk-tether",
   "version": "1.0.18",
   "description": "Wrapper and utils for Tether.",
-  "main": "index.js",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "tether": "^1.4.0"
-  },
+  "main": "index.js",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "gitHead": "6dea0c366b9237ca3a6df91c0f856594d30cc7d8"
+  "gitHead": "6dea0c366b9237ca3a6df91c0f856594d30cc7d8",
+  "dependencies": {
+    "tether": "^1.4.0"
+  }
 }

--- a/packages/bpk-theming/package.json
+++ b/packages/bpk-theming/package.json
@@ -1,23 +1,23 @@
 {
   "name": "bpk-theming",
   "version": "2.0.42",
-  "main": "index.js",
   "description": "Backpack theming utlities.",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "peerDependencies": {
-    "react": "^16.0.0"
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
   "dependencies": {
     "bpk-tokens": "^34.2.0",
     "prop-types": "^15.6.2"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "peerDependencies": {
+    "react": "^16.0.0"
+  }
 }

--- a/packages/bpk-tokens/package.json
+++ b/packages/bpk-tokens/package.json
@@ -2,21 +2,21 @@
   "name": "bpk-tokens",
   "version": "34.2.0",
   "description": "Backpack design tokens for colors, spacing, font, etc.",
-  "main": "index.js",
-  "scripts": {
-    "tokens": "gulp"
-  },
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"
   },
   "author": "Backpack Design System <backpack@skyscanner.net>",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "color": "^3.0.0"
-  },
+  "main": "index.js",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc"
+  "scripts": {
+    "tokens": "gulp"
+  },
+  "gitHead": "1bd082dd62cab6c998693f875ca156ae1d280ccc",
+  "dependencies": {
+    "color": "^3.0.0"
+  }
 }


### PR DESCRIPTION
After PR #2000 where we needed to format the package file, I have added the `format-package` library and command `format:packagejson` that will automatically format all the package files correctly so we don't need to manually do this 😄 

Currently its just manually run but we could possible add it as the pre-commit hook? Or it might make too much noise?

This PR also includes the output of running this command so all the `package.json` files have changed as it re-formats them.
