### PR TITLE
Koa 4467 voiceover bug fix for calendar on iOS

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Fixed:**
+- bpk-component-calendar:
+  - Fixed an issue when AT changed the month from the calendar navigation drop down, users could not navigate dates outside the current week.

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -215,6 +215,7 @@ BpkCalendarGrid.defaultProps = {
   cellClassName: null,
 };
 
+// On iOS, having transitions causes accessibility issues, so we disable it (KOA-4467).
 const BpkCalendarGridWithTransition = isDeviceIos()
   ? BpkCalendarGrid
   : addCalendarGridTransition(BpkCalendarGrid);

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -215,7 +215,7 @@ BpkCalendarGrid.defaultProps = {
   cellClassName: null,
 };
 
-const BpkCalendarGridWithTransition = isDeviceIos
+const BpkCalendarGridWithTransition = isDeviceIos()
   ? BpkCalendarGrid
   : addCalendarGridTransition(BpkCalendarGrid);
 

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -18,7 +18,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { cssModules } from 'bpk-react-utils';
+import { cssModules, isDeviceIos } from 'bpk-react-utils';
 
 import BpkCalendarGridHeader from './BpkCalendarGridHeader';
 import Week from './Week';
@@ -215,9 +215,9 @@ BpkCalendarGrid.defaultProps = {
   cellClassName: null,
 };
 
-const BpkCalendarGridWithTransition = addCalendarGridTransition(
-  BpkCalendarGrid,
-);
+const BpkCalendarGridWithTransition = isDeviceIos
+  ? BpkCalendarGrid
+  : addCalendarGridTransition(BpkCalendarGrid);
 
 export default BpkCalendarGrid;
 export { BpkCalendarGridWithTransition };


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

This fixes an issue with iOS and iPadOS with Asssitive Technologies when changing the month from the calendar dropdown meant that voiceover would get stuck in the current selected week and unable to navigate to new date rows

To do this we check if the device is an iOS device and return the calendar without grid transitions as this was causing the bug, a follow up PR/ticket will be done to review the transitions. 

Remember to include the following changes:

- [x] `UNRELEASED.md`
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
