### PR TITLE
[no-jira]: fixing bpk dependencies check script to support @skyscanner packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "create-component": "node scripts/npm/create-component.js",
     "danger": "danger ci",
     "fix-bpk-dependencies": "node scripts/npm/check-bpk-dependencies.js --fix",
+    "upgrade-foundations": "node scripts/npm/check-bpk-dependencies.js --fix --upgrade-foundations",
     "flow": "flow --max-warnings 0",
     "flow-typed": "flow-typed",
     "format:packagejson": "format-package -w",

--- a/packages/bpk-animate-height/package.json
+++ b/packages/bpk-animate-height/package.json
@@ -20,7 +20,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-button": "^5.0.4"
   }
 }

--- a/packages/bpk-component-accordion/package.json
+++ b/packages/bpk-component-accordion/package.json
@@ -25,7 +25,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-checkbox": "^3.0.7"
   }
 }

--- a/packages/bpk-component-badge/package.json
+++ b/packages/bpk-component-badge/package.json
@@ -22,7 +22,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-icon": "^9.0.7",
     "bpk-storybook-utils": "^1.0.5"
   }

--- a/packages/bpk-component-banner-alert/package.json
+++ b/packages/bpk-component-banner-alert/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-animate-height": "^4.0.5",
     "bpk-component-close-button": "^3.0.7",
     "bpk-component-icon": "^9.0.7",

--- a/packages/bpk-component-barchart/package.json
+++ b/packages/bpk-component-barchart/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-mobile-scroll-container": "^3.0.6",
     "bpk-mixins": "^22.0.0",
     "bpk-react-utils": "^4.0.0",

--- a/packages/bpk-component-breakpoint/package.json
+++ b/packages/bpk-component-breakpoint/package.json
@@ -23,6 +23,6 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0"
+    "@skyscanner/bpk-foundations-web": "^1.1.0"
   }
 }

--- a/packages/bpk-component-calendar/package.json
+++ b/packages/bpk-component-calendar/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-aria-live": "^2.0.10",
     "bpk-component-icon": "^9.0.7",
     "bpk-component-select": "^5.0.0",

--- a/packages/bpk-component-checkbox/package.json
+++ b/packages/bpk-component-checkbox/package.json
@@ -23,7 +23,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-storybook-utils": "^1.0.5"
   }
 }

--- a/packages/bpk-component-datatable/package.json
+++ b/packages/bpk-component-datatable/package.json
@@ -25,6 +25,6 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0"
+    "@skyscanner/bpk-foundations-web": "^1.1.0"
   }
 }

--- a/packages/bpk-component-datepicker/package.json
+++ b/packages/bpk-component-datepicker/package.json
@@ -27,7 +27,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-storybook-utils": "^1.0.5"
   }
 }

--- a/packages/bpk-component-drawer/package.json
+++ b/packages/bpk-component-drawer/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-close-button": "^3.0.7",
     "bpk-component-icon": "^9.0.7",
     "bpk-component-link": "^3.0.5",

--- a/packages/bpk-component-form-validation/package.json
+++ b/packages/bpk-component-form-validation/package.json
@@ -23,7 +23,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-button": "^5.0.4",
     "bpk-component-checkbox": "^3.0.7",
     "bpk-component-icon": "^9.0.7",

--- a/packages/bpk-component-horizontal-nav/package.json
+++ b/packages/bpk-component-horizontal-nav/package.json
@@ -23,7 +23,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-text": "^4.0.7",
     "bpk-storybook-utils": "^1.0.5"
   }

--- a/packages/bpk-component-icon/package.json
+++ b/packages/bpk-component-icon/package.json
@@ -17,8 +17,8 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
-    "@skyscanner/bpk-svgs": "^12.7.2",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
+    "@skyscanner/bpk-svgs": "^12.7.3",
     "bpk-mixins": "^22.0.0",
     "bpk-react-utils": "^4.0.0",
     "prop-types": "^15.6.2"

--- a/packages/bpk-component-image/package.json
+++ b/packages/bpk-component-image/package.json
@@ -24,7 +24,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-mobile-scroll-container": "^3.0.6",
     "bpk-component-text": "^4.0.7"
   }

