### PR TITLE
Fix role warning in bpk-component-banner-alert

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+- bpk-component-banner-alert:
+  - Updated role attribute for expandable alerts

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
@@ -184,7 +184,7 @@ const BpkBannerAlertInner = (props: Props) => {
     >
       <section className={sectionClassNames.join(' ')} role="alert">
         <div
-          role={isExpandable && 'button'}
+          role={isExpandable ? 'button' : undefined}
           className={headerClassNames.join(' ')}
           onClick={onBannerExpandToggle}
         >


### PR DESCRIPTION
[This change](https://github.com/Skyscanner/backpack/pull/2206) in `bpk-component-banner-alert` introduces a warning in the tests:
```
    Warning: Received `false` for a non-boolean attribute `role`.

    If you want to write it to the DOM, pass a string instead: role="false" or role={value.toString()}.

    If you used to conditionally omit it with role={condition && value}, pass role={condition ? value : undefined} instead.
```

As suggested, this pr changes the implementation to avoid providing a boolean to `role`.


Remember to include the following changes:

- [x] `UNRELEASED.md`
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
