### PR TITLE
DINGO 3759: Upgrade some deps to use latest RTG

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 > Place your changes below this line.
-**Breaking**
+**Fixed**
 
  - bpk-component-banner-alert
    - Upgrade `react-transition-group` dependency to `4.4.1`

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,16 @@
 # Unreleased
 
 > Place your changes below this line.
+**Breaking**
+
+ - bpk-component-banner-alert
+   - Upgrade `react-transition-group` dependency to `4.4.1`
+ - bpk-component-drawer
+   - Upgrade `react-transition-group` dependency to `4.4.1`
+ - bpk-component-image
+   - Upgrade `react-transition-group` dependency to `4.4.1`
+ - bpk-react-utils
+   - Upgrade `react-transition-group` dependency to `4.4.1`
 
 ## How to write a good changelog entry
 

--- a/packages/bpk-component-banner-alert/package-lock.json
+++ b/packages/bpk-component-banner-alert/package-lock.json
@@ -1,17 +1,30 @@
 {
 	"name": "bpk-component-banner-alert",
+	"version": "4.2.42",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"chain-function": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.1.tgz",
-			"integrity": "sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg=="
+		"@babel/runtime": {
+			"version": "7.12.5",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha1-QQ5+SHRB4bNgwpvnFdhw2bmFiC4=",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"csstype": {
+			"version": "3.0.5",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/csstype/-/csstype-3.0.5.tgz",
+			"integrity": "sha1-f97GoopnrhhkfFFmip/5W7L6e7g="
 		},
 		"dom-helpers": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+			"version": "5.2.0",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-helpers/-/dom-helpers-5.2.0.tgz",
+			"integrity": "sha1-V/0FTF+PNMUqPu/9t+fpPNNX2Vs=",
+			"requires": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
+			}
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -41,24 +54,20 @@
 			}
 		},
 		"react-transition-group": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-			"integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+			"version": "4.4.1",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-transition-group/-/react-transition-group-4.4.1.tgz",
+			"integrity": "sha1-Y4aPkyWjjqXulTXYKDJ/hXczRck=",
 			"requires": {
-				"chain-function": "^1.0.0",
-				"dom-helpers": "^3.2.0",
-				"loose-envify": "^1.3.1",
-				"prop-types": "^15.5.6",
-				"warning": "^3.0.0"
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
 			}
 		},
-		"warning": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-			"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U="
 		}
 	}
 }

--- a/packages/bpk-component-banner-alert/package.json
+++ b/packages/bpk-component-banner-alert/package.json
@@ -21,7 +21,7 @@
     "bpk-react-utils": "^3.0.7",
     "bpk-tokens": "^36.0.1",
     "prop-types": "^15.6.2",
-    "react-transition-group": "^2.5.3"
+    "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/bpk-component-drawer/package-lock.json
+++ b/packages/bpk-component-drawer/package-lock.json
@@ -1,12 +1,30 @@
 {
 	"name": "bpk-component-drawer",
+	"version": "3.0.51",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.12.5",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha1-QQ5+SHRB4bNgwpvnFdhw2bmFiC4=",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"csstype": {
+			"version": "3.0.5",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/csstype/-/csstype-3.0.5.tgz",
+			"integrity": "sha1-f97GoopnrhhkfFFmip/5W7L6e7g="
+		},
 		"dom-helpers": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+			"version": "5.2.0",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-helpers/-/dom-helpers-5.2.0.tgz",
+			"integrity": "sha1-V/0FTF+PNMUqPu/9t+fpPNNX2Vs=",
+			"requires": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
+			}
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -35,21 +53,21 @@
 				"object-assign": "^4.1.1"
 			}
 		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-		},
 		"react-transition-group": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
-			"integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
+			"version": "4.4.1",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-transition-group/-/react-transition-group-4.4.1.tgz",
+			"integrity": "sha1-Y4aPkyWjjqXulTXYKDJ/hXczRck=",
 			"requires": {
-				"dom-helpers": "^3.3.1",
-				"loose-envify": "^1.3.1",
-				"prop-types": "^15.6.2",
-				"react-lifecycles-compat": "^3.0.4"
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U="
 		}
 	}
 }

--- a/packages/bpk-component-drawer/package.json
+++ b/packages/bpk-component-drawer/package.json
@@ -22,7 +22,7 @@
     "bpk-scrim-utils": "^4.0.93",
     "bpk-tokens": "^36.0.1",
     "prop-types": "^15.6.2",
