### PR TITLE
Update README.md

### DIFF
--- a/packages/bpk-component-dialog/README.md
+++ b/packages/bpk-component-dialog/README.md
@@ -93,6 +93,10 @@ This is required unless `dismissible` is false.
 
 This will change the style of the default flare view. Should you wish to apply an image to the flare you would pass the image using the CSS property `background-image`.
 
+#### getApplicationElement
+
+This is a function that should return the DOM node of the root of your application, the node returned will be hidden from screen readers when the dialog is displayed. Be careful to return the correct node from this, as on iPhone this element is actually hidden from view also.
+
 ## Theme Props
 
 - `linkColor`


### PR DESCRIPTION
Add a prop type description for `getApplicationElement` in bpk-dialog. This is as a result of a bug on mobile iOS where our incorrect usage of getApplicationElement meant we ended up hiding our own dialog from view, and users were then stuck.

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Remember to include the following changes:

- [ ] `UNRELEASED.md`
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
