### PR TITLE
A11y fixes for nudger axe tests

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Added:**
+- bpk-component-nudger:
+  - Fixed A11y jest axe test
+  - Added ability to spread `rest` across the input component to add `aria` and other `input` props.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,4 +1,3 @@
 **Added:**
 - bpk-component-nudger:
-  - Fixed A11y jest axe test
   - Added ability to spread `rest` across the input component to add `aria` and other `input` props.

--- a/packages/bpk-component-nudger/examples.js
+++ b/packages/bpk-component-nudger/examples.js
@@ -54,11 +54,11 @@ class NudgerContainer extends Component<
 
     return (
       <div>
-        <BpkLabel htmlFor={id} className={labelClassName}>
+        <BpkLabel id="passenger-label" htmlFor={id} className={labelClassName}>
           Number of passengers
         </BpkLabel>
         <BpkNudger
-          aria-label={`${this.state.value} passengers`}
+          aria-labelledby="passenger-label"
           id={id}
           min={1}
           max={10}
@@ -114,9 +114,12 @@ class ConfigurableNudgerContainer extends Component<{}, { value: string }> {
   render() {
     return (
       <div>
-        <BpkLabel htmlFor="nudger">Traveller Class</BpkLabel>
+        <BpkLabel id="traveller-label" htmlFor="nudger">
+          Traveller Class
+        </BpkLabel>
         <BpkConfigurableNudger
           id="nudger"
+          aria-labelledby="traveller-label"
           min="economy"
           max="first"
           value={this.state.value}

--- a/packages/bpk-component-nudger/examples.js
+++ b/packages/bpk-component-nudger/examples.js
@@ -58,13 +58,14 @@ class NudgerContainer extends Component<
           Number of passengers
         </BpkLabel>
         <BpkNudger
+          aria-label={`${this.state.value} passengers`}
           id={id}
           min={1}
           max={10}
           value={this.state.value}
           onChange={this.handleChange}
-          decreaseButtonLabel="Decrease"
-          increaseButtonLabel="Increase"
+          decreaseButtonLabel="Remove passenger"
+          increaseButtonLabel="Add passenger"
           buttonType={buttonType}
         />
       </div>

--- a/packages/bpk-component-nudger/src/BpkConfigurableNudger.js
+++ b/packages/bpk-component-nudger/src/BpkConfigurableNudger.js
@@ -65,6 +65,7 @@ const BpkConfigurableNudger = <T>(props: Props<T>) => {
     incrementValue,
     decrementValue,
     compareValues,
+    ...rest
   } = props;
   const classNames = [getClassName('bpk-nudger')];
   if (className) {
@@ -106,6 +107,7 @@ const BpkConfigurableNudger = <T>(props: Props<T>) => {
       >
         <AlignedMinusIcon className={minusIconClassNames.join(' ')} />
       </ButtonComponent>
+      {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'. */}
       <input
         type="text"
         aria-live="assertive"
@@ -113,6 +115,7 @@ const BpkConfigurableNudger = <T>(props: Props<T>) => {
         value={formatValue(value)}
         id={id}
         className={inputStyles.join(' ')}
+        {...rest}
       />
       <ButtonComponent
         iconOnly

--- a/packages/bpk-component-nudger/src/accessibility-test.js
+++ b/packages/bpk-component-nudger/src/accessibility-test.js
@@ -28,17 +28,23 @@ describe('BpkNudger accessibility tests', () => {
   use of a read only input. We should improve it soon and then
   this test will become possible.
   */
-  it.skip('should not have programmatically-detectable accessibility issues', async () => {
+  it('should not have programmatically-detectable accessibility issues', async () => {
     const { container } = render(
-      <BpkNudger
-        id="nudger"
-        min={1}
-        max={9}
-        value={2}
-        onChange={() => null}
-        decreaseButtonLabel="Decrease"
-        increaseButtonLabel="Increase"
-      />,
+      <div>
+        <label id="label" htmlFor="nudger">
+          Nudger
+        </label>
+        <BpkNudger
+          id="nudger"
+          aria-labelledby="label"
+          min={1}
+          max={9}
+          value={2}
+          onChange={() => null}
+          decreaseButtonLabel="Decrease"
+          increaseButtonLabel="Increase"
+        />
+      </div>,
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Fixed failing axe tests - turns out the test only needed a `<label>` or `aria-label`.

Also modifed the storybook example for the buttons to be more descriptive and add an `aria-label` to give context of the field value and when `aria-live` updates.

Remember to include the following changes:

- [x] `UNRELEASED.md`
- [ ] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
