### PR TITLE
NO-JIRA: Update spelling of withLoadingBehavior in docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,6 @@
+# 2021-10-04
+
+**Fixed:**
+
+- bpk-component-image:
+  - Fixed a spelling error in the documentation.

--- a/packages/bpk-component-image/README.md
+++ b/packages/bpk-component-image/README.md
@@ -62,7 +62,7 @@ import BpkImage, { BpkBackgroundImage, withLazyLoading, withLoadingBehavior } fr
 import { breakpointDesktop, breakpointTablet } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 const FadingImage = withLoadingBehavior(BpkImage);
-const FadingBackgroundImage = withLoadingBehaviour(BpkBackgroundImage);
+const FadingBackgroundImage = withLoadingBehavior(BpkBackgroundImage);
 
 export default () => (
   <div>


### PR DESCRIPTION
# Description 

Fixed a spelling error: we export using American English but were using some British English in the code example, which fails.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- ~[ ] Tests~
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
