### PR TITLE
BPK-4032: Fix Modal a11y issue

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,6 +5,10 @@
 **Fixed:**
 - bpk-component-modal:
   - Fixed an issue where long titles could overlap the close button.
+  - Fixed an a11y issue where if the title wasn't supplied `aria-labelledby` would try to attach to a non-existing component and the naming of the title passed to the navigation component didn't match.
+
+- bpk-component-navigation-bar:
+  - Fixed the `id` generation for when a title component is passed vs. a string, so that the `aria-labelledby` matches the id of the title.
 
 ## How to write a good changelog entry
 

--- a/packages/bpk-component-dialog/src/__snapshots__/BpkDialog-test.js.snap
+++ b/packages/bpk-component-dialog/src/__snapshots__/BpkDialog-test.js.snap
@@ -13,7 +13,6 @@ exports[`BpkDialog should render correctly in the given target if renderTarget i
         role="presentation"
       />
       <section
-        aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-modal"
         id="my-modal"
         role="dialog"
@@ -62,7 +61,6 @@ exports[`BpkDialog should render correctly when it is not dismissible 2`] = `
         role="presentation"
       />
       <section
-        aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-modal"
         id="my-modal"
         role="dialog"
@@ -92,7 +90,6 @@ exports[`BpkDialog should render default icon dialog correctly 2`] = `
         role="presentation"
       />
       <section
-        aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-modal"
         id="my-modal"
         role="dialog"
@@ -137,7 +134,6 @@ exports[`BpkDialog should render destructive icon dialog correctly 2`] = `
         role="presentation"
       />
       <section
-        aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-modal"
         id="my-modal"
         role="dialog"
@@ -181,7 +177,6 @@ exports[`BpkDialog should render warning icon dialog correctly 2`] = `
         role="presentation"
       />
       <section
-        aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-modal"
         id="my-modal"
         role="dialog"
@@ -225,7 +220,6 @@ exports[`BpkDialog should render with flare dialog 2`] = `
         role="presentation"
       />
       <section
-        aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-modal"
         id="my-modal"
         role="dialog"
@@ -313,7 +307,6 @@ exports[`BpkDialog should render with flare dialog with flareClassName 2`] = `
         role="presentation"
       />
       <section
-        aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-modal"
         id="my-modal"
         role="dialog"

--- a/packages/bpk-component-modal/src/BpkModalDialog.js
+++ b/packages/bpk-component-modal/src/BpkModalDialog.js
@@ -77,7 +77,6 @@ const BpkModalDialog = (props: Props) => {
   }
 
   const headingId = `bpk-modal-heading-${props.id}`;
-  const navigationId = `bpk-modal-navigation-${props.id}`;
 
   const accessoryViewFinal = props.accessoryView ? (
     <span className={getClassName('bpk-modal__accessory-view')}>
@@ -95,7 +94,7 @@ const BpkModalDialog = (props: Props) => {
         id={props.id}
         tabIndex="-1"
         role="dialog"
-        aria-labelledby={headingId}
+        aria-labelledby={props.showHeader ? headingId : null}
         className={classNames.join(' ')}
         ref={props.dialogRef}
       >
@@ -103,7 +102,7 @@ const BpkModalDialog = (props: Props) => {
         {props.showHeader && (
           <header className={getClassName('bpk-modal__header')}>
             <BpkNavigationBar
-              id={navigationId}
+              id={headingId}
               className={navigationStyles.join(' ')}
               title={
                 <h2

--- a/packages/bpk-component-modal/src/__snapshots__/BpkModal-test.js.snap
+++ b/packages/bpk-component-modal/src/__snapshots__/BpkModal-test.js.snap
@@ -23,7 +23,7 @@ exports[`BpkModal should render correctly in the given target if renderTarget is
           class="bpk-modal__header"
         >
           <nav
-            aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+            aria-labelledby="bpk-modal-heading-my-modal"
             class="bpk-navigation-bar bpk-modal__navigation"
           >
             <h2

--- a/packages/bpk-component-modal/src/__snapshots__/BpkModalDialog-test.js.snap
+++ b/packages/bpk-component-modal/src/__snapshots__/BpkModalDialog-test.js.snap
@@ -12,7 +12,7 @@ exports[`BpkModalDialog should render correctly 1`] = `
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <h2
@@ -68,7 +68,7 @@ exports[`BpkModalDialog should render correctly when is iPhone 1`] = `
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <h2
@@ -124,7 +124,7 @@ exports[`BpkModalDialog should render correctly when it does not fills the scree
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <h2
@@ -180,7 +180,7 @@ exports[`BpkModalDialog should render correctly when it has a className 1`] = `
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <h2
@@ -236,7 +236,7 @@ exports[`BpkModalDialog should render correctly when it is fullscreen 1`] = `
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <h2
@@ -292,7 +292,7 @@ exports[`BpkModalDialog should render correctly with a custom content classname 
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <h2
@@ -348,7 +348,7 @@ exports[`BpkModalDialog should render correctly with an accessory view 1`] = `
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <span
@@ -418,7 +418,7 @@ exports[`BpkModalDialog should render correctly with closeText prop 1`] = `
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <h2
@@ -456,7 +456,7 @@ exports[`BpkModalDialog should render correctly with no padding 1`] = `
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <h2
@@ -512,7 +512,7 @@ exports[`BpkModalDialog should render correctly with wide prop 1`] = `
     className="bpk-modal__header"
   >
     <nav
-      aria-labelledby="bpk-modal-navigation-my-modal-bpk-navigation-bar-title"
+      aria-labelledby="bpk-modal-heading-my-modal"
       className="bpk-navigation-bar bpk-modal__navigation"
     >
       <h2

--- a/packages/bpk-component-modal/stories.js
+++ b/packages/bpk-component-modal/stories.js
@@ -230,7 +230,7 @@ storiesOf('bpk-component-modal', module)
       This is a full-screen modal. You can put anything you want in here,
       including other modals!
       <ModalContainer
-        title="Modal title"
+        title="Inner modal title"
         closeLabel="Close modal"
         wrapperProps={{ id: 'inner-modal-container' }}
         buttonLabel="Open another modal from this modal"

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.js
@@ -52,7 +52,10 @@ const BpkNavigationBar = (props: Props) => {
     ...rest
   } = props;
 
-  const titleId = `${id}-bpk-navigation-bar-title`;
+  // If the title is a component that sets its own id we want the aria-labelledby on the nav to match this so it can find the element
+  // Otherwise if its just a string we set the id on the title component.
+  const titleId =
+    typeof title === 'string' ? `${id}-bpk-navigation-bar-title` : id;
 
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.

--- a/packages/bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.js.snap
+++ b/packages/bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.js.snap
@@ -76,7 +76,7 @@ exports[`BpkNavigationBar should render correctly with a "traillingButton" attri
 
 exports[`BpkNavigationBar should render correctly with an element for the title attribute 1`] = `
 <nav
-  aria-labelledby="test-bpk-navigation-bar-title"
+  aria-labelledby="test"
   className="bpk-navigation-bar"
 >
   <span>


### PR DESCRIPTION
A11y fix whereby aria-labelled by was incorrect when applied on the modals/dialogs

Before:
![Screenshot 2020-11-18 at 13 59 56](https://user-images.githubusercontent.com/8831547/99539634-5f976780-29a6-11eb-81b3-ec8d20efb002.png)

After:
![Screenshot 2020-11-18 at 13 59 14](https://user-images.githubusercontent.com/8831547/99539649-6625df00-29a6-11eb-9408-e7a905d34cc6.png)
