### PR TITLE
[KOA-4564] Upgrade third-party dependencies for bar chart component

### DIFF
--- a/packages/bpk-component-barchart/package.json
+++ b/packages/bpk-component-barchart/package.json
@@ -18,8 +18,8 @@
     "bpk-mixins": "^20.1.33",
     "bpk-react-utils": "^3.1.0",
     "bpk-tokens": "^36.2.0",
-    "d3-path": "^1.0.5",
-    "d3-scale": "^2.1.0",
+    "d3-path": "^2.0.0",
+    "d3-scale": "^3.3.0",
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.6.2"
   },


### PR DESCRIPTION
These were non-breaking for us, as they just move to using ES2015 syntax that we already support.

- https://github.com/d3/d3-path/releases
- https://github.com/d3/d3-scale/releases

Ran locally in Storybook and all seems good.