### PR TITLE
[NO-JIRA]: Export BpkBackgroundImageProps from bpk-component-image package

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 > Place your changes below this line.
+ - bpk-component-image:
+   - Export `BpkBackgroundImageProps` prop from`BpkBackgroundImage` component and `bpk-component-image` package.
 
 ## How to write a good changelog entry
 

--- a/packages/bpk-component-image/index.js
+++ b/packages/bpk-component-image/index.js
@@ -17,7 +17,9 @@
  */
 
 import BpkImage from './src/BpkImage';
-import BpkBackgroundImage from './src/BpkBackgroundImage';
+import BpkBackgroundImage, {
+  BpkBackgroundImageProps,
+} from './src/BpkBackgroundImage';
 import withLazyLoading from './src/withLazyLoading';
 import withLoadingBehavior from './src/withLoadingBehavior';
 import BORDER_RADIUS_STYLES from './src/BpkImageBorderRadiusStyles';
@@ -26,6 +28,7 @@ export default BpkImage;
 
 export {
   BpkBackgroundImage,
+  BpkBackgroundImageProps,
   withLazyLoading,
   withLoadingBehavior,
   BORDER_RADIUS_STYLES,

--- a/packages/bpk-component-image/src/BpkBackgroundImage.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.js
@@ -29,7 +29,7 @@ import STYLES from './BpkBackgroundImage.scss';
 
 const getClassName = cssModules(STYLES);
 
-type BpkBackgroundImageProps = {
+export type BpkBackgroundImageProps = {
   children: Node,
   aspectRatio: number,
   height: number,


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
### What?
This PR simply exports `BpkBackgroundImageProps` from `bpk-component-image` package. 

### Why?
We need these props in our internal project for flow typing, and simply copying them breaks the link and can lead to
our copy becoming stale in case there's a change in future.


Remember to include the following changes:

- ~~[x] `UNRELEASED.md`~~
- ~~[x] `README.md`~~
- ~~[x] Tests~~
- ~~[x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)~~

React 16.4 compatibility:

- [x] I haven't used Hooks in any code that we ship to consumers.
