### PR TITLE
[KOA-4704]Fix tertiary label wrapping when using hanzi (Chinese characters)

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,5 @@
+# 2021-08-11
+**Fixed:**
+
+- `bpk-component-autosuggest`
+  - Fix tertiary label wrapping when using `hanzi` (Chinese characters) to make sure it won't occupy a large height.

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggest.module.scss
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggest.module.scss
@@ -135,6 +135,7 @@
     &-tertiary-label {
       display: table-cell;
       vertical-align: top;
+      word-break: keep-all;
 
       @include bpk-text;
       @include bpk-text--xs;

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion-test.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion-test.js
@@ -60,6 +60,16 @@ describe('BpkAutosuggestSuggestion', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  it('should render correctly with a "tertiaryLabel" but without a "subHeading" attribute when using hanzi', () => {
+    const { asFragment } = render(
+      <BpkAutosuggestSuggestion
+        value="深圳寶安國際"
+        tertiaryLabel="三級標籤"
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it('should render correctly with an "icon" attribute', () => {
     const { asFragment } = render(
       <BpkAutosuggestSuggestion value="Edinburgh" icon={FlightIcon} />,

--- a/packages/bpk-component-autosuggest/src/__snapshots__/BpkAutosuggestSuggestion-test.js.snap
+++ b/packages/bpk-component-autosuggest/src/__snapshots__/BpkAutosuggestSuggestion-test.js.snap
@@ -138,6 +138,32 @@ exports[`BpkAutosuggestSuggestion should render correctly with a "tertiaryLabel"
 </DocumentFragment>
 `;
 
+exports[`BpkAutosuggestSuggestion should render correctly with a "tertiaryLabel" but without a "subHeading" attribute when using hanzi 1`] = `
+<DocumentFragment>
+  <section
+    class="bpk-autosuggest__suggestion"
+  >
+    <div
+      class="bpk-autosuggest__suggestion-inner"
+    >
+      <span
+        class="bpk-autosuggest__suggestion-value"
+      >
+        深圳寶安國際
+      </span>
+      <small
+        class="bpk-autosuggest__suggestion-sub-heading"
+      />
+      <aside
+        class="bpk-autosuggest__suggestion-tertiary-label"
+      >
+        三級標籤
+      </aside>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
 exports[`BpkAutosuggestSuggestion should render correctly with a "value" attribute being an element 1`] = `
 <DocumentFragment>
   <section


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
## Context

See Slack thread: https://skyscanner.slack.com/archives/C0JHPDSSU/p1628653629032400



### [KOA-4704](https://gojira.skyscanner.net/browse/KOA-4704)

### Why Are We Making This Change?

`BpkAutosuggestSuggestion` tertiary label will force line breaks for Asian characters, which will occupy a large height when the word is long. 


### What Predictions Do We Have About When This Goes Live? 

- FIxed the bug and make sure that hanzi will look correct in tertiary label.

### Change Description

- add `word-break: keep-all;` to `BpkAutosuggest.module.scss` to adjust hanzi but keep other characters normal
- add releted tests

### Screenshots



#### Mobile

| Before                                                       | After                                                        |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| ![image-20210812145006273](https://user-images.githubusercontent.com/86780745/129152806-307d3659-902d-4ee6-8f7d-618afacf2148.png) | ![image-20210812145048669](https://user-images.githubusercontent.com/86780745/129152826-7e1be18e-64f5-413a-9d00-47b954889aec.png) |




#### Desktop

| Before                                                       | After                                                        |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| ![image-20210812144826782](https://user-images.githubusercontent.com/86780745/129152750-e5e729e0-b19f-4ec3-96ec-ef9c596980cb.png) | ![image-20210812144800106](https://user-images.githubusercontent.com/86780745/129152689-7444f966-062c-4b06-ac93-b2829e444fa8.png) |







Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
