### PR TITLE
[no jira]: Updating changed snapshots and tweaking threshold for snapshot differences

### DIFF
--- a/.storybook/storyshots-test.js
+++ b/.storybook/storyshots-test.js
@@ -36,13 +36,13 @@ const beforeScreenshot = () =>
 // Allow a small amount of deviation to account for
 // CI running on a different OS than local development.
 const getMatchOptions = () => ({
-  failureThreshold: 0.1,
+  failureThreshold: 0.05,
   failureThresholdType: 'percent',
 });
 
 initStoryshots({
   suite: 'Visual tests',
-  storyNameRegex: /Visual\stest$/i,
+  storyNameRegex: /Visual\stest\s?([a-z]*)?/i,
   test: imageSnapshot({
     storybookUrl: `file://${path.resolve(__dirname, '../dist-storybook')}`,
     getMatchOptions,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2021-11-01
+
+**Changed:**
+
+- bpk-component-barchart: 4.0.17 => 4.1.0
+  - Upgraded `d3-scale` to latest version.
+
 # 2021-10-19
 
 **Fixed:**

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,4 +1,0 @@
-**Changed:**
-
-- bpk-component-barchart:
-  - Upgraded `d3-scale` to latest version.


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

It seems we have outdated snapshots as the threshold for spotting differences is currently 10% in order to trigger failures. Comparing the differences it looks like the select component is changed here and the padding from the left has increased, possibly from a spacing change we recently made

Currently set it to 0% difference as I imagine this would capture all on both CI and local - but looking at the comments in the code it seems to be set to allow some deviation between ci and local environments, so we could tweak this but it may affect local and put us in a similar position?
