### PR TITLE
[KOA-4549] Update paragraph component to use the new spacing grid

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+- bpk-component-paragraph:
+  - Updating the paragraph component to use the new spacing grid.

--- a/packages/bpk-component-paragraph/src/BpkParagraph.module.css
+++ b/packages/bpk-component-paragraph/src/BpkParagraph.module.css
@@ -15,4 +15,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-@keyframes bpk-keyframe-spin{100%{transform:rotate(1turn)}}.bpk-paragraph{margin-top:0;margin-bottom:.75rem}
+@keyframes bpk-keyframe-spin{100%{transform:rotate(1turn)}}.bpk-paragraph{margin-top:0;margin-bottom:1rem}

--- a/packages/bpk-component-paragraph/src/BpkParagraph.module.scss
+++ b/packages/bpk-component-paragraph/src/BpkParagraph.module.scss
@@ -18,6 +18,8 @@
 
 @import '~bpk-mixins/index';
 
+$bpk-spacing-v2: true;
+
 .bpk-paragraph {
   @include bpk-paragraph;
 }

--- a/packages/bpk-mixins/src/mixins/_typography.scss
+++ b/packages/bpk-mixins/src/mixins/_typography.scss
@@ -564,7 +564,7 @@ $bpk-spacing-v2: true;
 
 @mixin bpk-paragraph {
   margin-top: $bpk-p-margin-top;
-  margin-bottom: $bpk-p-margin-bottom;
+  margin-bottom: bpk-spacing-base();
 }
 
 /// List.


### PR DESCRIPTION
Update paragraph component to use the new spacing grid.

Before: https://backpack.github.io/storybook/?path=/story/bpk-component-paragraph--example
After: https://backpack.github.io/storybook-prs/2250/?path=/story/bpk-component-paragraph--example

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
