### PR TITLE
NO-JIRA: BpkNudger internal props usage adjustment

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+ - bpk-component-nudger:
+   - Fixed use of internal props that generated console warnings due to their unneeded usage
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/packages/bpk-component-nudger/src/BpkConfigurableNudger.js
+++ b/packages/bpk-component-nudger/src/BpkConfigurableNudger.js
@@ -97,8 +97,6 @@ const BpkConfigurableNudger = <T>(props: Props<T>) => {
   return (
     <div className={classNames.join(' ')}>
       <ButtonComponent
-        secondary={buttonType === 'secondary'}
-        outline={buttonType === 'outline'}
         iconOnly
         onClick={() => onChange(decrementValue(value))}
         disabled={minButtonDisabled}
@@ -117,8 +115,6 @@ const BpkConfigurableNudger = <T>(props: Props<T>) => {
         className={inputStyles.join(' ')}
       />
       <ButtonComponent
-        secondary={buttonType === 'secondary'}
-        outline={buttonType === 'outline'}
         iconOnly
         onClick={() => onChange(incrementValue(value))}
         disabled={maxButtonDisabled}

--- a/packages/bpk-component-nudger/src/__snapshots__/BpkNudger-test.js.snap
+++ b/packages/bpk-component-nudger/src/__snapshots__/BpkNudger-test.js.snap
@@ -9,8 +9,6 @@ exports[`BpkNudger should render as a configurable nudger correctly 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Decrease"
     type="button"
   >
@@ -56,8 +54,6 @@ exports[`BpkNudger should render as a configurable nudger correctly 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Increase"
     type="button"
   >
@@ -102,8 +98,6 @@ exports[`BpkNudger should render as an outline nudger correctly 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--outline bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={true}
-    secondary={false}
     title="Decrease"
     type="button"
   >
@@ -149,8 +143,6 @@ exports[`BpkNudger should render as an outline nudger correctly 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--outline bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={true}
-    secondary={false}
     title="Increase"
     type="button"
   >
@@ -195,8 +187,6 @@ exports[`BpkNudger should render correctly 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Decrease"
     type="button"
   >
@@ -242,8 +232,6 @@ exports[`BpkNudger should render correctly 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Increase"
     type="button"
   >
@@ -288,8 +276,6 @@ exports[`BpkNudger should render correctly with a "className" attribute 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Decrease"
     type="button"
   >
@@ -335,8 +321,6 @@ exports[`BpkNudger should render correctly with a "className" attribute 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Increase"
     type="button"
   >
@@ -381,8 +365,6 @@ exports[`BpkNudger should render correctly with a value < min 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={true}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Decrease"
     type="button"
   >
@@ -428,8 +410,6 @@ exports[`BpkNudger should render correctly with a value < min 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Increase"
     type="button"
   >
@@ -474,8 +454,6 @@ exports[`BpkNudger should render correctly with a value = max 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Decrease"
     type="button"
   >
@@ -521,8 +499,6 @@ exports[`BpkNudger should render correctly with a value = max 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={true}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Increase"
     type="button"
   >
@@ -567,8 +543,6 @@ exports[`BpkNudger should render correctly with a value = min 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={true}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Decrease"
     type="button"
   >
@@ -614,8 +588,6 @@ exports[`BpkNudger should render correctly with a value = min 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Increase"
     type="button"
   >
@@ -660,8 +632,6 @@ exports[`BpkNudger should render correctly with a value > max 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={false}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Decrease"
     type="button"
   >
@@ -707,8 +677,6 @@ exports[`BpkNudger should render correctly with a value > max 1`] = `
     className="bpk-button bpk-button--icon-only bpk-button--secondary bpk-nudger__button"
     disabled={true}
     onClick={[Function]}
-    outline={false}
-    secondary={true}
     title="Increase"
     type="button"
   >


### PR DESCRIPTION
# Description 

In local development I see errors like:

```
Warning: Received `false` for a non-boolean attribute `outline`.

If you want to write it to the DOM, pass a string instead: outline="false" or outline={value.toString()}.

If you used to conditionally omit it with outline={condition && value}, pass outline={condition ? value : undefined} instead.
    in button (at BpkButtonBase.js:103)
    in BpkButton (at BpkButtonSecondary.js:41)
    in BpkButtonSecondary (at BpkConfigurableNudger.js:99)
    in div (at BpkConfigurableNudger.js:98)
    in BpkConfigurableNudger (at BpkNudger.js:48)
```

Poking around I think we are passing props unnecessarily.

Just above the changed lines we do:

```
const ButtonComponent =
    buttonType === 'secondary' ? BpkButtonSecondary : BpkButtonOutline;
```

This means at the point we pass in `outline` or `secondary` they are redundant; the type of button is already specific and no longer accepts these props.

# Checklist

Remember to include the following changes:

- [x] `UNRELEASED.md`
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

React 16.4 compatibility:

- [x] I haven't used Hooks in any code that we ship to consumers.
