### PR TITLE
[BPK-4286] Prevent navigation bar titles overlapping buttons

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,12 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- bpk-component-navigation-bar:
+- bpk-component-modal:
+  - Fixed an issue where long titles could overlap with the close button and accessory view.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/packages/bpk-component-modal/src/__snapshots__/BpkModal-test.js.snap
+++ b/packages/bpk-component-modal/src/__snapshots__/BpkModal-test.js.snap
@@ -26,6 +26,25 @@ exports[`BpkModal should render correctly in the given target if renderTarget is
             aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
             class="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
           >
+            <button
+              aria-label="Close"
+              class="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+              title="Close"
+              type="button"
+            >
+              <svg
+                class="bpk-close-button__icon"
+                height="18"
+                style="width: 1.125rem; height: 1.125rem;"
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.587 3.467a1.5 1.5 0 1 0-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 0 0 2.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 0 0 2.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 0 0-2.122-2.12l-6.44 6.438-6.44-6.44z"
+                />
+              </svg>
+            </button>
             <h2
               class="bpk-modal__heading"
               id="bpk-modal-heading-my-modal"
@@ -34,7 +53,7 @@ exports[`BpkModal should render correctly in the given target if renderTarget is
             </h2>
             <button
               aria-label="Close"
-              class="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+              class="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
               title="Close"
               type="button"
             >

--- a/packages/bpk-component-modal/src/__snapshots__/BpkModalDialog-test.js.snap
+++ b/packages/bpk-component-modal/src/__snapshots__/BpkModalDialog-test.js.snap
@@ -15,6 +15,31 @@ exports[`BpkModalDialog should render correctly 1`] = `
       aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
       className="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
     >
+      <button
+        aria-label="Close"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+        onClick={[MockFunction]}
+        title="Close"
+        type="button"
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.587 3.467a1.5 1.5 0 1 0-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 0 0 2.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 0 0 2.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 0 0-2.122-2.12l-6.44 6.438-6.44-6.44z"
+          />
+        </svg>
+      </button>
       <h2
         className="bpk-modal__heading"
         id="bpk-modal-heading-my-modal"
@@ -23,7 +48,7 @@ exports[`BpkModalDialog should render correctly 1`] = `
       </h2>
       <button
         aria-label="Close"
-        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         title="Close"
         type="button"
@@ -71,6 +96,31 @@ exports[`BpkModalDialog should render correctly when is iPhone 1`] = `
       aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
       className="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
     >
+      <button
+        aria-label="Close"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+        onClick={[MockFunction]}
+        title="Close"
+        type="button"
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.587 3.467a1.5 1.5 0 1 0-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 0 0 2.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 0 0 2.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 0 0-2.122-2.12l-6.44 6.438-6.44-6.44z"
+          />
+        </svg>
+      </button>
       <h2
         className="bpk-modal__heading"
         id="bpk-modal-heading-my-modal"
@@ -79,7 +129,7 @@ exports[`BpkModalDialog should render correctly when is iPhone 1`] = `
       </h2>
       <button
         aria-label="Close"
-        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         title="Close"
         type="button"
@@ -127,6 +177,31 @@ exports[`BpkModalDialog should render correctly when it does not fills the scree
       aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
       className="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
     >
+      <button
+        aria-label="Close"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+        onClick={[MockFunction]}
+        title="Close"
+        type="button"
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.587 3.467a1.5 1.5 0 1 0-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 0 0 2.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 0 0 2.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 0 0-2.122-2.12l-6.44 6.438-6.44-6.44z"
+          />
+        </svg>
+      </button>
       <h2
         className="bpk-modal__heading"
         id="bpk-modal-heading-my-modal"
@@ -135,7 +210,7 @@ exports[`BpkModalDialog should render correctly when it does not fills the scree
       </h2>
       <button
         aria-label="Close"
-        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         title="Close"
         type="button"
@@ -183,6 +258,31 @@ exports[`BpkModalDialog should render correctly when it has a className 1`] = `
       aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
       className="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
     >
+      <button
+        aria-label="Close"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+        onClick={[MockFunction]}
+        title="Close"
+        type="button"
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.587 3.467a1.5 1.5 0 1 0-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 0 0 2.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 0 0 2.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 0 0-2.122-2.12l-6.44 6.438-6.44-6.44z"
+          />
+        </svg>
+      </button>
       <h2
         className="bpk-modal__heading"
         id="bpk-modal-heading-my-modal"
@@ -191,7 +291,7 @@ exports[`BpkModalDialog should render correctly when it has a className 1`] = `
       </h2>
       <button
         aria-label="Close"
-        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         title="Close"
         type="button"
@@ -239,6 +339,31 @@ exports[`BpkModalDialog should render correctly when it is fullscreen 1`] = `
       aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
       className="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
     >
+      <button
+        aria-label="Close"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+        onClick={[MockFunction]}
+        title="Close"
+        type="button"
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.587 3.467a1.5 1.5 0 1 0-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 0 0 2.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 0 0 2.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 0 0-2.122-2.12l-6.44 6.438-6.44-6.44z"
+          />
+        </svg>
+      </button>
       <h2
         className="bpk-modal__heading"
         id="bpk-modal-heading-my-modal"
@@ -247,7 +372,7 @@ exports[`BpkModalDialog should render correctly when it is fullscreen 1`] = `
       </h2>
       <button
         aria-label="Close"
-        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         title="Close"
         type="button"
@@ -295,6 +420,31 @@ exports[`BpkModalDialog should render correctly with a custom content classname 
       aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
       className="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
     >
+      <button
+        aria-label="Close"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+        onClick={[MockFunction]}
+        title="Close"
+        type="button"
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.587 3.467a1.5 1.5 0 1 0-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 0 0 2.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 0 0 2.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 0 0-2.122-2.12l-6.44 6.438-6.44-6.44z"
+          />
+        </svg>
+      </button>
       <h2
         className="bpk-modal__heading"
         id="bpk-modal-heading-my-modal"
@@ -303,7 +453,7 @@ exports[`BpkModalDialog should render correctly with a custom content classname 
       </h2>
       <button
         aria-label="Close"
-        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         title="Close"
         type="button"
@@ -352,7 +502,7 @@ exports[`BpkModalDialog should render correctly with an accessory view 1`] = `
       className="bpk-navigation-bar bpk-modal__navigation false"
     >
       <button
-        className="bpk-link bpk-navigation-bar-button-link bpk-modal__leading-button bpk-navigation-bar__leading-item"
+        className="bpk-link bpk-navigation-bar-button-link bpk-modal__leading-button bpk-navigation-bar__item-leading"
         label="Close"
         onClick={[MockFunction]}
         type="button"
@@ -369,7 +519,7 @@ exports[`BpkModalDialog should render correctly with an accessory view 1`] = `
       </h2>
       <button
         aria-label="Close"
-        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         title="Close"
         type="button"
@@ -417,6 +567,13 @@ exports[`BpkModalDialog should render correctly with closeText prop 1`] = `
       aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
       className="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
     >
+      <button
+        className="bpk-link bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+        onClick={[MockFunction]}
+        type="button"
+      >
+        Dismiss
+      </button>
       <h2
         className="bpk-modal__heading"
         id="bpk-modal-heading-my-modal"
@@ -424,7 +581,7 @@ exports[`BpkModalDialog should render correctly with closeText prop 1`] = `
         Modal title
       </h2>
       <button
-        className="bpk-link bpk-navigation-bar__trailing-item"
+        className="bpk-link bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         type="button"
       >
@@ -455,6 +612,31 @@ exports[`BpkModalDialog should render correctly with no padding 1`] = `
       aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
       className="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
     >
+      <button
+        aria-label="Close"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+        onClick={[MockFunction]}
+        title="Close"
+        type="button"
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.587 3.467a1.5 1.5 0 1 0-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 0 0 2.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 0 0 2.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 0 0-2.122-2.12l-6.44 6.438-6.44-6.44z"
+          />
+        </svg>
+      </button>
       <h2
         className="bpk-modal__heading"
         id="bpk-modal-heading-my-modal"
@@ -463,7 +645,7 @@ exports[`BpkModalDialog should render correctly with no padding 1`] = `
       </h2>
       <button
         aria-label="Close"
-        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         title="Close"
         type="button"
@@ -511,6 +693,31 @@ exports[`BpkModalDialog should render correctly with wide prop 1`] = `
       aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
       className="bpk-navigation-bar bpk-modal__navigation bpk-modal__header--title-only"
     >
+      <button
+        aria-label="Close"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+        onClick={[MockFunction]}
+        title="Close"
+        type="button"
+      >
+        <svg
+          className="bpk-close-button__icon"
+          height="18"
+          style={
+            Object {
+              "height": "1.125rem",
+              "width": "1.125rem",
+            }
+          }
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.587 3.467a1.5 1.5 0 1 0-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 0 0 2.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 0 0 2.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 0 0-2.122-2.12l-6.44 6.438-6.44-6.44z"
+          />
+        </svg>
+      </button>
       <h2
         className="bpk-modal__heading"
         id="bpk-modal-heading-my-modal"
@@ -519,7 +726,7 @@ exports[`BpkModalDialog should render correctly with wide prop 1`] = `
       </h2>
       <button
         aria-label="Close"
-        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__trailing-item"
+        className="bpk-close-button bpk-modal__close-button bpk-navigation-bar__item-trailing"
         onClick={[MockFunction]}
         title="Close"
         type="button"

--- a/packages/bpk-component-modal/stories.js
+++ b/packages/bpk-component-modal/stories.js
@@ -264,7 +264,15 @@ storiesOf('bpk-component-modal', module)
         </BpkNavigationBarButtonLink>
       }
     >
-      The left hand button is intentally not functional. You can put anything
+      The left hand button is intentionally not functional. You can put anything
       you want in here.
+    </ModalContainer>
+  ))
+  .add('Long title', () => (
+    <ModalContainer
+      title="We have to remember what's important in life: friends, waffles, and work. Or waffles, friends, work. But work has to come third."
+      closeLabel="Close modal"
+    >
+      This is a default modal. You can put anything you want in here.
     </ModalContainer>
   ));

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.scss
@@ -24,7 +24,8 @@
   min-height: $bpk-spacing-xxl + $bpk-spacing-xs;
   padding: $bpk-spacing-sm;
   flex-direction: row;
