### PR TITLE
[No Jira] Add some debug data for Week component

### DIFF
--- a/packages/bpk-component-calendar/examples.js
+++ b/packages/bpk-component-calendar/examples.js
@@ -20,6 +20,8 @@ import React, { Component } from 'react';
 import { action } from 'bpk-storybook-utils';
 import addMonths from 'date-fns/add_months';
 import BpkText from 'bpk-component-text';
+import startOfDay from 'date-fns/start_of_day';
+import parseDate from 'date-fns/parse';
 
 import {
   formatMonth,
@@ -35,6 +37,7 @@ import {
 } from './test-utils';
 import MonthViewCalendar from './examples-components';
 import ColoredCalendar from './coloured-calendar-example';
+import Week from './src/Week';
 
 import BpkCalendar, {
   // BpkCalendarView,
@@ -309,6 +312,57 @@ const CustomColors = () => (
   />
 );
 
+const WeekExample = () => {
+  // eslint-disable-next-line react/prop-types
+  const DummyDateComponent = ({ date }) => <div>{date.toString()}</div>;
+
+  const weekProps = {
+    ...Week.defaultProps,
+    DateComponent: DummyDateComponent,
+    dateModifiers: {},
+    dates: [
+      new Date(1980, 5, 10),
+      new Date(1980, 5, 11),
+      new Date(1980, 5, 12),
+      new Date(1980, 5, 13),
+      new Date(1980, 5, 14),
+      new Date(1980, 5, 15),
+      new Date(1980, 5, 16),
+    ].map(startOfDay),
+    daysOfWeek: weekDays,
+    formatDateFull: d => d.toString(),
+    preventKeyboardFocus: false,
+    showWeekendSeparator: true,
+    markToday: true,
+    markOutsideDays: true,
+    isKeyboardFocusable: true,
+    month: new Date(1980, 5, 1),
+    weekStartsOn: 0,
+  };
+
+  return (
+    <div>
+      <p>
+        This is an internal-only component, it&apos;s not exported to consumers.
+      </p>
+      <table>
+        <tbody>
+          <Week
+            {...weekProps}
+            selectionStart={parseDate(`19800611`)}
+            selectionEnd={parseDate(`19800616`)}
+          />
+          <Week
+            {...weekProps}
+            selectionStart={parseDate(`19800601`)}
+            selectionEnd={parseDate(`19800607`)}
+          />
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
 export {
   DefaultExample,
   CalendarNavExample,
@@ -328,4 +382,5 @@ export {
   CustomComposedCalendar,
   CustomComposedCalendarSafariBug,
   CustomColors,
+  WeekExample,
 };

--- a/packages/bpk-component-calendar/src/Week.js
+++ b/packages/bpk-component-calendar/src/Week.js
@@ -78,9 +78,14 @@ class Week extends Component {
       'cellClassName',
     ];
 
+    // If any of the props have changed, component should update.
     if (!shallowEqualProps(this.props, nextProps, shallowProps)) {
       return true;
     }
+
+    // If focusedDate is changing, and it'll be included as part
+    // of either the week we're rendering now or the next week
+    // we'll render, component should update.
     if (
       (isSameWeek(nextProps.focusedDate, nextProps.dates[0], {
         weekStartsOn: nextProps.weekStartsOn,
@@ -92,6 +97,10 @@ class Week extends Component {
     ) {
       return true;
     }
+
+    // If selected date is changing, and it'll be included as part
+    // of either the week we're rendering now or the next week we'll
+    // render, component should update.
     if (
       (isSameWeek(nextProps.selectedDate, nextProps.dates[0], {
         weekStartsOn: nextProps.weekStartsOn,
@@ -103,9 +112,13 @@ class Week extends Component {
     ) {
       return true;
     }
+
+    // If min date is changing, component should update.
     if (!isSameDay(nextProps.minDate, this.props.minDate)) {
       return true;
     }
+
+    // If max date is changing, component should update.
     if (!isSameDay(nextProps.maxDate, this.props.maxDate)) {
       return true;
     }
@@ -123,6 +136,7 @@ class Week extends Component {
       const firstDate = startOfDay(nextProps.dates[0]).getTime() - 1;
       const lastDate =
         startOfDay(nextProps.dates[nextProps.dates.length - 1]).getTime() + 1;
+
       if (
         areRangesOverlapping(
           this.props.selectionStart,

--- a/packages/bpk-component-calendar/stories.js
+++ b/packages/bpk-component-calendar/stories.js
@@ -37,6 +37,7 @@ import {
   CustomComposedCalendar,
   CustomComposedCalendarSafariBug,
   CustomColors,
+  WeekExample,
 } from './examples';
 
 storiesOf('bpk-component-calendar', module)
@@ -63,4 +64,5 @@ storiesOf('bpk-component-calendar', module)
     'Custom composed calendar (Safari DST bug)',
     CustomComposedCalendarSafariBug,
   )
-  .add('Custom colours', CustomColors);
+  .add('Custom colours', CustomColors)
+  .add('Week', WeekExample);


### PR DESCRIPTION
I've added a story example along with some comments for the Week component. I need to merge this to `main` so I can compare how it behaves with date-fns@2.0.0. Doesn't affect any functionality, it's all internal stuff.