--- a/packages/bpk-component-link/package.json
+++ b/packages/bpk-component-link/package.json
@@ -22,7 +22,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-storybook-utils": "^1.0.5"
   }
 }

--- a/packages/bpk-component-mobile-scroll-container/package.json
+++ b/packages/bpk-component-mobile-scroll-container/package.json
@@ -23,6 +23,6 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0"
+    "@skyscanner/bpk-foundations-web": "^1.1.0"
   }
 }

--- a/packages/bpk-component-navigation-bar/package.json
+++ b/packages/bpk-component-navigation-bar/package.json
@@ -25,7 +25,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-icon": "^9.0.7",
     "bpk-storybook-utils": "^1.0.5"
   }

--- a/packages/bpk-component-navigation-stack/package.json
+++ b/packages/bpk-component-navigation-stack/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-mixins": "^22.0.0",
     "bpk-react-utils": "^4.0.0",
     "prop-types": "^15.6.2",

--- a/packages/bpk-component-nudger/package.json
+++ b/packages/bpk-component-nudger/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-button": "^5.0.4",
     "bpk-component-icon": "^9.0.7",
     "bpk-mixins": "^22.0.0",

--- a/packages/bpk-component-phone-input/package.json
+++ b/packages/bpk-component-phone-input/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-input": "^6.0.10",
     "bpk-component-label": "^5.0.5",
     "bpk-component-select": "^5.0.0",

--- a/packages/bpk-component-progress/package.json
+++ b/packages/bpk-component-progress/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-mixins": "^22.0.0",
     "bpk-react-utils": "^4.0.0",
     "lodash.clamp": "^4.0.3",

--- a/packages/bpk-component-radio/package.json
+++ b/packages/bpk-component-radio/package.json
@@ -22,7 +22,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-storybook-utils": "^1.0.5"
   }
 }

--- a/packages/bpk-component-rating/package.json
+++ b/packages/bpk-component-rating/package.json
@@ -23,7 +23,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-text": "^4.0.7"
   }
 }

--- a/packages/bpk-component-scrollable-calendar/package.json
+++ b/packages/bpk-component-scrollable-calendar/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-calendar": "^9.0.9",
     "bpk-component-text": "^4.0.7",
     "bpk-mixins": "^22.0.0",

--- a/packages/bpk-component-section-list/package.json
+++ b/packages/bpk-component-section-list/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "f9f94f86d7cfc75e43bc6ad5eb01b23e62a89cc8",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-icon": "^9.0.7",
     "bpk-component-text": "^4.0.7",
     "bpk-mixins": "^22.0.0",

--- a/packages/bpk-component-slider/package.json
+++ b/packages/bpk-component-slider/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-mixins": "^22.0.0",
     "bpk-react-utils": "^4.0.0",
     "prop-types": "^15.6.2",

--- a/packages/bpk-component-spinner/package.json
+++ b/packages/bpk-component-spinner/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e",
   "dependencies": {
-    "@skyscanner/bpk-svgs": "^12.7.2",
+    "@skyscanner/bpk-svgs": "^12.7.3",
     "bpk-mixins": "^22.0.0",
     "bpk-react-utils": "^4.0.0",
     "prop-types": "^15.6.2"

--- a/packages/bpk-component-theme-toggle/package.json
+++ b/packages/bpk-component-theme-toggle/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-label": "^5.0.5",
     "bpk-component-select": "^5.0.0",
     "bpk-mixins": "^22.0.0",

--- a/packages/bpk-component-tooltip/package.json
+++ b/packages/bpk-component-tooltip/package.json
@@ -23,7 +23,7 @@
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-component-text": "^4.0.7"
   }
 }

--- a/packages/bpk-mixins/package.json
+++ b/packages/bpk-mixins/package.json
@@ -14,8 +14,8 @@
   },
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
-    "@skyscanner/bpk-svgs": "^12.7.2"
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
+    "@skyscanner/bpk-svgs": "^12.7.3"
   },
   "peerDependencies": {
     "node-sass": "^4.12.0"

--- a/packages/bpk-stylesheets/package.json
+++ b/packages/bpk-stylesheets/package.json
@@ -17,7 +17,7 @@
   },
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "bpk-mixins": "^22.0.0",
     "normalize.css": "4.2.0"
   }

