### PR TITLE
[NO JIRA]: Changing the danger env token run correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm run danger
         if: github.ref != 'refs/heads/main' && github.repository == github.event.pull_request.head.repo.full_name
         env:
-          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Storybook
         run: |


### PR DESCRIPTION
Previously when using `DANGER_GITHUB_API_TOKEN` for the danger step it would fail due to not having the correct permissions to comment as `backpackbot` user.

![Screenshot 2021-04-28 at 17 53 42](https://user-images.githubusercontent.com/8831547/116447378-d5560800-a84f-11eb-8c61-9d5b736b831c.png)

Reviewing the following guidence for GH Actions from [dangerjs](https://danger.systems/js/guides/getting_started.html#setting-up-danger-to-run-on-your-ci) - it seems that danger works when you provide the default `GITHUB_ACTION` token that the CI generates at the start of each build to comment.

As you see from the below it now comments changes correct but rather than being the `backpackbot` user, it just comments as `github-actions` user. So I think its acceptable in order for this to work we don't use the `backpackbot` user for danger