### PR TITLE
[NO-JIRA] Fix column header sorting icons in datatable

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,10 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+ - bpk-component-datatable:
+   - Fixed arrow icons in column header sorting that were inverted
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
+++ b/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
@@ -52,7 +52,7 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
           className="bpk-data-table-column__sort-icons"
         >
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -69,7 +69,7 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
             />
           </svg>
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -285,7 +285,7 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
           className="bpk-data-table-column__sort-icons"
         >
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -302,7 +302,7 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
             />
           </svg>
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -518,7 +518,7 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
           className="bpk-data-table-column__sort-icons"
         >
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -535,7 +535,7 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
             />
           </svg>
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -751,7 +751,7 @@ exports[`BpkDataTable should render correctly with a custom rowClassName 1`] = `
           className="bpk-data-table-column__sort-icons"
         >
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -768,7 +768,7 @@ exports[`BpkDataTable should render correctly with a custom rowClassName 1`] = `
             />
           </svg>
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -976,7 +976,7 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
         className="bpk-data-table-column__sort-icons"
       >
         <svg
-          className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-icon--rtl-support"
+          className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
           height="18"
           style={
             Object {
@@ -993,7 +993,7 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
           />
         </svg>
         <svg
-          className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
+          className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
           height="18"
           style={
             Object {
@@ -1353,7 +1353,7 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
           className="bpk-data-table-column__sort-icons"
         >
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -1370,7 +1370,7 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
             />
           </svg>
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -1586,7 +1586,7 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
           className="bpk-data-table-column__sort-icons"
         >
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
             height="18"
             style={
               Object {
@@ -1603,7 +1603,7 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
             />
           </svg>
           <svg
-            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
             height="18"
             style={
               Object {

--- a/packages/bpk-component-datatable/src/bpkHeaderRenderer-test.js
+++ b/packages/bpk-component-datatable/src/bpkHeaderRenderer-test.js
@@ -47,7 +47,7 @@ describe('bpkHeaderRenderer', () => {
       dataKey: 'dataKey',
       label: 'Label',
       sortBy: 'dataKey',
-      sortDirection: SortDirection.ASC,
+      sortDirection: SortDirection.DESC,
     });
     const tree = renderer.create(<div>{header}</div>);
     expect(tree).toMatchSnapshot();
@@ -57,7 +57,7 @@ describe('bpkHeaderRenderer', () => {
       dataKey: 'dataKey',
       label: 'Label',
       sortBy: 'dataKey',
-      sortDirection: SortDirection.DESC,
+      sortDirection: SortDirection.ASC,
     });
     const tree = renderer.create(<div>{header}</div>);
     expect(tree).toMatchSnapshot();
@@ -76,19 +76,19 @@ describe('bpkHeaderRenderer', () => {
       );
     });
 
-    it('returns DESC for the up icon element', () => {
+    it('returns ASC for the up icon element', () => {
       const upIcon = mounted
         .find('svg')
         .find('.bpk-data-table-column__sort-icon--up');
       const sortDirection = getSortIconDirection(upIcon);
-      expect(sortDirection).toBe(SortDirection.DESC);
+      expect(sortDirection).toBe(SortDirection.ASC);
     });
-    it('returns ASC for the down path element', () => {
+    it('returns DESC for the down path element', () => {
       const downIcon = mounted
         .find('svg')
         .find('.bpk-data-table-column__sort-icon--down');
       const sortDirection = getSortIconDirection(downIcon);
-      expect(sortDirection).toBe(SortDirection.ASC);
+      expect(sortDirection).toBe(SortDirection.DESC);
     });
     it('returns null other things', () => {
       const headerLabel = mounted

--- a/packages/bpk-component-datatable/src/bpkHeaderRenderer.js
+++ b/packages/bpk-component-datatable/src/bpkHeaderRenderer.js
@@ -74,7 +74,7 @@ export default ({ dataKey, label, sortBy, sortDirection, disableSort }) => {
     ];
 
     if (sortBy === dataKey) {
-      (sortDirection === SortDirection.DESC
+      (sortDirection === SortDirection.ASC
         ? upIconClassNames
         : downIconClassNames
       ).push(getClassName('bpk-data-table-column__sort-icon--selected'));

--- a/packages/bpk-component-datatable/src/bpkHeaderRenderer.js
+++ b/packages/bpk-component-datatable/src/bpkHeaderRenderer.js
@@ -40,13 +40,13 @@ export const getSortIconDirection = element => {
     hasClassName(element, upIconClassName) ||
     hasClassName(element.parentNode, upIconClassName)
   ) {
-    return SortDirection.DESC;
+    return SortDirection.ASC;
   }
   if (
     hasClassName(element, downIconClassName) ||
     hasClassName(element.parentNode, downIconClassName)
   ) {
-    return SortDirection.ASC;
+    return SortDirection.DESC;
   }
   return null;
 };


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

The arrow icons being used in the datatable for sorting were inverted

Remember to include the following changes:

- [x] `UNRELEASED.md`
- [ ] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

React 16.4 compatibility:

- [x] I haven't used Hooks in any code that we ship to consumers.
