### PR TITLE
Modify banner alert roles for accessibility

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+- bpk-component-banner-alert:
+  - Updated role attribute for expandable alerts

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
@@ -153,7 +153,6 @@ const BpkBannerAlertInner = (props: Props) => {
   const isExpandable = configuration === CONFIGURATION.EXPANDABLE;
   const dismissable = configuration === CONFIGURATION.DISMISSABLE;
   const showChildren = isExpandable && expanded;
-  const ariaRoles = ['alert'];
 
   const headerClassNames = [getClassName('bpk-banner-alert__header')];
   const sectionClassNames = [
@@ -167,7 +166,6 @@ const BpkBannerAlertInner = (props: Props) => {
 
   if (isExpandable) {
     headerClassNames.push(getClassName('bpk-banner-alert__header--expandable'));
-    ariaRoles.push('button');
   }
 
   /* eslint-disable
@@ -184,9 +182,9 @@ const BpkBannerAlertInner = (props: Props) => {
       show={show}
       {...rest}
     >
-      <section className={sectionClassNames.join(' ')}>
+      <section className={sectionClassNames.join(' ')} role="alert">
         <div
-          role={ariaRoles.join(' ')}
+          role={isExpandable && 'button'}
           className={headerClassNames.join(' ')}
           onClick={onBannerExpandToggle}
         >

--- a/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlertInner-test.js.snap
+++ b/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlertInner-test.js.snap
@@ -9,10 +9,10 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--error"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -69,10 +69,10 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--error"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -129,10 +129,10 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--event"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -189,10 +189,10 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--neutral"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -249,10 +249,10 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--primary"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -309,10 +309,10 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--success"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -369,10 +369,10 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--warn"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -429,10 +429,10 @@ exports[`BpkBannerAlertInner should render correctly with a custom banner-alert 
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--warn custom-class"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -490,10 +490,10 @@ exports[`BpkBannerAlertInner should render correctly with a custom class name 1`
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--warn"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -550,10 +550,11 @@ exports[`BpkBannerAlertInner should render correctly with a element based messag
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--success"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header bpk-banner-alert__header--expandable"
-            role="alert button"
+            role="button"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -645,10 +646,10 @@ exports[`BpkBannerAlertInner should render correctly with animateOnLeave 1`] = `
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--warn"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -728,10 +729,10 @@ exports[`BpkBannerAlertInner should render correctly with arbitrary props 1`] = 
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--warn"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -788,10 +789,11 @@ exports[`BpkBannerAlertInner should render correctly with child nodes 1`] = `
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--success"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header bpk-banner-alert__header--expandable"
-            role="alert button"
+            role="button"
           >
             <span
               class="bpk-banner-alert__icon"
@@ -878,10 +880,10 @@ exports[`BpkBannerAlertInner should render correctly with dismissable option 1`]
       <div>
         <section
           class="bpk-banner-alert bpk-banner-alert--warn"
+          role="alert"
         >
           <div
             class="bpk-banner-alert__header"
-            role="alert"
           >
             <span
               class="bpk-banner-alert__icon"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

`<BpkBannerAlert>` with `isExpandable` would result in a role of `alert button` which was being flagged as invalid

Instead I've moved the `role=alert` up to the section, rather than the `div`, which is applicable for all banner alerts, and then if it is an expandable alert, add `role=button` on the div as it used to.

This way there are two elements with a single role, rather than one element with two roles on

Remember to include the following changes:

- [X] `UNRELEASED.md`
- [ ] `README.md`
- [X] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
