### PR TITLE
[no jira]: Tweaking threshold for snapshot differences and config

### DIFF
--- a/.storybook/storyshots-test.js
+++ b/.storybook/storyshots-test.js
@@ -36,13 +36,13 @@ const beforeScreenshot = () =>
 // Allow a small amount of deviation to account for
 // CI running on a different OS than local development.
 const getMatchOptions = () => ({
-  failureThreshold: 0.1,
+  failureThreshold: 0.05,
   failureThresholdType: 'percent',
 });
 
 initStoryshots({
   suite: 'Visual tests',
-  storyNameRegex: /Visual\stest$/i,
+  storyNameRegex: /Visual\stest\s?([a-z]*)?/i,
   test: imageSnapshot({
     storybookUrl: `file://${path.resolve(__dirname, '../dist-storybook')}`,
     getMatchOptions,


### PR DESCRIPTION
It seems we have outdated snapshots as the threshold for spotting differences is currently 10% in order to trigger failures. 

Currently set it to 5% difference as I imagine this would capture all on both CI and local - but looking at the comments in the code it seems to be set to allow some deviation between ci and local environments, so we could tweak this but it may affect local and put us in a similar position?