### PR TITLE
[DINGO-4320]: Calendar focus on null date

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- bpk-component-calendar
+  - A change from selectedDate from `Date` -> `null` is reflected in focussed date
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer-test.js
@@ -125,6 +125,34 @@ describe('BpkCalendarContainer', () => {
     expect(onDateSelect.mock.calls[0][0]).toEqual(new Date(2010, 1, 20));
   });
 
+  it('should account for focus state if selectedDate is set to null', () => {
+    const onDateSelect = jest.fn();
+    const initialSelectedDate = new Date(2010, 2, 1);
+    const minDate = new Date(2010, 1, 15);
+    const maxDate = new Date(2010, 2, 15);
+
+    const calendar = mount(
+      <BpkCalendarContainer
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        daysOfWeek={weekDays}
+        weekStartsOn={1}
+        changeMonthLabel="Change month"
+        id="myCalendar"
+        minDate={minDate}
+        maxDate={maxDate}
+        selectedDate={initialSelectedDate}
+        onDateSelect={onDateSelect}
+      />,
+    );
+
+    expect(calendar.state('focusedDate')).toEqual(initialSelectedDate);
+
+    calendar.setProps({ selectedDate: null });
+
+    expect(calendar.state('focusedDate')).toEqual(minDate);
+  });
+
   it('should set state only once on date selection', () => {
     const setStateSpy = jest.fn();
     const oldSetState = BpkCalendarContainer.prototype.setState;

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.js
@@ -41,7 +41,14 @@ const focusedDateHasChanged = (currentProps, nextProps) => {
   const rawNextSelectedDate = nextProps.selectedDate || nextProps.date;
   const rawSelectedDate = currentProps.selectedDate || currentProps.date;
 
-  if (!rawNextSelectedDate) {
+  if (!rawSelectedDate && !rawNextSelectedDate) {
+    return false;
+  }
+
+  if (
+    (rawSelectedDate && !rawNextSelectedDate) ||
+    (!rawSelectedDate && rawNextSelectedDate)
+  ) {
     return true;
   }
 

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.js
@@ -41,9 +41,11 @@ const focusedDateHasChanged = (currentProps, nextProps) => {
   const rawNextSelectedDate = nextProps.selectedDate || nextProps.date;
   const rawSelectedDate = currentProps.selectedDate || currentProps.date;
 
-  return (
-    rawNextSelectedDate && !isSameDay(rawNextSelectedDate, rawSelectedDate)
-  );
+  if (!rawNextSelectedDate) {
+    return true;
+  }
+
+  return !isSameDay(rawNextSelectedDate, rawSelectedDate);
 };
 
 const determineFocusedDate = (


### PR DESCRIPTION
# Description

Currently the flow is:
-  with no date selected the focus outline is on the `minDate` (See `determineFocusedDate` function) 
- a date is selected on the calendar, that date has a focus outline
- then the selected date is set to `null`, the focus outline will remain on the previously selected date

The desired flow is for the final point to change to:
- then the selected date is set to `null`, the focus outline will return to the `minDate`

At a code level what is happening is:
- The new `selectedDate` prop is given to the `BpkCalendarContainer`
- It runs `UNSAFE_componentWillReceiveProps`
- That runs `focusedDateHasChanged`

As the date could be passed in as `Date.now()` but we only care about the Day, not the time, then `isSameDay` is used to compare two Date type values.

Previously the check was:
```
rawNextSelectedDate && !isSameDay(rawNextSelectedDate, rawSelectedDate)
```

We can see here that in the case of `rawNextSelectedDate` being null then `false would be returned`.

The possible cases are:

| prevDate / nextDate | Is handled? |
| -- | --| 
| null / null     | This PR adds  |
| Date / null   | This PR adds, previously would be false|
| null / Date   | This PR adds |
| Date / Date | Already handled |

# Checklist

- [x] `UNRELEASED.md`
- ~[ ] `README.md`~
- [x] Tests
- ~[ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)~
