### PR TITLE
[No Jira] Remove unused 'create-react-class' dep from slider component

### DIFF
--- a/packages/bpk-component-slider/package-lock.json
+++ b/packages/bpk-component-slider/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "bpk-component-slider",
-	"version": "2.0.13",
+	"version": "2.0.86",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@babel/runtime": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-			"integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+			"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
 			"requires": {
-				"regenerator-runtime": "^0.13.2"
+				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"asap": {
@@ -18,40 +18,40 @@
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"bpk-component-link": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-2.0.13.tgz",
-			"integrity": "sha512-eTqgK5C7AXvoZB2EiEAiaL9+sJQ2gu+Wqg/sJTbLu++ZzUo+WT0FskuDsRsr5EJ7b2NNtjHaKN+xcXkQdq6c1A==",
+			"version": "2.1.13",
+			"resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-2.1.13.tgz",
+			"integrity": "sha512-mXa/ZyuN1+q5iLO8bXS1jvOqgztvpLzPVVk5VCnFeQTSL2vLmfGbypeVqY2eRIAAToyyQquPgUzs1E89106DWw==",
 			"dev": true,
 			"requires": {
-				"bpk-mixins": "^19.0.13",
-				"bpk-react-utils": "^2.8.0",
+				"bpk-mixins": "^20.1.1",
+				"bpk-react-utils": "^3.0.6",
 				"prop-types": "^15.6.2"
 			}
 		},
 		"bpk-component-rtl-toggle": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/bpk-component-rtl-toggle/-/bpk-component-rtl-toggle-2.0.13.tgz",
-			"integrity": "sha512-ZU1LV3rVqPj1MXBdlDaX9E/VSwkCe9F0Fpov3NIEGWkGse7AdJeYlxFVZTRwzX88qZ/gwLIGaFnIVHI6pW1z9Q==",
+			"version": "2.0.85",
+			"resolved": "https://registry.npmjs.org/bpk-component-rtl-toggle/-/bpk-component-rtl-toggle-2.0.85.tgz",
+			"integrity": "sha512-tsiBen1JGAPk1xgKNegRajtlcDgOX4X0K7hx9HjnZfxSLrfT+24GSUXSKjapria/o/6x88DHHPjcZmHiIwJQOQ==",
 			"dev": true,
 			"requires": {
-				"bpk-component-link": "^2.0.13",
-				"bpk-react-utils": "^2.8.0",
+				"bpk-component-link": "^2.1.13",
+				"bpk-react-utils": "^3.0.6",
 				"prop-types": "^15.6.2"
 			}
 		},
 		"bpk-mixins": {
-			"version": "19.0.13",
-			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-19.0.13.tgz",
-			"integrity": "sha512-ycIaA25wJNpOpXp/ePkN9kIdKZn+adaxKoMUW6y/usuFcPf01zVIJQXuvEVAXWLrel82ALfUgrnHy396qatQtg==",
+			"version": "20.1.1",
+			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-20.1.1.tgz",
+			"integrity": "sha512-DkO+1xA7OqV/YqepZ2RZVKU8TnPt8UjfgxZCUKsGgzQN169qtSPy/GaASd55CMtKK6kFEULlJBiywuruU+WSXg==",
 			"requires": {
-				"bpk-svgs": "^8.2.8",
-				"bpk-tokens": "^29.2.3"
+				"bpk-svgs": "^12.1.13",
+				"bpk-tokens": "^34.2.0"
 			}
 		},
 		"bpk-react-utils": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.8.0.tgz",
-			"integrity": "sha512-U98b1MJ5TILIJXFUX/J2OJdc7oPCZwZKWtJ1tGynmO8r74EHhxoNbf/EnAjj9u7kOhvkGDiVTS/Exp7qHmqBSw==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-3.0.6.tgz",
+			"integrity": "sha512-G9B08qAKz3W452Xq28ojnhNWNK4eSP9mdW1b7ARiuLn/lZZ4WnGSZd1q0pvxAzcf0n+12VOUDIZ0LH34crzZsA==",
 			"requires": {
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
@@ -60,14 +60,14 @@
 			}
 		},
 		"bpk-svgs": {
-			"version": "8.2.8",
-			"resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-8.2.8.tgz",
-			"integrity": "sha512-8TTAyHklZ7EiUKp8st2dvacEDGrdb0ueIC2+MrPBqytJ54L9IZYRWbn1HWOxAXsBiFwUzjHuxbshLIXAxBn8rg=="
+			"version": "12.1.13",
+			"resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-12.1.13.tgz",
+			"integrity": "sha512-vO/cXfsqdTRrQ8BU5ErZyNi7qCiQLnMTuXOgBslGJDVVnK1X19xzsC4weaw2QsKMM9rZIcsdMX3KJt5seXycXA=="
 		},
 		"bpk-tokens": {
-			"version": "29.2.3",
-			"resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-29.2.3.tgz",
-			"integrity": "sha512-BDRpIEQl5nt4JJZjJwnRnBZ2/hOpoa+zXf4kFze0cDQNkAM9WeJKHpnl5Mkgtm2xUQyrYuG+htwilqsRdGh7FA==",
+			"version": "34.2.0",
+			"resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-34.2.0.tgz",
+			"integrity": "sha512-VtZsLNsG9z/bk1383U4QWMpulGkLxufnSeClSDCLHpVl8qdI/wcMMLHR2COWvojeQoUCPtFYa6/Pu6qcOYam0Q==",
 			"requires": {
 				"color": "^3.0.0"
 			}
@@ -78,12 +78,12 @@
 			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
 		},
 		"color": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-			"integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
+			"integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
 			"requires": {
 				"color-convert": "^1.9.1",
-				"color-string": "^1.5.2"
+				"color-string": "^1.5.4"
 			}
 		},
 		"color-convert": {
@@ -100,9 +100,9 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-			"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+			"integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
 			"requires": {
 				"color-name": "^1.0.0",
 				"simple-swizzle": "^0.2.2"
@@ -112,17 +112,6 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-		},
-		"create-react-class": {
-			"version": "15.6.3",
-			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-			"integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-			"dev": true,
-			"requires": {
-				"fbjs": "^0.8.9",
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
-			}
 		},
 		"dom-helpers": {
 			"version": "3.4.0",
@@ -265,9 +254,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",

--- a/packages/bpk-component-slider/package.json
+++ b/packages/bpk-component-slider/package.json
@@ -24,7 +24,6 @@
     "react": "^16.0.0"
   },
   "devDependencies": {
-    "bpk-component-rtl-toggle": "^2.0.85",
-    "create-react-class": "^15.6.3"
+    "bpk-component-rtl-toggle": "^2.0.85"
   }
 }


### PR DESCRIPTION
Closes #2002 

We got a Snyk PR to upgrade this dep, but I looked in the code and it's not used anywhere. I ran the tests and storybook after removing it just to be safe too.