### PR TITLE
[KOA-4625]: Fixing components peer dependencies for React versions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Breaking:**
+
+- Updated peer dependencies versions for components that use newer React features to `16.3.0` as the minimum version.

--- a/packages/bpk-animate-height/package.json
+++ b/packages/bpk-animate-height/package.json
@@ -17,7 +17,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-accordion/package.json
+++ b/packages/bpk-component-accordion/package.json
@@ -22,7 +22,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-aria-live/package.json
+++ b/packages/bpk-component-aria-live/package.json
@@ -26,7 +26,7 @@
     "bpk-component-switch": "^1.2.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e"
 }

--- a/packages/bpk-component-autosuggest/package.json
+++ b/packages/bpk-component-autosuggest/package.json
@@ -21,7 +21,7 @@
     "react-autosuggest": "^9.4.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-icon": "^8.4.4"

--- a/packages/bpk-component-badge/package.json
+++ b/packages/bpk-component-badge/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-banner-alert/package.json
+++ b/packages/bpk-component-banner-alert/package.json
@@ -29,6 +29,6 @@
     "bpk-storybook-utils": "^0.1.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-barchart/package.json
+++ b/packages/bpk-component-barchart/package.json
@@ -24,7 +24,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-breakpoint": "^2.1.4",

--- a/packages/bpk-component-blockquote/package.json
+++ b/packages/bpk-component-blockquote/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-boilerplate/package.json
+++ b/packages/bpk-component-boilerplate/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-breadcrumb/package.json
+++ b/packages/bpk-component-breadcrumb/package.json
@@ -22,6 +22,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-breakpoint/package.json
+++ b/packages/bpk-component-breakpoint/package.json
@@ -20,7 +20,7 @@
     "react-responsive": "^5.0.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0"

--- a/packages/bpk-component-button/package.json
+++ b/packages/bpk-component-button/package.json
@@ -21,6 +21,6 @@
     "bpk-storybook-utils": "^0.1.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-calendar/package.json
+++ b/packages/bpk-component-calendar/package.json
@@ -24,7 +24,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.4.4",

--- a/packages/bpk-component-card/package.json
+++ b/packages/bpk-component-card/package.json
@@ -23,6 +23,6 @@
     "bpk-component-text": "^3.2.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-checkbox/package.json
+++ b/packages/bpk-component-checkbox/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-chip/package.json
+++ b/packages/bpk-component-chip/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-aria-live": "^1.1.5",

--- a/packages/bpk-component-close-button/package.json
+++ b/packages/bpk-component-close-button/package.json
@@ -23,6 +23,6 @@
     "bpk-storybook-utils": "^0.1.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-code/package.json
+++ b/packages/bpk-component-code/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-content-container/package.json
+++ b/packages/bpk-component-content-container/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-datatable/package.json
+++ b/packages/bpk-component-datatable/package.json
@@ -22,7 +22,7 @@
     "react-virtualized": "^9.22.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0"

--- a/packages/bpk-component-datepicker/package.json
+++ b/packages/bpk-component-datepicker/package.json
@@ -24,7 +24,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-description-list/package.json
+++ b/packages/bpk-component-description-list/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-dialog/package.json
+++ b/packages/bpk-component-dialog/package.json
@@ -22,7 +22,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.4.4",

--- a/packages/bpk-component-drawer/package.json
+++ b/packages/bpk-component-drawer/package.json
@@ -25,7 +25,7 @@
     "react-transition-group": "^2.5.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.4.4",

--- a/packages/bpk-component-fieldset/package.json
+++ b/packages/bpk-component-fieldset/package.json
@@ -21,7 +21,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-autosuggest": "^5.1.5",

--- a/packages/bpk-component-flare/package.json
+++ b/packages/bpk-component-flare/package.json
@@ -24,6 +24,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-form-validation/package.json
+++ b/packages/bpk-component-form-validation/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-grid-toggle/package.json
+++ b/packages/bpk-component-grid-toggle/package.json
@@ -20,6 +20,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-grid/package.json
+++ b/packages/bpk-component-grid/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-heading/package.json
+++ b/packages/bpk-component-heading/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-horizontal-nav/package.json
+++ b/packages/bpk-component-horizontal-nav/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-icon/package.json
+++ b/packages/bpk-component-icon/package.json
@@ -29,6 +29,6 @@
     "bpk-component-text": "^3.2.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-image/package.json
+++ b/packages/bpk-component-image/package.json
@@ -21,7 +21,7 @@
     "react-transition-group": "^2.5.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-infinite-scroll/package.json
+++ b/packages/bpk-component-infinite-scroll/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.4.4",

--- a/packages/bpk-component-input/package.json
+++ b/packages/bpk-component-input/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-banner-alert": "^4.3.5",

--- a/packages/bpk-component-label/package.json
+++ b/packages/bpk-component-label/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-link/package.json
+++ b/packages/bpk-component-link/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-list/package.json
+++ b/packages/bpk-component-list/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-loading-button/package.json
+++ b/packages/bpk-component-loading-button/package.json
@@ -25,6 +25,6 @@
     "bpk-storybook-utils": "^0.1.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-map/package.json
+++ b/packages/bpk-component-map/package.json
@@ -21,7 +21,7 @@
     "react-google-maps": "^9.4.5"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-icon": "^8.4.4",