-  justify-content: center;
+  justify-content: space-between;
+  align-items: center;
 
   @include bpk-themeable-property(
     background-color,
@@ -41,32 +42,25 @@
     );
   }
 
-  &__leading-item,
-  &__trailing-item {
-    position: absolute;
+  &--centered {
+    justify-content: center;
   }
 
-  &__leading-item {
-    left: $bpk-spacing-sm;
-
-    @include bpk-rtl {
-      right: $bpk-spacing-sm;
-      left: auto;
-    }
-  }
-
-  &__trailing-item {
-    right: $bpk-spacing-sm;
-
-    @include bpk-rtl {
-      right: auto;
-      left: $bpk-spacing-sm;
-    }
-  }
-
-  &__sticky {
+  &--sticky {
     position: sticky;
     top: 0;
     z-index: $bpk-zindex-tooltip - 1; // Allow tooltips/modals/... to be displayed above the navigation bar
+  }
+
+  &__item {
+    &-leading {
+      @include bpk-margin-trailing($bpk-spacing-sm);
+    }
+    &-trailing {
+      @include bpk-margin-leading($bpk-spacing-sm);
+    }
+    &--invisible {
+      visibility: hidden;
+    }
   }
 }

--- a/packages/bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.js.snap
+++ b/packages/bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.js.snap
@@ -3,7 +3,7 @@
 exports[`BpkNavigationBar should render correctly 1`] = `
 <nav
   aria-labelledby="test-bpk-navigation-bar-title"
-  className="bpk-navigation-bar"
+  className="bpk-navigation-bar bpk-navigation-bar--centered"
 >
   <span
     className="bpk-text bpk-text--base bpk-text--bold bpk-navigation-bar__title"
@@ -17,7 +17,7 @@ exports[`BpkNavigationBar should render correctly 1`] = `
 exports[`BpkNavigationBar should render correctly when sticky 1`] = `
 <nav
   aria-labelledby="test-bpk-navigation-bar-title"
-  className="bpk-navigation-bar bpk-navigation-bar__sticky"
+  className="bpk-navigation-bar bpk-navigation-bar--sticky bpk-navigation-bar--centered"
 >
   <span
     className="bpk-text bpk-text--base bpk-text--bold bpk-navigation-bar__title"
@@ -35,7 +35,7 @@ exports[`BpkNavigationBar should render correctly with a "leadingButton" attribu
 >
   <button
     aria-label="test"
-    className="bpk-close-button bpk-navigation-bar-icon-button bpk-navigation-bar__leading-item"
+    className="bpk-close-button bpk-navigation-bar-icon-button bpk-navigation-bar__item-leading"
     onClick={[Function]}
     title="test"
     type="button"
@@ -48,6 +48,15 @@ exports[`BpkNavigationBar should render correctly with a "leadingButton" attribu
   >
     test
   </span>
+  <button
+    aria-label="test"
+    className="bpk-close-button bpk-navigation-bar-icon-button bpk-navigation-bar__item-trailing bpk-navigation-bar__item--invisible"
+    onClick={[Function]}
+    title="test"
+    type="button"
+  >
+    <span />
+  </button>
 </nav>
 `;
 
@@ -56,6 +65,15 @@ exports[`BpkNavigationBar should render correctly with a "traillingButton" attri
   aria-labelledby="test-bpk-navigation-bar-title"
   className="bpk-navigation-bar"
 >
+  <button
+    aria-label="test"
+    className="bpk-close-button bpk-navigation-bar-icon-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+    onClick={[Function]}
+    title="test"
+    type="button"
+  >
+    <span />
+  </button>
   <span
     className="bpk-text bpk-text--base bpk-text--bold bpk-navigation-bar__title"
     id="test-bpk-navigation-bar-title"
@@ -64,7 +82,7 @@ exports[`BpkNavigationBar should render correctly with a "traillingButton" attri
   </span>
   <button
     aria-label="test"
-    className="bpk-close-button bpk-navigation-bar-icon-button bpk-navigation-bar__trailing-item"
+    className="bpk-close-button bpk-navigation-bar-icon-button bpk-navigation-bar__item-trailing"
     onClick={[Function]}
     title="test"
     type="button"
@@ -79,12 +97,21 @@ exports[`BpkNavigationBar should render correctly with an element for the title 
   aria-labelledby="test-bpk-navigation-bar-title"
   className="bpk-navigation-bar"
 >
+  <button
+    aria-label="test"
+    className="bpk-close-button bpk-navigation-bar-icon-button bpk-navigation-bar__item-leading bpk-navigation-bar__item--invisible"
+    onClick={[Function]}
+    title="test"
+    type="button"
+  >
+    <span />
+  </button>
   <span>
     test
   </span>
   <button
     aria-label="test"
-    className="bpk-close-button bpk-navigation-bar-icon-button bpk-navigation-bar__trailing-item"
+    className="bpk-close-button bpk-navigation-bar-icon-button bpk-navigation-bar__item-trailing"
     onClick={[Function]}
     title="test"
     type="button"
@@ -97,7 +124,7 @@ exports[`BpkNavigationBar should render correctly with an element for the title 
 exports[`BpkNavigationBar should render correctly with arbitrary props 1`] = `
 <nav
   aria-labelledby="test-bpk-navigation-bar-title"
-  className="bpk-navigation-bar"
+  className="bpk-navigation-bar bpk-navigation-bar--centered"
   testID="arbitrary value"
 >
   <span
@@ -112,7 +139,7 @@ exports[`BpkNavigationBar should render correctly with arbitrary props 1`] = `
 exports[`BpkNavigationBar should render correctly with custom class 1`] = `
 <nav
   aria-labelledby="test-bpk-navigation-bar-title"
-  className="bpk-navigation-bar my-custom-class"
+  className="bpk-navigation-bar bpk-navigation-bar--centered my-custom-class"
 >
   <span
     className="bpk-text bpk-text--base bpk-text--bold bpk-navigation-bar__title"

--- a/packages/bpk-component-navigation-bar/stories.js
+++ b/packages/bpk-component-navigation-bar/stories.js
@@ -37,6 +37,50 @@ import BpkNavigationBar, {
 const getClassNames = cssModules(STYLES);
 const ArrowIconWithRtl = withRtlSupport(ArrowIcon);
 
+const NavBarCollection = ({ title }: { title: string }) => {
+  return (
+    <>
+      <BpkNavigationBar id="test-0" title={title} />
+      <BpkNavigationBar
+        id="test-1"
+        title={title}
+        leadingButton={
+          <BpkNavigationBarIconButton
+            onClick={action('back clicked')}
+            icon={ArrowIconWithRtl}
+            label="back"
+          />
+        }
+      />
+      <BpkNavigationBar
+        id="test-2"
+        title={title}
+        trailingButton={
+          <BpkNavigationBarButtonLink onClick={action('done clicked')}>
+            Done
+          </BpkNavigationBarButtonLink>
+        }
+      />
+      <BpkNavigationBar
+        id="test-3"
+        title={title}
+        leadingButton={
+          <BpkNavigationBarIconButton
+            onClick={action('back clicked')}
+            icon={ArrowIconWithRtl}
+            label="back"
+          />
+        }
+        trailingButton={
+          <BpkNavigationBarButtonLink onClick={action('done clicked')}>
+            Done
+          </BpkNavigationBarButtonLink>
+        }
+      />
+    </>
+  );
+};
+
 storiesOf('bpk-component-navigation-bar', module)
   .add('Default', () => (
     <div className={getClassNames('bpk-navigation-bar-story')}>
@@ -108,6 +152,12 @@ storiesOf('bpk-component-navigation-bar', module)
           </BpkNavigationBarButtonLink>
         }
       />
+    </div>
+  ))
+  .add('Combination', () => (
+    <div className={getClassNames('bpk-navigation-bar-story')}>
+      <NavBarCollection title="Short title" />
+      <NavBarCollection title="We have to remember what's important in life: friends, waffles, and work. Or waffles, friends, work. But work has to come third." />
     </div>
   ))
   .add('With logo', () => (


### PR DESCRIPTION
Previously we were using absolute positioning for the buttons, meaning the title was always centered but the buttons could overlap when the title got long.

Now we're using flexbox, and to work around the centering problem I've added a workaround involving cloning the accessory view when only one is provided. This does have a downside that when both accessory views are provided, if they're different widths, the title is off centre. Tbh this does suck but it feels like the least-worst solution I can think of, and as @georgegillams  pointed out, if it affects any consumers we can fall back to them setting a max width on their accessory view.

I did try using CSS grid but that doesn't help here either.

There is one other thing we could do but it doesn't seem great, which is to set a fixed size for the accessory views at all times, meaning the title would always be centered, but longer accessory views would wrap which doesn't seem great.

Anyway here's some screenshots

_Note how the fourth one down has accessory views of different widths so the title is slightly off centre. Also note how the second one from the bottom has a big leading padding — that's the invisible clone of the 'Done' button._
<img width="683" alt="Screen Shot 2020-11-17 at 09 52 25" src="https://user-images.githubusercontent.com/73652/99379193-43b99600-28c0-11eb-90e7-6859afb244fb.png">

_This looks fine_
<img width="651" alt="Screen Shot 2020-11-17 at 09 53 05" src="https://user-images.githubusercontent.com/73652/99379382-811e2380-28c0-11eb-9a9d-514bb736a1e9.png">

_This looks ok too, although note the large leading padding due to the cloned X button._
<img width="628" alt="Screen Shot 2020-11-17 at 10 02 26" src="https://user-images.githubusercontent.com/73652/99379403-89765e80-28c0-11eb-93dd-fd45fab2b58f.png">

_This one isn't great tbh because 'Back to results' is so much longer than the X button._
<img width="588" alt="Screen Shot 2020-11-17 at 09 55 45" src="https://user-images.githubusercontent.com/73652/99379500-a874f080-28c0-11eb-8147-e55fd4bd7d11.png">

_If we reduce it to just say 'Back' it's not as bad though._
<img width="606" alt="Screen Shot 2020-11-17 at 09 57 32" src="https://user-images.githubusercontent.com/73652/99379526-b75ba300-28c0-11eb-967d-f6f664499abb.png">


