### PR TITLE
Export CALENDAR_SELECTION_TYPE from bpk-component-datepicker

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,5 @@
+**Added:**
+
+- bpk-component-datepicker
+- bpk-component-scrollable-calendar
+  - Export `CALENDAR_SELECTION_TYPE` so it can be imported from `bpk-component-datepicker` and `bpk-component-scrollable-calendar` instead of `bpk-component-calendar`

--- a/packages/bpk-component-datepicker/README.md
+++ b/packages/bpk-component-datepicker/README.md
@@ -12,7 +12,7 @@ npm install bpk-component-datepicker --save-dev
 
 ```js
 import React, { Component } from 'react';
-import BpkDatepicker from 'bpk-component-datepicker';
+import BpkDatepicker, { CALENDAR_SELECTION_TYPE } from 'bpk-component-datepicker';
 import format from 'date-fns/format';
 
 const formatDate = date => format(date, 'dd/MM/yyyy');

--- a/packages/bpk-component-datepicker/index.js
+++ b/packages/bpk-component-datepicker/index.js
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 
+import { CALENDAR_SELECTION_TYPE } from 'bpk-component-calendar';
+
 import BpkDatepicker from './src/BpkDatepicker';
 import themeAttributes from './src/themeAttributes';
 
 export default BpkDatepicker;
-export { themeAttributes };
+export { CALENDAR_SELECTION_TYPE, themeAttributes };

--- a/packages/bpk-component-scrollable-calendar/README.md
+++ b/packages/bpk-component-scrollable-calendar/README.md
@@ -13,7 +13,7 @@ npm install bpk-component-scrollable-calendar --save-dev
 ```js
 import React, { Component } from 'react';
 import { DateUtils } from 'bpk-component-calendar';
-import BpkScrollableCalendar from 'bpk-component-scrollable-calendar';
+import BpkScrollableCalendar, { CALENDAR_SELECTION_TYPE } from 'bpk-component-scrollable-calendar';
 import format from 'date-fns/format';
 
 const formatDateFull = date => format(date, 'EEEE, do MMMM yyyy');

--- a/packages/bpk-component-scrollable-calendar/index.js
+++ b/packages/bpk-component-scrollable-calendar/index.js
@@ -17,6 +17,8 @@
  */
 /* @flow strict */
 
+import { CALENDAR_SELECTION_TYPE } from 'bpk-component-calendar';
+
 import BpkScrollableCalendar from './src/BpkScrollableCalendar';
 import BpkScrollableCalendarDate from './src/BpkScrollableCalendarDate';
 import BpkScrollableCalendarGrid from './src/BpkScrollableCalendarGrid';
@@ -25,6 +27,7 @@ import BpkScrollableCalendarGridList from './src/BpkScrollableCalendarGridList';
 export default BpkScrollableCalendar;
 
 export {
+  CALENDAR_SELECTION_TYPE,
   BpkScrollableCalendarDate,
   BpkScrollableCalendarGrid,
   BpkScrollableCalendarGridList,


### PR DESCRIPTION
When using `bpk-component-datepicker`, it feels weird doing two different imports, specially taking into account `bpk-component-calendar` might not even be used in the project, as it's just an internal dependency that users don't need to know about:

```
import BpkDatepicker from 'bpk-component-datepicker';
import { CALENDAR_SELECTION_TYPE } from 'bpk-component-calendar';
```

I think it would be better to export `CALENDAR_SELECTION_TYPE` in `bpk-component-datepicker`, so only a single export is needed (and only in the package users have installed):

```
import BpkDatepicker, { CALENDAR_SELECTION_TYPE } from 'bpk-component-datepicker';
```

What do you think about this?


Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
