### PR TITLE
[no jira]: Add danger step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
         run: |
           nvm use
           npm test
+      
+      - name: Danger
+        run: npm run danger
+        env:
+          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
 
       - name: Build Storybook
         run: |


### PR DESCRIPTION
We had previously disabled Danger as part of CI but now we have a way to configure and run this as part of CI.