### PR TITLE
[NO JIRA]: Updating propTypes package and fixing incorrect proptypes

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -230,6 +230,7 @@ Animated.Image
 arrayOf
 bool
 displayName
+elementType
 FlatList
 func
 instanceOf

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,9 @@
+**Fixed:**
+- Updated `prop-types` to version `15.7.2`
+
+- bpk-component-barchart:
+- bpk-component-calendar:
+- bpk-component-datepicker:
+- bpk-component-infinite-scroll:
+- bpk-theming:
+  - Corrected component props to allow `elementType` for the correct props when components are being used.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,4 +6,4 @@
 - bpk-component-datepicker:
 - bpk-component-infinite-scroll:
 - bpk-theming:
-  - Corrected component props to use `elementType` for the props were a component type is expected.
+  - Corrected component props to use `elementType` for the props where a component type is expected.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,4 +6,4 @@
 - bpk-component-datepicker:
 - bpk-component-infinite-scroll:
 - bpk-theming:
-  - Corrected component props to allow `elementType` for the correct props when components are being used.
+  - Corrected component props to use `elementType` for the props were a component type is expected.

--- a/packages/bpk-animate-height/package.json
+++ b/packages/bpk-animate-height/package.json
@@ -14,7 +14,7 @@
   },
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e",
   "dependencies": {
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-accordion/package.json
+++ b/packages/bpk-component-accordion/package.json
@@ -19,7 +19,7 @@
     "bpk-component-text": "^4.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-autosuggest/package.json
+++ b/packages/bpk-component-autosuggest/package.json
@@ -17,7 +17,7 @@
     "bpk-component-input": "^6.0.19",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-autosuggest": "^9.4.3"
   },
   "peerDependencies": {

--- a/packages/bpk-component-badge/package.json
+++ b/packages/bpk-component-badge/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-banner-alert/package.json
+++ b/packages/bpk-component-banner-alert/package.json
@@ -20,7 +20,7 @@
     "bpk-component-icon": "^9.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-transition-group": "^2.5.3"
   },
   "devDependencies": {

--- a/packages/bpk-component-barchart/README.md
+++ b/packages/bpk-component-barchart/README.md
@@ -64,7 +64,7 @@ export default () => (
 | [onBarFocus](#onbarfocus)               | func                                  | false    | null                    |
 | [getBarLabel](#getbarlabel)             | func                                  | false    | See prop details        |
 | [getBarSelection](#getbarselection)     | func                                  | false    | See prop details        |
-| BarComponent                            | func                                  | false    | BpkBarchartBar          |
+| BarComponent                            | elementType                                  | false    | BpkBarchartBar          |
 | disableDataTable                        | bool                                  | false    | false                   |
 
 ### Theme Props

--- a/packages/bpk-component-barchart/package.json
+++ b/packages/bpk-component-barchart/package.json
@@ -21,7 +21,7 @@
     "d3-path": "^2.0.0",
     "d3-scale": "^3.3.0",
     "lodash.debounce": "^4.0.8",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-barchart/src/BpkBarchart.js
+++ b/packages/bpk-component-barchart/src/BpkBarchart.js
@@ -329,7 +329,7 @@ BpkBarchart.propTypes = {
   onBarFocus: PropTypes.func,
   getBarLabel: PropTypes.func,
   getBarSelection: PropTypes.func,
-  BarComponent: PropTypes.func,
+  BarComponent: PropTypes.elementType,
   disableDataTable: PropTypes.bool,
 };
 

--- a/packages/bpk-component-barchart/src/BpkBarchartBars.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartBars.js
@@ -143,7 +143,7 @@ BpkBarchartBars.propTypes = {
     right: PropTypes.number,
   }).isRequired,
   getBarLabel: PropTypes.func.isRequired,
-  BarComponent: PropTypes.func.isRequired,
+  BarComponent: PropTypes.elementType.isRequired,
 
   getBarSelection: PropTypes.func,
   outerPadding: PropTypes.number,

--- a/packages/bpk-component-blockquote/package.json
+++ b/packages/bpk-component-blockquote/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-breadcrumb/package.json
+++ b/packages/bpk-component-breadcrumb/package.json
@@ -19,7 +19,7 @@
     "bpk-component-text": "^4.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-breakpoint/package.json
+++ b/packages/bpk-component-breakpoint/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-responsive": "^6.1.2"
   },
   "peerDependencies": {

--- a/packages/bpk-component-button/package.json
+++ b/packages/bpk-component-button/package.json
@@ -15,7 +15,7 @@
   "gitHead": "5c156b97cb0ba5e75851d3c763334578714c895e",
   "dependencies": {
     "bpk-mixins": "^23.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "bpk-storybook-utils": "^1.0.10"

--- a/packages/bpk-component-calendar/README.md
+++ b/packages/bpk-component-calendar/README.md
@@ -221,7 +221,7 @@ The BpkCalendarGrid component displays a month as a table.
 
 | Property              | PropType             | Required | Default Value    |
 | --------------------- | -------------------- | -------- | ---------------- |
-| DateComponent         | func                 | true     | -                |
+| DateComponent         | elementType          | true     | -                |
 | daysOfWeek            | array(object)        | true     | -                |
 | formatDateFull        | func                 | true     | -                |
 | formatMonth           | func                 | true     | -                |

--- a/packages/bpk-component-calendar/package.json
+++ b/packages/bpk-component-calendar/package.json
@@ -21,7 +21,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "date-fns": "^2.21.1",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -165,7 +165,7 @@ class BpkCalendarGrid extends Component {
 
 export const propTypes = {
   // Required
-  DateComponent: PropTypes.func.isRequired,
+  DateComponent: PropTypes.elementType.isRequired,
   daysOfWeek: CustomPropTypes.DaysOfWeek.isRequired,
   formatDateFull: PropTypes.func.isRequired,
   formatMonth: PropTypes.func.isRequired,

--- a/packages/bpk-component-calendar/src/BpkCalendarGridTransition.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridTransition.js
@@ -195,7 +195,7 @@ class BpkCalendarGridTransition extends Component {
 }
 
 BpkCalendarGridTransition.propTypes = {
-  TransitionComponent: PropTypes.func.isRequired,
+  TransitionComponent: PropTypes.elementType.isRequired,
   className: PropTypes.string,
   month: PropTypes.instanceOf(Date),
   focusedDate: PropTypes.instanceOf(Date),

--- a/packages/bpk-component-calendar/src/Week.js
+++ b/packages/bpk-component-calendar/src/Week.js
@@ -283,7 +283,7 @@ class Week extends Component {
 }
 
 Week.propTypes = {
-  DateComponent: PropTypes.func.isRequired,
+  DateComponent: PropTypes.elementType.isRequired,
   dateModifiers: CustomPropTypes.DateModifiers.isRequired,
   dates: PropTypes.arrayOf(Date).isRequired,
   daysOfWeek: CustomPropTypes.DaysOfWeek.isRequired,

--- a/packages/bpk-component-card/package.json
+++ b/packages/bpk-component-card/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "bpk-component-link": "^3.0.10",

--- a/packages/bpk-component-checkbox/package.json
+++ b/packages/bpk-component-checkbox/package.json
@@ -17,7 +17,7 @@
     "bpk-component-icon": "^9.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-chip/package.json
+++ b/packages/bpk-component-chip/package.json
@@ -17,7 +17,7 @@
     "bpk-component-icon": "^9.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-close-button/package.json
+++ b/packages/bpk-component-close-button/package.json
@@ -17,7 +17,7 @@
     "bpk-component-icon": "^9.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "bpk-storybook-utils": "^1.0.10"

--- a/packages/bpk-component-code/package.json
+++ b/packages/bpk-component-code/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-content-container/package.json
+++ b/packages/bpk-component-content-container/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-datatable/package.json
+++ b/packages/bpk-component-datatable/package.json
@@ -18,7 +18,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "lodash": "^4.17.20",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-virtualized": "^9.22.3"
   },
   "peerDependencies": {

--- a/packages/bpk-component-datepicker/README.md
+++ b/packages/bpk-component-datepicker/README.md
@@ -134,7 +134,7 @@ For more information on some these props, check the BpkCalendar documentation.
 | formatDate            | func                  | true     | -                                   |
 | formatDateFull        | func                  | true     | -                                   |
 | formatMonth           | func                  | true     | -                                   |
-| calendarComponent     | oneOfType(func, node) | false    | BpkCalendar                         |
+| calendarComponent     | elementType           | false    | BpkCalendar                         |
 | date                  | Date                  | false    | null                                |
 | dateModifiers         | object                | false    | {} (\*)                             |
 | inputProps            | object                | false    | {}                                  |

--- a/packages/bpk-component-datepicker/package.json
+++ b/packages/bpk-component-datepicker/package.json
@@ -21,7 +21,7 @@
     "bpk-component-popover": "^4.0.17",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -207,7 +207,7 @@ BpkDatepicker.propTypes = {
   previousMonthLabel: PropTypes.string.isRequired,
   weekStartsOn: PropTypes.number.isRequired,
   // Optional
-  calendarComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  calendarComponent: PropTypes.elementType,
   date: PropTypes.instanceOf(Date),
   dateModifiers: CustomPropTypes.DateModifiers,
   inputProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types

--- a/packages/bpk-component-description-list/package.json
+++ b/packages/bpk-component-description-list/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-dialog/package.json
+++ b/packages/bpk-component-dialog/package.json
@@ -19,7 +19,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "bpk-scrim-utils": "^5.0.10",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-drawer/package.json
+++ b/packages/bpk-component-drawer/package.json
@@ -21,7 +21,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "bpk-scrim-utils": "^5.0.10",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-transition-group": "^2.5.3"
   },
   "peerDependencies": {

--- a/packages/bpk-component-fieldset/package.json
+++ b/packages/bpk-component-fieldset/package.json
@@ -18,7 +18,7 @@
     "bpk-component-label": "^5.0.10",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-flare/package.json
+++ b/packages/bpk-component-flare/package.json
@@ -21,7 +21,7 @@
     "bpk-component-text": "^4.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-form-validation/examples.js
+++ b/packages/bpk-component-form-validation/examples.js
@@ -95,7 +95,7 @@ class InputContainer extends Component {
 }
 
 InputContainer.propTypes = {
-  FormComponent: PropTypes.func.isRequired,
+  FormComponent: PropTypes.elementType.isRequired,
 };
 
 const DefaultExample = () => (

--- a/packages/bpk-component-form-validation/package.json
+++ b/packages/bpk-component-form-validation/package.json
@@ -17,7 +17,7 @@
     "bpk-animate-height": "^4.0.10",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-grid-toggle/package.json
+++ b/packages/bpk-component-grid-toggle/package.json
@@ -17,7 +17,7 @@
     "bpk-component-link": "^3.0.10",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-grid/package.json
+++ b/packages/bpk-component-grid/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-heading/package.json
+++ b/packages/bpk-component-heading/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-horizontal-nav/package.json
+++ b/packages/bpk-component-horizontal-nav/package.json
@@ -17,7 +17,7 @@
     "bpk-component-mobile-scroll-container": "^3.0.11",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-icon/package.json
+++ b/packages/bpk-component-icon/package.json
@@ -21,7 +21,7 @@
     "@skyscanner/bpk-svgs": "^14.0.4",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "bpk-component-button": "^5.0.9",

--- a/packages/bpk-component-image/package.json
+++ b/packages/bpk-component-image/package.json
@@ -17,7 +17,7 @@
     "bpk-component-spinner": "^5.0.4",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-transition-group": "^2.5.3"
   },
   "peerDependencies": {

--- a/packages/bpk-component-infinite-scroll/README.md
+++ b/packages/bpk-component-infinite-scroll/README.md
@@ -170,8 +170,8 @@ Updates the internal array and triggers all listeners.
 | loaderMinDisplay        | oneOf(['small', 'half', 'full']) | false    | 'full'        |
 | onScroll                | func                             | false    | null          |
 | onScrollFinished        | func                             | false    | null          |
-| renderLoadingComponent  | elementType                      | false    | null          |
-| renderSeeMoreComponent  | elementType                      | false    | null          |
+| renderLoadingComponent  | func                             | false    | null          |
+| renderSeeMoreComponent  | func                             | false    | null          |
 | seeMoreAfter            | number                           | false    | null          |
 
 ## `elementsPerScroll`

--- a/packages/bpk-component-infinite-scroll/README.md
+++ b/packages/bpk-component-infinite-scroll/README.md
@@ -170,8 +170,8 @@ Updates the internal array and triggers all listeners.
 | loaderMinDisplay        | oneOf(['small', 'half', 'full']) | false    | 'full'        |
 | onScroll                | func                             | false    | null          |
 | onScrollFinished        | func                             | false    | null          |
-| renderLoadingComponent  | func                             | false    | null          |
-| renderSeeMoreComponent  | func                             | false    | null          |
+| renderLoadingComponent  | elementType                      | false    | null          |
+| renderSeeMoreComponent  | elementType                      | false    | null          |
 | seeMoreAfter            | number                           | false    | null          |
 
 ## `elementsPerScroll`

--- a/packages/bpk-component-infinite-scroll/package.json
+++ b/packages/bpk-component-infinite-scroll/package.json
@@ -17,7 +17,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "intersection-observer": "^0.7.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -75,8 +75,8 @@ const propTypes = {
   loaderIntersectionTrigger: PropTypes.oneOf(['small', 'half', 'full']),
   onScroll: PropTypes.func,
   onScrollFinished: PropTypes.func,
-  renderLoadingComponent: PropTypes.func,
-  renderSeeMoreComponent: PropTypes.func,
+  renderLoadingComponent: PropTypes.elementType,
+  renderSeeMoreComponent: PropTypes.elementType,
   seeMoreAfter: PropTypes.number,
 };
 

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -75,8 +75,8 @@ const propTypes = {
   loaderIntersectionTrigger: PropTypes.oneOf(['small', 'half', 'full']),
   onScroll: PropTypes.func,
   onScrollFinished: PropTypes.func,
-  renderLoadingComponent: PropTypes.elementType,
-  renderSeeMoreComponent: PropTypes.elementType,
+  renderLoadingComponent: PropTypes.func,
+  renderSeeMoreComponent: PropTypes.func,
   seeMoreAfter: PropTypes.number,
 };
 

--- a/packages/bpk-component-input/package.json
+++ b/packages/bpk-component-input/package.json
@@ -17,7 +17,7 @@
     "bpk-component-icon": "^9.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-label/package.json
+++ b/packages/bpk-component-label/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-link/package.json
+++ b/packages/bpk-component-link/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-list/package.json
+++ b/packages/bpk-component-list/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-loading-button/package.json
+++ b/packages/bpk-component-loading-button/package.json
@@ -19,7 +19,7 @@
     "bpk-component-spinner": "^5.0.4",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "bpk-storybook-utils": "^1.0.10"

--- a/packages/bpk-component-mobile-scroll-container/package.json
+++ b/packages/bpk-component-mobile-scroll-container/package.json
@@ -17,7 +17,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "lodash.debounce": "^4.0.8",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-modal/package.json
+++ b/packages/bpk-component-modal/package.json
@@ -21,7 +21,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "bpk-scrim-utils": "^5.0.10",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-navigation-bar/package.json
+++ b/packages/bpk-component-navigation-bar/package.json
@@ -19,7 +19,7 @@
     "bpk-component-text": "^4.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-navigation-stack/package.json
+++ b/packages/bpk-component-navigation-stack/package.json
@@ -17,7 +17,7 @@
     "@skyscanner/bpk-foundations-web": "^2.1.0",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-transition-group": "^2.5.3"
   },
   "peerDependencies": {

--- a/packages/bpk-component-nudger/package.json
+++ b/packages/bpk-component-nudger/package.json
@@ -20,7 +20,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "lodash.clamp": "^4.0.3",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-pagination/package.json
+++ b/packages/bpk-component-pagination/package.json
@@ -17,7 +17,7 @@
     "bpk-component-button": "^5.0.9",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-panel/package.json
+++ b/packages/bpk-component-panel/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-paragraph/package.json
+++ b/packages/bpk-component-paragraph/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-phone-input/package.json
+++ b/packages/bpk-component-phone-input/package.json
@@ -21,7 +21,7 @@
     "bpk-component-text": "^4.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-progress/package.json
+++ b/packages/bpk-component-progress/package.json
@@ -18,7 +18,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "lodash.clamp": "^4.0.3",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-radio/package.json
+++ b/packages/bpk-component-radio/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-rtl-toggle/package.json
+++ b/packages/bpk-component-rtl-toggle/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-component-link": "^3.0.10",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-section-list/package.json
+++ b/packages/bpk-component-section-list/package.json
@@ -19,7 +19,7 @@
     "bpk-component-text": "^4.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "bpk-storybook-utils": "^1.0.10"

--- a/packages/bpk-component-select/package.json
+++ b/packages/bpk-component-select/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "bpk-storybook-utils": "^1.0.10"

--- a/packages/bpk-component-slider/package.json
+++ b/packages/bpk-component-slider/package.json
@@ -17,7 +17,7 @@
     "@skyscanner/bpk-foundations-web": "^2.1.0",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-slider": "^1.3.1"
   },
   "peerDependencies": {

--- a/packages/bpk-component-spinner/package.json
+++ b/packages/bpk-component-spinner/package.json
@@ -17,7 +17,7 @@
     "@skyscanner/bpk-svgs": "^14.0.4",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-star-rating/package.json
+++ b/packages/bpk-component-star-rating/package.json
@@ -17,7 +17,7 @@
     "bpk-component-icon": "^9.0.12",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-table/package.json
+++ b/packages/bpk-component-table/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-text/package.json
+++ b/packages/bpk-component-text/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-textarea/package.json
+++ b/packages/bpk-component-textarea/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "bpk-component-label": "^5.0.10",

--- a/packages/bpk-component-theme-toggle/package.json
+++ b/packages/bpk-component-theme-toggle/package.json
@@ -20,7 +20,7 @@
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
     "konami": "^1.6.2",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-ticket/package.json
+++ b/packages/bpk-component-ticket/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-component-tooltip/package.json
+++ b/packages/bpk-component-tooltip/package.json
@@ -17,7 +17,7 @@
     "@skyscanner/popper.js": "^1.12.9-beta.1",
     "bpk-mixins": "^23.0.0",
     "bpk-react-utils": "^4.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/packages/bpk-react-utils/package.json
+++ b/packages/bpk-react-utils/package.json
@@ -15,7 +15,7 @@
   "gitHead": "c2217d61875a1f3aa2bb9ed9583c50e3f1523501",
   "dependencies": {
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-transition-group": "^2.5.3",
     "recompose": "^0.30.0"
   },

--- a/packages/bpk-theming/README.md
+++ b/packages/bpk-theming/README.md
@@ -39,5 +39,5 @@ export default class App extends Component {
 | -----------         | ---------------------------------- | ---------------- | ------------- |
 | children            | node                               | true             | -             |
 | themeAttributes     | arrayOf(string)                    | true             | -             |
-| component           | oneOf(function, string)            | false            | div           |
+| component           | elementType                        | false            | div           |
 | theme               | object                             | false            | null          |

--- a/packages/bpk-theming/package.json
+++ b/packages/bpk-theming/package.json
@@ -15,7 +15,7 @@
   "gitHead": "c2217d61875a1f3aa2bb9ed9583c50e3f1523501",
   "dependencies": {
     "@skyscanner/bpk-foundations-web": "^2.1.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/bpk-theming/src/BpkThemeProvider.js
+++ b/packages/bpk-theming/src/BpkThemeProvider.js
@@ -136,7 +136,7 @@ BpkThemeProvider.propTypes = {
   theme: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   themeAttributes: themeAttributesPropType, // eslint-disable-line react/require-default-props
   // (disabled because isRequired is inside the custom validator)
-  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  component: PropTypes.elementType,
   style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

This PR solves two things:

- Upgrades `propTypes` to latest version to allow use of `elementType` prop ([see more](https://github.com/facebook/prop-types/pull/211))
- Fixed an issue where component props were being set as just `func` but in newer React versions its not strictly the case

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