-    "react-transition-group": "^2.5.3"
+    "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/bpk-component-image/package-lock.json
+++ b/packages/bpk-component-image/package-lock.json
@@ -1,12 +1,30 @@
 {
 	"name": "bpk-component-image",
+	"version": "4.3.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.12.5",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha1-QQ5+SHRB4bNgwpvnFdhw2bmFiC4=",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"csstype": {
+			"version": "3.0.5",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/csstype/-/csstype-3.0.5.tgz",
+			"integrity": "sha1-f97GoopnrhhkfFFmip/5W7L6e7g="
+		},
 		"dom-helpers": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+			"version": "5.2.0",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-helpers/-/dom-helpers-5.2.0.tgz",
+			"integrity": "sha1-V/0FTF+PNMUqPu/9t+fpPNNX2Vs=",
+			"requires": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
+			}
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -35,21 +53,21 @@
 				"object-assign": "^4.1.1"
 			}
 		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-		},
 		"react-transition-group": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
-			"integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
+			"version": "4.4.1",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-transition-group/-/react-transition-group-4.4.1.tgz",
+			"integrity": "sha1-Y4aPkyWjjqXulTXYKDJ/hXczRck=",
 			"requires": {
-				"dom-helpers": "^3.3.1",
-				"loose-envify": "^1.3.1",
-				"prop-types": "^15.6.2",
-				"react-lifecycles-compat": "^3.0.4"
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U="
 		}
 	}
 }

--- a/packages/bpk-component-image/package.json
+++ b/packages/bpk-component-image/package.json
@@ -18,7 +18,7 @@
     "bpk-mixins": "^20.1.10",
     "bpk-react-utils": "^3.0.7",
     "prop-types": "^15.6.2",
-    "react-transition-group": "^2.5.3"
+    "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/bpk-react-utils/package-lock.json
+++ b/packages/bpk-react-utils/package-lock.json
@@ -1,5 +1,6 @@
 {
 	"name": "bpk-react-utils",
+	"version": "3.0.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -26,10 +27,34 @@
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 		},
+		"csstype": {
+			"version": "3.0.5",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/csstype/-/csstype-3.0.5.tgz",
+			"integrity": "sha1-f97GoopnrhhkfFFmip/5W7L6e7g="
+		},
 		"dom-helpers": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+			"version": "5.2.0",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-helpers/-/dom-helpers-5.2.0.tgz",
+			"integrity": "sha1-V/0FTF+PNMUqPu/9t+fpPNNX2Vs=",
+			"requires": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.12.5",
+					"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.12.5.tgz",
+					"integrity": "sha1-QQ5+SHRB4bNgwpvnFdhw2bmFiC4=",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.7",
+					"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+					"integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U="
+				}
+			}
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -130,14 +155,29 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-transition-group": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
-			"integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
+			"version": "4.4.1",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-transition-group/-/react-transition-group-4.4.1.tgz",
+			"integrity": "sha1-Y4aPkyWjjqXulTXYKDJ/hXczRck=",
 			"requires": {
-				"dom-helpers": "^3.3.1",
-				"loose-envify": "^1.3.1",
-				"prop-types": "^15.6.2",
-				"react-lifecycles-compat": "^3.0.4"
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.12.5",
+					"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.12.5.tgz",
+					"integrity": "sha1-QQ5+SHRB4bNgwpvnFdhw2bmFiC4=",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.7",
+					"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+					"integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U="
+				}
 			}
 		},
 		"recompose": {

--- a/packages/bpk-react-utils/package.json
+++ b/packages/bpk-react-utils/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "react-transition-group": "^2.5.3",
+    "react-transition-group": "^4.4.1",
     "recompose": "^0.30.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

The apparent breaking changes for `react-transition-group` upgrade is
- `3.x.x` - use new style react context - requires react v16.6 or above
- `4.x.x` - in environments where esm is supported importing from commonjs requires explicitly adding the .default after require() when resolving to the esm build

More info here https://github.com/reactjs/react-transition-group/blob/master/CHANGELOG.md

Remember to include the following changes:

- [x] `UNRELEASED.md`
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

React 16.4 compatibility:

- [x] I haven't used Hooks in any code that we ship to consumers.
