### PR TITLE
[KOA_3653]: 8px spacing fixes for icons

### DIFF
--- a/packages/bpk-tokens/src/web/base/icons.json
+++ b/packages/bpk-tokens/src/web/base/icons.json
@@ -1,17 +1,14 @@
 {
-  "imports": [
-    "./aliases.json"
-  ],
   "global": {
     "type": "size",
     "category": "icons"
   },
   "props": {
     "ICON_SIZE_SM": {
-      "value": "{!SPACING_MD}"
+      "value": "1.125rem"
     },
     "ICON_SIZE_LG": {
-      "value": "{!SPACING_BASE}"
+      "value": "1.5rem"
     }
   }
 }

--- a/packages/bpk-tokens/tokens/base.raw.json
+++ b/packages/bpk-tokens/tokens/base.raw.json
@@ -2128,14 +2128,14 @@
       "type": "size",
       "category": "icons",
       "value": "1.5rem",
-      "originalValue": "{!SPACING_BASE}",
+      "originalValue": "1.5rem",
       "name": "ICON_SIZE_LG"
     },
     "ICON_SIZE_SM": {
       "type": "size",
       "category": "icons",
       "value": "1.125rem",
-      "originalValue": "{!SPACING_MD}",
+      "originalValue": "1.125rem",
       "name": "ICON_SIZE_SM"
     },
     "INPUT_BACKGROUND": {


### PR DESCRIPTION
As part of the 8px spacing update #2148 - It was found that icons CSS/JS variables are currently using spacing tokens in order to determine their size. 

As such because we are not adjusting the sizing of the icons as part of the grid updates and they need to stay their same size as per icon design definition, this PR is migrating from using spacing tokens to having their correct sizing defined on the token. 


Remember to include the following changes:

- [Not applicable as this is an internal change to the current value] `UNRELEASED.md`
- [N/A] `README.md`
- [N/A] Tests
- [N/A] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
