### PR TITLE
[KOA-4642] Improve the accessibility of Bar Chart

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,5 @@
+**Fixed:**
+- bpk-component-barchart:
+  - Axes are now hidden from assistive technology as the information they convey is included in the bars themselves.
+  - Each bar is now exposed to AT as a single element, instead of multiple.
+

--- a/packages/bpk-component-barchart/src/BpkBarchartBar.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartBar.js
@@ -94,7 +94,6 @@ const BpkBarchartBar = (props: Props) => {
 
   return (
     <g className={classNames} transform={`translate(${x}, ${y})`}>
-      <title>{label}</title>
       {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'. */}
       <rect
         className={rectClassNames}

--- a/packages/bpk-component-barchart/src/BpkChartAxis.js
+++ b/packages/bpk-component-barchart/src/BpkChartAxis.js
@@ -126,6 +126,7 @@ const BpkChartAxis = (props: Props) => {
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
     <g
       className={getClassName('bpk-chart__axis')}
+      aria-hidden="true"
       {...containerProps}
       {...rest}
     >

--- a/packages/bpk-component-barchart/src/__snapshots__/BpkBarchartBar-test.js.snap
+++ b/packages/bpk-component-barchart/src/__snapshots__/BpkBarchartBar-test.js.snap
@@ -7,9 +7,6 @@ exports[`BpkBarchartBar should render as an outlier 1`] = `
       class="bpk-barchart-bar"
       transform="translate(10, 10)"
     >
-      <title>
-        Bar
-      </title>
       <rect
         class="bpk-barchart-bar__rect bpk-barchart-bar__rect--outlier"
         height="100"
@@ -40,9 +37,6 @@ exports[`BpkBarchartBar should render as aria-pressed if onClick present and sel
       class="bpk-barchart-bar bpk-barchart-bar--selected bpk-barchart-bar--interactive"
       transform="translate(10, 10)"
     >
-      <title>
-        Bar
-      </title>
       <rect
         class="bpk-barchart-bar__rect"
         height="100"
@@ -75,9 +69,6 @@ exports[`BpkBarchartBar should render as selected 1`] = `
       class="bpk-barchart-bar bpk-barchart-bar--selected"
       transform="translate(10, 10)"
     >
-      <title>
-        Bar
-      </title>
       <rect
         class="bpk-barchart-bar__rect"
         height="100"
@@ -108,9 +99,6 @@ exports[`BpkBarchartBar should render correctly 1`] = `
       class="bpk-barchart-bar"
       transform="translate(10, 10)"
     >
-      <title>
-        Bar
-      </title>
       <rect
         class="bpk-barchart-bar__rect"
         height="100"
@@ -141,9 +129,6 @@ exports[`BpkBarchartBar should render with "padding" prop 1`] = `
       class="bpk-barchart-bar"
       transform="translate(10, 10)"
     >
-      <title>
-        Bar
-      </title>
       <rect
         class="bpk-barchart-bar__rect"
         height="100"
@@ -174,9 +159,6 @@ exports[`BpkBarchartBar should render with an onClick handler 1`] = `
       class="bpk-barchart-bar bpk-barchart-bar--interactive"
       transform="translate(10, 10)"
     >
-      <title>
-        Bar
-      </title>
       <rect
         class="bpk-barchart-bar__rect"
         height="100"
@@ -209,9 +191,6 @@ exports[`BpkBarchartBar should render with an onHover handler 1`] = `
       class="bpk-barchart-bar bpk-barchart-bar--interactive"
       transform="translate(10, 10)"
     >
-      <title>
-        Bar
-      </title>
       <rect
         class="bpk-barchart-bar__rect"
         height="100"

--- a/packages/bpk-component-barchart/src/__snapshots__/BpkChartAxis-test.js.snap
+++ b/packages/bpk-component-barchart/src/__snapshots__/BpkChartAxis-test.js.snap
@@ -4,6 +4,7 @@ exports[`BpkChartAxis X should render band scale 1`] = `
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="middle"
       transform="translate(0, 120)"
@@ -83,6 +84,7 @@ exports[`BpkChartAxis X should render band scale with "tickEvery" and "tickOffse
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="middle"
       transform="translate(0, 120)"
@@ -129,6 +131,7 @@ exports[`BpkChartAxis X should render band scale with "tickEvery" attribute 1`] 
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="middle"
       transform="translate(0, 120)"
@@ -175,6 +178,7 @@ exports[`BpkChartAxis X should render linear scale 1`] = `
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="middle"
       transform="translate(0, 120)"
@@ -287,6 +291,7 @@ exports[`BpkChartAxis X should render linear scale with "numTicks" attribute 1`]
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="middle"
       transform="translate(0, 120)"
@@ -322,6 +327,7 @@ exports[`BpkChartAxis X should render with label 1`] = `
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="middle"
       transform="translate(0, 120)"
@@ -442,6 +448,7 @@ exports[`BpkChartAxis Y should render band scale 1`] = `
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="end"
       transform="translate(0, 0)"
@@ -527,6 +534,7 @@ exports[`BpkChartAxis Y should render band scale with "tickEvery" and "tickOffse
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="end"
       transform="translate(0, 0)"
@@ -576,6 +584,7 @@ exports[`BpkChartAxis Y should render band scale with "tickEvery" attribute 1`] 
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="end"
       transform="translate(0, 0)"
@@ -625,6 +634,7 @@ exports[`BpkChartAxis Y should render linear scale 1`] = `
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="end"
       transform="translate(0, 0)"
@@ -746,6 +756,7 @@ exports[`BpkChartAxis Y should render linear scale with "numTicks" attribute 1`]
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="end"
       transform="translate(0, 0)"
@@ -783,6 +794,7 @@ exports[`BpkChartAxis Y should render with label 1`] = `
 <DocumentFragment>
   <svg>
     <g
+      aria-hidden="true"
       class="bpk-chart__axis"
       text-anchor="end"
       transform="translate(0, 0)"


### PR DESCRIPTION
# Before:

 - Axes are read out separately, although they don't really convey any information on their own
 - Each bar appears as 3 elements

https://user-images.githubusercontent.com/30267516/128365054-a58ded23-ed0e-4a1b-8baa-8b995c644744.mov

# After

 - Axes are skipped
  - Each bar appears as a single element

https://user-images.githubusercontent.com/30267516/128365072-8e9b637c-e9e6-495a-972c-b3331d7a0a1b.mov

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
