### PR TITLE
Fix import in the bpk-component-skip-link example

### DIFF
--- a/packages/bpk-component-skip-link/README.md
+++ b/packages/bpk-component-skip-link/README.md
@@ -12,7 +12,7 @@ npm install bpk-component-skip-link --save-dev
 
 ```js
 import React from 'react';
-import BpkSkipLink from 'bpk-component-code';
+import BpkSkipLink from 'bpk-component-skip-link';
 
 export default () => <BpkSkipLink href="#main" label="Skip to main content" />;
 ```


### PR DESCRIPTION
I noticed this when browsing the docs site:
https://backpack.github.io/components/skip-link?platform=web

Remember to include the following changes:

- [ ] `UNRELEASED.md`
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
