### PR TITLE
[BPK-3607] Make tooltips focusable and add required ariaLabel prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Breaking:**
+
+- bpk-component-tooltip:
+  - Added a required `ariaLabel` prop to improve accessibility. You **must** include this prop to describe the tooltip's content to assistive technologies. See [the documentation](https://backpack.github.io/components/tooltip/?platform=web#readme) for more information.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/packages/bpk-component-tooltip/README.md
+++ b/packages/bpk-component-tooltip/README.md
@@ -49,6 +49,8 @@ const App = () => (
 
 Tooltips are invisible to assistive technologies such as screen readers. To improve accessibility, `ariaLabel` is required to describe the content of the tooltip to assistive technologies.
 
+The label will be used on the `target` element, so any existing `aria-label` attached to `target` will be overridden.
+
 #### `popperModifiers`
 
 Please refer to the [documentation](https://github.com/FezVrasta/popper.js/blob/v1.12.9/docs/_includes/popper-documentation.md#modifiers) for the underlying positioning library "Popper.js". You can achieve various behaviours such as allowing the tooltip to overflow the viewport etc.

--- a/packages/bpk-component-tooltip/README.md
+++ b/packages/bpk-component-tooltip/README.md
@@ -17,6 +17,7 @@ import BpkTooltip from 'bpk-component-tooltip';
 
 const App = () => (
   <BpkTooltip
+    ariaLabel="London Heathrow"
     id="my-tooltip"
     target={<BpkText textStyle="lg">LHR</BpkText>}
   >
@@ -29,6 +30,7 @@ const App = () => (
 
 | Property              | PropType                                       | Required | Default Value       |
 | --------------------- | ---------------------------------------------- | -------- | ------------------- |
+| ariaLabel             | string                                         | true     | -                   |
 | id                    | string                                         | true     | -                   |
 | children              | node                                           | true     | -                   |
 | target                | node                                           | true     | -                   |
@@ -43,6 +45,10 @@ const App = () => (
 
 ### Prop Details
 
-#### popperModifiers
+#### `ariaLabel`
+
+Tooltips are invisible to assistive technologies such as screen readers. To improve accessibility, `ariaLabel` is required to describe the content of the tooltip to assistive technologies.
+
+#### `popperModifiers`
 
 Please refer to the [documentation](https://github.com/FezVrasta/popper.js/blob/v1.12.9/docs/_includes/popper-documentation.md#modifiers) for the underlying positioning library "Popper.js". You can achieve various behaviours such as allowing the tooltip to overflow the viewport etc.

--- a/packages/bpk-component-tooltip/examples.js
+++ b/packages/bpk-component-tooltip/examples.js
@@ -41,7 +41,11 @@ const Heading = withDefaultProps(BpkText, {
 
 const DefaultExample = () => (
   <div style={wrapperStyle}>
-    <BpkTooltip id="my-tooltip" target={<Heading>YUL</Heading>}>
+    <BpkTooltip
+      ariaLabel="Montréal-Trudeau International Airport"
+      id="my-tooltip"
+      target={<Heading>YUL</Heading>}
+    >
       Montréal-Trudeau International Airport
     </BpkTooltip>
   </div>
@@ -50,6 +54,7 @@ const DefaultExample = () => (
 const DarkExample = () => (
   <div style={wrapperStyle}>
     <BpkTooltip
+      ariaLabel="Edinburgh Airport"
       type={TOOLTIP_TYPES.dark}
       id="my-tooltip"
       target={<Heading>EDI</Heading>}
@@ -62,6 +67,7 @@ const DarkExample = () => (
 const SideExample = () => (
   <div style={wrapperStyle}>
     <BpkTooltip
+      ariaLabel="Julius Nyerere International Airport, Dar es Salaam"
       id="my-tooltip"
       target={<Heading>DAR</Heading>}
       placement="right"
@@ -73,7 +79,12 @@ const SideExample = () => (
 
 const NoPaddingExample = () => (
   <div style={{ height: '500px', margin: '30px', textAlign: 'center' }}>
-    <BpkTooltip id="my-tooltip" target={<Heading>SIN</Heading>} padded={false}>
+    <BpkTooltip
+      ariaLabel="Singapore Changi Airport"
+      id="my-tooltip"
+      target={<Heading>SIN</Heading>}
+      padded={false}
+    >
       <div
         style={{
           borderBottomWidth: '5px',
@@ -91,6 +102,7 @@ const NoPaddingExample = () => (
 const LinkExample = () => (
   <div style={wrapperStyle}>
     <BpkTooltip
+      ariaLabel="We do hotels too!"
       id="my-tooltip"
       target={
         <a
@@ -110,6 +122,7 @@ const LinkExample = () => (
 const PopperModifiersExample = () => (
   <div style={wrapperStyle}>
     <BpkTooltip
+      ariaLabel="Berlin Brandenburg Airport"
       id="my-tooltip"
       target={<Heading>BER</Heading>}
       popperModifiers={{
@@ -121,6 +134,42 @@ const PopperModifiersExample = () => (
   </div>
 );
 
+const FocusExample = () => (
+  <div style={wrapperStyle}>
+    <BpkTooltip
+      ariaLabel="Should be focused on first"
+      id="my-tooltip"
+      target={<Heading>One</Heading>}
+    >
+      Should be focused on first
+    </BpkTooltip>
+    <BpkTooltip
+      ariaLabel="Should be focused on second"
+      id="my-tooltip"
+      target={<Heading>Two</Heading>}
+    >
+      Should be focused on second
+    </BpkTooltip>
+    <BpkTooltip
+      ariaLabel="Should be focused on third"
+      id="my-tooltip"
+      target={<Heading>Three</Heading>}
+    >
+      Should be focused on third
+    </BpkTooltip>
+    <button type="button" onClick={() => {}}>
+      Four
+    </button>
+    <BpkTooltip
+      ariaLabel="Should be focused on fifth"
+      id="my-tooltip"
+      target={<Heading>Five</Heading>}
+    >
+      Should be focused on fifth
+    </BpkTooltip>
+  </div>
+);
+
 export {
   DefaultExample,
   DarkExample,
@@ -128,4 +177,5 @@ export {
   NoPaddingExample,
   LinkExample,
   PopperModifiersExample,
+  FocusExample,
 };

--- a/packages/bpk-component-tooltip/src/BpkTooltip.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltip.js
@@ -18,6 +18,12 @@
 
 /* @flow strict */
 
+/*
+This is the component for the tooltip that is displayed to users.
+
+The actual component that developers create (i.e. the default export from this package) is BpkTooltipPortal.
+*/
+
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';
 import { TransitionInitialMount, cssModules } from 'bpk-react-utils';

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal-test.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal-test.js
@@ -39,7 +39,11 @@ describe('BpkTooltipPortal', () => {
   it('should render correctly', () => {
     const tree = renderer
       .create(
-        <BpkTooltipPortal id="my-tooltip" target={<div>target</div>}>
+        <BpkTooltipPortal
+          ariaLabel="My tooltip content"
+          id="my-tooltip"
+          target={<div>target</div>}
+        >
           My tooltip content
         </BpkTooltipPortal>,
       )
@@ -52,6 +56,7 @@ describe('BpkTooltipPortal', () => {
     const tree = renderer
       .create(
         <BpkTooltipPortal
+          ariaLabel="My tooltip content"
           id="my-tooltip"
           target={<div>target</div>}
           portalClassName="my-custom-class"
@@ -68,6 +73,7 @@ describe('BpkTooltipPortal', () => {
     const tree = renderer
       .create(
         <BpkTooltipPortal
+          ariaLabel="My tooltip content"
           id="my-tooltip"
           target={<div>target</div>}
           className="my-custom-class"
@@ -84,6 +90,7 @@ describe('BpkTooltipPortal', () => {
     const tree = renderer
       .create(
         <BpkTooltipPortal
+          ariaLabel="My tooltip content"
           id="my-tooltip"
           target={<div>target</div>}
           portalStyle={{ color: colorPanjin }}

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -20,7 +20,7 @@
 
 import Popper from '@skyscanner/popper.js';
 import PropTypes from 'prop-types';
-import React, { Component, type Node } from 'react';
+import React, { Component, type Node, type Element } from 'react';
 import { Portal, cssModules } from 'bpk-react-utils';
 
 import BpkTooltip, {
@@ -42,7 +42,8 @@ const hasTouchSupport = () =>
 
 export type Props = {
   ...$Exact<TooltipProps>,
-  target: Node,
+  ariaLabel: string,
+  target: Element<any>,
   children: Node,
   placement: 'top' | 'right' | 'bottom' | 'left' | 'auto',
   hideOnTouchDevices: boolean,
@@ -63,6 +64,7 @@ class BpkTooltipPortal extends Component<Props, State> {
 
   static propTypes = {
     ...tooltipPropTypes,
+    ariaLabel: PropTypes.string.isRequired,
     target: PropTypes.node.isRequired,
     children: PropTypes.node.isRequired,
     placement: PropTypes.oneOf(Popper.placements),
@@ -98,6 +100,8 @@ class BpkTooltipPortal extends Component<Props, State> {
     if (this.targetRef) {
       const ref = this.targetRef;
 
+      ref.addEventListener('focusin', this.openTooltip);
+      ref.addEventListener('focusout', this.closeTooltip);
       ref.addEventListener('mouseenter', this.openTooltip);
       ref.addEventListener('mouseleave', this.closeTooltip);
     }
@@ -107,6 +111,8 @@ class BpkTooltipPortal extends Component<Props, State> {
     if (this.targetRef) {
       const ref = this.targetRef;
 
+      ref.addEventListener('focusin', this.openTooltip);
+      ref.addEventListener('focusout', this.closeTooltip);
       ref.removeEventListener('mouseenter', this.openTooltip);
       ref.removeEventListener('mouseleave', this.closeTooltip);
     }
@@ -154,6 +160,7 @@ class BpkTooltipPortal extends Component<Props, State> {
 
   render() {
     const {
+      ariaLabel,
       padded,
       target,
       children,
@@ -169,13 +176,18 @@ class BpkTooltipPortal extends Component<Props, State> {
     const classNames = [getClassName('bpk-tooltip-portal')];
     const renderPortal = !hasTouchSupport() || !hideOnTouchDevices;
 
+    const targetWithAccessibilityProps = React.cloneElement(target, {
+      tabIndex: '0',
+      'aria-label': ariaLabel,
+    });
+
     if (portalClassName) {
       classNames.push(portalClassName);
     }
 
     return renderPortal ? (
       <Portal
-        target={target}
+        target={targetWithAccessibilityProps}
         targetRef={targetRef => {
           this.targetRef = targetRef;
         }}
@@ -192,7 +204,7 @@ class BpkTooltipPortal extends Component<Props, State> {
         </BpkTooltip>
       </Portal>
     ) : (
-      target
+      targetWithAccessibilityProps
     );
   }
 }

--- a/packages/bpk-component-tooltip/src/__snapshots__/BpkTooltipPortal-test.js.snap
+++ b/packages/bpk-component-tooltip/src/__snapshots__/BpkTooltipPortal-test.js.snap
@@ -9,7 +9,10 @@ exports[`BpkTooltipPortal should render correctly 1`] = `
   renderTarget={null}
   style={null}
   target={
-    <div>
+    <div
+      aria-label="My tooltip content"
+      tabIndex="0"
+    >
       target
     </div>
   }
@@ -44,7 +47,10 @@ exports[`BpkTooltipPortal should render correctly with a custom portal className
   renderTarget={null}
   style={null}
   target={
-    <div>
+    <div
+      aria-label="My tooltip content"
+      tabIndex="0"
+    >
       target
     </div>
   }
@@ -79,7 +85,10 @@ exports[`BpkTooltipPortal should render correctly with a custom tooltip classNam
   renderTarget={null}
   style={null}
   target={
-    <div>
+    <div
+      aria-label="My tooltip content"
+      tabIndex="0"
+    >
       target
     </div>
   }
@@ -118,7 +127,10 @@ exports[`BpkTooltipPortal should render correctly with custom portal style 1`] =
     }
   }
   target={
-    <div>
+    <div
+      aria-label="My tooltip content"
+      tabIndex="0"
+    >
       target
     </div>
   }

--- a/packages/bpk-component-tooltip/stories.js
+++ b/packages/bpk-component-tooltip/stories.js
@@ -27,6 +27,7 @@ import {
   NoPaddingExample,
   LinkExample,
   PopperModifiersExample,
+  FocusExample,
 } from './examples';
 
 storiesOf('bpk-component-tooltip', module)
@@ -35,4 +36,5 @@ storiesOf('bpk-component-tooltip', module)
   .add('On the side', SideExample)
   .add('Without padding', NoPaddingExample)
   .add('On a link', LinkExample)
-  .add('Popper modifiers', PopperModifiersExample);
+  .add('Popper modifiers', PopperModifiersExample)
+  .add('Focus example', FocusExample);


### PR DESCRIPTION
In addition to this, I'm going to add a note to the docs site page to mention that tooltips aren't a great pattern as they don't work well on touchscreens.

- [x] `UNRELEASED.md`
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
