### PR TITLE
Move "bpk-component-aria-live" to "dependencies" in "bpk-component-calendar"

### DIFF
--- a/packages/bpk-component-calendar/package.json
+++ b/packages/bpk-component-calendar/package.json
@@ -14,6 +14,7 @@
   },
   "gitHead": "6d446e75ee484e7babe153e3c7248fa1ed8bd46c",
   "dependencies": {
+    "bpk-component-aria-live": "^1.0.46",
     "bpk-component-icon": "^8.3.24",
     "bpk-component-select": "^3.0.119",
     "bpk-mixins": "^20.1.31",
@@ -26,7 +27,6 @@
     "react": "^16.0.0"
   },
   "devDependencies": {
-    "bpk-component-aria-live": "^1.0.46",
     "bpk-component-button": "^3.3.31",
     "bpk-component-text": "^3.1.50",
     "bpk-storybook-utils": "^0.0.19"


### PR DESCRIPTION
`bpk-component-aria-live` is used in [`BpkCalendarNav`](https://github.com/Skyscanner/backpack/blob/ffe76cabda2cb933de143e4c51f574a78290a284/packages/bpk-component-calendar/src/BpkCalendarNav.js#L25), so I think it should be in `dependencies` and not in `devDependencies`.

Remember to include the following changes:

- [ ] `UNRELEASED.md`
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
