### PR TITLE
[KOA-4570] Upgrade tether to 2.x

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Changed:**
+- bpk-tether:
+  - Upgraded `tether` to `2.0.0`.

--- a/packages/bpk-tether/package.json
+++ b/packages/bpk-tether/package.json
@@ -14,6 +14,6 @@
   },
   "gitHead": "09fc99e4e67a5b71dc15f41a5409ad412bc139d4",
   "dependencies": {
-    "tether": "^1.4.0"
+    "tether": "^2.0.0"
   }
 }


### PR DESCRIPTION
Ran locally and seems fine. The breaking change in 2.0 was removing something from git that we weren't using, so it's non breaking for us.