### PR TITLE
NO-JIRA: Update react-responsive to v6 in bpk-component-breakpoint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Please include a description of the changes you are introducing and some screens
 
 Remember to include the following changes:
 
-- [ ] `UNRELEASED.md`
+- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
 - [ ] `README.md`
 - [ ] Tests
 - [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,4 @@
+**Fixed**
+
 - bpk-component-breakpoint:
   - Updated `react-responsive` dependency to 6.1.2. This requires a minimum React version of 16.3.0 as it migrates some life cycle methods to their `UNSAFE_` names.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,2 @@
+- bpk-component-breakpoint:
+  - Updated `react-responsive` dependency to 6.1.2. This requires a minimum React version of 16.3.0 as it migrates some life cycle methods to their `UNSAFE_` names.

--- a/packages/bpk-component-breakpoint/package-lock.json
+++ b/packages/bpk-component-breakpoint/package-lock.json
@@ -1,17 +1,18 @@
 {
 	"name": "bpk-component-breakpoint",
+	"version": "3.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"css-mediaquery": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
 			"integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
 		},
 		"hyphenate-style-name": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+			"version": "1.0.4",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+			"integrity": "sha1-aRh5r44iCupXUOiCfbTvYqVONh0="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -27,9 +28,9 @@
 			}
 		},
 		"matchmediaquery": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.0.tgz",
-			"integrity": "sha512-u0dlv+VENJ+3YepvwSPBieuvnA6DWfaYa/ctwysAR13y4XLJNyt7bEVKzNj/Nvjo+50d88Pj+xL9xaSo6JmX/w==",
+			"version": "0.3.1",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
+			"integrity": "sha1-gkftxH5Jnrt8WPYqn/nM9bgVxtc=",
 			"requires": {
 				"css-mediaquery": "^0.1.2"
 			}
@@ -49,9 +50,9 @@
 			}
 		},
 		"react-responsive": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-5.0.0.tgz",
-			"integrity": "sha512-oEimZ0FTCC3/pjGDEBHOz06nWbBNDIbMGOdRYp6K9SBUmrqgNAX77hTiqvmRQeLyI97zz4F4kiaFRxFspDxE+w==",
+			"version": "6.1.2",
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-responsive/-/react-responsive-6.1.2.tgz",
+			"integrity": "sha1-ubnMPuNfN+gMsDbxyQOO9zrskgs=",
 			"requires": {
 				"hyphenate-style-name": "^1.0.0",
 				"matchmediaquery": "^0.3.0",

--- a/packages/bpk-component-breakpoint/package.json
+++ b/packages/bpk-component-breakpoint/package.json
@@ -17,7 +17,7 @@
     "bpk-mixins": "^21.0.3",
     "bpk-react-utils": "^4.0.0",
     "prop-types": "^15.6.2",
-    "react-responsive": "^5.0.0"
+    "react-responsive": "^6.1.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"


### PR DESCRIPTION
`bpk-component-breakpoint` uses an older version of `react-responsive` that produces the following warnings when running locally:

![Screenshot 2021-07-20 at 11 25 27](https://user-images.githubusercontent.com/25118364/126310351-39437dd8-5180-4570-bff9-4223f239d438.png)

This PR updates to a newer version, but still not the latest.

v6 should fix this and requires 16.3.0, while v7+ require 16.8.0 which Backpack currently does not support as a minimum version.

https://github.com/contra/react-responsive/blob/master/CHANGELOG.md#v600


Remember to include the following changes:

- [x] `UNRELEASED.md`
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
