### PR TITLE
[NO-JIRA] Make main deploys remove old files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           personal_token: ${{ secrets.DEPLOY_TOKEN }}
           publish_dir: dist-sassdoc/
-          keep_files: true
+          keep_files: false
           external_repository: backpack/sassdoc
           publish_branch: master
 
@@ -63,7 +63,7 @@ jobs:
         with:
           personal_token: ${{ secrets.DEPLOY_TOKEN }}
           publish_dir: dist-storybook/
-          keep_files: true
+          keep_files: false
           external_repository: backpack/storybook
           publish_branch: master
 


### PR DESCRIPTION
Using `keep_files: true` means that if we rename a page, the old page's index.html will still be present.

For example, https://backpack.github.io/using/status still exists even though we've deployed a new version with https://backpack.github.io/using/backpack-status.

For PR builds we want to use `keep_files` (as we don't want to remove another PR's build when we deploy) but for the main docs deploys I think we shouldn't keep files