### PR TITLE
[KOA-4458] Add some jest-axe tests and tweak accordion to pass a11y test

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,10 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+- bpk-component-accordion:
+  - Improved accessibility by removing invalid `aria-level="3"` attribute on `BpkAccordionItem`.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/decisions/accessibility-tests.md
+++ b/decisions/accessibility-tests.md
@@ -1,0 +1,8 @@
+# Accessibility tests
+
+## Decision
+We use [`jest-axe`](https://www.npmjs.com/package/jest-axe) to add automated accessibility tests to our components.
+
+Generally, we only test the public interface of a component to reflect how it would be used in reality. For example, we have an accessibility test for `BpkAccordion` with `BpkAccordionItem` children, but we don't test them separately because they would never be used that way by a consumer.
+
+We put the accessibility tests in their own test file, named `Bpk<ComponentName>-accessibility-test.js`.

--- a/flow-typed/npm/jest_v21.x.x.js
+++ b/flow-typed/npm/jest_v21.x.x.js
@@ -136,8 +136,12 @@ type EnzymeMatchersType = {
   toMatchSelector(selector: string): void
 };
 
+type JestAxeType = {
+  toHaveNoViolations(): void
+};
+
 type JestExpectType = {
-  not: JestExpectType & EnzymeMatchersType,
+  not: JestExpectType & EnzymeMatchersType & JestAxeType,
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -587,7 +591,7 @@ type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
-  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType & JestAxeType,
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,
   /** Add a module that formats application-specific data structures. */

--- a/packages/bpk-animate-height/src/AnimateHeight-accessibility-test.js
+++ b/packages/bpk-animate-height/src/AnimateHeight-accessibility-test.js
@@ -1,0 +1,35 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { axe } from 'jest-axe';
+import { render } from '@testing-library/react';
+
+import AnimateHeight from './AnimateHeight';
+
+describe('AnimateHeight accessibility tests', () => {
+  it('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(
+      <AnimateHeight duration={200} height="auto">
+        Content
+      </AnimateHeight>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/bpk-animate-height/src/AnimateHeight-accessibility-test.js
+++ b/packages/bpk-animate-height/src/AnimateHeight-accessibility-test.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 import { axe } from 'jest-axe';
 import { render } from '@testing-library/react';

--- a/packages/bpk-component-accordion/src/BpkAccordion-accessibility-test.js
+++ b/packages/bpk-component-accordion/src/BpkAccordion-accessibility-test.js
@@ -1,0 +1,38 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import BpkAccordion from './BpkAccordion';
+import BpkAccordionItem from './BpkAccordionItem';
+
+describe('BpkAccordion accessibility tests', () => {
+  it('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(
+      <BpkAccordion>
+        <BpkAccordionItem id="item" title="item">
+          Accordion item
+        </BpkAccordionItem>
+      </BpkAccordion>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -86,11 +86,7 @@ const BpkAccordionItem = (props: Props) => {
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
     <div id={id} {...rest}>
-      <dt
-        aria-level="3"
-        aria-labelledby={id}
-        className={getClassName('bpk-accordion__title')}
-      >
+      <dt aria-labelledby={id} className={getClassName('bpk-accordion__title')}>
         <button
           type="button"
           aria-expanded={expanded}

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -7,7 +7,6 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button
@@ -73,7 +72,6 @@ exports[`BpkAccordionItem should render correctly 1`] = `
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button
@@ -140,7 +138,6 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button
@@ -206,7 +203,6 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button
@@ -270,7 +266,6 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button
@@ -336,7 +331,6 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button
@@ -402,7 +396,6 @@ exports[`BpkAccordionItem should render correctly with "weight" prop set to bold
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button
@@ -468,7 +461,6 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button

--- a/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
@@ -7,7 +7,6 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button
@@ -73,7 +72,6 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button
@@ -139,7 +137,6 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
   >
     <dt
       aria-labelledby="my-accordion"
-      aria-level="3"
       class="bpk-accordion__title"
     >
       <button

--- a/packages/bpk-component-aria-live/src/BpkAriaLive-accessibility-test.js
+++ b/packages/bpk-component-aria-live/src/BpkAriaLive-accessibility-test.js
@@ -1,0 +1,32 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* @flow strict */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import BpkAriaLive from './BpkAriaLive';
+
+describe('BpkAriaLive accessibility tests', () => {
+  it('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(<BpkAriaLive>Backpack</BpkAriaLive>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggest-accessibility-test.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggest-accessibility-test.js
@@ -1,0 +1,59 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import BpkAutosuggest from './BpkAutosuggest';
+
+const suggestions = ['Edinburgh', 'Glasgow', 'London'];
+const onSuggestionsFetchRequested = () => null;
+const onSuggestionsClearRequested = () => null;
+const getSuggestionValue = suggestion => suggestion;
+const renderSuggestion = suggestion => <span>{suggestion}</span>;
+const inputProps = {
+  id: 'origin',
+  name: 'Origin',
+  value: 'Edinburgh',
+  onChange: () => null,
+};
+
+describe('BpkAutosuggest accessibility tests', () => {
+  /*
+  This component isn't as accessible as it could be due to the underlying
+  library we use for it. At some point we plan to replace it, but for now
+  it won't pass the accessibility test.
+  */
+  it.skip('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(
+      <BpkAutosuggest
+        suggestions={suggestions}
+        onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+        onSuggestionsClearRequested={onSuggestionsClearRequested}
+        getSuggestionValue={getSuggestionValue}
+        renderSuggestion={renderSuggestion}
+        inputProps={inputProps}
+      />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/bpk-component-badge/src/BpkBadge-accessibility-test.js
+++ b/packages/bpk-component-badge/src/BpkBadge-accessibility-test.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';

--- a/packages/bpk-component-badge/src/BpkBadge-accessibility-test.js
+++ b/packages/bpk-component-badge/src/BpkBadge-accessibility-test.js
@@ -1,0 +1,31 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import BpkBadge from './BpkBadge';
+
+describe('BpkBadge accessibility tests', () => {
+  it('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(<BpkBadge>Promociando</BpkBadge>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/bpk-component-button/src/BpkButton-accessibility-test.js
+++ b/packages/bpk-component-button/src/BpkButton-accessibility-test.js
@@ -16,24 +16,21 @@
  * limitations under the License.
  */
 
-/* @flow strict */
-
 import React from 'react';
-import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
+import { render } from '@testing-library/react';
 
-import BpkAccordion from './BpkAccordion';
-import BpkAccordionItem from './BpkAccordionItem';
+import BpkButton from './BpkButton';
 
-describe('BpkAccordion accessibility tests', () => {
-  it('should not have programmatically-detectable accessibility issues', async () => {
-    const { container } = render(
-      <BpkAccordion>
-        <BpkAccordionItem id="item" title="item">
-          Accordion item
-        </BpkAccordionItem>
-      </BpkAccordion>,
-    );
+describe('BpkButton accessibility tests', () => {
+  it('should not have programmatically-detectable accessibility issues when used as a button', async () => {
+    const { container } = render(<BpkButton>My button</BpkButton>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should not have programmatically-detectable accessibility issues when used as a link', async () => {
+    const { container } = render(<BpkButton href="#">My button</BpkButton>);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/packages/bpk-component-button/src/BpkButton-test.js
+++ b/packages/bpk-component-button/src/BpkButton-test.js
@@ -23,10 +23,8 @@ import { render } from '@testing-library/react';
 import BpkButton from './BpkButton';
 
 describe('BpkButton accessibility tests', () => {
-  it('should not have programmatically detectable accessibility issues', async () => {
-    const { container } = render(
-      <BpkButton onClick={() => {}}>My button</BpkButton>,
-    );
+  it('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(<BpkButton>My button</BpkButton>);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/packages/bpk-component-button/src/BpkButton-test.js
+++ b/packages/bpk-component-button/src/BpkButton-test.js
@@ -17,18 +17,9 @@
  */
 
 import React from 'react';
-import { axe } from 'jest-axe';
 import { render } from '@testing-library/react';
 
 import BpkButton from './BpkButton';
-
-describe('BpkButton accessibility tests', () => {
-  it('should not have programmatically-detectable accessibility issues', async () => {
-    const { container } = render(<BpkButton>My button</BpkButton>);
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
-  });
-});
 
 describe('BpkButton', () => {
   it('should render correctly', () => {


### PR DESCRIPTION
I migrated a few components just to validate the approach, and if we're happy with it I'll continue and do the rest.