### PR TITLE
[KOA-3657] Update nudger component to use the new spacing grid

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+- bpk-component-nudger:
+  - Updating the nudger component to use the new spacing grid.

--- a/packages/bpk-component-nudger/src/BpkNudger.module.css
+++ b/packages/bpk-component-nudger/src/BpkNudger.module.css
@@ -15,4 +15,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-@keyframes bpk-keyframe-spin{100%{transform:rotate(1turn)}}.bpk-nudger__button{position:relative}.bpk-nudger__input{display:inline-block;padding:.375rem 0;border:none;text-align:center;vertical-align:middle;margin:0;font-size:1.5rem;line-height:1.9375rem;font-weight:400}.bpk-nudger__input--outline{background-color:transparent;color:#fff}.bpk-nudger__input--numeric{width:2.25rem}
+@keyframes bpk-keyframe-spin{100%{transform:rotate(1turn)}}.bpk-nudger__button{position:relative}.bpk-nudger__input{display:inline-block;padding:0.5rem 0;border:none;text-align:center;vertical-align:middle;margin:0;font-size:1.5rem;line-height:1.9375rem;font-weight:400}.bpk-nudger__input--outline{background-color:transparent;color:#fff}.bpk-nudger__input--numeric{width:2.5rem}

--- a/packages/bpk-component-nudger/src/BpkNudger.module.scss
+++ b/packages/bpk-component-nudger/src/BpkNudger.module.scss
@@ -18,6 +18,8 @@
 
 @import '~bpk-mixins/index';
 
+$bpk-spacing-v2: true;
+
 .bpk-nudger {
   &__button {
     position: relative;
@@ -25,7 +27,7 @@
 
   &__input {
     display: inline-block;
-    padding: $bpk-button-padding-y 0;
+    padding: bpk-spacing-md() 0;
     border: none;
     text-align: center;
     vertical-align: middle;
@@ -39,7 +41,7 @@
     }
 
     &--numeric {
-      $size: $bpk-button-line-height + ($bpk-button-padding-y * 2);
+      $size: bpk-spacing-lg() + (bpk-spacing-md() * 2);
 
       width: $size;
     }


### PR DESCRIPTION
Before: https://backpack.github.io/storybook/?path=/story/bpk-component-nudger--default
After: https://backpack.github.io/storybook-prs/2248/?path=/story/bpk-component-nudger--default

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