--- a/packages/bpk-component-mobile-scroll-container/package.json
+++ b/packages/bpk-component-mobile-scroll-container/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0"

--- a/packages/bpk-component-modal/package.json
+++ b/packages/bpk-component-modal/package.json
@@ -24,7 +24,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.4.4",

--- a/packages/bpk-component-navigation-bar/package.json
+++ b/packages/bpk-component-navigation-bar/package.json
@@ -22,7 +22,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-navigation-stack/package.json
+++ b/packages/bpk-component-navigation-stack/package.json
@@ -21,7 +21,7 @@
     "react-transition-group": "^2.5.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.4.4",

--- a/packages/bpk-component-nudger/package.json
+++ b/packages/bpk-component-nudger/package.json
@@ -23,7 +23,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-label": "^4.1.4",

--- a/packages/bpk-component-overlay/package.json
+++ b/packages/bpk-component-overlay/package.json
@@ -18,7 +18,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-image": "^4.4.4",

--- a/packages/bpk-component-pagination/package.json
+++ b/packages/bpk-component-pagination/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-icon": "^8.4.4"

--- a/packages/bpk-component-panel/package.json
+++ b/packages/bpk-component-panel/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-paragraph/package.json
+++ b/packages/bpk-component-paragraph/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-phone-input/package.json
+++ b/packages/bpk-component-phone-input/package.json
@@ -24,7 +24,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-fieldset": "^2.1.5",

--- a/packages/bpk-component-popover/package.json
+++ b/packages/bpk-component-popover/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.4.4",

--- a/packages/bpk-component-progress/package.json
+++ b/packages/bpk-component-progress/package.json
@@ -21,7 +21,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.4.4",

--- a/packages/bpk-component-radio/package.json
+++ b/packages/bpk-component-radio/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-rating/package.json
+++ b/packages/bpk-component-rating/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-component-rtl-toggle/package.json
+++ b/packages/bpk-component-rtl-toggle/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-scrollable-calendar/package.json
+++ b/packages/bpk-component-scrollable-calendar/package.json
@@ -27,6 +27,6 @@
     "bpk-storybook-utils": "^0.1.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-section-list/package.json
+++ b/packages/bpk-component-section-list/package.json
@@ -25,6 +25,6 @@
     "bpk-storybook-utils": "^0.1.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-select/package.json
+++ b/packages/bpk-component-select/package.json
@@ -22,6 +22,6 @@
     "bpk-storybook-utils": "^0.1.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-skip-link/package.json
+++ b/packages/bpk-component-skip-link/package.json
@@ -10,7 +10,7 @@
   "author": "Backpack Design System <backpack@skyscanner.net>",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^16.3.0"
   },
   "dependencies": {
     "bpk-mixins": "^20.2.4",

--- a/packages/bpk-component-slider/package.json
+++ b/packages/bpk-component-slider/package.json
@@ -21,7 +21,7 @@
     "react-slider": "^1.1.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-rtl-toggle": "^2.1.5"

--- a/packages/bpk-component-spinner/package.json
+++ b/packages/bpk-component-spinner/package.json
@@ -20,6 +20,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-star-rating/package.json
+++ b/packages/bpk-component-star-rating/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-table": "^2.1.4",

--- a/packages/bpk-component-switch/package.json
+++ b/packages/bpk-component-switch/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-table/package.json
+++ b/packages/bpk-component-table/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-text/package.json
+++ b/packages/bpk-component-text/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-textarea/package.json
+++ b/packages/bpk-component-textarea/package.json
@@ -23,6 +23,6 @@
     "bpk-storybook-utils": "^0.1.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-theme-toggle/package.json
+++ b/packages/bpk-component-theme-toggle/package.json
@@ -23,6 +23,6 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-component-ticket/package.json
+++ b/packages/bpk-component-ticket/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "bpk-component-button": "^3.4.4",

--- a/packages/bpk-component-tooltip/package.json
+++ b/packages/bpk-component-tooltip/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@skyscanner/bpk-foundations-web": "^1.0.0",

--- a/packages/bpk-react-utils/package.json
+++ b/packages/bpk-react-utils/package.json
@@ -20,7 +20,7 @@
     "recompose": "^0.30.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   }
 }

--- a/packages/bpk-scrim-utils/package.json
+++ b/packages/bpk-scrim-utils/package.json
@@ -18,5 +18,8 @@
     "a11y-focus-store": "^1.0.0",
     "bpk-mixins": "^20.2.4",
     "bpk-react-utils": "^3.1.0"
+  },
+  "peerDependencies": {
+    "react": "^16.3.0"
   }
 }

--- a/packages/bpk-storybook-utils/package.json
+++ b/packages/bpk-storybook-utils/package.json
@@ -17,7 +17,7 @@
     "bpk-react-utils": "^3.1.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e"
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Fixing the peer dependencies for components to be the correct minimum React version to be `16.3.0` as our components use newer features.

The reason all packages in this case change is because the minimum version of React needed in `bpk-react-utils` is 16.3 - this is due to it using `UNSAFE_` features within this packages which is used by all components.

Remember to include the following changes:

- [x] `UNRELEASED.md`
- [x] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
