### PR TITLE
[KOA-4727]: Adding dependabot config to open automatic PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "10:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependabot
+  versioning-strategy: increase-if-necessary
+  allow:
+    - dependency-type: "direct"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           path: .storybook/__image_snapshots__/__diff_output__
 
       - name: Post a comment about the visual tests (if they pass)
-        uses: unsplash/comment-on-pr@master
+        uses: unsplash/comment-on-pr@v1.3.0
         if: github.ref != 'refs/heads/main' && github.repository == github.event.pull_request.head.repo.full_name && steps.visualTests.outcome == 'success'
         with:
           msg: "Visual regression tests passed 😎. Bear in mind that they only run in Chromium on static components – they aren't perfect."
@@ -70,7 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post a comment about the visual tests (if they fail)
-        uses: unsplash/comment-on-pr@master
+        uses: unsplash/comment-on-pr@v1.3.0
         if: failure() && steps.visualTests.outcome == 'failure'
         with:
           msg: "Visual regression tests failed 😢. You can download the failure diffs from the 'Artifacts' section of the failed CI run. To update the tests, run `npm run jest:visual-tests:update` locally."
@@ -123,7 +123,7 @@ jobs:
           publish_branch: main
 
       - name: Link to the pull request build
-        uses: unsplash/comment-on-pr@master
+        uses: unsplash/comment-on-pr@v1.3.0
         if: github.ref != 'refs/heads/main' && github.repository == github.event.pull_request.head.repo.full_name
         with:
           msg: "Visit https://backpack.github.io/storybook-prs/${{ env.PR_NUMBER }} to see this build running in a browser."


### PR DESCRIPTION
This config was missing therefore no automatic PRs to fix issues were being raised.

The dependabot config is now setup also to be a lot less noisy similar to the backpack-docs config where it targets direct dependencies so should reduce some of the noise down and fix the critical things!