### PR TITLE
NEON-154: Fix rowCount value on PropSorter, bpk-component-datatable

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -29,3 +29,5 @@ See [`CHANGELOG.md`](CHANGELOG.md) for real-world examples of good changelog ent
 
 - bpk-component-horcrux:
   - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+- bpk-component-datatable:
+  - Fixed issue where `rowCount` does not update when props have changed.

--- a/packages/bpk-component-datatable/src/sorter.js
+++ b/packages/bpk-component-datatable/src/sorter.js
@@ -148,6 +148,7 @@ class PropSorter<Row> {
       sort: nextProps.sort,
     };
     this.list = nextProps.rows;
+    this.rowCount = nextProps.rows.length;
   }
 
   onHeaderClick(): Sorter<Row> {


### PR DESCRIPTION
### Description:
Update rowCount value when the props of PropSorter have changed

Remember to include the following changes:

- [x] `UNRELEASED.md`
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
