### PR TITLE
DINGO-4358: Android screenreader datepicker bug

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,13 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- bpk-component-datepicker:
+  - Remove `readOnly` prop from input as it is already set by the `withOpenEvents` HOC.
+- bpk-component-input:
+  - Fix input not being able to open on Android devices when rendered with `withOpenEvents`.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -124,7 +124,6 @@ class BpkDatepicker extends Component {
         onChange={() => null}
         onOpen={this.onOpen}
         isOpen={this.state.isOpen}
-        readOnly
         valid={valid}
         {...inputProps}
       />

--- a/packages/bpk-component-datepicker/src/__snapshots__/BpkDatepicker-test.js.snap
+++ b/packages/bpk-component-datepicker/src/__snapshots__/BpkDatepicker-test.js.snap
@@ -38,7 +38,6 @@ exports[`BpkDatepicker should render correctly 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   placeholder="placeholder"
-  readOnly={true}
   type="text"
   value="15/02/2010"
 />
@@ -60,7 +59,6 @@ exports[`BpkDatepicker should render correctly when not valid 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   placeholder="placeholder"
-  readOnly={true}
   type="text"
   value="15/02/2010"
 />

--- a/packages/bpk-component-input/src/__snapshots__/withOpenEvents-test.js.snap
+++ b/packages/bpk-component-input/src/__snapshots__/withOpenEvents-test.js.snap
@@ -3,11 +3,14 @@
 exports[`withOpenEvents should attach different event handlers when touch is supported 1`] = `
 <input
   aria-invalid={false}
+  aria-readonly={false}
   className="bpk-input bpk-input--with-open-events"
   id="my-input"
   name="my-input"
+  onBlur={[Function]}
   onChange={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   onTouchEnd={[Function]}

--- a/packages/bpk-component-input/src/withOpenEvents.js
+++ b/packages/bpk-component-input/src/withOpenEvents.js
@@ -115,16 +115,20 @@ const withOpenEvents = InputComponent => {
       };
 
       if (hasTouchSupport) {
-        // Prevents the mobile keyboard from opening (iOS / Android)
+        // Prevents the mobile keyboard from opening (iOS / Android), while not announcing it as 'read only' to a screen reader
         eventHandlers.readOnly = 'readOnly';
+        eventHandlers['aria-readonly'] = false;
+
         eventHandlers.onTouchEnd = withEventHandler(
           this.handleTouchEnd,
           onTouchEnd,
         );
-      } else {
-        eventHandlers.onFocus = withEventHandler(this.handleFocus, onFocus);
-        eventHandlers.onBlur = withEventHandler(this.handleBlur, onBlur);
       }
+
+      // Needed on desktop to allow the intended behaviour of opening on focus
+      // Needed on mobile as some Android devices do not trigger onClick or onTouch when TalkBack is active but do trigger onFocus
+      eventHandlers.onFocus = withEventHandler(this.handleFocus, onFocus);
+      eventHandlers.onBlur = withEventHandler(this.handleBlur, onBlur);
 
       return (
         <InputComponent


### PR DESCRIPTION
# Description 

The Datepicker component renders an input that when clicked opens either a popover (on desktop) or a full screen modal (mobile) containing a calendar.

On mobile the `readOnly` prop is applied to the input as a way to prevent the native keyboard opening when the input receives focus. The keyboard would be both interruptive and useless when the inputs value is controlled by the calendar component.

On iOS this works without problem, but on Android it has been found that the modal (containing the calendar) cannot be opened when a screen reader (TalkBack) is in use. The input receives accessibility focus, reads out that it is 'read only' but does not trigger either click or touch events. TalkBack seems to be trying to be clever and stopping these events from triggering due to the read only nature of the input.

Quick experimentation shows that `onFocus` does trigger, so is available for use. It triggers not on initial focus but after 'double tap to activate' has been used. This can be seen to first be assistive technology focus that then triggers the full browser focus.

The input in the Datepicker is constructed using `withOpenEvents(BpkInput)`. If we look inside `withOpenEvents` we can see that `onFocus` is already set up for desktop, but is not used on mobile. By allowing this to also work on mobile we see Android now works as expected, and iOS appears unaffected (which is good).

We can also add the `aria-readonly=false` attribute to prevent the screen reader confusing the user by announcing that the input is read only.

The only [reference to this externally](https://stackoverflow.com/questions/57719547/onclick-event-for-input-field-doesnt-work-while-accessibility-screen-reader-is) that I can find indicate that in older (v8) versions of Android this was not the behaviour - so when built this component likely did not have this problem but with newer versions of Android it has been introduced as a side effect.

# Checklist

- [x] `UNRELEASED.md`
- ~[ ] `README.md`~
- [x] Tests
- ~[ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)~