--- a/packages/bpk-theming/package.json
+++ b/packages/bpk-theming/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "c2217d61875a1f3aa2bb9ed9583c50e3f1523501",
   "dependencies": {
-    "@skyscanner/bpk-foundations-web": "^1.0.0",
+    "@skyscanner/bpk-foundations-web": "^1.1.0",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {

--- a/scripts/npm/check-bpk-dependencies.js
+++ b/scripts/npm/check-bpk-dependencies.js
@@ -115,11 +115,7 @@ const getLatestProductionVersion = version => {
 
 const getBpkPackageVersions = packageFiles =>
   packageFiles.reduce((acc, pkg) => {
-    if (
-      pkg === '' ||
-      !pkg.includes('bpk-') ||
-      !pkg.includes('@skyscanner/bpk-')
-    ) {
+    if (pkg === '' || !pkg.includes('bpk-')) {
       return acc;
     }
     const pfContent = JSON.parse(fs.readFileSync(pkg));
@@ -139,6 +135,21 @@ let packageFiles = execSync(
 
 packageFiles = packageFiles.filter(s => s !== '');
 const bpkPackageVersions = getBpkPackageVersions(packageFiles);
+
+const svgsVersion = execSync('npm show @skyscanner/bpk-svgs version')
+  .toString()
+  .split('\n');
+
+const foundationsVersion = execSync(
+  'npm show @skyscanner/bpk-foundations-web version',
+)
+  .toString()
+  .split('\n');
+
+// eslint-disable-next-line prefer-destructuring
+bpkPackageVersions['@skyscanner/bpk-svgs'] = svgsVersion[0];
+// eslint-disable-next-line prefer-destructuring
+bpkPackageVersions['@skyscanner/bpk-foundations-web'] = foundationsVersion[0];
 
 packageFiles.forEach(pf => {
   checkBpkDependencies(pf, bpkPackageVersions);

--- a/scripts/npm/check-bpk-dependencies.js
+++ b/scripts/npm/check-bpk-dependencies.js
@@ -136,20 +136,25 @@ let packageFiles = execSync(
 packageFiles = packageFiles.filter(s => s !== '');
 const bpkPackageVersions = getBpkPackageVersions(packageFiles);
 
-const svgsVersion = execSync('npm show @skyscanner/bpk-svgs version')
-  .toString()
-  .split('\n');
+if (
+  process.argv.includes('--upgrade-foundations') ||
+  process.argv.includes('-uf')
+) {
+  const svgsVersion = execSync('npm show @skyscanner/bpk-svgs version')
+    .toString()
+    .split('\n');
 
-const foundationsVersion = execSync(
-  'npm show @skyscanner/bpk-foundations-web version',
-)
-  .toString()
-  .split('\n');
+  const foundationsVersion = execSync(
+    'npm show @skyscanner/bpk-foundations-web version',
+  )
+    .toString()
+    .split('\n');
 
-// eslint-disable-next-line prefer-destructuring
-bpkPackageVersions['@skyscanner/bpk-svgs'] = svgsVersion[0];
-// eslint-disable-next-line prefer-destructuring
-bpkPackageVersions['@skyscanner/bpk-foundations-web'] = foundationsVersion[0];
+  // eslint-disable-next-line prefer-destructuring
+  bpkPackageVersions['@skyscanner/bpk-svgs'] = svgsVersion[0];
+  // eslint-disable-next-line prefer-destructuring
+  bpkPackageVersions['@skyscanner/bpk-foundations-web'] = foundationsVersion[0];
+}
 
 packageFiles.forEach(pf => {
   checkBpkDependencies(pf, bpkPackageVersions);


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Whilst reviewing dependency versions I found that the `check-bpk-dependencies` script didn't work as expected for working with the external foundations packages and therefore not updating foundations dependencies correctly in projects (particularly if we run major releases).

This PR solves this and fixes the package.json files to update to the latest versions of foundations and svgs (not lockfiles as these install in range already).

Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
