### PR TITLE
NEON-167 DataTable rowClassName can be a function

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Added:**
+
+- bpk-component-datatable:
+  - `rowClassName` can be a function like in react-virtualized Table.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/packages/bpk-component-datatable/src/BpkDataTable-test.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable-test.js
@@ -107,13 +107,39 @@ describe('BpkDataTable', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('should render correctly with a custom rowClassName', () => {
+  it('should render correctly with a custom rowClassName string', () => {
     const tree = renderer
       .create(
         <BpkDataTable
           rows={rows}
           height={200}
           rowClassName="custom-data-table__row"
+        >
+          <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+          <BpkDataTableColumn
+            label="Description"
+            dataKey="description"
+            width={100}
+            flexGrow={1}
+          />
+          <BpkDataTableColumn label="Bla" dataKey="bla" width={100} />
+        </BpkDataTable>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render correctly with a custom rowClassName function', () => {
+    const tree = renderer
+      .create(
+        <BpkDataTable
+          rows={rows}
+          height={200}
+          rowClassName={({ index }) =>
+            index % 2 === 0
+              ? 'custom-data-table__row_even'
+              : 'custom-data-table__row_odd'
+          }
         >
           <BpkDataTableColumn label="Name" dataKey="name" width={100} />
           <BpkDataTableColumn

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -103,7 +103,10 @@ class BpkDataTable<Row> extends Component<Props<Row>, State<Row>> {
     }));
   };
 
-  rowClassName = (consumerClassName: ?string, { index }: { index: number }) => {
+  rowClassName = (
+    consumerClassName: ?string | ?(({ index: number }) => string),
+    { index }: { index: number },
+  ) => {
     const classNames = [getClassName('bpk-data-table__row')];
     if (this.state.rowSelected === index) {
       classNames.push(getClassName('bpk-data-table__row--selected'));
@@ -115,7 +118,11 @@ class BpkDataTable<Row> extends Component<Props<Row>, State<Row>> {
       classNames.push(getClassName('bpk-data-table__header-row'));
     }
     if (consumerClassName) {
-      classNames.push(consumerClassName);
+      if (typeof consumerClassName === 'function') {
+        classNames.push(consumerClassName({ index }));
+      } else {
+        classNames.push(consumerClassName);
+      }
     }
     return classNames;
   };

--- a/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
+++ b/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
@@ -699,7 +699,240 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
 </div>
 `;
 
-exports[`BpkDataTable should render correctly with a custom rowClassName 1`] = `
+exports[`BpkDataTable should render correctly with a custom rowClassName function 1`] = `
+<div
+  style={
+    Object {
+      "overflow": "visible",
+      "width": 0,
+    }
+  }
+>
+  <div
+    className="ReactVirtualized__Table bpk-data-table"
+    role="grid"
+    style={Object {}}
+  >
+    <div
+      className="ReactVirtualized__Table__headerRow bpk-data-table__row bpk-data-table__header-row custom-data-table__row_odd"
+      role="row"
+      style={
+        Object {
+          "height": 60,
+          "overflow": "hidden",
+          "paddingRight": 0,
+          "width": 0,
+        }
+      }
+    >
+      <div
+        aria-label="Name"
+        aria-sort="ascending"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__header-column"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "0 1 100px",
+            "flex": "0 1 100px",
+            "msFlex": "0 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="bpk-data-table-column__header"
+          title="Name"
+        >
+          Name
+        </span>
+        <div
+          className="bpk-data-table-column__sort-icons"
+        >
+          <svg
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
+            height="18"
+            style={
+              Object {
+                "height": "1.125rem",
+                "width": "1.125rem",
+              }
+            }
+            viewBox="0 0 24 24"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7.463 15.75h9.074a1.358 1.358 0 0 0 1.11-2.251l-4.354-4.77a1.53 1.53 0 0 0-2.184-.04l-4.718 4.77a1.357 1.357 0 0 0 1.072 2.291z"
+            />
+          </svg>
+          <svg
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
+            height="18"
+            style={
+              Object {
+                "height": "1.125rem",
+                "width": "1.125rem",
+              }
+            }
+            viewBox="0 0 24 24"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16.537 8.25H7.463a1.358 1.358 0 0 0-1.11 2.251l4.354 4.77a1.53 1.53 0 0 0 2.184.04l4.718-4.77a1.357 1.357 0 0 0-1.072-2.291z"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        aria-label="Description"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__header-column"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "1 1 100px",
+            "flex": "1 1 100px",
+            "msFlex": "1 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="bpk-data-table-column__header"
+          title="Description"
+        >
+          Description
+        </span>
+        <div
+          className="bpk-data-table-column__sort-icons"
+        >
+          <svg
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-icon--rtl-support"
+            height="18"
+            style={
+              Object {
+                "height": "1.125rem",
+                "width": "1.125rem",
+              }
+            }
+            viewBox="0 0 24 24"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7.463 15.75h9.074a1.358 1.358 0 0 0 1.11-2.251l-4.354-4.77a1.53 1.53 0 0 0-2.184-.04l-4.718 4.77a1.357 1.357 0 0 0 1.072 2.291z"
+            />
+          </svg>
+          <svg
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
+            height="18"
+            style={
+              Object {
+                "height": "1.125rem",
+                "width": "1.125rem",
+              }
+            }
+            viewBox="0 0 24 24"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16.537 8.25H7.463a1.358 1.358 0 0 0-1.11 2.251l4.354 4.77a1.53 1.53 0 0 0 2.184.04l4.718-4.77a1.357 1.357 0 0 0-1.072-2.291z"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        aria-label="Bla"
+        className="ReactVirtualized__Table__headerColumn bpk-data-table__header-column"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="columnheader"
+        style={
+          Object {
+            "WebkitFlex": "0 1 100px",
+            "flex": "0 1 100px",
+            "msFlex": "0 1 100px",
+          }
+        }
+        tabIndex={0}
+      >
+        <span
+          className="bpk-data-table-column__header"
+          title="Bla"
+        >
+          Bla
+        </span>
+        <div
+          className="bpk-data-table-column__sort-icons"
+        >
+          <svg
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--up bpk-icon--rtl-support"
+            height="18"
+            style={
+              Object {
+                "height": "1.125rem",
+                "width": "1.125rem",
+              }
+            }
+            viewBox="0 0 24 24"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7.463 15.75h9.074a1.358 1.358 0 0 0 1.11-2.251l-4.354-4.77a1.53 1.53 0 0 0-2.184-.04l-4.718 4.77a1.357 1.357 0 0 0 1.072 2.291z"
+            />
+          </svg>
+          <svg
+            className="bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--down bpk-icon--rtl-support"
+            height="18"
+            style={
+              Object {
+                "height": "1.125rem",
+                "width": "1.125rem",
+              }
+            }
+            viewBox="0 0 24 24"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16.537 8.25H7.463a1.358 1.358 0 0 0-1.11 2.251l4.354 4.77a1.53 1.53 0 0 0 2.184.04l4.718-4.77a1.357 1.357 0 0 0-1.072-2.291z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-label="grid"
+      aria-readonly={true}
+      className="ReactVirtualized__Grid ReactVirtualized__Table__Grid"
+      onScroll={[Function]}
+      role="rowgroup"
+      style={
+        Object {
+          "WebkitOverflowScrolling": "touch",
+          "boxSizing": "border-box",
+          "direction": undefined,
+          "height": 140,
+          "overflowX": "hidden",
+          "overflowY": "hidden",
+          "position": "relative",
+          "width": 0,
+          "willChange": "transform",
+        }
+      }
+      tabIndex={0}
+    />
+  </div>
+</div>
+`;
+
+exports[`BpkDataTable should render correctly with a custom rowClassName string 1`] = `
 <div
   style={
     Object {


### PR DESCRIPTION
While working on a feature to dynamically change the background of a row depending on a value, I noticed that `BpkDataTable` did not allow to pass a function for `rowClassName` while the original react-virtualized `Table` [does](https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md).

This PR extends the component to allow passing a function as in `Table`

Remember to include the following changes:

- [x] `UNRELEASED.md`
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
