### PR TITLE
[NO JIRA]: Add missing deprecation warning for bpk-spacing-xs()

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Fixed:**
+- bpk-tokens:
+  - Added missing deprecation warning for `bpk-spacing-xs()` function as this spacing no longer exists in the new grid system.

--- a/packages/bpk-tokens/src/web/base/spacing.json
+++ b/packages/bpk-tokens/src/web/base/spacing.json
@@ -8,8 +8,9 @@
   },
   "props": {
     "SPACING_FUNCTION_XS": {
-      "value": "@function bpk-spacing-xs() { @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return {!SPACING_SM_V2}; } @return {!SPACING_XS}; }",
-      "type": "function"
+      "value": "@function bpk-spacing-xs() { @warn 'bpk-spacing-xs has been deprecated in the new system and will be removed in the future.'; @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return {!SPACING_SM_V2}; } @return {!SPACING_XS}; }",
+      "type": "function",
+      "deprecated": true
     },
     "SPACING_XS": {
       "value": "{!SPACING_XS}"

--- a/packages/bpk-tokens/tokens/base.default.scss
+++ b/packages/bpk-tokens/tokens/base.default.scss
@@ -730,7 +730,7 @@ $bpk-spacing-base: 1.5rem !default;
 /// @group spacings
 @function bpk-spacing-xl() { @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return 2rem; } @return 2.250rem; }
 /// @group spacings
-@function bpk-spacing-xs() { @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return .25rem; } @return .375rem; }
+@function bpk-spacing-xs() { @warn 'bpk-spacing-xs has been deprecated in the new system and will be removed in the future.'; @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return .25rem; } @return .375rem; }
 /// @group spacings
 @function bpk-spacing-xxl() { @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return 2.5rem; } @return 2.625rem; }
 /// @group spacings

--- a/packages/bpk-tokens/tokens/base.raw.json
+++ b/packages/bpk-tokens/tokens/base.raw.json
@@ -2792,8 +2792,9 @@
     "SPACING_FUNCTION_XS": {
       "type": "function",
       "category": "spacings",
-      "value": "@function bpk-spacing-xs() { @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return .25rem; } @return .375rem; }",
-      "originalValue": "@function bpk-spacing-xs() { @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return {!SPACING_SM_V2}; } @return {!SPACING_XS}; }",
+      "value": "@function bpk-spacing-xs() { @warn 'bpk-spacing-xs has been deprecated in the new system and will be removed in the future.'; @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return .25rem; } @return .375rem; }",
+      "deprecated": true,
+      "originalValue": "@function bpk-spacing-xs() { @warn 'bpk-spacing-xs has been deprecated in the new system and will be removed in the future.'; @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return {!SPACING_SM_V2}; } @return {!SPACING_XS}; }",
       "name": "SPACING_FUNCTION_XS"
     },
     "SPACING_FUNCTION_XXL": {

--- a/packages/bpk-tokens/tokens/base.scss
+++ b/packages/bpk-tokens/tokens/base.scss
@@ -730,7 +730,7 @@ $bpk-spacing-base: 1.5rem;
 /// @group spacings
 @function bpk-spacing-xl() { @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return 2rem; } @return 2.250rem; }
 /// @group spacings
-@function bpk-spacing-xs() { @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return .25rem; } @return .375rem; }
+@function bpk-spacing-xs() { @warn 'bpk-spacing-xs has been deprecated in the new system and will be removed in the future.'; @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return .25rem; } @return .375rem; }
 /// @group spacings
 @function bpk-spacing-xxl() { @if global-variable-exists('bpk-spacing-v2') and $bpk-spacing-v2 { @return 2.5rem; } @return 2.625rem; }
 /// @group spacings


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

When we created the new spacing functions we forgot to add a deprecation warning for `bpi-spacing-xs()` as in the new spacing system this value is no longer part of the scale.

So adding this warning to alert consumers that they need to migrate away from `XS` size.

Remember to include the following changes:

- [x] `UNRELEASED.md`
- [N/A] `README.md`
- [x] Tests
- [N/A] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
