### PR TITLE
[NO JIRA]: Upgrade eslint-config-skyscanner to latest to support incomming TS support

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -37,7 +37,7 @@ const EnhancedThemeProvider = updateOnThemeChange(BpkThemeProvider);
 
 addDecorator(withA11y);
 addDecorator(withKnobs);
-addDecorator(story => (
+addDecorator((story) => (
   <div style={{ padding: TOKENS.spacingBase }}>
     <EnhancedThemeProvider themeAttributes={themeableAttributes}>
       {story()}

--- a/.storybook/storyshots-test.js
+++ b/.storybook/storyshots-test.js
@@ -27,7 +27,7 @@ import { imageSnapshot } from '@storybook/addon-storyshots-puppeteer';
 // See: https://www.npmjs.com/package/@storybook/addon-storyshots-puppeteer#specifying-options-to-jest-image-snapshots
 // Its primary function is to delay the screenshot being taken to prevent regressions due to mounting animations & images loading.
 const beforeScreenshot = () =>
-  new Promise(resolve =>
+  new Promise((resolve) =>
     setTimeout(() => {
       resolve();
     }, 800),

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -28,7 +28,7 @@ import { includes } from 'lodash';
 import { danger, fail, warn, markdown } from 'danger';
 
 // Applies to js, css, scss and sh files that are not located in dist or flow-typed folders.
-const shouldContainLicensingInformation = filePath =>
+const shouldContainLicensingInformation = (filePath) =>
   filePath.match(/\.(js|css|scss|sh)$/) &&
   !filePath.includes('dist/') &&
   !filePath.includes('flow-typed/');
@@ -40,9 +40,9 @@ const AVOID_EXACT_WORDS = [
 const createdFiles = danger.git.created_files;
 const modifiedFiles = danger.git.modified_files;
 const fileChanges = [...modifiedFiles, ...createdFiles];
-const markdownChanges = fileChanges.filter(path => path.endsWith('md'));
+const markdownChanges = fileChanges.filter((path) => path.endsWith('md'));
 
-const svgsChangedOrCreated = fileChanges.some(filePath =>
+const svgsChangedOrCreated = fileChanges.some((filePath) =>
   filePath.endsWith('svg'),
 );
 
@@ -54,7 +54,7 @@ if (svgsChangedOrCreated) {
     `);
 }
 
-const componentChangedOrCreated = fileChanges.some(filePath =>
+const componentChangedOrCreated = fileChanges.some((filePath) =>
   filePath.match(/packages\/bpk-component.+\/src\/.+\.js/),
 );
 
@@ -70,7 +70,7 @@ if (componentChangedOrCreated) {
 // If any of the packages have changed, the UNRELEASED log should have been updated.
 const unreleasedModified = includes(modifiedFiles, 'UNRELEASED.md');
 const packagesModified = fileChanges.some(
-  filePath => filePath.startsWith('packages/') && !filePath.endsWith('.md'),
+  (filePath) => filePath.startsWith('packages/') && !filePath.endsWith('.md'),
 );
 if (packagesModified && !unreleasedModified) {
   warn(
@@ -80,13 +80,13 @@ if (packagesModified && !unreleasedModified) {
 
 // If source files have changed, the snapshots should have been updated.
 const componentSourceFilesModified = fileChanges.some(
-  filePath =>
+  (filePath) =>
     // packages/(one or more chars)/src/(one or more chars).js
     filePath.match(/packages\/.*bpk-component.+\/src\/.+\.js/) &&
     !filePath.includes('-test.'),
 );
 
-const snapshotsModified = fileChanges.some(filePath =>
+const snapshotsModified = fileChanges.some((filePath) =>
   filePath.endsWith('.js.snap'),
 );
 
@@ -97,7 +97,7 @@ if (componentSourceFilesModified && !snapshotsModified) {
 }
 
 // New files should include the Backpack license heading.
-const unlicensedFiles = createdFiles.filter(filePath => {
+const unlicensedFiles = createdFiles.filter((filePath) => {
   if (shouldContainLicensingInformation(filePath)) {
     const fileContent = fs.readFileSync(filePath);
     return !fileContent.includes(
@@ -115,7 +115,7 @@ if (unlicensedFiles.length > 0) {
 }
 
 const nonModuleCssFiles = fileChanges.filter(
-  filePath =>
+  (filePath) =>
     filePath.match(/bpk-component/) &&
     filePath.match(/\.s?css/) &&
     !filePath.match('_') &&
@@ -129,14 +129,14 @@ if (nonModuleCssFiles.length) {
   );
 }
 
-markdownChanges.forEach(path => {
+markdownChanges.forEach((path) => {
   const fileContent = fs.readFileSync(path);
 
   fileContent
     .toString()
     .split(/\r?\n/)
     .forEach((line, lineIndex) => {
-      AVOID_EXACT_WORDS.forEach(phrase => {
+      AVOID_EXACT_WORDS.forEach((phrase) => {
         if (line.includes(phrase.word)) {
           warn(`${phrase.reason} on line ${lineIndex + 1} in ${path}`);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -629,6 +629,33 @@
         }
       }
     },
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.8",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
+          "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
@@ -3745,6 +3772,124 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
     },
+    "@eslint/eslintrc": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "espree": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+          "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.4.0",
+            "acorn-jsx": "^5.3.1",
+            "eslint-visitor-keys": "^1.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "globals": {
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
     "@evocateur/libnpmaccess": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.0.tgz",
@@ -4124,6 +4269,40 @@
       "requires": {
         "@hapi/hoek": "^8.3.0"
       }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
     },
     "@icons/material": {
       "version": "0.2.4",
@@ -10682,33 +10861,611 @@
         "@types/node": "*"
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==",
       "dev": true,
       "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "1.13.0",
-        "eslint-scope": "^4.0.0"
-      }
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
+        "@typescript-eslint/scope-manager": "5.10.0",
+        "@typescript-eslint/type-utils": "5.10.0",
+        "@typescript-eslint/utils": "5.10.0",
+        "debug": "^4.3.2",
+        "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
         "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.7",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.scandir": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+          "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "2.0.5",
+            "run-parallel": "^1.1.9"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+          "dev": true
+        },
+        "@nodelib/fs.walk": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+          "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.scandir": "2.1.5",
+            "fastq": "^1.6.0"
+          }
+        },
+        "@types/json-schema": {
+          "version": "7.0.9",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+          "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+          "dev": true
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+          "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/visitor-keys": "4.33.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+          "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+          "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/visitor-keys": "4.33.0",
+            "debug": "^4.3.1",
+            "globby": "^11.0.3",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+          "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.33.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
+        "esrecurse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+              "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+              "dev": true
+            }
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "merge2": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.0.tgz",
+      "integrity": "sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.10.0",
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/typescript-estree": "5.10.0",
+        "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz",
+      "integrity": "sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/visitor-keys": "5.10.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.0.tgz",
+      "integrity": "sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "5.10.0",
+        "debug": "^4.3.2",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.0.tgz",
+      "integrity": "sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz",
+      "integrity": "sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/visitor-keys": "5.10.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.scandir": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+          "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "2.0.5",
+            "run-parallel": "^1.1.9"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+          "dev": true
+        },
+        "@nodelib/fs.walk": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+          "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.scandir": "2.1.5",
+            "fastq": "^1.6.0"
+          }
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "merge2": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
+      "integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.10.0",
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/typescript-estree": "5.10.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.9",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+          "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "esrecurse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+              "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz",
+      "integrity": "sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.10.0",
+        "eslint-visitor-keys": "^3.0.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -11019,9 +11776,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
     },
     "acorn-walk": {
@@ -12802,130 +13559,169 @@
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
-          "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+          "version": "7.16.8",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
+          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.11.0",
+            "@babel/types": "^7.16.8",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+          "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.10.4",
-            "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/helper-get-function-arity": "^7.16.7",
+            "@babel/template": "^7.16.7",
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+          "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.16.7"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+          "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.11.0"
+            "@babel/types": "^7.16.7"
           }
         },
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
+        },
         "@babel/highlight": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+          "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
-          "integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==",
+          "version": "7.16.8",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
+          "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==",
           "dev": true
         },
         "@babel/template": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+          "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/code-frame": "^7.16.7",
+            "@babel/parser": "^7.16.7",
+            "@babel/types": "^7.16.7"
           },
           "dependencies": {
             "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+              "version": "7.16.7",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+              "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
               "dev": true,
               "requires": {
-                "@babel/highlight": "^7.10.4"
+                "@babel/highlight": "^7.16.7"
               }
             }
           }
         },
         "@babel/traverse": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-          "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+          "version": "7.16.8",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.8.tgz",
+          "integrity": "sha512-xe+H7JlvKsDQwXRsBhSnq1/+9c+LlQcCK3Tn/l5sbx02HYns/cn7ibp9+RV1sIUqu7hKg91NWsgHurO9dowITQ==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.11.0",
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.11.0",
-            "@babel/parser": "^7.11.0",
-            "@babel/types": "^7.11.0",
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.16.8",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.16.7",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.16.8",
+            "@babel/types": "^7.16.8",
             "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "globals": "^11.1.0"
           },
           "dependencies": {
             "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+              "version": "7.16.7",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+              "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
               "dev": true,
               "requires": {
-                "@babel/highlight": "^7.10.4"
+                "@babel/highlight": "^7.16.7"
               }
             }
           }
         },
         "@babel/types": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-          "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+          "version": "7.16.8",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
+          "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "is-core-module": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+          "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
           }
         },
         "js-tokens": {
@@ -12947,12 +13743,14 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+          "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "is-core-module": "^2.8.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
           }
         },
         "source-map": {
@@ -15084,12 +15882,33 @@
       }
     },
     "bpk-tokens": {
-      "version": "32.0.5",
-      "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-32.0.5.tgz",
-      "integrity": "sha512-TJatn33/7yQQm/wjBoOnymCudR3+aIIruIrj04PqvDjVZ4Y507JsDx5wpU+ME8p1k5L/afdk1oisJmi1wOsRDQ==",
+      "version": "36.2.3",
+      "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-36.2.3.tgz",
+      "integrity": "sha512-TosnLCpYTDs+SNfCKs5a3W14p/jEu7klyhYOgzyUoHbhWWBRGuiVltdWlB/jscCeYycjC/Ea9b3+eljiXKBYTA==",
       "dev": true,
       "requires": {
-        "color": "^3.0.0"
+        "color": "^3.1.3"
+      },
+      "dependencies": {
+        "color": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+          "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.3",
+            "color-string": "^1.6.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        }
       }
     },
     "brace-expansion": {
@@ -15100,6 +15919,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "brorand": {
@@ -16555,6 +17383,16 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color-string": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -16778,9 +17616,9 @@
       }
     },
     "confusing-browser-globals": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-      "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
     },
     "connect-history-api-fallback": {
@@ -16808,12 +17646,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true
-    },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "content-disposition": {
@@ -18875,6 +19707,49 @@
         "unique-concat": "~0.2.2"
       }
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
@@ -19111,9 +19986,9 @@
       }
     },
     "damerau-levenshtein": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
-      "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
     "danger": {
@@ -21513,13 +22388,13 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.0.tgz",
-      "integrity": "sha512-Fz4JIUKkrhO0du2cg5opdyPKQXOI2MvF8KUvN2710nJMT6jaRUpRE2swrJftAjVGL7T1otLM5ieo5RqS1v9Udg==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
+      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^14.2.0",
-        "object.assign": "^4.1.0",
+        "eslint-config-airbnb-base": "^14.2.1",
+        "object.assign": "^4.1.2",
         "object.entries": "^1.1.2"
       },
       "dependencies": {
@@ -21533,22 +22408,43 @@
           }
         },
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
           }
         },
         "es-to-primitive": {
@@ -21562,6 +22458,17 @@
             "is-symbol": "^1.0.2"
           }
         },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -21572,39 +22479,72 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
           "dev": true
         },
+        "internal-slot": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+          "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+          "dev": true,
+          "requires": {
+            "get-intrinsic": "^1.1.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
         "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
-            "has-symbols": "^1.0.1"
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
           }
         },
         "is-symbol": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+          "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
           "dev": true,
           "requires": {
-            "has-symbols": "^1.0.1"
+            "has-symbols": "^1.0.2"
           }
         },
         "object-inspect": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
         },
         "object-keys": {
@@ -21613,27 +22553,106 @@
           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
           "dev": true
         },
-        "object.entries": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
-          "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5",
-            "has": "^1.0.3"
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "object.entries": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+          "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.19.1"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
+          }
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
           }
         }
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz",
-      "integrity": "sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
       "dev": true,
       "requires": {
-        "confusing-browser-globals": "^1.0.9",
-        "object.assign": "^4.1.0",
+        "confusing-browser-globals": "^1.0.10",
+        "object.assign": "^4.1.2",
         "object.entries": "^1.1.2"
       },
       "dependencies": {
@@ -21647,22 +22666,43 @@
           }
         },
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
           }
         },
         "es-to-primitive": {
@@ -21676,6 +22716,17 @@
             "is-symbol": "^1.0.2"
           }
         },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -21686,39 +22737,72 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
           "dev": true
         },
+        "internal-slot": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+          "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+          "dev": true,
+          "requires": {
+            "get-intrinsic": "^1.1.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
         "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
-            "has-symbols": "^1.0.1"
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
           }
         },
         "is-symbol": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+          "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
           "dev": true,
           "requires": {
-            "has-symbols": "^1.0.1"
+            "has-symbols": "^1.0.2"
           }
         },
         "object-inspect": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
         },
         "object-keys": {
@@ -21727,63 +22811,185 @@
           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
           "dev": true
         },
-        "object.entries": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
-          "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5",
-            "has": "^1.0.3"
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "object.entries": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+          "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.19.1"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
+          }
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
           }
         }
       }
     },
     "eslint-config-prettier": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
-      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-          "dev": true
-        }
-      }
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true
     },
     "eslint-config-skyscanner": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-skyscanner/-/eslint-config-skyscanner-7.0.0.tgz",
-      "integrity": "sha512-8ba7KJp8ZjHHKCYb46tvftVck+FpGgUk5wL3m2OmHALk8R8UrYcxbTz3HWugl7vHzJYtAsgKUBQM8KaAyJ1DyA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-skyscanner/-/eslint-config-skyscanner-10.4.0.tgz",
+      "integrity": "sha512-E5m+xjsoASkKHvkqSV4L6e2obvdfq8j9ExFcMTmzOfR1nKJnJ3yF1LIxk3GteK1A4IpMO1XNT0CpcZ9aRmV/tg==",
       "dev": true,
       "requires": {
+        "@typescript-eslint/eslint-plugin": "^5.9.0",
+        "@typescript-eslint/parser": "^5.9.1",
         "babel-eslint": "^10.1.0",
         "colors": "^1.4.0",
-        "eslint": "^5.16.0",
-        "eslint-config-airbnb": "^18.1.0",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-plugin-backpack": "^2.0.0",
+        "eslint": "^7.25.0",
+        "eslint-config-airbnb": "^18.2.1",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-backpack": "^3.0.1",
         "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-import": "^2.22.0",
-        "eslint-plugin-jest": "^22.21.0",
-        "eslint-plugin-jest-formatting": "^2.0.0",
-        "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-prettier": "^3.1.4",
-        "eslint-plugin-react": "^7.20.5",
-        "eslint-plugin-react-hooks": "^2.3.0",
-        "prettier": "^1.19.1"
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-jest": "^24.3.6",
+        "eslint-plugin-jest-formatting": "^2.0.1",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-prettier": "^3.4.1",
+        "eslint-plugin-react": "^7.28.0",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-typescript-enum": "^2.1.0",
+        "prettier": "^2.5.1"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+          "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
+            }
+          }
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -21793,9 +22999,75 @@
           }
         },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+              "dev": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "colors": {
@@ -21804,81 +23076,142 @@
           "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
           "dev": true
         },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "ms": "2.1.2"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
         },
         "eslint": {
-          "version": "5.16.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-          "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+          "version": "7.32.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+          "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "ajv": "^6.9.1",
-            "chalk": "^2.1.0",
-            "cross-spawn": "^6.0.5",
+            "@babel/code-frame": "7.12.11",
+            "@eslint/eslintrc": "^0.4.3",
+            "@humanwhocodes/config-array": "^0.5.0",
+            "ajv": "^6.10.0",
+            "chalk": "^4.0.0",
+            "cross-spawn": "^7.0.2",
             "debug": "^4.0.1",
             "doctrine": "^3.0.0",
-            "eslint-scope": "^4.0.3",
-            "eslint-utils": "^1.3.1",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^5.0.1",
-            "esquery": "^1.0.1",
+            "enquirer": "^2.3.5",
+            "escape-string-regexp": "^4.0.0",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^2.1.0",
+            "eslint-visitor-keys": "^2.0.0",
+            "espree": "^7.3.1",
+            "esquery": "^1.4.0",
             "esutils": "^2.0.2",
-            "file-entry-cache": "^5.0.1",
+            "fast-deep-equal": "^3.1.3",
+            "file-entry-cache": "^6.0.1",
             "functional-red-black-tree": "^1.0.1",
-            "glob": "^7.1.2",
-            "globals": "^11.7.0",
+            "glob-parent": "^5.1.2",
+            "globals": "^13.6.0",
             "ignore": "^4.0.6",
             "import-fresh": "^3.0.0",
             "imurmurhash": "^0.1.4",
-            "inquirer": "^6.2.2",
-            "js-yaml": "^3.13.0",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
             "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.11",
+            "levn": "^0.4.1",
+            "lodash.merge": "^4.6.2",
             "minimatch": "^3.0.4",
-            "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
-            "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.2",
+            "optionator": "^0.9.1",
             "progress": "^2.0.0",
-            "regexpp": "^2.0.1",
-            "semver": "^5.5.1",
-            "strip-ansi": "^4.0.0",
-            "strip-json-comments": "^2.0.1",
-            "table": "^5.2.3",
-            "text-table": "^0.2.0"
+            "regexpp": "^3.1.0",
+            "semver": "^7.2.1",
+            "strip-ansi": "^6.0.0",
+            "strip-json-comments": "^3.1.0",
+            "table": "^6.0.9",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
           }
         },
-        "espree": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-          "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
           "dev": true,
           "requires": {
-            "acorn": "^6.0.7",
-            "acorn-jsx": "^5.0.0",
-            "eslint-visitor-keys": "^1.0.0"
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+              "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+              "dev": true
+            }
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
+        "espree": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+          "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.4.0",
+            "acorn-jsx": "^5.3.1",
+            "eslint-visitor-keys": "^1.3.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+              "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+              "dev": true
+            }
+          }
+        },
+        "esrecurse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+              "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+              "dev": true
+            }
           }
         },
         "fast-deep-equal": {
@@ -21887,6 +23220,63 @@
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
+        "file-entry-cache": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+          "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+          "dev": true,
+          "requires": {
+            "flat-cache": "^3.0.4"
+          }
+        },
+        "flat-cache": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+          "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+          "dev": true,
+          "requires": {
+            "flatted": "^3.1.0",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "flatted": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+          "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globals": {
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -21894,19 +23284,40 @@
           "dev": true
         },
         "import-fresh": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
           "dev": true,
           "requires": {
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
           }
         },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
           "dev": true
         },
         "json-schema-traverse": {
@@ -21915,119 +23326,282 @@
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "slice-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "astral-regex": "^1.0.0",
-            "is-fullwidth-code-point": "^2.0.0"
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
           }
         },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "dev": true,
               "requires": {
-                "ansi-regex": "^4.1.0"
+                "color-convert": "^2.0.1"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+              "dev": true,
+              "requires": {
+                "color-name": "~1.1.4"
               }
             }
           }
         },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         },
         "table": {
-          "version": "5.4.6",
-          "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-          "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+          "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
           "dev": true,
           "requires": {
-            "ajv": "^6.10.2",
-            "lodash": "^4.17.14",
-            "slice-ansi": "^2.1.0",
-            "string-width": "^3.0.0"
+            "ajv": "^8.0.1",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "8.9.0",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+              "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+              "dev": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "json-schema-traverse": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+              "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+              "dev": true
+            }
           }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
-      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.13.1"
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
       },
       "dependencies": {
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "ms": "^2.1.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "is-core-module": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+          "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+          "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.8.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
           }
         }
       }
     },
     "eslint-module-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.2.tgz",
+      "integrity": "sha512-zquepFnWCY2ISMFwD/DqzaM++H+7PDzOpUvotJWm/y1BAFt5R4oeULgdrTejKqLkz7MA/tgstsUMNYc7wNdTrg==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "pkg-dir": "^2.0.0"
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-backpack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-backpack/-/eslint-plugin-backpack-2.0.0.tgz",
-      "integrity": "sha512-siQ4bx6htPz6+qFlnVFcfBJrL/Gv1Dd1OrI8eEffKJ3ZBAS7yH/JywFbYN41wqpbWQwMiCiGgSLBbN473jDfsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-backpack/-/eslint-plugin-backpack-3.0.1.tgz",
+      "integrity": "sha512-nO3PErhxD6CJaPhnnz4T60tUwWSqr57+CXRDbGnoEwzzw5IoqsxzexoUHypvK9cnm8ag8nvVVYKaEy+GA/h3LQ==",
       "dev": true,
       "requires": {
-        "bpk-tokens": "^32.0.2",
-        "lodash": "^4.17.16",
+        "bpk-tokens": "^36.0.0",
+        "lodash": "^4.17.20",
         "tinycolor2": "^1.4.1"
       }
     },
@@ -22042,9 +23616,9 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
           "dev": true
         }
       }
@@ -22067,383 +23641,58 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
-      "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+      "version": "2.25.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
+      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.1",
-        "array.prototype.flat": "^1.2.3",
-        "contains-path": "^0.1.0",
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
         "debug": "^2.6.9",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.3",
-        "eslint-module-utils": "^2.6.0",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.2",
         "has": "^1.0.3",
+        "is-core-module": "^2.8.0",
+        "is-glob": "^4.0.3",
         "minimatch": "^3.0.4",
-        "object.values": "^1.1.1",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.17.0",
-        "tsconfig-paths": "^3.9.0"
+        "object.values": "^1.1.5",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.12.0"
       },
       "dependencies": {
         "array-includes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-          "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+          "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.2",
             "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0",
-            "is-string": "^1.0.5"
+            "es-abstract": "^1.19.1",
+            "get-intrinsic": "^1.1.1",
+            "is-string": "^1.0.7"
           }
         },
         "array.prototype.flat": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
-          "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
+          "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.2",
             "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1"
+            "es-abstract": "^1.19.0"
           }
         },
-        "define-properties": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
           "dev": true,
           "requires": {
-            "object-keys": "^1.0.12"
-          }
-        },
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
-          }
-        },
-        "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        },
-        "is-string": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-          "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        },
-        "object-inspect": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        },
-        "object.values": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-          "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3"
-          }
-        },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        }
-      }
-    },
-    "eslint-plugin-jest": {
-      "version": "22.21.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.21.0.tgz",
-      "integrity": "sha512-OaqnSS7uBgcGiqXUiEnjoqxPNKvR4JWG5mSRkzVoR6+vDwlqqp11beeql1hYs0HTbdhiwrxWLxbX0Vx7roG3Ew==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "^1.13.0"
-      }
-    },
-    "eslint-plugin-jest-formatting": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-2.0.0.tgz",
-      "integrity": "sha512-DLL2vg+cXmtONUBiIVE4nk9YQXnpT2ljHfAvW1vRYOGFA9Jfo5kqG+1lzYxcnphdFyUFN0Tx+rGkmsAZy2paxA==",
-      "dev": true
-    },
-    "eslint-plugin-jsx-a11y": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
-      "integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.10.2",
-        "aria-query": "^4.2.2",
-        "array-includes": "^3.1.1",
-        "ast-types-flow": "^0.0.7",
-        "axe-core": "^3.5.4",
-        "axobject-query": "^2.1.2",
-        "damerau-levenshtein": "^1.0.6",
-        "emoji-regex": "^9.0.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.4.1",
-        "language-tags": "^1.0.5"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "array-includes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-          "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0",
-            "is-string": "^1.0.5"
-          }
-        },
-        "axe-core": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-          "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
-          "dev": true
-        },
-        "define-properties": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-          "dev": true,
-          "requires": {
-            "object-keys": "^1.0.12"
-          }
-        },
-        "emoji-regex": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
-          "integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
-          "dev": true
-        },
-        "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        },
-        "is-string": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-          "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        },
-        "object-inspect": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-prettier": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
-      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
-    "eslint-plugin-react": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.5.tgz",
-      "integrity": "sha512-ajbJfHuFnpVNJjhyrfq+pH1C0gLc2y94OiCbAXT5O0J0YCKaFEHDV8+3+mDOr+w8WguRX+vSs1bM2BDG0VLvCw==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.1",
-        "array.prototype.flatmap": "^1.2.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.4.1",
-        "object.entries": "^1.1.2",
-        "object.fromentries": "^2.0.2",
-        "object.values": "^1.1.1",
-        "prop-types": "^15.7.2",
-        "resolve": "^1.17.0",
-        "string.prototype.matchall": "^4.0.2"
-      },
-      "dependencies": {
-        "array-includes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-          "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0",
-            "is-string": "^1.0.5"
+            "get-intrinsic": "^1.0.2"
           }
         },
         "define-properties": {
@@ -22465,22 +23714,31 @@
           }
         },
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
           }
         },
         "es-to-primitive": {
@@ -22494,6 +23752,17 @@
             "is-symbol": "^1.0.2"
           }
         },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -22504,39 +23773,617 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
           "dev": true
         },
-        "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+        "internal-slot": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+          "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
           "dev": true,
           "requires": {
-            "has-symbols": "^1.0.1"
+            "get-intrinsic": "^1.1.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+          "dev": true
+        },
+        "is-core-module": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+          "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
           }
         },
         "is-string": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-          "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
           "dev": true,
           "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+          "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.2"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "object.values": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+          "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.19.1"
+          }
+        },
+        "resolve": {
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+          "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.8.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
+      "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^4.0.1"
+      }
+    },
+    "eslint-plugin-jest-formatting": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-2.0.1.tgz",
+      "integrity": "sha512-t6oc6GcXqzQ4lwatnVoKxGTLqo8kFIdA5kpaS3mrkwnTNxhsgFo9reMFdrtNtllx72ohNUsXsay7RJR/LLLk3Q==",
+      "dev": true
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz",
+      "integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.16.3",
+        "aria-query": "^4.2.2",
+        "array-includes": "^3.1.4",
+        "ast-types-flow": "^0.0.7",
+        "axe-core": "^4.3.5",
+        "axobject-query": "^2.2.0",
+        "damerau-levenshtein": "^1.0.7",
+        "emoji-regex": "^9.2.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^3.2.1",
+        "language-tags": "^1.0.5",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "array-includes": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+          "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.19.1",
+            "get-intrinsic": "^1.1.1",
+            "is-string": "^1.0.7"
+          }
+        },
+        "axe-core": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
+          "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
+          "dev": true
+        },
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "es-abstract": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
             "has-symbols": "^1.0.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        },
+        "internal-slot": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+          "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+          "dev": true,
+          "requires": {
+            "get-intrinsic": "^1.1.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+          "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.2"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz",
+      "integrity": "sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.0.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.7.2",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.6"
+      },
+      "dependencies": {
+        "array-includes": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+          "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.19.1",
+            "get-intrinsic": "^1.1.1",
+            "is-string": "^1.0.7"
+          }
+        },
+        "array.prototype.flatmap": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+          "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.19.0"
+          }
+        },
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        },
+        "internal-slot": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+          "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+          "dev": true,
+          "requires": {
+            "get-intrinsic": "^1.1.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+          "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.2"
           }
         },
         "loose-envify": {
@@ -22549,9 +24396,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
         },
         "object-keys": {
@@ -22560,62 +24407,162 @@
           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
           "dev": true
         },
-        "object.entries": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
-          "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5",
-            "has": "^1.0.3"
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "object.entries": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+          "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.19.1"
+          }
+        },
+        "object.fromentries": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+          "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.19.1"
           }
         },
         "object.values": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-          "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+          "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.2",
             "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3"
+            "es-abstract": "^1.19.1"
           }
         },
         "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "version": "15.8.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "react-is": "^16.13.1"
           }
         },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+        "regexp.prototype.flags": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+          "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "resolve": {
+          "version": "2.0.0-next.3",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
+          "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
+        "string.prototype.matchall": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+          "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.19.1",
+            "get-intrinsic": "^1.1.1",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "regexp.prototype.flags": "^1.3.1",
+            "side-channel": "^1.0.4"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
           }
         }
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
-      "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true
+    },
+    "eslint-plugin-typescript-enum": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-enum/-/eslint-plugin-typescript-enum-2.1.0.tgz",
+      "integrity": "sha512-n6RO89KJ2V2nHVAdIq1q3IBeYZSNZjBreqXOzpjmsBtw+NNhSTTSQXqwO00VYOce9Gy8cr2cDEYpj0Km+Ij90Q==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.3.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "5.10.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.10.0.tgz",
+          "integrity": "sha512-GeQAPqQMI5DVMGOUwGbSR+NdsirryyKOgUFRTWInhlsKUArns/MVnXmPpzxfrzB1nU36cT5WJAwmfCsjoaVBWg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/utils": "5.10.0"
+          }
+        }
+      }
     },
     "eslint-scope": {
       "version": "4.0.3",
@@ -22628,18 +24575,26 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.1.0"
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
       "dev": true
     },
     "eslint_d": {
@@ -22732,18 +24687,18 @@
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }
@@ -23695,6 +25650,32 @@
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
       "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
       "dev": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
     },
     "filter-obj": {
       "version": "1.1.0",
@@ -26208,6 +28189,54 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -28609,6 +30638,12 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -28643,6 +30678,23 @@
       "dev": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
+      }
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
       }
     },
     "has-unicode": {
@@ -30120,6 +32172,15 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -30496,6 +32557,12 @@
       "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
       "dev": true
     },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true
+    },
     "is-ssh": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
@@ -30570,6 +32637,53 @@
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
       "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
       "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
+      }
     },
     "is-whitespace-character": {
       "version": "1.0.4",
@@ -32863,24 +34977,36 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
-      "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
+      "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.1",
-        "object.assign": "^4.1.0"
+        "array-includes": "^3.1.3",
+        "object.assign": "^4.1.2"
       },
       "dependencies": {
         "array-includes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-          "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+          "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.2",
             "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0",
-            "is-string": "^1.0.5"
+            "es-abstract": "^1.19.1",
+            "get-intrinsic": "^1.1.1",
+            "is-string": "^1.0.7"
+          }
+        },
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
           }
         },
         "define-properties": {
@@ -32893,22 +35019,31 @@
           }
         },
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
+            "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
           }
         },
         "es-to-primitive": {
@@ -32922,6 +35057,17 @@
             "is-symbol": "^1.0.2"
           }
         },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -32932,45 +35078,60 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
           "dev": true
         },
+        "internal-slot": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+          "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+          "dev": true,
+          "requires": {
+            "get-intrinsic": "^1.1.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
         "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
-            "has-symbols": "^1.0.1"
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
           }
         },
         "is-string": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-          "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
           "dev": true,
           "requires": {
-            "has-symbols": "^1.0.1"
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+          "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.2"
           }
         },
         "object-inspect": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
         },
         "object-keys": {
@@ -32978,6 +35139,49 @@
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
           "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
         }
       }
     },
@@ -33070,9 +35274,9 @@
       }
     },
     "language-subtag-registry": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
-      "integrity": "sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
+      "integrity": "sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==",
       "dev": true
     },
     "language-tags": {
@@ -33907,26 +36111,6 @@
         }
       }
     },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -34395,10 +36579,10 @@
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true
     },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "lodash.uniq": {
@@ -35895,6 +38079,24 @@
       "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
       "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==",
       "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+          "dev": true
+        }
+      }
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -37623,6 +39825,202 @@
         "es-abstract": "^1.5.1"
       }
     },
+    "object.hasown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-abstract": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        },
+        "internal-slot": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+          "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+          "dev": true,
+          "requires": {
+            "get-intrinsic": "^1.1.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+          "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.2"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
+      }
+    },
     "object.map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
@@ -38477,21 +40875,10 @@
       "dev": true
     },
     "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true,
-      "requires": {
-        "pify": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -39232,9 +41619,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -41377,27 +43764,6 @@
         "readdir-scoped-modules": "^1.0.0"
       }
     },
-    "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "dev": true,
-      "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
-      }
-    },
     "readable-stream": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
@@ -41985,9 +44351,9 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
     "regexpu-core": {
@@ -46919,6 +49285,12 @@
         }
       }
     },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
     "sver-compat": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
@@ -48555,9 +50927,9 @@
       "dev": true
     },
     "tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
@@ -48588,6 +50960,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
+    },
+    "tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "ttf2eot": {
       "version": "2.0.0",
@@ -48752,6 +51133,26 @@
       "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
       "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
       "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
+      }
     },
     "unbzip2-stream": {
       "version": "1.4.3",
@@ -51066,6 +53467,94 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        },
+        "is-boolean-object": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+          "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-number-object": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+          "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+          "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.2"
+          }
+        }
       }
     },
     "which-module": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-to-json": "^3.3.5",
-    "eslint-config-skyscanner": "^7.0.0",
+    "eslint-config-skyscanner": "^10.4.0",
     "eslint-plugin-flowtype": "^4.0.0",
     "eslint_d": "^9.1.1",
     "extract-text-webpack-plugin": "^3.0.2",

--- a/packages/bpk-animate-height/examples.js
+++ b/packages/bpk-animate-height/examples.js
@@ -42,7 +42,7 @@ class AnimateHeightExample extends Component<Props, State> {
   }
 
   onClick = () => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const height =
         prevState.height !== this.props.fromHeight
           ? this.props.fromHeight

--- a/packages/bpk-animate-height/src/AnimateHeight.js
+++ b/packages/bpk-animate-height/src/AnimateHeight.js
@@ -22,7 +22,7 @@ import React, { Component } from 'react';
 // IE11 doesn't support `Number.isNaN` so we must use the global.
 // When IE11 support drops we can migrate.
 // eslint-disable-next-line no-restricted-globals
-const isNumber = n => !isNaN(parseFloat(n)) && isFinite(n);
+const isNumber = (n) => !isNaN(parseFloat(n)) && isFinite(n);
 
 const isTransitionEndSupported = () =>
   !!(typeof window !== 'undefined' && 'TransitionEvent' in window);
@@ -127,14 +127,8 @@ class AnimateHeight extends Component {
   };
 
   render() {
-    const {
-      children,
-      duration,
-      easing,
-      onAnimationComplete,
-      style,
-      ...rest
-    } = this.props;
+    const { children, duration, easing, onAnimationComplete, style, ...rest } =
+      this.props;
 
     const { height, overflow } = this.state;
 
@@ -159,7 +153,7 @@ class AnimateHeight extends Component {
         {...rest}
       >
         <div
-          ref={el => {
+          ref={(el) => {
             this.contentElement = el;
           }}
         >

--- a/packages/bpk-component-accordion/examples.js
+++ b/packages/bpk-component-accordion/examples.js
@@ -44,7 +44,7 @@ const StatefulAccordionItem = withAccordionItemState(BpkAccordionItem);
 const AlignedStopsIcon = withAlignment(StopsIcon, lineHeightBase, iconSizeSm);
 const AlignedTimeIcon = withAlignment(TimeIcon, lineHeightBase, iconSizeSm);
 
-const CheckboxWrapper = props => (
+const CheckboxWrapper = (props) => (
   <div style={{ padding: `1rem 0` }} {...props} />
 );
 

--- a/packages/bpk-component-accordion/src/withAccordionItemState.js
+++ b/packages/bpk-component-accordion/src/withAccordionItemState.js
@@ -56,7 +56,7 @@ const withAccordionItemState = (ComposedComponent: ComponentType<any>) => {
 
     onClick = () => {
       this.setState(
-        prevState => ({
+        (prevState) => ({
           expanded: !prevState.expanded,
         }),
         this.props.onClick || (() => {}),

--- a/packages/bpk-component-accordion/src/withSingleItemAccordionState-test.js
+++ b/packages/bpk-component-accordion/src/withSingleItemAccordionState-test.js
@@ -84,13 +84,13 @@ describe('withSingleItemAccordionState(BpkAccordion)', () => {
     expect(accordionContainer.state('expanded')).toEqual('.1');
 
     accordionContainer
-      .findWhere(e => e.text() === 'Accordion Item 1')
+      .findWhere((e) => e.text() === 'Accordion Item 1')
       .first()
       .prop('onClick')();
     expect(accordionContainer.state('expanded')).toEqual('.0');
 
     accordionContainer
-      .findWhere(e => e.text() === 'Accordion Item 3')
+      .findWhere((e) => e.text() === 'Accordion Item 3')
       .first()
       .prop('onClick')();
     expect(accordionContainer.state('expanded')).toEqual('.2');

--- a/packages/bpk-component-accordion/src/withSingleItemAccordionState.js
+++ b/packages/bpk-component-accordion/src/withSingleItemAccordionState.js
@@ -29,7 +29,7 @@ import React, {
 } from 'react';
 import { wrapDisplayName } from 'bpk-react-utils';
 
-const getInitiallyExpanded = children => {
+const getInitiallyExpanded = (children) => {
   const accordionItems = Children.toArray(children);
   const result = accordionItems.reduceRight(
     (prev, item) => (item.props.initiallyExpanded ? item : prev),

--- a/packages/bpk-component-aria-live/examples.js
+++ b/packages/bpk-component-aria-live/examples.js
@@ -91,7 +91,7 @@ class SelectExample extends React.Component<
   };
 
   toggleDirectness = () => {
-    this.setState(prevState => ({ direct: !prevState.direct }));
+    this.setState((prevState) => ({ direct: !prevState.direct }));
   };
 
   id = 'aria-live-select-example';
@@ -119,7 +119,7 @@ class SelectExample extends React.Component<
                 id="destination"
                 name="destination"
                 value={destination}
-                onChange={event => {
+                onChange={(event) => {
                   this.onChangeDestination(event.target.value);
                 }}
               >
@@ -184,7 +184,7 @@ class ChipsExample extends React.Component<
   id = 'aria-live-chips-example';
 
   toggleCategory = (category: string) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const nextState = prevState;
       nextState.categories[category] = !prevState.categories[category];
       nextState.updates.push(
@@ -210,7 +210,7 @@ class ChipsExample extends React.Component<
             <BpkCode>aria-controls=&quot;{this.id}&quot;</BpkCode> to link it to
             the ARIA live region below with the same ID.
           </BpkParagraph>
-          {Object.keys(categories).map(category => (
+          {Object.keys(categories).map((category) => (
             <BpkChip
               className={getClassName('bpk-storybook-aria-live-demo__chip')}
               aria-controls={this.id}
@@ -235,7 +235,7 @@ class ChipsExample extends React.Component<
             </BpkParagraph>
           }
         >
-          {updates.map(update => (
+          {updates.map((update) => (
             <BpkParagraph>
               <strong>{update}</strong>
             </BpkParagraph>

--- a/packages/bpk-component-aria-live/src/BpkAriaLive-test.js
+++ b/packages/bpk-component-aria-live/src/BpkAriaLive-test.js
@@ -28,7 +28,7 @@ describe('BpkAriaLive', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  Object.keys(POLITENESS_SETTINGS).forEach(politenessSetting => {
+  Object.keys(POLITENESS_SETTINGS).forEach((politenessSetting) => {
     it(`should render correctly with politenessSetting="${politenessSetting}"`, () => {
       const { asFragment } = render(
         <BpkAriaLive politenessSetting={politenessSetting}>

--- a/packages/bpk-component-autosuggest/check-autosuggest-version-test.js
+++ b/packages/bpk-component-autosuggest/check-autosuggest-version-test.js
@@ -21,7 +21,7 @@
 import packageFile from './package.json';
 
 describe('Check version of react-autosuggest', () => {
-  it('it should not be v10 or higher due to compatibility issues with react version < 16.3', () => {
+  it('should not be v10 or higher due to compatibility issues with react version < 16.3', () => {
     expect(packageFile.dependencies['react-autosuggest']).toBe('^9.4.3');
   });
 });

--- a/packages/bpk-component-autosuggest/examples.js
+++ b/packages/bpk-component-autosuggest/examples.js
@@ -108,11 +108,11 @@ const getSuggestions = (value, hanzi) => {
   return inputLength === 0
     ? []
     : data.filter(
-        office => office.name.toLowerCase().indexOf(inputValue) !== -1,
+        (office) => office.name.toLowerCase().indexOf(inputValue) !== -1,
       );
 };
 
-const getSuggestionValue = suggestion =>
+const getSuggestionValue = (suggestion) =>
   `${suggestion.name} (${suggestion.code})`;
 
 type State = {
@@ -181,7 +181,7 @@ class AutosuggestExample extends React.Component<Props, State> {
         onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
         onSuggestionsClearRequested={this.onSuggestionsClearRequested}
         getSuggestionValue={getSuggestionValue}
-        renderSuggestion={suggestion => (
+        renderSuggestion={(suggestion) => (
           <BpkAutosuggestSuggestion
             value={getSuggestionValue(suggestion)}
             indent={suggestion.indent}

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggest-test.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggest-test.js
@@ -27,8 +27,8 @@ import BpkAutosuggest from './BpkAutosuggest';
 const suggestions = ['Edinburgh', 'Glasgow', 'London'];
 const onSuggestionsFetchRequested = () => null;
 const onSuggestionsClearRequested = () => null;
-const getSuggestionValue = suggestion => suggestion;
-const renderSuggestion = suggestion => <span>{suggestion}</span>;
+const getSuggestionValue = (suggestion) => suggestion;
+const renderSuggestion = (suggestion) => <span>{suggestion}</span>;
 const inputProps = {
   id: 'origin',
   name: 'Origin',
@@ -69,7 +69,7 @@ describe('BpkAutosuggest', () => {
   it('should set the input reference', () => {
     let inputRef;
 
-    const storeAutosuggestReference = ref => {
+    const storeAutosuggestReference = (ref) => {
       inputRef = ref;
     };
 

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggest.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggest.js
@@ -62,7 +62,7 @@ Autosuggest.defaultProps.renderInputComponent = (inputProps: Props) => {
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
     <BpkInput
-      inputRef={element => {
+      inputRef={(element) => {
         ref(element);
 
         if (typeof inputRef === 'function') {

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion.js
@@ -37,15 +37,8 @@ type Props = {
 
 const BpkSuggestion = (props: Props) => {
   const classNames = [getClassName('bpk-autosuggest__suggestion')];
-  const {
-    indent,
-    className,
-    icon,
-    subHeading,
-    tertiaryLabel,
-    value,
-    ...rest
-  } = props;
+  const { indent, className, icon, subHeading, tertiaryLabel, value, ...rest } =
+    props;
   const Icon = icon;
 
   if (indent) {

--- a/packages/bpk-component-autosuggest/src/accessibility-test.js
+++ b/packages/bpk-component-autosuggest/src/accessibility-test.js
@@ -27,8 +27,8 @@ import BpkAutosuggest from './BpkAutosuggest';
 const suggestions = ['Edinburgh', 'Glasgow', 'London'];
 const onSuggestionsFetchRequested = () => null;
 const onSuggestionsClearRequested = () => null;
-const getSuggestionValue = suggestion => suggestion;
-const renderSuggestion = suggestion => <span>{suggestion}</span>;
+const getSuggestionValue = (suggestion) => suggestion;
+const renderSuggestion = (suggestion) => <span>{suggestion}</span>;
 const inputProps = {
   id: 'origin',
   name: 'Origin',

--- a/packages/bpk-component-badge/src/BpkBadge-test.js
+++ b/packages/bpk-component-badge/src/BpkBadge-test.js
@@ -57,7 +57,7 @@ describe('BpkBadge', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  Object.keys(BADGE_TYPES).forEach(badgeType => {
+  Object.keys(BADGE_TYPES).forEach((badgeType) => {
     it(`should render correctly with type="${badgeType}"`, () => {
       const { asFragment } = render(
         <BpkBadge type={badgeType}>Promociando</BpkBadge>,

--- a/packages/bpk-component-banner-alert/examples.js
+++ b/packages/bpk-component-banner-alert/examples.js
@@ -68,7 +68,7 @@ class BpkBannerAlertDismissableState extends Component<Props, State> {
           show={!this.state.dismissed}
           dismissButtonLabel="Dismiss"
           onDismiss={() => {
-            this.setState(prevState => ({
+            this.setState((prevState) => ({
               dismissed: true,
               updates: [...prevState.updates, 'Success alert dismissed'],
             }));
@@ -80,7 +80,7 @@ class BpkBannerAlertDismissableState extends Component<Props, State> {
           <BpkButtonPrimary
             className={getClassName('bpk-banner-alert-examples__component')}
             onClick={() => {
-              this.setState(prevState => ({
+              this.setState((prevState) => ({
                 dismissed: false,
                 updates: [...prevState.updates, 'Success alert added'],
               }));
@@ -93,7 +93,7 @@ class BpkBannerAlertDismissableState extends Component<Props, State> {
           visible
           className={getClassName('bpk-banner-alert-examples__component')}
         >
-          {this.state.updates.map(u => (
+          {this.state.updates.map((u) => (
             <>
               {u}
               <br />

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.js
@@ -158,7 +158,7 @@ const BpkBannerAlertInner = (props: Props) => {
   const sectionClassNames = [
     'bpk-banner-alert',
     `bpk-banner-alert--${type}`,
-  ].map(sectionClassName => getClassName(sectionClassName));
+  ].map((sectionClassName) => getClassName(sectionClassName));
 
   if (bannerClassName) {
     sectionClassNames.push(bannerClassName);

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState-test.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState-test.js
@@ -65,10 +65,7 @@ describe('withBannerAlertState(BpkBannerAlertDismissable)', () => {
       />,
     );
 
-    wrapper
-      .find(BpkCloseButton)
-      .first()
-      .simulate('click');
+    wrapper.find(BpkCloseButton).first().simulate('click');
     expect(onDismissMock).toHaveBeenCalled();
   });
 
@@ -135,10 +132,7 @@ describe('withBannerAlertState(BpkBannerAlertExpandable)', () => {
       </BpkBannerAlertExpandableState>,
     );
 
-    wrapper
-      .find('button')
-      .first()
-      .simulate('click');
+    wrapper.find('button').first().simulate('click');
     expect(onExpandMock).toHaveBeenCalled();
   });
 });

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState.js
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState.js
@@ -117,7 +117,7 @@ const withBannerAlertState = (WrappedComponent: ComponentType<any>) => {
     }
 
     onExpandToggle = () => {
-      this.setState(prevState => {
+      this.setState((prevState) => {
         const expanded = !prevState.expanded;
 
         if (this.props.onExpandToggle) {

--- a/packages/bpk-component-barchart/examples.js
+++ b/packages/bpk-component-barchart/examples.js
@@ -48,7 +48,7 @@ const Heading = withDefaultProps(BpkText, {
 const RtlBarchart = updateOnDirectionChange(BpkBarchart);
 const SelectableBarChart = withSelectedState(RtlBarchart);
 
-const data = require('./data');
+const data = require('./data.json');
 
 const margin = {
   top: 0,
@@ -112,7 +112,7 @@ const AxesAndGridlines = () => {
     .domain([5, 480])
     .range([0, size - 40]);
   const scale2 = scaleBand()
-    .domain(dataset.map(d => d[0]))
+    .domain(dataset.map((d) => d[0]))
     .range([0, size - 40]);
 
   return (
@@ -246,7 +246,7 @@ const CustomTickLabels = () => (
     }}
     xAxisLabel="Month"
     xAxisMargin={3 * remToPx(lineHeightSm) + 12}
-    xAxisTickValue={tick => {
+    xAxisTickValue={(tick) => {
       let season = '❄️';
       if (['Mar', 'Apr', 'May'].indexOf(tick) > -1) {
         season = '🌻';
@@ -269,7 +269,7 @@ const CustomTickLabels = () => (
     }}
     yAxisLabel="Average Price"
     yAxisMargin={4 * remToPx(lineHeightSm)}
-    yAxisTickValue={v => `£${v}`}
+    yAxisTickValue={(v) => `£${v}`}
   />
 );
 

--- a/packages/bpk-component-barchart/src/BpkBarchart.js
+++ b/packages/bpk-component-barchart/src/BpkBarchart.js
@@ -212,12 +212,12 @@ class BpkBarchart extends Component<Props, State> {
     const width = this.state.width - margin.left - margin.right;
     const height = this.state.height - margin.bottom - margin.top;
     const maxYValue = getMaxYValue(
-      data.map(d => d[yScaleDataKey]),
+      data.map((d) => d[yScaleDataKey]),
       outlierPercentage,
     );
 
     this.xScale.rangeRound([0, width]);
-    this.xScale.domain(transformedData.map(d => d[xScaleDataKey]));
+    this.xScale.domain(transformedData.map((d) => d[xScaleDataKey]));
     this.yScale.rangeRound([height, 0]);
     this.yScale.domain([yAxisDomain[0] || 0, yAxisDomain[1] || maxYValue]);
 
@@ -241,7 +241,7 @@ class BpkBarchart extends Component<Props, State> {
           className={classNames.join(' ')}
           width={this.state.width}
           height={this.state.height}
-          ref={svgEl => {
+          ref={(svgEl) => {
             this.svgEl = svgEl;
           }}
           {...rest}

--- a/packages/bpk-component-barchart/src/BpkBarchartBar.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartBar.js
@@ -33,7 +33,7 @@ const KEYCODES = {
   SPACEBAR: 32,
 };
 
-const handleKeyboardEvent = callback => event => {
+const handleKeyboardEvent = (callback) => (event) => {
   if (event.keyCode === KEYCODES.ENTER || event.keyCode === KEYCODES.SPACEBAR) {
     event.preventDefault();
     callback(event);

--- a/packages/bpk-component-barchart/src/BpkBarchartBars-test.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartBars-test.js
@@ -40,11 +40,9 @@ const margin = {
 };
 const { prices } = data;
 const size = 200;
-const yScale = scaleLinear()
-  .domain([0, 500])
-  .range([0, size]);
+const yScale = scaleLinear().domain([0, 500]).range([0, size]);
 const xScale = scaleBand()
-  .domain(prices.map(d => d.month))
+  .domain(prices.map((d) => d.month))
   .range([0, size]);
 
 describe('BpkBarchartBars', () => {
@@ -199,7 +197,7 @@ describe('BpkBarchartBars', () => {
         }
         BarComponent={BpkBarchartBar}
         padding={0}
-        getBarSelection={point => point.month === 'Mar'}
+        getBarSelection={(point) => point.month === 'Mar'}
       />,
     );
     expect(toJson(tree)).toMatchSnapshot();

--- a/packages/bpk-component-barchart/src/BpkBarchartBars.js
+++ b/packages/bpk-component-barchart/src/BpkBarchartBars.js
@@ -115,9 +115,9 @@ const BpkBarchartBars = (props: Props) => {
             height={outlier ? barHeight + borderRadius : barHeight}
             label={getBarLabel(point, xScaleDataKey, yScaleDataKey)}
             outlier={isOutlier(point, props)}
-            onClick={onBarClick ? e => onBarClick(e, { point }) : null}
-            onHover={onBarHover ? e => onBarHover(e, { point }) : null}
-            onFocus={onBarFocus ? e => onBarFocus(e, { point }) : null}
+            onClick={onBarClick ? (e) => onBarClick(e, { point }) : null}
+            onHover={onBarHover ? (e) => onBarHover(e, { point }) : null}
+            onFocus={onBarFocus ? (e) => onBarFocus(e, { point }) : null}
             selected={getBarSelection(point)}
             padding={innerPadding}
             {...rest}

--- a/packages/bpk-component-barchart/src/BpkChartAxis-test.js
+++ b/packages/bpk-component-barchart/src/BpkChartAxis-test.js
@@ -37,9 +37,7 @@ const margin = {
 };
 
 const size = 200;
-const linearScale = scaleLinear()
-  .domain([5, 480])
-  .range([0, size]);
+const linearScale = scaleLinear().domain([5, 480]).range([0, size]);
 const bandScale = scaleBand()
   .domain([
     'North America',

--- a/packages/bpk-component-barchart/src/BpkChartAxis.js
+++ b/packages/bpk-component-barchart/src/BpkChartAxis.js
@@ -53,7 +53,7 @@ const getAxisConfig = ({ orientation, margin, height, width, scale }) => {
         x: (width - margin.left - margin.right) / 2,
         y: margin.bottom - spacing,
       },
-      tickPosition: tick => [position(tick), 0],
+      tickPosition: (tick) => [position(tick), 0],
     };
   }
 
@@ -77,7 +77,7 @@ const getAxisConfig = ({ orientation, margin, height, width, scale }) => {
     labelProps: {
       transform: `translate(${labelTranslateX}, ${labelTranslateY}) rotate(-90)`,
     },
-    tickPosition: tick => [0, position(tick)],
+    tickPosition: (tick) => [0, position(tick)],
   };
 };
 
@@ -114,9 +114,8 @@ const BpkChartAxis = (props: Props) => {
     ...rest
   } = props;
 
-  const { textProps, tickPosition, containerProps, labelProps } = getAxisConfig(
-    props,
-  );
+  const { textProps, tickPosition, containerProps, labelProps } =
+    getAxisConfig(props);
 
   const ticks = scale.ticks
     ? scale.ticks(numTicks)

--- a/packages/bpk-component-barchart/src/BpkChartGridLines-test.js
+++ b/packages/bpk-component-barchart/src/BpkChartGridLines-test.js
@@ -37,9 +37,7 @@ const margin = {
 };
 
 const size = 200;
-const linearScale = scaleLinear()
-  .domain([5, 480])
-  .range([0, size]);
+const linearScale = scaleLinear().domain([5, 480]).range([0, size]);
 const bandScale = scaleBand()
   .domain([
     'North America',

--- a/packages/bpk-component-barchart/src/BpkChartGridLines.js
+++ b/packages/bpk-component-barchart/src/BpkChartGridLines.js
@@ -62,7 +62,7 @@ const BpkChartGridLines = (props: Props) => {
     : scale.domain().filter((tick, i) => (i - tickOffset) % tickEvery === 0);
   const position = (scale.bandwidth ? center : identity)(scale.copy());
 
-  const lineProps = tick => {
+  const lineProps = (tick) => {
     const value = position(tick);
     return orientation === ORIENTATION_X
       ? {

--- a/packages/bpk-component-barchart/src/utils-test.js
+++ b/packages/bpk-component-barchart/src/utils-test.js
@@ -37,13 +37,9 @@ describe('utils', () => {
   });
 
   describe('center', () => {
-    const domain = data.prices.map(c => c.month);
-    const scale = scaleBand()
-      .domain(domain)
-      .range([0, 100]);
-    const scaleRound = scaleBand()
-      .domain(domain)
-      .rangeRound([0, 100]);
+    const domain = data.prices.map((c) => c.month);
+    const scale = scaleBand().domain(domain).range([0, 100]);
+    const scaleRound = scaleBand().domain(domain).rangeRound([0, 100]);
 
     it('should return a function', () => {
       expect(typeof center(scale) === 'function').toBe(true);

--- a/packages/bpk-component-blockquote/src/BpkBlockquote.js
+++ b/packages/bpk-component-blockquote/src/BpkBlockquote.js
@@ -24,7 +24,7 @@ import STYLES from './BpkBlockquote.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkBlockquote = props => {
+const BpkBlockquote = (props) => {
   const classNames = [getClassName('bpk-blockquote')];
   if (props.extraSpace) {
     classNames.push(getClassName('bpk-blockquote--extra-spacing'));

--- a/packages/bpk-component-breakpoint/examples.js
+++ b/packages/bpk-component-breakpoint/examples.js
@@ -42,27 +42,27 @@ const MediaQueryStatus = (props: { children: Node, isActive: boolean }) => {
 const DefaultExample = () => (
   <div className={getClassName('bpk-breakpoints-demo')}>
     <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
-      {isActive => (
+      {(isActive) => (
         <MediaQueryStatus isActive={isActive}>MOBILE</MediaQueryStatus>
       )}
     </BpkBreakpoint>
     <BpkBreakpoint query={BREAKPOINTS.TABLET}>
-      {isActive => (
+      {(isActive) => (
         <MediaQueryStatus isActive={isActive}>TABLET</MediaQueryStatus>
       )}
     </BpkBreakpoint>
     <BpkBreakpoint query={BREAKPOINTS.TABLET_ONLY}>
-      {isActive => (
+      {(isActive) => (
         <MediaQueryStatus isActive={isActive}>TABLET ONLY</MediaQueryStatus>
       )}
     </BpkBreakpoint>
     <BpkBreakpoint query={BREAKPOINTS.ABOVE_MOBILE}>
-      {isActive => (
+      {(isActive) => (
         <MediaQueryStatus isActive={isActive}>ABOVE MOBILE</MediaQueryStatus>
       )}
     </BpkBreakpoint>
     <BpkBreakpoint query={BREAKPOINTS.ABOVE_TABLET}>
-      {isActive => (
+      {(isActive) => (
         <MediaQueryStatus isActive={isActive}>ABOVE TABLET</MediaQueryStatus>
       )}
     </BpkBreakpoint>

--- a/packages/bpk-component-breakpoint/src/BpkBreakpoint-test.js
+++ b/packages/bpk-component-breakpoint/src/BpkBreakpoint-test.js
@@ -28,11 +28,13 @@ describe('BpkBreakpoint', () => {
   it('should render if the breakpoint is matched', () => {
     jest.resetModules();
     const BpkBreakpoint = require('./BpkBreakpoint').default; // eslint-disable-line global-require
-    jest.mock('react-responsive', () => props => props.children(true));
+    jest.mock('react-responsive', () => (props) => props.children(true));
 
     const { asFragment } = render(
       <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
-        {matches => (matches ? <div>matches</div> : <div>does not match</div>)}
+        {(matches) =>
+          matches ? <div>matches</div> : <div>does not match</div>
+        }
       </BpkBreakpoint>,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -41,11 +43,13 @@ describe('BpkBreakpoint', () => {
   it('should render if the breakpoint is not matched', () => {
     jest.resetModules();
     const BpkBreakpoint = require('./BpkBreakpoint').default; // eslint-disable-line global-require
-    jest.mock('react-responsive', () => props => props.children(false));
+    jest.mock('react-responsive', () => (props) => props.children(false));
 
     const { asFragment } = render(
       <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
-        {matches => (matches ? <div>matches</div> : <div>does not match</div>)}
+        {(matches) =>
+          matches ? <div>matches</div> : <div>does not match</div>
+        }
       </BpkBreakpoint>,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -60,7 +64,7 @@ describe('BpkBreakpoint', () => {
     beforeEach(() => {
       jest.resetModules();
       BpkBreakpoint = require('./BpkBreakpoint').default; // eslint-disable-line global-require
-      jest.mock('react-responsive', () => props => props.children());
+      jest.mock('react-responsive', () => (props) => props.children());
 
       errorOrWarningSpy = jest.fn();
       oldError = window.console.error;

--- a/packages/bpk-component-breakpoint/src/BpkBreakpoint.js
+++ b/packages/bpk-component-breakpoint/src/BpkBreakpoint.js
@@ -45,7 +45,7 @@ const BpkBreakpoint = (props: Props) => {
 const queryValidator = (props: Props, ...rest) => {
   if (!props.legacy) {
     return PropTypes.oneOf(
-      Object.keys(BREAKPOINTS).map(key => BREAKPOINTS[key]),
+      Object.keys(BREAKPOINTS).map((key) => BREAKPOINTS[key]),
     ).isRequired(props, ...rest);
   }
   return PropTypes.string.isRequired(props, ...rest);

--- a/packages/bpk-component-breakpoint/src/accessibility-test.js
+++ b/packages/bpk-component-breakpoint/src/accessibility-test.js
@@ -28,7 +28,9 @@ describe('BpkBreakpoint accessibility tests', () => {
   it('should not have programmatically-detectable accessibility issues', async () => {
     const { container } = render(
       <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
-        {matches => (matches ? <div>matches</div> : <div>does not match</div>)}
+        {(matches) =>
+          matches ? <div>matches</div> : <div>does not match</div>
+        }
       </BpkBreakpoint>,
     );
     const results = await axe(container);

--- a/packages/bpk-component-button/examples.js
+++ b/packages/bpk-component-button/examples.js
@@ -47,8 +47,10 @@ const AlignedLargeLongArrowRightIcon = withLargeButtonAlignment(
   withRtlSupport(LargeLongArrowRightIcon),
 );
 
-const cssModules = (styles = {}) => className =>
-  styles[className] ? styles[className] : className;
+const cssModules =
+  (styles = {}) =>
+  (className) =>
+    styles[className] ? styles[className] : className;
 
 const getClassName = cssModules(STYLES);
 
@@ -155,7 +157,7 @@ const ComponentButtonLinkExample = (props: {}) => (
 const ComponentButtonLinkWithPaddingExample = (props: {}) => (
   /* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'. */
   <ButtonStory
-    wrapped={wrappedProps => <BpkButtonLink padded {...wrappedProps} />}
+    wrapped={(wrappedProps) => <BpkButtonLink padded {...wrappedProps} />}
     {...props}
   />
 );

--- a/packages/bpk-component-button/src/BpkButton.js
+++ b/packages/bpk-component-button/src/BpkButton.js
@@ -48,15 +48,8 @@ type Props = {
 };
 
 const BpkButton = (props: Props) => {
-  const {
-    secondary,
-    destructive,
-    featured,
-    outline,
-    link,
-    padded,
-    ...rest
-  } = props;
+  const { secondary, destructive, featured, outline, link, padded, ...rest } =
+    props;
 
   if (secondary) {
     return <BpkButtonSecondary {...rest} />;

--- a/packages/bpk-component-button/src/BpkButtonBase.js
+++ b/packages/bpk-component-button/src/BpkButtonBase.js
@@ -27,8 +27,10 @@ import COMMON_STYLES from './BpkButtonBase.module.scss';
 // we decided to inline it in this particular component so as not to bloat the
 // the bundles of consumers who are not yet on webpack 2
 // We'll revisit this again soon.
-const cssModules = (styles: {} = {}) => (className: string) =>
-  styles[className] ? styles[className] : className;
+const cssModules =
+  (styles: {} = {}) =>
+  (className: string) =>
+    styles[className] ? styles[className] : className;
 
 const getCommonClassName = cssModules(COMMON_STYLES);
 

--- a/packages/bpk-component-button/src/commonButtonTests.js
+++ b/packages/bpk-component-button/src/commonButtonTests.js
@@ -19,7 +19,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-const commonButtonTests = ButtonToTest => {
+const commonButtonTests = (ButtonToTest) => {
   describe('ButtonToTest', () => {
     it('should render correctly', () => {
       const { asFragment } = render(<ButtonToTest>My button</ButtonToTest>);
@@ -111,4 +111,6 @@ const commonButtonTests = ButtonToTest => {
   });
 };
 
+// This is a valid export as its used for other button tests
+// eslint-disable-next-line jest/no-export
 export default commonButtonTests;

--- a/packages/bpk-component-calendar/coloured-calendar-example.js
+++ b/packages/bpk-component-calendar/coloured-calendar-example.js
@@ -34,41 +34,11 @@ import {
 } from './index';
 
 const prices = [
-  125,
-  56,
-  75,
-  57,
-  78,
-  92,
-  133,
-  90,
-  148,
-  80,
-  122,
-  67,
-  70,
-  123,
-  77,
-  66,
-  64,
-  56,
-  105,
-  138,
-  52,
-  70,
-  106,
-  77,
-  66,
-  64,
-  56,
-  105,
-  138,
-  52,
-  70,
-  106,
+  125, 56, 75, 57, 78, 92, 133, 90, 148, 80, 122, 67, 70, 123, 77, 66, 64, 56,
+  105, 138, 52, 70, 106, 77, 66, 64, 56, 105, 138, 52, 70, 106,
 ];
 
-const MyCalendarDate = props => {
+const MyCalendarDate = (props) => {
   const day = props.date.getDate();
   const price = prices[day - 1];
 
@@ -104,7 +74,7 @@ class ColoredCalendar extends Component {
     return (
       <StatefulCalendar
         {...this.props}
-        onDateSelect={date => {
+        onDateSelect={(date) => {
           this.setState({
             selectionConfiguration: {
               type: this.props.selectionConfiguration.type,

--- a/packages/bpk-component-calendar/examples-components.js
+++ b/packages/bpk-component-calendar/examples-components.js
@@ -49,45 +49,14 @@ import BpkCalendar, {
 
 const LeftIcon = withButtonAlignment(withRtlSupport(SmallLongArrowLeftIcon));
 const RightIcon = withButtonAlignment(withRtlSupport(SmallLongArrowRightIcon));
-const withDirection = (Nav, direction) => props => (
-  <Nav {...props} direction={direction} />
-);
-const withPrices = (DateComponent, prices) => props => (
-  <DateComponent {...props} prices={prices} />
-);
+const withDirection = (Nav, direction) => (props) =>
+  <Nav {...props} direction={direction} />;
+const withPrices = (DateComponent, prices) => (props) =>
+  <DateComponent {...props} prices={prices} />;
 
 const prices = [
-  125,
-  56,
-  75,
-  57,
-  78,
-  92,
-  133,
-  90,
-  148,
-  80,
-  122,
-  67,
-  70,
-  123,
-  77,
-  66,
-  64,
-  56,
-  105,
-  138,
-  52,
-  70,
-  106,
-  139,
-  88,
-  97,
-  73,
-  114,
-  119,
-  141,
-  118,
+  125, 56, 75, 57, 78, 92, 133, 90, 148, 80, 122, 67, 70, 123, 77, 66, 64, 56,
+  105, 138, 52, 70, 106, 139, 88, 97, 73, 114, 119, 141, 118,
 ];
 
 const MyCalendarNav = ({ month, onMonthChange, direction }) => (
@@ -102,7 +71,7 @@ const MyCalendarNav = ({ month, onMonthChange, direction }) => (
     <div>
       <BpkButton
         iconOnly
-        onClick={event =>
+        onClick={(event) =>
           onMonthChange(event, { month: addMonths(month, -1), source: 'PREV' })
         }
       >
@@ -111,7 +80,7 @@ const MyCalendarNav = ({ month, onMonthChange, direction }) => (
       &nbsp;
       <BpkButton
         iconOnly
-        onClick={event =>
+        onClick={(event) =>
           onMonthChange(event, { month: addMonths(month, 1), source: 'NEXT' })
         }
       >
@@ -121,7 +90,7 @@ const MyCalendarNav = ({ month, onMonthChange, direction }) => (
   </div>
 );
 
-const MyCalendarDate = props => {
+const MyCalendarDate = (props) => {
   const cx = {
     textAlign: 'center',
     fontSize: '0.8em',
@@ -187,8 +156,8 @@ class MonthViewCalendar extends Component {
           nextMonthLabel="Go to next month"
           date={this.state.departDate}
           fixedWidth={false}
-          onDateSelect={departDate => {
-            this.setState(prevState => ({
+          onDateSelect={(departDate) => {
+            this.setState((prevState) => ({
               departDate,
               returnDate: dateToBoundaries(
                 prevState.returnDate,
@@ -216,8 +185,8 @@ class MonthViewCalendar extends Component {
           nextMonthLabel="Go to next month"
           date={this.state.returnDate}
           fixedWidth={false}
-          onDateSelect={returnDate => {
-            this.setState(prevState => ({
+          onDateSelect={(returnDate) => {
+            this.setState((prevState) => ({
               returnDate,
               departDate: dateToBoundaries(
                 prevState.departDate,

--- a/packages/bpk-component-calendar/examples.js
+++ b/packages/bpk-component-calendar/examples.js
@@ -252,7 +252,7 @@ const CustomColors = () => (
     daysOfWeek={weekDays}
     month={new Date()}
     weekStartsOn={1}
-    onDateSelect={date => {
+    onDateSelect={(date) => {
       // TODO we shouldn't do this but as it's only for demo purposes and works I guess it's fine
       // eslint-disable-next-line react/no-this-in-sfc
       this.setState({ date });
@@ -279,7 +279,7 @@ const WeekExample = () => {
       new Date(1980, 5, 16),
     ].map(startOfDay),
     daysOfWeek: weekDays,
-    formatDateFull: d => d.toString(),
+    formatDateFull: (d) => d.toString(),
     preventKeyboardFocus: false,
     markToday: true,
     markOutsideDays: true,

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.js
@@ -98,7 +98,7 @@ const determineFocusedDate = (
  * @param {Object} selectionConfig - The configuration of calendar to be used
  * @returns {Array} An array or single of multiple dates
  */
-const getRawSelectedDate = selectionConfig => {
+const getRawSelectedDate = (selectionConfig) => {
   let rawDate = [];
 
   switch (selectionConfig.type) {
@@ -116,7 +116,7 @@ const getRawSelectedDate = selectionConfig => {
   return rawDate;
 };
 
-const withCalendarState = Calendar => {
+const withCalendarState = (Calendar) => {
   class BpkCalendarContainer extends Component {
     constructor(props) {
       super(props);
@@ -181,7 +181,7 @@ const withCalendarState = Calendar => {
       );
     };
 
-    handleDateSelect = date => {
+    handleDateSelect = (date) => {
       const { onDateSelect, selectionConfiguration } = this.props;
       const keyboardFocusState = { preventKeyboardFocus: false };
 
@@ -219,7 +219,7 @@ const withCalendarState = Calendar => {
       });
     };
 
-    handleDateKeyDown = event => {
+    handleDateKeyDown = (event) => {
       event.persist();
       const reverse = isRTL() ? -1 : 1;
       const { focusedDate } = this.state;

--- a/packages/bpk-component-calendar/src/BpkCalendarDate.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate.js
@@ -92,7 +92,7 @@ class BpkCalendarDate extends PureComponent {
     }
   }
 
-  getButtonRef = button => {
+  getButtonRef = (button) => {
     this.button = button;
   };
 
@@ -117,7 +117,7 @@ class BpkCalendarDate extends PureComponent {
 
     const classNames = [getClassName('bpk-calendar-date')];
 
-    Object.keys(modifiers).forEach(modifier => {
+    Object.keys(modifiers).forEach((modifier) => {
       if (modifiers[modifier](this.props)) {
         classNames.push(
           getClassName(`bpk-calendar-date--modifier-${modifier}`),

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid-test.js
@@ -65,7 +65,7 @@ describe('BpkCalendarGrid', () => {
   });
 
   it('should render correctly with a custom date component', () => {
-    const MyCustomDate = props => {
+    const MyCustomDate = (props) => {
       const cx = {
         backgroundColor: colorPanjin,
         width: '50%',
@@ -111,17 +111,11 @@ describe('BpkCalendarGrid', () => {
 
     expect(onDateClick.mock.calls.length).toBe(0);
 
-    grid
-      .find('button')
-      .at(10)
-      .simulate('click');
+    grid.find('button').at(10).simulate('click');
     expect(onDateClick.mock.calls.length).toBe(1);
     expect(onDateClick.mock.calls[0][0]).toEqual(new Date(2016, 9, 5));
 
-    grid
-      .find('button')
-      .at(11)
-      .simulate('click');
+    grid.find('button').at(11).simulate('click');
     expect(onDateClick.mock.calls.length).toBe(2);
     expect(onDateClick.mock.calls[1][0]).toEqual(new Date(2016, 9, 6));
   });

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -121,7 +121,7 @@ class BpkCalendarGrid extends Component {
           weekStartsOn={weekStartsOn}
         />
         <tbody>
-          {calendarMonthWeeks.map(dates => (
+          {calendarMonthWeeks.map((dates) => (
             <Week
               key={formatIsoDate(dates[0])}
               month={month}

--- a/packages/bpk-component-calendar/src/BpkCalendarGridHeader.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridHeader.js
@@ -29,7 +29,7 @@ const getClassName = cssModules(STYLES);
 /*
   WeekDay - table header cells such as "Mon", "Tue", "Wed"...
 */
-const WeekDay = props => {
+const WeekDay = (props) => {
   const { weekDay, weekDayKey, Element } = props;
 
   return (
@@ -73,7 +73,7 @@ class BpkCalendarGridHeader extends PureComponent {
     return (
       <Header className={classNames.join(' ')} aria-hidden>
         <List className={getClassName('bpk-calendar-header__week')}>
-          {daysOfWeek.map(weekDay => (
+          {daysOfWeek.map((weekDay) => (
             <WeekDay
               Element={Item}
               key={weekDay.index}

--- a/packages/bpk-component-calendar/src/BpkCalendarGridTransition-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridTransition-test.js
@@ -24,7 +24,7 @@ import BpkCalendarGridTransition, {
   addCalendarGridTransition,
 } from './BpkCalendarGridTransition';
 
-const MyComponent = props => <div>{JSON.stringify(props)}</div>;
+const MyComponent = (props) => <div>{JSON.stringify(props)}</div>;
 const TransitioningMyComponent = addCalendarGridTransition(MyComponent);
 
 describe('BpkCalendar', () => {

--- a/packages/bpk-component-calendar/src/BpkCalendarGridTransition.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridTransition.js
@@ -207,12 +207,13 @@ BpkCalendarGridTransition.defaultProps = {
   focusedDate: null,
 };
 
-const addCalendarGridTransition = TransitionComponent => props => (
-  <BpkCalendarGridTransition
-    TransitionComponent={TransitionComponent}
-    {...props}
-  />
-);
+const addCalendarGridTransition = (TransitionComponent) => (props) =>
+  (
+    <BpkCalendarGridTransition
+      TransitionComponent={TransitionComponent}
+      {...props}
+    />
+  );
 
 export default BpkCalendarGridTransition;
 export { addCalendarGridTransition };

--- a/packages/bpk-component-calendar/src/BpkCalendarNav-test.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarNav-test.js
@@ -23,7 +23,7 @@ import format from 'date-fns/format';
 
 import BpkCalendarNav from './BpkCalendarNav';
 
-const formatMonth = date => format(date, 'MMMM yyyy');
+const formatMonth = (date) => format(date, 'MMMM yyyy');
 
 describe('BpkCalendarNav', () => {
   it('should render correctly', () => {
@@ -97,10 +97,7 @@ describe('BpkCalendarNav', () => {
 
     // Previous month
     const prevEventStub = { persist: jest.fn() };
-    nav
-      .find('button')
-      .at(0)
-      .simulate('click', prevEventStub);
+    nav.find('button').at(0).simulate('click', prevEventStub);
     expect(onMonthChange.mock.calls.length).toBe(1);
     expect(onMonthChange.mock.calls[0][0]).toEqual(prevEventStub);
     expect(onMonthChange.mock.calls[0][1]).toEqual({
@@ -110,10 +107,7 @@ describe('BpkCalendarNav', () => {
 
     // Next month
     const nextEventStub = { persist: jest.fn() };
-    nav
-      .find('button')
-      .at(1)
-      .simulate('click', nextEventStub);
+    nav.find('button').at(1).simulate('click', nextEventStub);
     expect(onMonthChange.mock.calls.length).toBe(2);
     expect(onMonthChange.mock.calls[1][0]).toEqual(nextEventStub);
     expect(onMonthChange.mock.calls[1][1]).toEqual({

--- a/packages/bpk-component-calendar/src/BpkCalendarNav.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarNav.js
@@ -37,16 +37,18 @@ import STYLES from './BpkCalendarNav.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const changeMonth = ({ month, min, max, callback, source }) => event => {
-  // Safeguard for disabled buttons is due to React bug in Chrome: https://github.com/facebook/react/issues/8308
-  // PR: https://github.com/facebook/react/pull/8329 - unresolved as of 22/12/2016
-  if (isWithinRange(month, { start: min, end: max })) {
-    event.persist();
-    callback(event, { month, source });
-  }
-};
+const changeMonth =
+  ({ month, min, max, callback, source }) =>
+  (event) => {
+    // Safeguard for disabled buttons is due to React bug in Chrome: https://github.com/facebook/react/issues/8308
+    // PR: https://github.com/facebook/react/pull/8329 - unresolved as of 22/12/2016
+    if (isWithinRange(month, { start: min, end: max })) {
+      event.persist();
+      callback(event, { month, source });
+    }
+  };
 
-const BpkCalendarNav = props => {
+const BpkCalendarNav = (props) => {
   const {
     id,
     month,
@@ -104,7 +106,7 @@ const BpkCalendarNav = props => {
             name="months"
             value={formatIsoMonth(baseMonth)}
             disabled={disabled}
-            onChange={event => {
+            onChange={(event) => {
               event.persist();
               onMonthChange(event, {
                 month: parseIsoDate(event.target.value),
@@ -112,7 +114,7 @@ const BpkCalendarNav = props => {
               });
             }}
           >
-            {navigatableMonths.map(m => (
+            {navigatableMonths.map((m) => (
               <option value={formatIsoMonth(m)} key={m.toString()}>
                 {formatMonth(m)}
               </option>

--- a/packages/bpk-component-calendar/src/Week-test.js
+++ b/packages/bpk-component-calendar/src/Week-test.js
@@ -40,7 +40,7 @@ const initialProps = {
     new Date(1980, 5, 15),
     new Date(1980, 5, 16),
   ].map(startOfDay),
-  formatDateFull: d => d.toString(),
+  formatDateFull: (d) => d.toString(),
   preventKeyboardFocus: false,
   markToday: true,
   markOutsideDays: true,
@@ -251,7 +251,7 @@ describe('Week', () => {
     it(`should${
       expected ? '' : ' not'
     } update when selection range ${reason}`, () => {
-      const date = dt => parse(`1980${dt}`, 'yyyyMMdd', new Date());
+      const date = (dt) => parse(`1980${dt}`, 'yyyyMMdd', new Date());
       const week = shallow(
         <Week
           {...initialProps}

--- a/packages/bpk-component-calendar/src/Week.js
+++ b/packages/bpk-component-calendar/src/Week.js
@@ -305,7 +305,7 @@ class Week extends Component {
     } = this.props;
 
     if (ignoreOutsideDate) {
-      const daysOutside = this.props.dates.map(date =>
+      const daysOutside = this.props.dates.map((date) =>
         isSameMonth(date, month),
       );
 
@@ -318,7 +318,7 @@ class Week extends Component {
 
     return (
       <tr className={getClassName('bpk-calendar-grid__week')}>
-        {this.props.dates.map(date => {
+        {this.props.dates.map((date) => {
           const isBlocked =
             minDate && maxDate
               ? !isWithinRange(date, { start: minDate, end: maxDate })
@@ -421,7 +421,7 @@ Week.defaultProps = {
 /*
   DateContainer - one for each date in the grid; wraps the actual BpkCalendarDate (or custom) component
 */
-const DateContainer = props => {
+const DateContainer = (props) => {
   const { className, children, selectionType, isBlocked, isEmptyCell } = props;
 
   const classNames = getClassName(

--- a/packages/bpk-component-calendar/src/composeCalendar-test.js
+++ b/packages/bpk-component-calendar/src/composeCalendar-test.js
@@ -138,15 +138,15 @@ describe('composeCalendar', () => {
 
   it('should pass props to their respective components', () => {
     const PropsBasedCalendarComponent = composeCalendar(
-      props => props.name,
-      props => props.name,
-      props => (
+      (props) => props.name,
+      (props) => props.name,
+      (props) => (
         <div>
           <h1>{props.name}</h1>
           <props.DateComponent {...props.dateProps} />
         </div>
       ),
-      props => props.name,
+      (props) => props.name,
     );
 
     const { asFragment } = render(

--- a/packages/bpk-component-calendar/src/composeCalendar.js
+++ b/packages/bpk-component-calendar/src/composeCalendar.js
@@ -26,7 +26,7 @@ import STYLES from './BpkCalendar.module.scss';
 const getClassName = cssModules(STYLES);
 
 const composeCalendar = (Nav, GridHeader, Grid, CalendarDate) => {
-  const BpkCalendar = props => {
+  const BpkCalendar = (props) => {
     const classNames = [getClassName('bpk-calendar')];
 
     const {

--- a/packages/bpk-component-calendar/src/custom-proptypes.js
+++ b/packages/bpk-component-calendar/src/custom-proptypes.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 
 import { isBefore, isSameDay } from './date-utils';
 
-const DateType = key => props => {
+const DateType = (key) => (props) => {
   const { startDate, endDate } = props[key];
 
   // No range selected

--- a/packages/bpk-component-calendar/src/date-utils.js
+++ b/packages/bpk-component-calendar/src/date-utils.js
@@ -112,7 +112,7 @@ function getCalendarMonthWeeks(date, weekStartsOn) {
 }
 
 function getLastDayOfWeekend(daysOfWeek) {
-  const weekend = daysOfWeek.map(day => day.isWeekend);
+  const weekend = daysOfWeek.map((day) => day.isWeekend);
 
   if (weekend[0] && weekend[6]) {
     // weekend stretches over turn the of the week
@@ -122,7 +122,7 @@ function getLastDayOfWeekend(daysOfWeek) {
 }
 
 function getFirstDayOfWeekend(daysOfWeek) {
-  const weekend = daysOfWeek.map(day => day.isWeekend);
+  const weekend = daysOfWeek.map((day) => day.isWeekend);
 
   if (weekend[0] && weekend[6]) {
     // weekend stretches over turn the of the week
@@ -185,8 +185,8 @@ const setMonthYear = (date, newMonth, newYear) => {
 };
 
 const parseIsoDate = parseISO;
-const formatIsoDate = date => format(date, 'yyyy-MM-dd');
-const formatIsoMonth = date => format(date, 'yyyy-MM');
+const formatIsoDate = (date) => format(date, 'yyyy-MM-dd');
+const formatIsoMonth = (date) => format(date, 'yyyy-MM');
 
 export {
   getCalendarMonthWeeks,

--- a/packages/bpk-component-calendar/src/utils.js
+++ b/packages/bpk-component-calendar/src/utils.js
@@ -23,7 +23,7 @@ import {
 
 const CSS_UNIT_REGEX = /(^[+-]?(?:\d*\.)?\d+)(.+)/i;
 
-const splitToken = value => {
+const splitToken = (value) => {
   const match = value.match(CSS_UNIT_REGEX);
   if (!match) {
     throw new Error(
@@ -47,7 +47,7 @@ export const getCalendarGridWidth = (multiplier = 1) => {
   return `${width}${sizeUnit}`;
 };
 
-export const getTransformStyles = transformValue => {
+export const getTransformStyles = (transformValue) => {
   const transform = `translateX(${transformValue})`;
   return {
     transform,

--- a/packages/bpk-component-calendar/test-utils.js
+++ b/packages/bpk-component-calendar/test-utils.js
@@ -18,19 +18,19 @@
 
 import format from 'date-fns/format';
 
-export const formatDateFull = date => format(date, 'EEEE, do MMMM yyyy');
-export const formatDateFullArabic = date => {
+export const formatDateFull = (date) => format(date, 'EEEE, do MMMM yyyy');
+export const formatDateFullArabic = (date) => {
   const dateString = 'EEEE, dd، MMMM، yyyy';
   const newString = dateString.replace('yyyy', date.getUTCFullYear());
   return format(date, newString);
 };
-export const formatDateFullJapanese = date => {
+export const formatDateFullJapanese = (date) => {
   const dateString = 'Y年M月d日EEEE';
   const newString = dateString.replace('Y', date.getUTCFullYear());
   return format(date, newString);
 };
-export const formatMonth = date => format(date, 'MMMM yyyy');
-export const formatMonthArabic = date => {
+export const formatMonth = (date) => format(date, 'MMMM yyyy');
+export const formatMonthArabic = (date) => {
   const months = [
     'يناير',
     'فبراير',
@@ -47,7 +47,7 @@ export const formatMonthArabic = date => {
   ];
   return `${months[date.getMonth()]} ${date.getFullYear()}`;
 };
-export const formatMonthJapanese = date => {
+export const formatMonthJapanese = (date) => {
   const months = [
     '1月',
     '2月',

--- a/packages/bpk-component-checkbox/examples.js
+++ b/packages/bpk-component-checkbox/examples.js
@@ -52,7 +52,7 @@ class StatefulCheckbox extends Component<Props, State> {
   }
 
   handleChange = () => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isChecked: !prevState.isChecked,
     }));
     // $FlowFixMe[incompatible-type] - ignoring as purely for storybook

--- a/packages/bpk-component-checkbox/src/BpkCheckbox.js
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.js
@@ -86,7 +86,7 @@ const BpkCheckbox = (props: Props) => {
         aria-label={label}
         aria-invalid={isInvalid}
         data-indeterminate={indeterminate}
-        ref={e => {
+        ref={(e) => {
           if (e) {
             e.indeterminate = indeterminate;
           }

--- a/packages/bpk-component-chip/examples.js
+++ b/packages/bpk-component-chip/examples.js
@@ -75,9 +75,7 @@ class StatefulSelectableChip extends React.Component<
   }
 
   toggleSelected = () => {
-    this.setState(prevState => {
-      return { selected: !prevState.selected };
-    });
+    this.setState((prevState) => ({ selected: !prevState.selected }));
   };
 
   render() {
@@ -106,7 +104,7 @@ class StatefulDismissibleChipsExample extends React.Component<
   }
 
   removeChip = (indexToRemove: number) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const newChips = prevState.chips;
       const removedChip = newChips.splice(indexToRemove, 1)[0];
 
@@ -139,7 +137,7 @@ class StatefulDismissibleChipsExample extends React.Component<
         <AriaLiveDemo
           className={getClassName('bpk-banner-alert-examples__component')}
         >
-          {this.state.updates.map(u => (
+          {this.state.updates.map((u) => (
             <>
               {u}
               <br />
@@ -167,12 +165,10 @@ class StatefulRadioGroupChipsExample extends React.Component<
   selectChip = (indexToSelect: number) => {
     const selectedChip = this.state.chips[indexToSelect];
 
-    this.setState(prevState => {
-      return {
-        selectedIndex: indexToSelect,
-        updates: [...prevState.updates, `${selectedChip} selected.`],
-      };
-    });
+    this.setState((prevState) => ({
+      selectedIndex: indexToSelect,
+      updates: [...prevState.updates, `${selectedChip} selected.`],
+    }));
   };
 
   render() {
@@ -208,7 +204,7 @@ class StatefulRadioGroupChipsExample extends React.Component<
         <AriaLiveDemo
           className={getClassName('bpk-banner-alert-examples__component')}
         >
-          {this.state.updates.map(update => (
+          {this.state.updates.map((update) => (
             <>
               {update}
               <br />
@@ -317,7 +313,7 @@ const AllTypesExample = () => (
     <BpkText textStyle={TEXT_STYLES.lg} tagName="h2">
       Selectable chips
     </BpkText>
-    {Object.keys(CHIP_TYPES).map(chipType => (
+    {Object.keys(CHIP_TYPES).map((chipType) => (
       <>
         <BpkText>{chipType}</BpkText>
         <AllSelectableChips type={chipType} />
@@ -326,7 +322,7 @@ const AllTypesExample = () => (
     <BpkText textStyle={TEXT_STYLES.lg} tagName="h2">
       Dismissible chips
     </BpkText>
-    {Object.keys(CHIP_TYPES).map(chipType => (
+    {Object.keys(CHIP_TYPES).map((chipType) => (
       <>
         <BpkText>{chipType}</BpkText>
         <StatefulDismissibleChipsExample type={chipType} />

--- a/packages/bpk-component-chip/src/BpkDismissibleChip-test.js
+++ b/packages/bpk-component-chip/src/BpkDismissibleChip-test.js
@@ -54,7 +54,7 @@ describe('BpkDismissibleChip', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  Object.keys(CHIP_TYPES).forEach(chipType => {
+  Object.keys(CHIP_TYPES).forEach((chipType) => {
     it(`should render correctly with type="${chipType}"`, () => {
       const { asFragment } = render(<TestChip type={chipType} />);
       expect(asFragment()).toMatchSnapshot();

--- a/packages/bpk-component-chip/src/BpkSelectableChip-test.js
+++ b/packages/bpk-component-chip/src/BpkSelectableChip-test.js
@@ -38,7 +38,7 @@ describe('BpkSelectableChip', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  Object.keys(CHIP_TYPES).forEach(chipType => {
+  Object.keys(CHIP_TYPES).forEach((chipType) => {
     it(`should render correctly with type="${chipType}"`, () => {
       const { asFragment } = render(<TestChip type={chipType} />);
       expect(asFragment()).toMatchSnapshot();

--- a/packages/bpk-component-content-container/src/BpkContentContainer-test.js
+++ b/packages/bpk-component-content-container/src/BpkContentContainer-test.js
@@ -37,7 +37,7 @@ describe('BpkContentContainer', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render correctly with a "bareHtml" attribute ', () => {
+  it('should render correctly with a "bareHtml" attribute', () => {
     const { asFragment } = render(
       <BpkContentContainer bareHtml>
         <h1>Heading</h1>
@@ -67,7 +67,7 @@ describe('BpkContentContainer', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render correctly with a custom "className" attribute ', () => {
+  it('should render correctly with a custom "className" attribute', () => {
     const { asFragment } = render(
       <BpkContentContainer className="my-test-class">
         <h1>Heading</h1>

--- a/packages/bpk-component-content-container/src/BpkContentContainer.js
+++ b/packages/bpk-component-content-container/src/BpkContentContainer.js
@@ -24,7 +24,7 @@ import STYLES from './BpkContentContainer.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkContentContainer = props => {
+const BpkContentContainer = (props) => {
   const {
     tagName: TagName,
     className,

--- a/packages/bpk-component-datatable/examples.js
+++ b/packages/bpk-component-datatable/examples.js
@@ -50,7 +50,7 @@ const rows = [
 ];
 
 // eslint-disable-next-line no-alert
-const onRowClick = row => alert(JSON.stringify(row));
+const onRowClick = (row) => alert(JSON.stringify(row));
 
 const AutowidthExample = () => (
   <BpkDataTable rows={rows} height={400} onRowClick={onRowClick}>

--- a/packages/bpk-component-datatable/src/BpkDataTable-test.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable-test.js
@@ -317,8 +317,8 @@ describe('BpkDataTable', () => {
     let sortDirectionValue = 'DESC';
     const sortFunction = ({ sortBy, sortDirection }) => {
       complexRows = _sortBy(complexRows, [
-        row => row.seat.office,
-        row => row.seat.desk,
+        (row) => row.seat.office,
+        (row) => row.seat.desk,
       ]);
       sortByValue = sortBy;
       sortDirectionValue = sortDirection;
@@ -399,10 +399,7 @@ describe('BpkDataTable', () => {
       </BpkDataTable>,
     );
 
-    wrapper
-      .find('.bpk-data-table__row')
-      .last()
-      .simulate('click');
+    wrapper.find('.bpk-data-table__row').last().simulate('click');
 
     expect(onRowClick).toHaveBeenCalledTimes(1);
     expect(onRowClick).toHaveBeenCalledWith(rows[1]);
@@ -425,10 +422,7 @@ describe('BpkDataTable', () => {
 
     // Select the last element in the table, which after sorting
     // it will be letter Z so index 0.
-    wrapper
-      .find('.bpk-data-table__row')
-      .last()
-      .simulate('click');
+    wrapper.find('.bpk-data-table__row').last().simulate('click');
 
     expect(onRowClick).toHaveBeenCalledTimes(1);
     expect(onRowClick).toHaveBeenCalledWith(abcRows[0]);

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -84,7 +84,7 @@ class BpkDataTable<Row> extends Component<Props<Row>, State<Row>> {
     event: SyntheticEvent<HTMLDivElement>,
   }) => {
     const column = React.Children.toArray(this.props.children).find(
-      child => child.props.dataKey === sortBy,
+      (child) => child.props.dataKey === sortBy,
     );
 
     if (!column) {
@@ -98,7 +98,7 @@ class BpkDataTable<Row> extends Component<Props<Row>, State<Row>> {
     // See: https://reactjs.org/docs/legacy-event-pooling.html
     const eventTarget = event.target;
     if (eventTarget instanceof Element) {
-      this.setState(prevState => ({
+      this.setState((prevState) => ({
         sorter: prevState.sorter.onHeaderClick(sortBy, eventTarget, column),
       }));
     }
@@ -157,7 +157,7 @@ class BpkDataTable<Row> extends Component<Props<Row>, State<Row>> {
         rowCount={this.state.sorter.rowCount}
         rowGetter={({ index }) => this.state.sorter.getRow(index)}
         headerClassName={headerClassNames.join(' ')}
-        rowClassName={row => this.rowClassName(rowClassName, row)}
+        rowClassName={(row) => this.rowClassName(rowClassName, row)}
         onRowClick={this.onRowClicked}
         onHeaderClick={this.onHeaderClick}
         {...this.state.sorter.sortProps}

--- a/packages/bpk-component-datatable/src/common-types.js
+++ b/packages/bpk-component-datatable/src/common-types.js
@@ -42,7 +42,7 @@ export type Props<Row> = {
   headerHeight: number,
   className: ?string,
   defaultColumnSortIndex: number,
-  onRowClick: Row => mixed,
+  onRowClick: (Row) => mixed,
   ...$Exact<_SortProps>,
 };
 

--- a/packages/bpk-component-datatable/src/hasChildrenOfType-test.js
+++ b/packages/bpk-component-datatable/src/hasChildrenOfType-test.js
@@ -61,7 +61,7 @@ describe('hasChildrenOfType', () => {
     );
   });
 
-  it('should return an error if it has single non matching child ', () => {
+  it('should return an error if it has single non matching child', () => {
     const error = runPropTypeValidatorWith(
       <Component>
         <div />
@@ -72,7 +72,7 @@ describe('hasChildrenOfType', () => {
     );
   });
 
-  it('should return an error if it has a mix of matching and non matching children ', () => {
+  it('should return an error if it has a mix of matching and non matching children', () => {
     const error = runPropTypeValidatorWith(
       <Component>
         <Child />

--- a/packages/bpk-component-datatable/src/hasChildrenOfType.js
+++ b/packages/bpk-component-datatable/src/hasChildrenOfType.js
@@ -29,31 +29,31 @@ export function getDisplayName(Component: AbstractComponent<any>): string {
   );
 }
 
-const hasChildrenOfType = (
-  type: AbstractComponent<any>,
-  atLeast: number = 1,
-) => (props: { [string]: any }, propType: string, componentName: string) => {
-  if (Children.count(props[propType]) < atLeast) {
-    const inflectedNoun = atLeast === 1 ? 'child' : 'children';
-    return Error(
-      `${componentName} requires at least ${atLeast} '${getDisplayName(
-        type,
-      )}' ${inflectedNoun}.`,
-    );
-  }
-
-  const children = Children.toArray(props[propType]);
-  for (let i = 0; i < children.length; i += 1) {
-    const child = children[i];
-    if (child.type !== type && !(child.type.prototype instanceof type)) {
+const hasChildrenOfType =
+  (type: AbstractComponent<any>, atLeast: number = 1) =>
+  (props: { [string]: any }, propType: string, componentName: string) => {
+    if (Children.count(props[propType]) < atLeast) {
+      const inflectedNoun = atLeast === 1 ? 'child' : 'children';
       return Error(
-        `${componentName} only allows '${getDisplayName(type)}' as children. ` +
-          `Found '${getDisplayName(child.type)}'.`,
+        `${componentName} requires at least ${atLeast} '${getDisplayName(
+          type,
+        )}' ${inflectedNoun}.`,
       );
     }
-  }
 
-  return undefined;
-};
+    const children = Children.toArray(props[propType]);
+    for (let i = 0; i < children.length; i += 1) {
+      const child = children[i];
+      if (child.type !== type && !(child.type.prototype instanceof type)) {
+        return Error(
+          `${componentName} only allows '${getDisplayName(
+            type,
+          )}' as children. Found '${getDisplayName(child.type)}'.`,
+        );
+      }
+    }
+
+    return undefined;
+  };
 
 export default hasChildrenOfType;

--- a/packages/bpk-component-datepicker/examples.js
+++ b/packages/bpk-component-datepicker/examples.js
@@ -52,7 +52,7 @@ import BpkInput, { withOpenEvents } from 'bpk-component-input';
 
 import BpkDatepicker from './index';
 
-const formatDate = date => format(date, 'dd/MM/yyyy');
+const formatDate = (date) => format(date, 'dd/MM/yyyy');
 
 const Input = withOpenEvents(BpkInput);
 
@@ -163,7 +163,7 @@ const getBackgroundForDate = memoize(
   () => [colorSagano, colorBagan, colorPetra][parseInt(Math.random() * 3, 10)],
 );
 
-const ColoredCalendarDate = props => {
+const ColoredCalendarDate = (props) => {
   let style = {};
 
   if (!props.isFocused && !props.isOutside && !props.isBlocked) {
@@ -218,8 +218,8 @@ class ReturnDatepicker extends Component {
             formatDateFull={formatDateFull}
             inputProps={inputProps}
             date={this.state.departDate}
-            onDateSelect={departDate => {
-              this.setState(prevState => ({
+            onDateSelect={(departDate) => {
+              this.setState((prevState) => ({
                 departDate,
                 returnDate: dateToBoundaries(
                   prevState.returnDate,
@@ -250,8 +250,8 @@ class ReturnDatepicker extends Component {
             formatDateFull={formatDateFull}
             inputProps={inputProps}
             date={this.state.returnDate}
-            onDateSelect={returnDate => {
-              this.setState(prevState => ({
+            onDateSelect={(returnDate) => {
+              this.setState((prevState) => ({
                 returnDate,
                 departDate: dateToBoundaries(
                   prevState.departDate,
@@ -261,7 +261,7 @@ class ReturnDatepicker extends Component {
               }));
               action('Selected return date')(returnDate);
             }}
-            onOpenChange={isOpen => {
+            onOpenChange={(isOpen) => {
               this.setState({
                 isReturnPickerOpen: isOpen,
               });

--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.js
@@ -39,7 +39,7 @@ jest.mock(
     },
 );
 
-const formatDate = date => format(date, 'dd/MM/yyyy');
+const formatDate = (date) => format(date, 'dd/MM/yyyy');
 
 const inputProps = {
   onChange: () => null,

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.js
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.js
@@ -142,13 +142,8 @@ class BpkDatepicker extends Component {
   };
 
   handleDateSelect = (startDate, endDate = null) => {
-    const {
-      onDateSelect,
-      selectionConfiguration,
-      minDate,
-      maxDate,
-      onClose,
-    } = this.props;
+    const { onDateSelect, selectionConfiguration, minDate, maxDate, onClose } =
+      this.props;
 
     // When the calendar is a single date we always want to close it when a date is selected
     // or if its a range calendar we only want to close the calendar when a range is selected.
@@ -264,7 +259,7 @@ class BpkDatepicker extends Component {
 
     return (
       <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
-        {isMobile =>
+        {(isMobile) =>
           isMobile ? (
             <BpkModal
               id={`${id}-modal`}

--- a/packages/bpk-component-datepicker/src/accessibility-test.js
+++ b/packages/bpk-component-datepicker/src/accessibility-test.js
@@ -40,7 +40,7 @@ jest.mock(
 // eslint-disable-next-line import/first
 import BpkDatepicker from './BpkDatepicker';
 
-const formatDate = date => format(date, 'dd/MM/yyyy');
+const formatDate = (date) => format(date, 'dd/MM/yyyy');
 
 const inputProps = {
   onChange: () => null,

--- a/packages/bpk-component-drawer/src/BpkDrawerContent-test.js
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent-test.js
@@ -23,8 +23,11 @@ import { render } from '@testing-library/react';
 
 import BpkDrawerContent from './BpkDrawerContent';
 
-jest.mock('react-transition-group/Transition', () => ({ children }) =>
-  children('entered'),
+jest.mock(
+  'react-transition-group/Transition',
+  () =>
+    ({ children }) =>
+      children('entered'),
 );
 
 describe('BpkDrawerContent', () => {

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.js
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.js
@@ -98,7 +98,7 @@ const BpkDrawerContent = (props: Props) => {
       in={isDrawerShown}
       onExited={onCloseAnimationComplete}
     >
-      {status => (
+      {(status) => (
         // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
         <section
           id={id}

--- a/packages/bpk-component-fieldset/examples.js
+++ b/packages/bpk-component-fieldset/examples.js
@@ -46,7 +46,7 @@ import BpkFieldset, {
 
 const getClassName = cssModules(STYLES);
 
-const formatDate = date => format(date, 'dd/MM/yyyy');
+const formatDate = (date) => format(date, 'dd/MM/yyyy');
 
 const offices = [
   {
@@ -102,18 +102,18 @@ const offices = [
   },
 ];
 
-const getSuggestions = value => {
+const getSuggestions = (value) => {
   const inputValue = value.trim().toLowerCase();
   const inputLength = inputValue.length;
 
   return inputLength === 0
     ? []
     : offices.filter(
-        office => office.name.toLowerCase().indexOf(inputValue) !== -1,
+        (office) => office.name.toLowerCase().indexOf(inputValue) !== -1,
       );
 };
 
-const getSuggestionValue = suggestion =>
+const getSuggestionValue = (suggestion) =>
   `${suggestion.name} (${suggestion.code})`;
 
 let instances = 0;
@@ -179,7 +179,7 @@ class Autosuggest extends Component<{}, AutosuggestState> {
           onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
           onSuggestionsClearRequested={this.onSuggestionsClearRequested}
           getSuggestionValue={getSuggestionValue}
-          renderSuggestion={suggestion => (
+          renderSuggestion={(suggestion) => (
             <BpkAutosuggestSuggestion
               value={getSuggestionValue(suggestion)}
               indent={suggestion.indent}
@@ -241,7 +241,7 @@ class FieldsetContainer extends Component<FieldsetProps, FieldsetState> {
   };
 
   toggleStates = () => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       let nextValidState = prevState.validState + 1;
       let isChecked = prevState.checked;
 
@@ -265,13 +265,8 @@ class FieldsetContainer extends Component<FieldsetProps, FieldsetState> {
   };
 
   render() {
-    const {
-      children,
-      isCheckbox,
-      validStates,
-      className,
-      ...rest
-    } = this.props;
+    const { children, isCheckbox, validStates, className, ...rest } =
+      this.props;
     const valid = validStates[this.state.validState];
 
     const dynamicProps = isCheckbox

--- a/packages/bpk-component-flare/src/BpkContentBubble.js
+++ b/packages/bpk-component-flare/src/BpkContentBubble.js
@@ -25,7 +25,7 @@ import STYLES from './bpk-content-bubble.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkContentBubble = props => {
+const BpkContentBubble = (props) => {
   const {
     flareProps,
     className,

--- a/packages/bpk-component-flare/src/BpkFlareBar.js
+++ b/packages/bpk-component-flare/src/BpkFlareBar.js
@@ -26,7 +26,7 @@ import CornerRadius from './__generated__/js/corner-radius';
 
 const getClassName = cssModules(STYLES);
 
-const BpkFlareBar = props => {
+const BpkFlareBar = (props) => {
   const { className, svgClassName, rounded, ...rest } = props;
 
   const classNames = [getClassName('bpk-flare-bar__container')];

--- a/packages/bpk-component-form-validation/examples.js
+++ b/packages/bpk-component-form-validation/examples.js
@@ -43,7 +43,7 @@ class FormValidationContainer extends Component {
   }
 
   toggleExpanded = () => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       expanded: !prevState.expanded,
     }));
   };
@@ -79,12 +79,12 @@ class InputContainer extends Component {
     if (FormComponent === BpkCheckbox) {
       overrideProps = {
         checked: this.state.value,
-        onChange: e => this.setState({ value: e.target.checked }),
+        onChange: (e) => this.setState({ value: e.target.checked }),
       };
     } else {
       overrideProps = {
         value: this.state.value,
-        onChange: e => this.setState({ value: e.target.value }),
+        onChange: (e) => this.setState({ value: e.target.value }),
       };
       if (FormComponent === BpkInput) {
         overrideProps.onClear = () => this.setState({ value: '' });

--- a/packages/bpk-component-form-validation/src/BpkFormValidation.js
+++ b/packages/bpk-component-form-validation/src/BpkFormValidation.js
@@ -36,15 +36,9 @@ const AlignedExclamationIcon = withAlignment(
   iconSizeSm,
 );
 
-const BpkFormValidation = props => {
-  const {
-    children,
-    expanded,
-    isCheckbox,
-    className,
-    containerProps,
-    ...rest
-  } = props;
+const BpkFormValidation = (props) => {
+  const { children, expanded, isCheckbox, className, containerProps, ...rest } =
+    props;
 
   const classNames = getClassName(
     'bpk-form-validation',

--- a/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
+++ b/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
@@ -47,20 +47,20 @@ class BpkGridToggle extends React.Component {
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     if (e.ctrlKey && e.metaKey && e.key.toLowerCase() === 'g') {
       this.toggleGrid(e);
     }
   };
 
-  toggleGrid = e => {
+  toggleGrid = (e) => {
     e.preventDefault();
 
     document
       .querySelector(this.props.targetContainer)
       .classList.toggle(GRID_CLASS_NAME);
 
-    this.setState(state => ({
+    this.setState((state) => ({
       gridEnabled: !state.gridEnabled,
     }));
   };

--- a/packages/bpk-component-grid/src/BpkGridColumn.js
+++ b/packages/bpk-component-grid/src/BpkGridColumn.js
@@ -27,9 +27,9 @@ const getClassName = cssModules(STYLES);
 // IE11 doesn't support `Number.isNaN` so we must use the global.
 // When IE11 support drops we can migrate.
 // eslint-disable-next-line no-restricted-globals
-const isNumeric = n => !isNaN(parseFloat(n)) && isFinite(n);
+const isNumeric = (n) => !isNaN(parseFloat(n)) && isFinite(n);
 
-const BpkGridColumn = props => {
+const BpkGridColumn = (props) => {
   const {
     children,
     width,

--- a/packages/bpk-component-grid/src/BpkGridContainer.js
+++ b/packages/bpk-component-grid/src/BpkGridContainer.js
@@ -24,7 +24,7 @@ import STYLES from './BpkGridContainer.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkGridContainer = props => {
+const BpkGridContainer = (props) => {
   const { children, className, debug, fullWidth, ...rest } = props;
   const classNames = [getClassName('bpk-grid__container')];
 

--- a/packages/bpk-component-grid/src/BpkGridRow.js
+++ b/packages/bpk-component-grid/src/BpkGridRow.js
@@ -24,7 +24,7 @@ import STYLES from './BpkGridRow.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkGridRow = props => {
+const BpkGridRow = (props) => {
   const classNames = [getClassName('bpk-grid__row')];
   const { children, padded, className, ...rest } = props;
 

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -165,12 +165,12 @@ class BpkHorizontalNav extends Component<Props> {
     let children = rawChildren;
 
     if (autoScrollToSelected || type === HORIZONTAL_NAV_TYPES.light) {
-      children = React.Children.map(rawChildren, child => {
+      children = React.Children.map(rawChildren, (child) => {
         const childProps = {};
 
         if (autoScrollToSelected) {
           if (child && child.props && child.props.selected) {
-            childProps.ref = ref => {
+            childProps.ref = (ref) => {
               this.selectedItemRef = ref;
             };
           }
@@ -191,7 +191,7 @@ class BpkHorizontalNav extends Component<Props> {
         className={classNames}
         leadingIndicatorClassName={leadingScrollIndicatorClassName}
         trailingIndicatorClassName={trailingScrollIndicatorClassName}
-        scrollerRef={ref => {
+        scrollerRef={(ref) => {
           this.scrollRef = ref;
         }}
         {...rest}

--- a/packages/bpk-component-icon/all.js
+++ b/packages/bpk-component-icon/all.js
@@ -19,7 +19,7 @@
 function requireAll(requireContext) {
   const hash = {};
 
-  requireContext.keys().forEach(key => {
+  requireContext.keys().forEach((key) => {
     const moduleName = key.replace('./', '').replace('.js', '');
     hash[moduleName] = requireContext(key).default;
   });

--- a/packages/bpk-component-icon/examples.js
+++ b/packages/bpk-component-icon/examples.js
@@ -61,7 +61,7 @@ const RtlAlignedLargeLongArrowRightIcon = withRtlSupport(
 
 const SmallIconsExample = () => (
   <BpkList>
-    {Object.keys(sm).map(icon => {
+    {Object.keys(sm).map((icon) => {
       const Icon = sm[icon];
       return (
         <BpkListItem key={icon}>
@@ -74,7 +74,7 @@ const SmallIconsExample = () => (
 
 const LargeIconsExample = () => (
   <BpkList>
-    {Object.keys(lg).map(icon => {
+    {Object.keys(lg).map((icon) => {
       const Icon = lg[icon];
       return (
         <BpkListItem key={icon}>

--- a/packages/bpk-component-icon/gulpfile.babel.js
+++ b/packages/bpk-component-icon/gulpfile.babel.js
@@ -24,12 +24,12 @@ import gulp from 'gulp';
 
 const ICONS_FOLDER_PATH = './node_modules/@skyscanner/bpk-svgs/dist/js/icons';
 
-const getFolders = dir =>
+const getFolders = (dir) =>
   fs
     .readdirSync(dir)
-    .filter(file => fs.statSync(path.join(dir, file)).isDirectory());
+    .filter((file) => fs.statSync(path.join(dir, file)).isDirectory());
 
-gulp.task('clean', done => del(getFolders(ICONS_FOLDER_PATH), done));
+gulp.task('clean', (done) => del(getFolders(ICONS_FOLDER_PATH), done));
 
 gulp.task('copy', () =>
   gulp.src(`${ICONS_FOLDER_PATH}/**/*.js`).pipe(gulp.dest('.')),

--- a/packages/bpk-component-icon/gulpfile.js
+++ b/packages/bpk-component-icon/gulpfile.js
@@ -29,4 +29,5 @@ require('@babel/register')({
   rootMode: 'upward',
 });
 
+// eslint-disable-next-line import/extensions
 require('./gulpfile.babel.js');

--- a/packages/bpk-component-icon/src/classNameModifierHOCFactory-test.js
+++ b/packages/bpk-component-icon/src/classNameModifierHOCFactory-test.js
@@ -26,7 +26,7 @@ describe('classNameModifierHOCFactory', () => {
     const withTestClass = classNameModifierHOCFactory('withTestClass', [
       'test-class',
     ]);
-    const MyComponent = props => <div {...props}>test</div>;
+    const MyComponent = (props) => <div {...props}>test</div>;
     const MyTestClassComponent = withTestClass(MyComponent);
 
     const { asFragment } = render(<MyTestClassComponent />);
@@ -38,7 +38,7 @@ describe('classNameModifierHOCFactory', () => {
       'test-class-1',
       'test-class-2',
     ]);
-    const MyComponent = props => <div {...props}>test</div>;
+    const MyComponent = (props) => <div {...props}>test</div>;
     const MyTestClassComponent = withTestClass(MyComponent);
 
     const { asFragment } = render(<MyTestClassComponent />);
@@ -49,7 +49,7 @@ describe('classNameModifierHOCFactory', () => {
     const withTestClass = classNameModifierHOCFactory('withTestClass', [
       'test-class',
     ]);
-    const MyComponent = props => <div {...props}>test</div>;
+    const MyComponent = (props) => <div {...props}>test</div>;
     const MyTestClassComponent = withTestClass(MyComponent);
 
     const { asFragment } = render(
@@ -63,7 +63,7 @@ describe('classNameModifierHOCFactory', () => {
       'test-class-1',
       'test-class-2',
     ]);
-    const MyComponent = props => <div {...props}>test</div>;
+    const MyComponent = (props) => <div {...props}>test</div>;
     const MyTestClassComponent = withTestClass(MyComponent);
 
     const { asFragment } = render(
@@ -74,7 +74,7 @@ describe('classNameModifierHOCFactory', () => {
 
   it('should render correctly with no classNames', () => {
     const withTestClass = classNameModifierHOCFactory('withTestClass');
-    const MyComponent = props => <div {...props}>test</div>;
+    const MyComponent = (props) => <div {...props}>test</div>;
     const MyTestClassComponent = withTestClass(MyComponent);
 
     const { asFragment } = render(<MyTestClassComponent />);

--- a/packages/bpk-component-icon/src/classNameModifierHOCFactory.js
+++ b/packages/bpk-component-icon/src/classNameModifierHOCFactory.js
@@ -20,33 +20,34 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { wrapDisplayName } from 'bpk-react-utils';
 
-export default (displayName, classNamesToAdd = []) => ComposedComponent => {
-  const ClassNameModifierHOC = props => {
-    let classNames = [];
-    const { className, ...rest } = props;
+export default (displayName, classNamesToAdd = []) =>
+  (ComposedComponent) => {
+    const ClassNameModifierHOC = (props) => {
+      let classNames = [];
+      const { className, ...rest } = props;
 
-    if (className) {
-      classNames.push(className);
-    }
-    classNames = classNamesToAdd.length
-      ? classNames.concat(classNamesToAdd)
-      : classNames;
+      if (className) {
+        classNames.push(className);
+      }
+      classNames = classNamesToAdd.length
+        ? classNames.concat(classNamesToAdd)
+        : classNames;
 
-    return <ComposedComponent className={classNames.join(' ')} {...rest} />;
+      return <ComposedComponent className={classNames.join(' ')} {...rest} />;
+    };
+
+    ClassNameModifierHOC.propTypes = {
+      className: PropTypes.string,
+    };
+
+    ClassNameModifierHOC.defaultProps = {
+      className: null,
+    };
+
+    ClassNameModifierHOC.displayName = wrapDisplayName(
+      ComposedComponent,
+      displayName,
+    );
+
+    return ClassNameModifierHOC;
   };
-
-  ClassNameModifierHOC.propTypes = {
-    className: PropTypes.string,
-  };
-
-  ClassNameModifierHOC.defaultProps = {
-    className: null,
-  };
-
-  ClassNameModifierHOC.displayName = wrapDisplayName(
-    ComposedComponent,
-    displayName,
-  );
-
-  return ClassNameModifierHOC;
-};

--- a/packages/bpk-component-icon/src/withAlignment-test.js
+++ b/packages/bpk-component-icon/src/withAlignment-test.js
@@ -43,7 +43,7 @@ describe('withAlignment', () => {
   it('should render correctly', () => {
     for (let l = 0; l < lineHeights.length; l += 1) {
       for (let i = 0; i < iconSizes.length; i += 1) {
-        const MyComponent = props => (
+        const MyComponent = (props) => (
           <div {...props}>
             test lineHeight {lineHeights[l]} and iconsSize {iconSizes[i]}
           </div>
@@ -61,7 +61,7 @@ describe('withAlignment', () => {
   });
 
   it('should keep wrapped-component styling', () => {
-    const FloatingComponent = props => (
+    const FloatingComponent = (props) => (
       <div {...props}>
         test lineHeight {lineHeightLg} and iconsSize {iconSizeSm}
       </div>
@@ -80,7 +80,7 @@ describe('withAlignment', () => {
 
   it('should wrap the component display name', () => {
     const AlignedComponent = withAlignment(
-      props => <div {...props}>test</div>,
+      (props) => <div {...props}>test</div>,
       lineHeightLg,
       iconSizeSm,
     );

--- a/packages/bpk-component-icon/src/withAlignment.js
+++ b/packages/bpk-component-icon/src/withAlignment.js
@@ -20,13 +20,12 @@ import React from 'react';
 import { wrapDisplayName } from 'bpk-react-utils';
 
 export default function withAlignment(Component, objectHeight, subjectHeight) {
-  const WithAlignment = props => {
+  const WithAlignment = (props) => {
     const objectHeightDecimal = `${objectHeight}`.replace('rem', '');
     const subjectHeightDecimal = `${subjectHeight}`.replace('rem', '');
-    const marginTopCalculated = `${Math.max(
-      0,
-      objectHeightDecimal - subjectHeightDecimal,
-    ) / 2}rem`;
+    const marginTopCalculated = `${
+      Math.max(0, objectHeightDecimal - subjectHeightDecimal) / 2
+    }rem`;
 
     return (
       <span

--- a/packages/bpk-component-icon/src/withDescription.js
+++ b/packages/bpk-component-icon/src/withDescription.js
@@ -29,7 +29,7 @@ export default function withDescription(
   Component: AbstractComponent<any>,
   description: string,
 ): AbstractComponent<any> {
-  const WithDescription = props => (
+  const WithDescription = (props) => (
     <span>
       <Component {...props} />
       <span className={getClassName('bpk-icon-description')}>

--- a/packages/bpk-component-image/src/BpkBackgroundImage.js
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.js
@@ -124,15 +124,8 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
   };
 
   render(): Node {
-    const {
-      children,
-      className,
-      inView,
-      loading,
-      src,
-      imageStyle,
-      style,
-    } = this.props;
+    const { children, className, inView, loading, src, imageStyle, style } =
+      this.props;
 
     const calculatedAspectRatio = this.getAspectRatio();
     const aspectRatioPc = `${100 / calculatedAspectRatio}%`;

--- a/packages/bpk-component-image/src/BpkImage.js
+++ b/packages/bpk-component-image/src/BpkImage.js
@@ -62,7 +62,7 @@ class Image extends Component<ImageProps> {
     }
   }
 
-  setImgRef = el => {
+  setImgRef = (el) => {
     this.img = el;
   };
 
@@ -195,7 +195,7 @@ class BpkImage extends Component<BpkImageProps> {
     return (
       <div style={style} className={className}>
         <div
-          ref={div => {
+          ref={(div) => {
             this.placeholder = div;
           }}
           style={{ height: 0, paddingBottom: aspectRatioPercentage }}

--- a/packages/bpk-component-image/src/withLazyLoading.js
+++ b/packages/bpk-component-image/src/withLazyLoading.js
@@ -163,7 +163,7 @@ export default function withLazyLoading(
       return (
         <div
           id={this.placeholderReference}
-          ref={element => {
+          ref={(element) => {
             this.element = element;
           }}
           style={style}

--- a/packages/bpk-component-infinite-scroll/examples.js
+++ b/packages/bpk-component-infinite-scroll/examples.js
@@ -57,7 +57,7 @@ const elementsArray = [
 
 const List = ({ elements }) => (
   <BpkList className={getClassName('bpk-infinite-scroll-stories__list')}>
-    {elements.map(element => (
+    {elements.map((element) => (
       <BpkListItem key={element}>{element}</BpkListItem>
     ))}
   </BpkList>
@@ -71,7 +71,7 @@ const InfiniteList = withInfiniteScroll(List);
 
 class DelayedDataSource extends ArrayDataSource {
   fetchItems(index, nElements) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       setTimeout(() => resolve(super.fetchItems(index, nElements)), 500);
     });
   }
@@ -86,7 +86,7 @@ class InfiniteDataSource extends DataSource {
   }
 
   fetchItems(index, nElements) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       for (let i = index; i < index + nElements; i += 1) {
         this.elements.push(i);
       }

--- a/packages/bpk-component-infinite-scroll/src/DataSource-test.js
+++ b/packages/bpk-component-infinite-scroll/src/DataSource-test.js
@@ -61,21 +61,22 @@ const withCommonTests = (createNewInstance, extraTests) => {
   }
 };
 
-describe('DataSource', () =>
+describe('DataSource', () => {
   withCommonTests(
     () => new DataSource(),
-    getDs => {
-      it('it throws an error when fetchItems is called directly', () => {
+    (getDs) => {
+      it('throws an error when fetchItems is called directly', () => {
         expect(() => getDs().fetchItems()).toThrow(/Not implemented/);
       });
     },
-  ));
+  );
+});
 
 describe('ArrayDataSource', () => {
   const elements = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   withCommonTests(
     () => new ArrayDataSource(elements),
-    getDs => {
+    (getDs) => {
       describe('fetchItems', () => {
         it('fetches items correctly', async () => {
           expect(await getDs().fetchItems(0, 5)).toEqual([1, 2, 3, 4, 5]);

--- a/packages/bpk-component-infinite-scroll/src/DataSource.js
+++ b/packages/bpk-component-infinite-scroll/src/DataSource.js
@@ -50,7 +50,7 @@ class DataSource<T = any> {
   }
 
   triggerListeners = (...args: Array<any>): void => {
-    this.listeners.forEach(cb => cb(...args));
+    this.listeners.forEach((cb) => cb(...args));
   };
 }
 
@@ -64,7 +64,7 @@ export class ArrayDataSource<T = any> extends DataSource<T> {
 
   fetchItems(index: number, nElements: number): Promise<Array<T>> {
     const { elements } = this;
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       const totalElements = elements.length;
       const n = totalElements - index;
       if (n <= 0) {

--- a/packages/bpk-component-infinite-scroll/src/accessibility-test.js
+++ b/packages/bpk-component-infinite-scroll/src/accessibility-test.js
@@ -32,9 +32,9 @@ describe('withInfiniteScroll accessibility tests', () => {
       elementsArray.push(`Element ${i}`);
     }
 
-    const List = props => (
+    const List = (props) => (
       <div id="list">
-        {props.elements.map(element => (
+        {props.elements.map((element) => (
           <div key={element}>{element}</div>
         ))}
       </div>

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.flow.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.flow.js
@@ -48,7 +48,7 @@ class List extends Component<ListProps> {
     return (
       // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
       <div id="list" {...rest}>
-        {elements.forEach(element => (
+        {elements.forEach((element) => (
           <div key={element}>{element}</div>
         ))}
       </div>
@@ -88,10 +88,10 @@ const InfiniteList = withInfiniteScroll(List);
       elementsPerScroll={5}
       initiallyLoadedElements={1}
       loaderIntersectionTrigger="small"
-      onScroll={evt => {}} // eslint-disable-line no-unused-vars
-      onScrollFinished={evt => {}} // eslint-disable-line no-unused-vars
+      onScroll={(evt) => {}} // eslint-disable-line no-unused-vars
+      onScrollFinished={(evt) => {}} // eslint-disable-line no-unused-vars
       renderLoadingComponent={() => <div />}
-      renderSeeMoreComponent={onClick => (
+      renderSeeMoreComponent={(onClick) => (
         <button type="button" onClick={onClick}>
           Button
         </button>

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
@@ -25,8 +25,8 @@ import toJson from 'enzyme-to-json';
 import withInfiniteScroll from './withInfiniteScroll';
 import { ArrayDataSource } from './DataSource';
 
-const nextTick = () => new Promise(res => setImmediate(res));
-const mockDataSource = data => {
+const nextTick = () => new Promise((res) => setImmediate(res));
+const mockDataSource = (data) => {
   const myDs = new ArrayDataSource(data);
   const mockFetch = myDs.fetchItems.bind(myDs);
   myDs.fetchItems = jest.fn((...args) => mockFetch(...args));
@@ -40,9 +40,9 @@ describe('withInfiniteScroll', () => {
     elementsArray.push(`Element ${i}`);
   }
 
-  const List = props => (
+  const List = (props) => (
     <div id="list">
-      {props.elements.map(element => (
+      {props.elements.map((element) => (
         <div key={element}>{element}</div>
       ))}
     </div>

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -137,7 +137,7 @@ const withInfiniteScroll = <T: ExtendedProps>(
     componentDidMount() {
       this.fetchItems({
         elementsPerScroll: this.props.initiallyLoadedElements,
-      }).then(newState => {
+      }).then((newState) => {
         this.setState(newState);
       });
     }
@@ -154,7 +154,7 @@ const withInfiniteScroll = <T: ExtendedProps>(
           index: 0,
           elementsPerScroll: this.props.elementsPerScroll,
           elementsToRender: [],
-        }).then(newState => this.setStateAfterDsUpdate(newState));
+        }).then((newState) => this.setStateAfterDsUpdate(newState));
       }
     }
 
@@ -191,29 +191,25 @@ const withInfiniteScroll = <T: ExtendedProps>(
         elementsPerScroll: isFirstLoad ? this.props.elementsPerScroll : index,
         elementsToRender: [],
         computeShowSeeMore: isFirstLoad,
-      }).then(newState => this.setStateAfterDsUpdate(newState));
+      }).then((newState) => this.setStateAfterDsUpdate(newState));
     };
 
     fetchItems(config): Promise<$Shape<State>> {
       const { onScrollFinished, seeMoreAfter } = this.props;
-      const {
-        index,
-        elementsPerScroll,
-        elementsToRender,
-        computeShowSeeMore,
-      } = extend(
-        {
-          index: this.state.index,
-          elementsPerScroll: this.props.elementsPerScroll,
-          elementsToRender: this.state.elementsToRender,
-          computeShowSeeMore: true,
-        },
-        config,
-      );
+      const { index, elementsPerScroll, elementsToRender, computeShowSeeMore } =
+        extend(
+          {
+            index: this.state.index,
+            elementsPerScroll: this.props.elementsPerScroll,
+            elementsToRender: this.state.elementsToRender,
+            computeShowSeeMore: true,
+          },
+          config,
+        );
 
       return this.props.dataSource
         .fetchItems(index, elementsPerScroll)
-        .then(nextElements => {
+        .then((nextElements) => {
           let result = {
             isListFinished: true,
           };
@@ -247,7 +243,7 @@ const withInfiniteScroll = <T: ExtendedProps>(
         if (onScroll) {
           onScroll({ currentIndex: this.state.index });
         }
-        return this.fetchItems().then(newState => {
+        return this.fetchItems().then((newState) => {
           this.setState(newState);
         });
       }
@@ -255,7 +251,7 @@ const withInfiniteScroll = <T: ExtendedProps>(
     };
 
     handleSeeMoreClick = () => {
-      this.fetchItems().then(newState => {
+      this.fetchItems().then((newState) => {
         this.setState(newState);
       });
     };
@@ -276,7 +272,7 @@ const withInfiniteScroll = <T: ExtendedProps>(
         } else {
           loadingOrButton = (
             <div
-              ref={spinner => {
+              ref={(spinner) => {
                 this.sentinel = spinner;
               }}
               className={

--- a/packages/bpk-component-infinite-scroll/stories.js
+++ b/packages/bpk-component-infinite-scroll/stories.js
@@ -39,7 +39,7 @@ import {
  * at the botton, which will cause the next story to load all items up to that position.
  * That is not a problem but we want each story to start with a clean state.
  */
-const withScrollReset = story => {
+const withScrollReset = (story) => {
   window.scrollTo(0, 0);
   return story();
 };

--- a/packages/bpk-component-input/examples.js
+++ b/packages/bpk-component-input/examples.js
@@ -65,7 +65,7 @@ class ClearableInput extends Component<Props, State> {
     };
   }
 
-  onChange = e => {
+  onChange = (e) => {
     this.setState({ value: e.target.value });
   };
 

--- a/packages/bpk-component-input/src/BpkInput-test.js
+++ b/packages/bpk-component-input/src/BpkInput-test.js
@@ -213,7 +213,7 @@ describe('BpkInput', () => {
 
   it('should expose input reference to parent components', () => {
     let inputRef;
-    const storeInputReference = ref => {
+    const storeInputReference = (ref) => {
       inputRef = ref;
     };
     const tree = mount(
@@ -225,10 +225,7 @@ describe('BpkInput', () => {
         onChange={() => {}}
       />,
     );
-    const input = tree
-      .find('input')
-      .at(0)
-      .instance();
+    const input = tree.find('input').at(0).instance();
     expect(input).toEqual(inputRef);
   });
 

--- a/packages/bpk-component-input/src/BpkInput.js
+++ b/packages/bpk-component-input/src/BpkInput.js
@@ -127,7 +127,7 @@ class BpkInput extends Component<Props, State> {
       // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
       <input
         className={classNames.join(' ')}
-        ref={input => {
+        ref={(input) => {
           ref = input;
           if (inputRef) {
             inputRef(input);
@@ -155,7 +155,7 @@ class BpkInput extends Component<Props, State> {
             tabIndex="-1"
             label={clearButtonLabel || ''}
             onMouseDown={onMouseDown}
-            onClick={e => {
+            onClick={(e) => {
               if (ref) {
                 ref.focus();
               }

--- a/packages/bpk-component-input/src/common-types.js
+++ b/packages/bpk-component-input/src/common-types.js
@@ -57,7 +57,7 @@ export const clearablePropType = (
   propName: string,
   componentName: string,
 ): ?Error => {
-  const createError = message =>
+  const createError = (message) =>
     new Error(
       `Invalid prop \`${propName}\` supplied to \`${componentName}\`. ${message}.`,
     );

--- a/packages/bpk-component-input/src/withOpenEvents.js
+++ b/packages/bpk-component-input/src/withOpenEvents.js
@@ -29,21 +29,21 @@ const KEYCODES = {
   SPACEBAR: 32,
 };
 
-const handleKeyEvent = (keyCode, callback) => e => {
+const handleKeyEvent = (keyCode, callback) => (e) => {
   if (e.keyCode === keyCode) {
     e.preventDefault();
     callback();
   }
 };
 
-const withEventHandler = (fn, eventHandler) => e => {
+const withEventHandler = (fn, eventHandler) => (e) => {
   fn(e);
   if (eventHandler) {
     eventHandler(e);
   }
 };
 
-const withOpenEvents = InputComponent => {
+const withOpenEvents = (InputComponent) => {
   class WithOpenEvents extends React.Component {
     constructor(props) {
       super(props);
@@ -51,7 +51,7 @@ const withOpenEvents = InputComponent => {
       this.focusCanOpen = true;
     }
 
-    handleTouchEnd = event => {
+    handleTouchEnd = (event) => {
       // preventDefault fixes an issue on Android and iOS in which the popover closes immediately
       // because a touch event is registered on one of the dates.
       // We can only run preventDefault when the input is already focused - otherwise it would never set

--- a/packages/bpk-component-label/src/BpkLabel.js
+++ b/packages/bpk-component-label/src/BpkLabel.js
@@ -35,15 +35,8 @@ export type Props = {
 };
 
 const BpkLabel = (props: Props) => {
-  const {
-    children,
-    required,
-    white,
-    disabled,
-    valid,
-    className,
-    ...rest
-  } = props;
+  const { children, required, white, disabled, valid, className, ...rest } =
+    props;
   const classNames = [getClassName('bpk-label')];
   const invalid = valid === false;
 

--- a/packages/bpk-component-loading-button/src/BpkLoadingButton.js
+++ b/packages/bpk-component-loading-button/src/BpkLoadingButton.js
@@ -35,7 +35,7 @@ export const ICON_POSITION = {
   TRAILING: 'trailing',
 };
 
-const getPropsIcon = props => {
+const getPropsIcon = (props) => {
   const { disabled, loading, icon, iconDisabled, iconLoading } = props;
 
   if (loading) {

--- a/packages/bpk-component-map/examples.js
+++ b/packages/bpk-component-map/examples.js
@@ -149,7 +149,7 @@ class StatefulBpkPriceMarker extends Component<
   };
 
   selectVenue = (id: string) => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       selectedId: id,
       viewedVenues: [...prevState.viewedVenues, id],
     }));
@@ -161,7 +161,7 @@ class StatefulBpkPriceMarker extends Component<
         zoom={15}
         center={{ latitude: 55.944665, longitude: -3.1964903 }}
       >
-        {venues.map(venue => (
+        {venues.map((venue) => (
           <BpkPriceMarker
             id={venue.id}
             label={venue.price}
@@ -204,7 +204,7 @@ class StatefulBpkIconMarker extends Component<
         zoom={15}
         center={{ latitude: 55.944665, longitude: -3.1964903 }}
       >
-        {venues.map(venue => (
+        {venues.map((venue) => (
           <BpkIconMarker
             position={{ latitude: venue.latitude, longitude: venue.longitude }}
             onClick={() => {
@@ -221,7 +221,7 @@ class StatefulBpkIconMarker extends Component<
   }
 }
 
-const onZoom = level => {
+const onZoom = (level) => {
   action(`Zoom changed to ${level}`);
 };
 

--- a/packages/bpk-component-map/src/BpkMap.js
+++ b/packages/bpk-component-map/src/BpkMap.js
@@ -35,7 +35,7 @@ export type MapRef = ?{
   getBounds: () => Bounds,
   getCenter: () => LatLong,
   getZoom: () => number,
-  fitBounds: Bounds => void,
+  fitBounds: (Bounds) => void,
 };
 
 type Props = {

--- a/packages/bpk-component-map/src/BpkPriceMarker-test.js
+++ b/packages/bpk-component-map/src/BpkPriceMarker-test.js
@@ -35,7 +35,7 @@ describe('BpkMapMarker', () => {
     expect(toJson(tree)).toMatchSnapshot();
   });
 
-  it('should render correctly with "status" attribute as "focused" ', () => {
+  it('should render correctly with "status" attribute as "focused"', () => {
     const tree = shallow(
       <BpkPriceMarker
         label="£120"
@@ -46,7 +46,7 @@ describe('BpkMapMarker', () => {
     expect(toJson(tree)).toMatchSnapshot();
   });
 
-  it('should render correctly with "status" attribute as "viewed" ', () => {
+  it('should render correctly with "status" attribute as "viewed"', () => {
     const tree = shallow(
       <BpkPriceMarker
         label="£120"

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
@@ -211,7 +211,7 @@ class BpkMobileScrollContainer extends Component<Props, State> {
         style={{ ...style, height: this.state.computedHeight }}
       >
         <div
-          ref={el => {
+          ref={(el) => {
             if (scrollerRef) {
               scrollerRef(el);
             }
@@ -221,7 +221,7 @@ class BpkMobileScrollContainer extends Component<Props, State> {
           className={scrollerClassNames}
         >
           <InnerContainer
-            ref={el => {
+            ref={(el) => {
               this.innerEl = el;
             }}
             className={getClassName('bpk-mobile-scroll-container__inner')}

--- a/packages/bpk-component-modal/examples.js
+++ b/packages/bpk-component-modal/examples.js
@@ -149,13 +149,8 @@ class ModalContainer extends Component<
   };
 
   render() {
-    const {
-      children,
-      wrapperProps,
-      buttonLabel,
-      accessoryView,
-      ...rest
-    } = this.props;
+    const { children, wrapperProps, buttonLabel, accessoryView, ...rest } =
+      this.props;
 
     return (
       <div id="modal-container" {...wrapperProps}>

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton-test.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton-test.js
@@ -24,7 +24,7 @@ import { render } from '@testing-library/react';
 import BpkNavigationIconButton from './BpkNavigationBarIconButton';
 
 describe('BpkNavigationIconButton', () => {
-  const Icon = props => <span {...props} />;
+  const Icon = (props) => <span {...props} />;
 
   it('should render correctly', () => {
     const { asFragment } = render(

--- a/packages/bpk-component-navigation-stack/examples.js
+++ b/packages/bpk-component-navigation-stack/examples.js
@@ -52,14 +52,14 @@ const getClassName = cssModules(STYLES);
 const DefaultExample = () => (
   <StatefulNavigationStack
     className={getClassName('bpk-navigation-stack-story-wrapper')}
-    initialViews={[<View centered>{props => <SimpleNav {...props} />}</View>]}
+    initialViews={[<View centered>{(props) => <SimpleNav {...props} />}</View>]}
   />
 );
 
 const WithNavBarExample = () => (
   <StatefulNavigationStack
     className={getClassName('bpk-navigation-stack-story-wrapper')}
-    initialViews={[<View>{props => <NavigationBar {...props} />}</View>]}
+    initialViews={[<View>{(props) => <NavigationBar {...props} />}</View>]}
   />
 );
 

--- a/packages/bpk-component-navigation-stack/src/withNavigationStackState.js
+++ b/packages/bpk-component-navigation-stack/src/withNavigationStackState.js
@@ -57,7 +57,7 @@ export default (
     }
 
     pushView = (view: Element<any>) => {
-      this.setState(prevState => {
+      this.setState((prevState) => {
         const views = prevState.views.slice();
         views.push(view);
 
@@ -68,7 +68,7 @@ export default (
     };
 
     popView = () => {
-      this.setState(prevState => {
+      this.setState((prevState) => {
         const views = prevState.views.slice();
         views.pop();
 
@@ -90,7 +90,7 @@ export default (
       };
 
       const [views, optionalCallbacks] = assignCallbacksToChildren
-        ? [this.state.views.map(view => cloneElement(view, callbacks)), {}]
+        ? [this.state.views.map((view) => cloneElement(view, callbacks)), {}]
         : [this.state.views, callbacks];
 
       return (

--- a/packages/bpk-component-navigation-stack/stories-components.js
+++ b/packages/bpk-component-navigation-stack/stories-components.js
@@ -102,7 +102,7 @@ export const SimpleNav = ({
         pushView &&
         pushView(
           <View index={index + 1} centered>
-            {props => <SimpleNav {...props} />}
+            {(props) => <SimpleNav {...props} />}
           </View>,
         )
       }
@@ -147,7 +147,7 @@ export const NavigationBar = ({
           pushView(
             (nextView && nextView()) || (
               <View index={index + 1}>
-                {props => <NavigationBar {...props} />}
+                {(props) => <NavigationBar {...props} />}
               </View>
             ),
           )

--- a/packages/bpk-component-nudger/src/BpkConfigurableNudger.js
+++ b/packages/bpk-component-nudger/src/BpkConfigurableNudger.js
@@ -43,9 +43,9 @@ const AlignedPlusIcon = withButtonAlignment(PlusIcon);
 type Props<T> = {
   ...$Exact<CommonProps<T>>,
   inputClassName: ?string,
-  formatValue: T => string,
-  incrementValue: T => T,
-  decrementValue: T => T,
+  formatValue: (T) => string,
+  incrementValue: (T) => T,
+  decrementValue: (T) => T,
   compareValues: (T, T) => number,
 };
 

--- a/packages/bpk-component-nudger/src/BpkNudger-test.js
+++ b/packages/bpk-component-nudger/src/BpkNudger-test.js
@@ -64,19 +64,19 @@ describe('BpkNudger', () => {
       return aIndex - bIndex;
     };
 
-    const incrementValue = currentValue => {
+    const incrementValue = (currentValue) => {
       const options = ['economy', 'premium', 'business', 'first'];
       const [aIndex] = [options.indexOf(currentValue) + 1];
       return options[aIndex];
     };
 
-    const decrementValue = currentValue => {
+    const decrementValue = (currentValue) => {
       const options = ['economy', 'premium', 'business', 'first'];
       const [aIndex] = [options.indexOf(currentValue) - 1];
       return options[aIndex];
     };
 
-    const formatValue = a => a.toString();
+    const formatValue = (a) => a.toString();
 
     const { asFragment } = render(
       <BpkConfigurableNudger

--- a/packages/bpk-component-nudger/src/common-types.js
+++ b/packages/bpk-component-nudger/src/common-types.js
@@ -23,7 +23,7 @@ export type CommonProps<T> = {
   min: T,
   max: T,
   value: T,
-  onChange: T => mixed,
+  onChange: (T) => mixed,
   className: ?string,
   increaseButtonLabel: string,
   decreaseButtonLabel: string,

--- a/packages/bpk-component-overlay/src/BpkOverlay-test.js
+++ b/packages/bpk-component-overlay/src/BpkOverlay-test.js
@@ -41,7 +41,7 @@ describe('BpkOverlay', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  Object.keys(OVERLAY_TYPES).map(overlayType =>
+  Object.keys(OVERLAY_TYPES).map((overlayType) =>
     it(`should render correctly with overlayType={${overlayType}}`, () => {
       const { asFragment } = render(
         <BpkOverlay overlayType={overlayType}>
@@ -52,7 +52,7 @@ describe('BpkOverlay', () => {
     }),
   );
 
-  Object.keys(BORDER_RADIUS_STYLES).map(borderRadiusStyle =>
+  Object.keys(BORDER_RADIUS_STYLES).map((borderRadiusStyle) =>
     it(`should render correctly with borderRadiusStyle={${borderRadiusStyle}}`, () => {
       const { asFragment } = render(
         <BpkOverlay borderRadiusStyle={borderRadiusStyle}>

--- a/packages/bpk-component-pagination/examples.js
+++ b/packages/bpk-component-pagination/examples.js
@@ -42,7 +42,7 @@ class PaginationContainer extends Component {
         <BpkPagination
           pageCount={pageCount}
           selectedPageIndex={this.state.pageIndex}
-          onPageChange={pageIndex => {
+          onPageChange={(pageIndex) => {
             this.handleChange(pageIndex);
           }}
           previousLabel="previous"

--- a/packages/bpk-component-pagination/src/BpkPagination-test.js
+++ b/packages/bpk-component-pagination/src/BpkPagination-test.js
@@ -99,11 +99,7 @@ describe('BpkPagination', () => {
     const page = pagination.find('ul');
     expect(onPageChange.mock.calls.length).toBe(0);
 
-    page
-      .find('li')
-      .at(4)
-      .find('button')
-      .simulate('click');
+    page.find('li').at(4).find('button').simulate('click');
 
     expect(onPageChange.mock.calls.length).toBe(1);
     expect(onPageChange.mock.calls[0][0]).toEqual(19);

--- a/packages/bpk-component-pagination/src/BpkPagination.js
+++ b/packages/bpk-component-pagination/src/BpkPagination.js
@@ -26,13 +26,13 @@ import STYLES from './BpkPagination.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const handlePageChange = (onPageChange, pageCount) => nextPageIndex => {
+const handlePageChange = (onPageChange, pageCount) => (nextPageIndex) => {
   if (onPageChange && nextPageIndex < pageCount && nextPageIndex >= 0) {
     onPageChange(nextPageIndex);
   }
 };
 
-const BpkPagination = props => {
+const BpkPagination = (props) => {
   const classNames = [getClassName('bpk-pagination')];
   const {
     pageCount,

--- a/packages/bpk-component-pagination/src/BpkPaginationBreak.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationBreak.js
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const BpkPaginationBreak = props => {
+const BpkPaginationBreak = (props) => {
   const { breakLabel } = props;
   return <div>{breakLabel}</div>;
 };

--- a/packages/bpk-component-pagination/src/BpkPaginationList-test.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationList-test.js
@@ -40,12 +40,7 @@ describe('BpkPaginationList', () => {
 
     expect(list.length).toBe(5);
     expect(list.at(3).contains(<BpkPaginationBreak />)).toBe(true);
-    expect(
-      list
-        .at(4)
-        .find('BpkPaginationPage')
-        .prop('page'),
-    ).toBe(20);
+    expect(list.at(4).find('BpkPaginationPage').prop('page')).toBe(20);
   });
 
   it('should display two ellipses when the 6th page is selected', () => {
@@ -66,12 +61,7 @@ describe('BpkPaginationList', () => {
     expect(list.length).toBe(7);
     expect(list.at(1).contains(<BpkPaginationBreak />)).toBe(true);
     expect(list.at(5).contains(<BpkPaginationBreak />)).toBe(true);
-    expect(
-      list
-        .at(4)
-        .find('BpkPaginationPage')
-        .prop('page'),
-    ).toBe(7);
+    expect(list.at(4).find('BpkPaginationPage').prop('page')).toBe(7);
   });
 
   it('should display all pages when there are only 4 pages', () => {
@@ -90,29 +80,9 @@ describe('BpkPaginationList', () => {
     const list = paginationList.find('li');
 
     expect(list.length).toBe(4);
-    expect(
-      list
-        .at(0)
-        .find('BpkPaginationPage')
-        .prop('page'),
-    ).toBe(1);
-    expect(
-      list
-        .at(1)
-        .find('BpkPaginationPage')
-        .prop('page'),
-    ).toBe(2);
-    expect(
-      list
-        .at(2)
-        .find('BpkPaginationPage')
-        .prop('page'),
-    ).toBe(3);
-    expect(
-      list
-        .at(3)
-        .find('BpkPaginationPage')
-        .prop('page'),
-    ).toBe(4);
+    expect(list.at(0).find('BpkPaginationPage').prop('page')).toBe(1);
+    expect(list.at(1).find('BpkPaginationPage').prop('page')).toBe(2);
+    expect(list.at(2).find('BpkPaginationPage').prop('page')).toBe(3);
+    expect(list.at(3).find('BpkPaginationPage').prop('page')).toBe(4);
   });
 });

--- a/packages/bpk-component-pagination/src/BpkPaginationList.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationList.js
@@ -26,7 +26,7 @@ import STYLES from './BpkPaginationList.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkPaginationList = props => {
+const BpkPaginationList = (props) => {
   const {
     selectedPageIndex,
     pageCount,
@@ -82,7 +82,7 @@ const BpkPaginationList = props => {
       }
       return null;
     })
-    .filter(page => !!page);
+    .filter((page) => !!page);
 
   return (
     <ul className={getClassName('bpk-pagination-page-list')}>{children}</ul>

--- a/packages/bpk-component-pagination/src/BpkPaginationNudger.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationNudger.js
@@ -31,7 +31,7 @@ const AlignedArrowRightIcon = withButtonAlignment(
   withRtlSupport(ArrowRightIcon),
 );
 
-const nudgerIcon = forward =>
+const nudgerIcon = (forward) =>
   forward ? (
     <AlignedArrowRightIcon
       className={getClassName('bpk-pagination-nudger__icon')}
@@ -42,7 +42,7 @@ const nudgerIcon = forward =>
     />
   );
 
-const BpkPaginationNudger = props => {
+const BpkPaginationNudger = (props) => {
   const { label, onNudge, forward, disabled } = props;
 
   return (

--- a/packages/bpk-component-pagination/src/BpkPaginationPage.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationPage.js
@@ -25,7 +25,7 @@ import STYLES from './BpkPaginationPage.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkPaginationPage = props => {
+const BpkPaginationPage = (props) => {
   const classNames = [getClassName('bpk-pagination-page')];
   const { page, onSelect, isSelected, pageLabel } = props;
 

--- a/packages/bpk-component-panel/src/BpkPanel.js
+++ b/packages/bpk-component-panel/src/BpkPanel.js
@@ -24,7 +24,7 @@ import STYLES from './BpkPanel.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkPanel = props => {
+const BpkPanel = (props) => {
   const classNames = [getClassName('bpk-panel')];
   const { children, className, padded, fullWidth, ...rest } = props;
 

--- a/packages/bpk-component-phone-input/examples.js
+++ b/packages/bpk-component-phone-input/examples.js
@@ -32,7 +32,7 @@ const DIALING_CODE_TO_ID_MAP = {
   '998_uz': 'uz',
 };
 
-const getFlag = dialingCode => {
+const getFlag = (dialingCode) => {
   const countryCode = DIALING_CODE_TO_ID_MAP[dialingCode];
   const url = `https://images.skyscnr.com/images/country/flag/header/${countryCode}.png`;
   return <BpkImage altText="Flag" height={38} width={50} src={url} />;

--- a/packages/bpk-component-phone-input/src/BpkPhoneInput.js
+++ b/packages/bpk-component-phone-input/src/BpkPhoneInput.js
@@ -90,7 +90,7 @@ const BpkPhoneInput = (props: Props) => {
   };
 
   const dialingCodeDefinition = dialingCodes.find(
-    dialingCodeDef => dialingCodeDef.code === dialingCode,
+    (dialingCodeDef) => dialingCodeDef.code === dialingCode,
   );
   if (!dialingCodeDefinition) {
     throw new Error(
@@ -106,7 +106,7 @@ const BpkPhoneInput = (props: Props) => {
     displayValue = `${numberPrefix} ${value}`;
   }
 
-  const handleChange = e => {
+  const handleChange = (e) => {
     if (!onChange) {
       return;
     }

--- a/packages/bpk-component-popover/examples.js
+++ b/packages/bpk-component-popover/examples.js
@@ -105,13 +105,8 @@ class PopoverContainer extends Component<Props, State> {
   };
 
   render() {
-    const {
-      targetFunction,
-      changeProps,
-      id,
-      inputTrigger,
-      ...rest
-    } = this.props;
+    const { targetFunction, changeProps, id, inputTrigger, ...rest } =
+      this.props;
     let target = null;
     let openButton = <BpkButton onClick={this.openPopover}> Open </BpkButton>;
 

--- a/packages/bpk-component-popover/src/BpkPopover-test.js
+++ b/packages/bpk-component-popover/src/BpkPopover-test.js
@@ -121,10 +121,7 @@ describe('BpkPopover', () => {
     const event = {
       target: '<BpkCloseButton>',
     };
-    popover
-      .find('BpkCloseButton')
-      .at(0)
-      .simulate('click', event);
+    popover.find('BpkCloseButton').at(0).simulate('click', event);
 
     expect(onCloseSpy.mock.calls[0][0].target).toEqual('<BpkCloseButton>');
     expect(onCloseSpy.mock.calls[0][1]).toEqual({ source: 'CLOSE_BUTTON' });
@@ -154,10 +151,7 @@ describe('BpkPopover', () => {
       const event = {
         target: '<BpkButtonLink>',
       };
-      popover
-        .find('BpkButtonLink')
-        .at(0)
-        .simulate('click', event);
+      popover.find('BpkButtonLink').at(0).simulate('click', event);
 
       expect(onCloseSpy.mock.calls[0][0].target).toEqual('<BpkButtonLink>');
       expect(onCloseSpy.mock.calls[0][1]).toEqual({ source: 'CLOSE_LINK' });
@@ -187,10 +181,7 @@ describe('BpkPopover', () => {
       const event = {
         target: '<BpkButtonLink>',
       };
-      popover
-        .find('BpkButtonLink')
-        .at(0)
-        .simulate('click', event);
+      popover.find('BpkButtonLink').at(0).simulate('click', event);
 
       expect(onCloseSpy.mock.calls[0][0].target).toEqual('<BpkButtonLink>');
       expect(onCloseSpy.mock.calls[0][1]).toEqual({ source: 'CLOSE_LINK' });

--- a/packages/bpk-component-popover/src/BpkPopover.js
+++ b/packages/bpk-component-popover/src/BpkPopover.js
@@ -35,7 +35,7 @@ const EVENT_SOURCES = {
   CLOSE_LINK: 'CLOSE_LINK',
 };
 
-const bindEventSource = (source, callback) => event => {
+const bindEventSource = (source, callback) => (event) => {
   if (event.persist) {
     event.persist();
   }

--- a/packages/bpk-component-popover/src/keyboardFocusScope.js
+++ b/packages/bpk-component-popover/src/keyboardFocusScope.js
@@ -27,7 +27,7 @@ import focusin from 'focusin';
 let polyfilled = false;
 let focusTrapped = false;
 
-const init = element => {
+const init = (element) => {
   // lazily polyfill focusin for firefox
   if (!polyfilled) {
     focusin.polyfill();
@@ -46,7 +46,7 @@ const init = element => {
     focusTrapped = false;
   };
 
-  const checkFocus = event => {
+  const checkFocus = (event) => {
     if (!focusTrapped) {
       return;
     }
@@ -73,7 +73,7 @@ const init = element => {
 
 let teardownFn;
 
-const scopeFocus = element => {
+const scopeFocus = (element) => {
   if (teardownFn) teardownFn();
   teardownFn = init(element);
 };

--- a/packages/bpk-component-progress/src/BpkProgress-test.js
+++ b/packages/bpk-component-progress/src/BpkProgress-test.js
@@ -92,10 +92,7 @@ describe('BpkProgress', () => {
     expect(onCompleteTransitionEndSpy).toHaveBeenCalled();
     expect(onCompleteTransitionEndSpy.mock.calls.length).toBe(1);
 
-    tree
-      .childAt(0)
-      .props()
-      .onTransitionEnd();
+    tree.childAt(0).props().onTransitionEnd();
     expect(onCompleteTransitionEndSpy).toHaveBeenCalled();
     expect(onCompleteTransitionEndSpy.mock.calls.length).toBe(2);
   });

--- a/packages/bpk-component-radio/examples.js
+++ b/packages/bpk-component-radio/examples.js
@@ -43,14 +43,14 @@ class GroupExample extends React.Component<{}, { value: string }> {
     const { ...rest } = this.props;
     return (
       <div>
-        {['Lagos', 'Kano', 'Ibadan', 'Benin City'].map(city => (
+        {['Lagos', 'Kano', 'Ibadan', 'Benin City'].map((city) => (
           <div>
             <BpkRadio
               {...rest}
               id={city}
               name={city}
               label={city}
-              onChange={event => {
+              onChange={(event) => {
                 this.updateValue(event.target.value);
               }}
               value={city}

--- a/packages/bpk-component-radio/src/BpkRadio.js
+++ b/packages/bpk-component-radio/src/BpkRadio.js
@@ -37,16 +37,8 @@ type Props = {
 };
 
 const BpkRadio = (props: Props) => {
-  const {
-    ariaLabel,
-    name,
-    label,
-    disabled,
-    white,
-    className,
-    valid,
-    ...rest
-  } = props;
+  const { ariaLabel, name, label, disabled, white, className, valid, ...rest } =
+    props;
 
   // Explicit check for false primitive value as undefined is
   // treated as neither valid nor invalid

--- a/packages/bpk-component-rating/src/BpkRating.js
+++ b/packages/bpk-component-rating/src/BpkRating.js
@@ -39,7 +39,7 @@ const getMinValue = () =>
   // If this ever changes, this function should be changed to return
   // different values based on the rating scale.
   0;
-const getMaxValue = ratingScale => {
+const getMaxValue = (ratingScale) => {
   switch (ratingScale) {
     case RATING_SCALES.zeroToFive:
       return 5;
@@ -48,10 +48,10 @@ const getMaxValue = ratingScale => {
   }
 };
 
-const getMediumRatingThreshold = ratingScale =>
+const getMediumRatingThreshold = (ratingScale) =>
   getMaxValue(ratingScale) * MEDIUM_RATING_THRESHOLD;
 
-const getHighRatingThreshold = ratingScale =>
+const getHighRatingThreshold = (ratingScale) =>
   getMaxValue(ratingScale) * HIGH_RATING_THRESHOLD;
 
 export type Props = {

--- a/packages/bpk-component-rtl-toggle/src/BpkRtlToggle.js
+++ b/packages/bpk-component-rtl-toggle/src/BpkRtlToggle.js
@@ -24,7 +24,7 @@ import { getHtmlElement, DIRECTIONS, DIRECTION_CHANGE_EVENT } from './utils';
 
 const getDirection = () => getHtmlElement().dir || DIRECTIONS.LTR;
 
-const setDirection = direction => {
+const setDirection = (direction) => {
   const htmlElement = getHtmlElement();
 
   htmlElement.dir = direction;
@@ -48,13 +48,13 @@ class BpkRtlToggle extends React.Component {
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     if (e.ctrlKey && e.metaKey && e.key.toLowerCase() === 'r') {
       this.toggleRtl(e);
     }
   };
 
-  toggleRtl = e => {
+  toggleRtl = (e) => {
     e.preventDefault();
 
     const direction =

--- a/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange.js
+++ b/packages/bpk-component-rtl-toggle/src/updateOnDirectionChange.js
@@ -21,7 +21,7 @@ import { wrapDisplayName } from 'bpk-react-utils';
 
 import { getHtmlElement, DIRECTION_CHANGE_EVENT } from './utils';
 
-const updateOnDirectionChange = EnhancedComponent => {
+const updateOnDirectionChange = (EnhancedComponent) => {
   class UpdateOnDirectionChange extends Component {
     componentDidMount() {
       getHtmlElement().addEventListener(

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGrid-test.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGrid-test.js
@@ -76,7 +76,7 @@ describe('BpkCalendarScrollGrid', () => {
   });
 
   it('should render correctly with a custom date component', () => {
-    const MyCustomDate = props => {
+    const MyCustomDate = (props) => {
       const cx = {
         backgroundColor: colorPanjin,
         width: '50%',
@@ -122,17 +122,11 @@ describe('BpkCalendarScrollGrid', () => {
 
     expect(onDateClick.mock.calls.length).toBe(0);
 
-    grid
-      .find('button')
-      .at(10)
-      .simulate('click');
+    grid.find('button').at(10).simulate('click');
     expect(onDateClick.mock.calls.length).toBe(1);
     expect(onDateClick.mock.calls[0][0]).toEqual(new Date(2016, 9, 11));
 
-    grid
-      .find('button')
-      .at(11)
-      .simulate('click');
+    grid.find('button').at(11).simulate('click');
     expect(onDateClick.mock.calls.length).toBe(2);
     expect(onDateClick.mock.calls[1][0]).toEqual(new Date(2016, 9, 12));
   });

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGrid.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGrid.js
@@ -28,7 +28,7 @@ import STYLES from './BpkScrollableCalendarGrid.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkScrollableCalendarGrid = props => {
+const BpkScrollableCalendarGrid = (props) => {
   const { month, className, ...rest } = props;
 
   const classNames = getClassName('bpk-scrollable-calendar-grid', className);

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.js
@@ -85,7 +85,7 @@ describe('BpkCalendarScrollGridList', () => {
   });
 
   it('should render correctly with a custom date component', () => {
-    const MyCustomDate = props => {
+    const MyCustomDate = (props) => {
       const cx = {
         backgroundColor: colorPanjin,
         width: '50%',

--- a/packages/bpk-component-scrollable-calendar/test-utils.js
+++ b/packages/bpk-component-scrollable-calendar/test-utils.js
@@ -18,19 +18,19 @@
 
 import format from 'date-fns/format';
 
-export const formatDateFull = date => format(date, 'EEEE, do MMMM yyyy');
-export const formatDateFullArabic = date => {
+export const formatDateFull = (date) => format(date, 'EEEE, do MMMM yyyy');
+export const formatDateFullArabic = (date) => {
   const dateString = 'EEEE, dd، MMMM، yyyy';
   const newString = dateString.replace('yyyy', date.getUTCFullYear());
   return format(date, newString);
 };
-export const formatDateFullJapanese = date => {
+export const formatDateFullJapanese = (date) => {
   const dateString = 'Y年M月d日EEEE';
   const newString = dateString.replace('Y', date.getUTCFullYear());
   return format(date, newString);
 };
-export const formatMonth = date => format(date, 'MMMM yyyy');
-export const formatMonthArabic = date => {
+export const formatMonth = (date) => format(date, 'MMMM yyyy');
+export const formatMonthArabic = (date) => {
   const months = [
     'يناير',
     'فبراير',
@@ -47,7 +47,7 @@ export const formatMonthArabic = date => {
   ];
   return `${months[date.getMonth()]} ${date.getFullYear()}`;
 };
-export const formatMonthJapanese = date => {
+export const formatMonthJapanese = (date) => {
   const months = [
     '1月',
     '2月',

--- a/packages/bpk-component-section-list/src/BpkSectionListSection.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListSection.js
@@ -45,7 +45,7 @@ const BpkSectionListSection = (props: Props) => {
         </header>
       )}
       <ul className={getClassName('bpk-section-list-section')}>
-        {React.Children.map(children, child => (
+        {React.Children.map(children, (child) => (
           <li>{child}</li>
         ))}
       </ul>

--- a/packages/bpk-component-select/examples.js
+++ b/packages/bpk-component-select/examples.js
@@ -28,7 +28,7 @@ class StatefulBpkSelect extends React.Component {
     this.state = { value: 'oranges' };
   }
 
-  onChange = value => {
+  onChange = (value) => {
     action(`BpkSelect changed. New value: ${value}`);
     this.setState({ value });
   };
@@ -39,7 +39,7 @@ class StatefulBpkSelect extends React.Component {
         id="destination"
         name="destination"
         value={this.state.value}
-        onChange={event => {
+        onChange={(event) => {
           this.onChange(event.target.value);
         }}
         {...this.props}
@@ -55,7 +55,7 @@ class StatefulBpkSelect extends React.Component {
   }
 }
 
-const getFlagUriFromCountryCode = countryCode =>
+const getFlagUriFromCountryCode = (countryCode) =>
   `https://images.skyscnr.com/images/country/flag/header/${countryCode.toLowerCase()}.png`;
 
 const countries = [
@@ -79,8 +79,8 @@ class SelectWithImage extends React.Component {
 
   getItemByValue = () => {
     const { options } = this.props;
-    return val => {
-      const items = options.filter(o => o.id === val);
+    return (val) => {
+      const items = options.filter((o) => o.id === val);
       if (!items.length) throw new Error('Item does not exists');
       return items[0];
     };
@@ -88,7 +88,7 @@ class SelectWithImage extends React.Component {
 
   getItem = this.getItemByValue();
 
-  handleChange = e => {
+  handleChange = (e) => {
     const item = this.getItem(e.target.value);
 
     this.setState({
@@ -96,7 +96,7 @@ class SelectWithImage extends React.Component {
     });
   };
 
-  image = id => <img alt="Flag" src={getFlagUriFromCountryCode(id)} />;
+  image = (id) => <img alt="Flag" src={getFlagUriFromCountryCode(id)} />;
 
   render() {
     const { options, ...rest } = this.props;
@@ -107,7 +107,7 @@ class SelectWithImage extends React.Component {
         image={this.image(this.getItem(this.state.selected).id)}
         onChange={this.handleChange}
       >
-        {options.map(o => (
+        {options.map((o) => (
           <option key={o.id} disabled={o.disabled && 'disabled'} value={o.id}>
             {o.name}
           </option>

--- a/packages/bpk-component-slider/examples.js
+++ b/packages/bpk-component-slider/examples.js
@@ -31,11 +31,11 @@ class SliderContainer extends Component {
     };
   }
 
-  handleChange = value => {
+  handleChange = (value) => {
     this.setState({ value });
   };
 
-  valueTimeFormatter = value => `12:${value.toString().padStart(2, '0')}pm`;
+  valueTimeFormatter = (value) => `12:${value.toString().padStart(2, '0')}pm`;
 
   valueComponent = (min, max, formatter) => (
     <p>
@@ -69,7 +69,7 @@ class SliderContainer extends Component {
           {...this.props}
           value={this.state.value}
           ariaLabel={['minimum', 'maximum']}
-          ariaValuetext={time ? s => this.valueTimeFormatter(s.value) : null}
+          ariaValuetext={time ? (s) => this.valueTimeFormatter(s.value) : null}
         />
         <br />
       </div>

--- a/packages/bpk-component-slider/src/BpkSlider.js
+++ b/packages/bpk-component-slider/src/BpkSlider.js
@@ -25,7 +25,7 @@ import STYLES from './BpkSlider.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkSlider = props => {
+const BpkSlider = (props) => {
   const { large, className, ...rest } = props;
   const invert = isRTL();
   const classNames = [getClassName('bpk-slider')];

--- a/packages/bpk-component-spinner/SpinnerLayout.js
+++ b/packages/bpk-component-spinner/SpinnerLayout.js
@@ -36,7 +36,7 @@ const SpinnerLayout = (props: Props) => {
   const { children } = props;
   return (
     <div className={getClassName('bpk-spinner-layout')}>
-      {Children.map(children, child => {
+      {Children.map(children, (child) => {
         const classNames = [getClassName('bpk-spinner-layout__spinner')];
 
         if (child.props.type === SPINNER_TYPES.light) {

--- a/packages/bpk-component-star-rating/examples.js
+++ b/packages/bpk-component-star-rating/examples.js
@@ -37,7 +37,7 @@ import BpkStarRating, { BpkStar, STAR_TYPES, ROUNDING_TYPES } from './index';
 const InteractiveStarRating = withInteractiveStarRatingState(
   BpkInteractiveStarRating,
 );
-const StarRating = props => (
+const StarRating = (props) => (
   <BpkStarRating ratingLabel={(r, m) => `${r} out of ${m} stars`} {...props} />
 );
 

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStar.js
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStar.js
@@ -38,16 +38,8 @@ type Props = {
 };
 
 const BpkInteractiveStar = (props: Props) => {
-  const {
-    selected,
-    type,
-    name,
-    value,
-    onClick,
-    onMouseEnter,
-    label,
-    ...rest
-  } = props;
+  const { selected, type, name, value, onClick, onMouseEnter, label, ...rest } =
+    props;
 
   const buttonClassNames = getClassName(
     'bpk-interactive-star',

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.js
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.js
@@ -80,10 +80,10 @@ const BpkInteractiveStarRating = (props: Props) => {
     stars.push(
       <BpkInteractiveStar
         key={`star-${starNumber}`}
-        onClick={event => onRatingSelect(starNumber, event)}
+        onClick={(event) => onRatingSelect(starNumber, event)}
         type={type}
         large={large}
-        onMouseEnter={event => onRatingHover(starNumber, event)}
+        onMouseEnter={(event) => onRatingHover(starNumber, event)}
         selected={rating === starNumber}
         label={getStarLabel(starNumber, maxRating)}
         name={`${id}_rating`}

--- a/packages/bpk-component-text/src/BpkText-test.js
+++ b/packages/bpk-component-text/src/BpkText-test.js
@@ -82,7 +82,7 @@ describe('BpkText', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  ['xl', 'xxl', 'xxxl', 'xxxxl', 'xxxxxl'].forEach(textStyle => {
+  ['xl', 'xxl', 'xxxl', 'xxxxl', 'xxxxxl'].forEach((textStyle) => {
     it(`should render correctly with weight="black" and supported textStyle="${textStyle}"`, () => {
       const { asFragment } = render(
         <BpkText textStyle={textStyle} weight={WEIGHT_STYLES.black}>
@@ -119,7 +119,7 @@ describe('BpkText', () => {
   });
 
   ['xs', 'sm', 'base', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxl', 'xxxxxl'].forEach(
-    textStyle => {
+    (textStyle) => {
       it(`should render correctly with textStyle="${textStyle}"`, () => {
         const { asFragment } = render(
           <BpkText textStyle={textStyle}>

--- a/packages/bpk-component-theme-toggle/src/BpkThemeToggle.js
+++ b/packages/bpk-component-theme-toggle/src/BpkThemeToggle.js
@@ -30,7 +30,7 @@ const inputId = 'theme-select';
 const getClassName = cssModules(STYLES);
 const availableThemes = Object.keys(bpkCustomThemes);
 
-const setTheme = theme => {
+const setTheme = (theme) => {
   const htmlElement = getHtmlElement();
   htmlElement.dispatchEvent(
     new CustomEvent(THEME_CHANGE_EVENT, { detail: { theme } }),
@@ -60,13 +60,13 @@ class BpkThemeToggle extends React.Component {
     }
   }
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     if (e.ctrlKey && e.metaKey && e.key.toLowerCase() === 't') {
       this.cycleTheme();
     }
   };
 
-  handleChange = e => {
+  handleChange = (e) => {
     const selectedTheme = e.target.value;
     this.setState({ selectedTheme });
     setTheme(bpkCustomThemes[selectedTheme]);
@@ -106,7 +106,7 @@ class BpkThemeToggle extends React.Component {
             Change theme
           </option>
           <option value="skyscanner">None</option>
-          {availableThemes.map(themeName => (
+          {availableThemes.map((themeName) => (
             <option key={themeName} value={themeName}>
               {themeName}
             </option>

--- a/packages/bpk-component-theme-toggle/src/updateOnThemeChange.js
+++ b/packages/bpk-component-theme-toggle/src/updateOnThemeChange.js
@@ -22,7 +22,7 @@ import { wrapDisplayName } from 'bpk-react-utils';
 
 import { getHtmlElement, THEME_CHANGE_EVENT } from './utils';
 
-const updateOnThemeChange = EnhancedComponent => {
+const updateOnThemeChange = (EnhancedComponent) => {
   class UpdateOnThemeChange extends Component {
     constructor() {
       super();
@@ -47,7 +47,7 @@ const updateOnThemeChange = EnhancedComponent => {
       );
     }
 
-    onThemeChange = e => {
+    onThemeChange = (e) => {
       const { theme } = e.detail;
       this.setState({ theme });
       this.forceUpdate();

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -188,7 +188,7 @@ class BpkTooltipPortal extends Component<Props, State> {
     return renderPortal ? (
       <Portal
         target={targetWithAccessibilityProps}
-        targetRef={targetRef => {
+        targetRef={(targetRef) => {
           this.targetRef = targetRef;
         }}
         isOpen={this.state.isOpen}

--- a/packages/bpk-mixins/sass-functions.js
+++ b/packages/bpk-mixins/sass-functions.js
@@ -19,7 +19,7 @@
 const nodeSass = require('node-sass');
 
 module.exports = {
-  'encodebase64($string)': str => {
+  'encodebase64($string)': (str) => {
     const buffer = Buffer.from(str.getValue());
 
     return nodeSass.types.String(buffer.toString('base64'));

--- a/packages/bpk-react-utils/src/accessibility-test.js
+++ b/packages/bpk-react-utils/src/accessibility-test.js
@@ -54,7 +54,7 @@ describe('TransitionInitialMount accessibility tests', () => {
 
 describe('withDefaultProps accessibility tests', () => {
   it('should not have programmatically-detectable accessibility issues', async () => {
-    const TestComponent = props => <div {...props} />;
+    const TestComponent = (props) => <div {...props} />;
 
     const Component = withDefaultProps(TestComponent, {
       a: 1,

--- a/packages/bpk-react-utils/src/cssModules.js
+++ b/packages/bpk-react-utils/src/cssModules.js
@@ -18,13 +18,12 @@
 
 /* @flow strict */
 
-export default (styles: {} = {}) => (
-  ...classNames: Array<?string | ?boolean | ?number | ?{}>
-) =>
-  classNames.reduce((className, currentClass) => {
-    if (currentClass && typeof currentClass === 'string') {
-      const realName = styles[currentClass] || currentClass;
-      return className ? `${className} ${realName}` : realName;
-    }
-    return className;
-  }, '');
+export default (styles: {} = {}) =>
+  (...classNames: Array<?string | ?boolean | ?number | ?{}>) =>
+    classNames.reduce((className, currentClass) => {
+      if (currentClass && typeof currentClass === 'string') {
+        const realName = styles[currentClass] || currentClass;
+        return className ? `${className} ${realName}` : realName;
+      }
+      return className;
+    }, '');

--- a/packages/bpk-react-utils/src/deprecated.js
+++ b/packages/bpk-react-utils/src/deprecated.js
@@ -20,18 +20,20 @@
 import { type PropType } from 'prop-types';
 
 // $FlowIssue[value-as-type] - PropType is imported as a type so is incorrectly reporting the PropType is not a valid type
-const deprecated = (propType: PropType, alternativeSuggestion: string) => (
-  props: { [string]: any },
-  propName: string,
-  componentName: string,
-  ...rest: [any]
-) => {
-  if (props[propName] != null) {
-    const message = `Warning: "${propName}" property of "${componentName}" has been deprecated. ${alternativeSuggestion}`;
-    // eslint-disable-next-line no-console
-    console.warn(message);
-  }
-  return propType(props, propName, componentName, ...rest);
-};
+const deprecated =
+  (propType: PropType, alternativeSuggestion: string) =>
+  (
+    props: { [string]: any },
+    propName: string,
+    componentName: string,
+    ...rest: [any]
+  ) => {
+    if (props[propName] != null) {
+      const message = `Warning: "${propName}" property of "${componentName}" has been deprecated. ${alternativeSuggestion}`;
+      // eslint-disable-next-line no-console
+      console.warn(message);
+    }
+    return propType(props, propName, componentName, ...rest);
+  };
 
 export default deprecated;

--- a/packages/bpk-react-utils/src/deviceDetection.js
+++ b/packages/bpk-react-utils/src/deviceDetection.js
@@ -18,20 +18,14 @@
 
 /* @flow strict */
 
-const isDeviceIphone = () => {
-  return /iPhone/i.test(
+const isDeviceIphone = () =>
+  /iPhone/i.test(
     typeof window !== 'undefined' ? window.navigator.platform : '',
   );
-};
 
-const isDeviceIpad = () => {
-  return /iPad/i.test(
-    typeof window !== 'undefined' ? window.navigator.platform : '',
-  );
-};
+const isDeviceIpad = () =>
+  /iPad/i.test(typeof window !== 'undefined' ? window.navigator.platform : '');
 
-const isDeviceIos = () => {
-  return isDeviceIphone() || isDeviceIpad();
-};
+const isDeviceIos = () => isDeviceIphone() || isDeviceIpad();
 
 export { isDeviceIphone, isDeviceIpad, isDeviceIos };

--- a/packages/bpk-react-utils/src/withDefaultProps-test.js
+++ b/packages/bpk-react-utils/src/withDefaultProps-test.js
@@ -23,7 +23,7 @@ import { render } from '@testing-library/react';
 
 import withDefaultProps from './withDefaultProps';
 
-const TestComponent = props => <div {...props} />;
+const TestComponent = (props) => <div {...props} />;
 
 describe('withDefaultProps', () => {
   it('should render correctly', () => {

--- a/packages/bpk-scrim-utils/src/BpkScrim.js
+++ b/packages/bpk-scrim-utils/src/BpkScrim.js
@@ -24,7 +24,7 @@ import STYLES from './bpk-scrim.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkScrim = props => (
+const BpkScrim = (props) => (
   <TransitionInitialMount
     appearClassName={getClassName('bpk-scrim--appear')}
     appearActiveClassName={getClassName('bpk-scrim--appear-active')}

--- a/packages/bpk-scrim-utils/src/accessibility-test.js
+++ b/packages/bpk-scrim-utils/src/accessibility-test.js
@@ -33,7 +33,7 @@ describe('BpkScrim accessibility tests', () => {
 
 describe('withScrim accessibility tests', () => {
   it('should not have programmatically-detectable accessibility issues', async () => {
-    const TestComponent = props => <div {...props} />;
+    const TestComponent = (props) => <div {...props} />;
     const Component = withScrim(TestComponent);
     const { container } = render(
       <Component

--- a/packages/bpk-scrim-utils/src/withScrim.js
+++ b/packages/bpk-scrim-utils/src/withScrim.js
@@ -41,7 +41,7 @@ import { onClosePropType } from './customPropTypes';
 
 const getClassName = cssModules(STYLES);
 
-const withScrim = WrappedComponent => {
+const withScrim = (WrappedComponent) => {
   class WithScrim extends Component {
     static propTypes = {
       getApplicationElement: PropTypes.func.isRequired,
@@ -116,7 +116,7 @@ const withScrim = WrappedComponent => {
       focusStore.restoreFocus();
     }
 
-    dialogRef = ref => {
+    dialogRef = (ref) => {
       this.dialogElement = ref;
     };
 

--- a/packages/bpk-storybook-utils/src/BpkStorybookUtils.js
+++ b/packages/bpk-storybook-utils/src/BpkStorybookUtils.js
@@ -18,7 +18,10 @@
 /* @flow strict */
 
 /* eslint-disable global-require, no-console, import/no-mutable-exports */
-let action = (...args: Array<any>) => () => console.info(args);
+let action =
+  (...args: Array<any>) =>
+  () =>
+    console.info(args);
 
 try {
   const storybookAction = require('@storybook/addon-actions').action;

--- a/packages/bpk-stylesheets/build.js
+++ b/packages/bpk-stylesheets/build.js
@@ -34,6 +34,7 @@ require('@babel/register')({
 
 const webpack = require('webpack');
 
+// eslint-disable-next-line import/extensions
 const config = require('./webpack.config.babel.js');
 
 /* eslint-disable no-console */

--- a/packages/bpk-stylesheets/index.js
+++ b/packages/bpk-stylesheets/index.js
@@ -36,6 +36,6 @@ import './index.scss';
   // add more feature tests here...
 
   document.documentElement.className += ` ${classNames
-    .map(className => `bpk-${className}`)
+    .map((className) => `bpk-${className}`)
     .join(' ')}`;
 })();

--- a/packages/bpk-tether/src/applyRTLTransforms.js
+++ b/packages/bpk-tether/src/applyRTLTransforms.js
@@ -18,7 +18,7 @@
 
 import { isRTL } from 'bpk-react-utils';
 
-const tryFlipAttachmentString = value => {
+const tryFlipAttachmentString = (value) => {
   if (value.indexOf('right') !== -1) {
     return value.replace('right', 'left');
   }
@@ -26,7 +26,7 @@ const tryFlipAttachmentString = value => {
   return value.replace('left', 'right');
 };
 
-const transform = tetherOptions => {
+const transform = (tetherOptions) => {
   const { attachment, targetAttachment, ...rest } = tetherOptions;
 
   const options = {};

--- a/packages/bpk-tether/src/getArrowPositionCallback.js
+++ b/packages/bpk-tether/src/getArrowPositionCallback.js
@@ -41,7 +41,7 @@ const getArrowPositionCallback = (
     return () => null;
   }
 
-  return props => {
+  return (props) => {
     const { top, left, targetPos } = props;
 
     const shouldApplyLeftOffset =

--- a/packages/bpk-theming/src/BpkThemeProvider.js
+++ b/packages/bpk-theming/src/BpkThemeProvider.js
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 
 const uniq = (arr = []) => {
   const seen = {};
-  return arr.filter(item => {
+  return arr.filter((item) => {
     if (seen.hasOwnProperty[item]) {
       return false;
     }
@@ -37,11 +37,11 @@ const createStyle = (theme, themeAttributes) => {
   const flattenedThemeAttributes = [].concat(...themeAttributes);
   let style = {};
   const missingThemeAttributes = [];
-  flattenedThemeAttributes.forEach(attribute => {
+  flattenedThemeAttributes.forEach((attribute) => {
     if (theme[attribute]) {
       const cssName = attribute
-        .replace(/([A-Z])/g, variable => `-${variable.toLowerCase()}`)
-        .replace(/([0-9])/, variable => `-${variable.toLowerCase()}`);
+        .replace(/([A-Z])/g, (variable) => `-${variable.toLowerCase()}`)
+        .replace(/([0-9])/, (variable) => `-${variable.toLowerCase()}`);
       const value = theme[attribute];
       style[`--bpk-${cssName}`] = value;
     } else {
@@ -103,7 +103,7 @@ const themeAttributesPropType = (props, propName, componentName) => {
   themeAttributes = [].concat(...themeAttributes);
   const extraneousThemeAttributes = { ...theme };
   const missingThemeAttributes = [];
-  themeAttributes.forEach(attribute => {
+  themeAttributes.forEach((attribute) => {
     if (theme[attribute]) {
       delete extraneousThemeAttributes[attribute];
     } else {

--- a/scripts/npm/check-bpk-dependencies.js
+++ b/scripts/npm/check-bpk-dependencies.js
@@ -29,7 +29,7 @@ const findReplace = (file, findReplaces) => {
       return console.log(err);
     }
     let result = data;
-    findReplaces.forEach(fr => {
+    findReplaces.forEach((fr) => {
       const splitFile = result.split(fr.find);
       if (splitFile.length === 1) {
         return null;
@@ -38,7 +38,7 @@ const findReplace = (file, findReplaces) => {
       return null;
     });
 
-    fs.writeFile(file, result, 'utf8', err2 => {
+    fs.writeFile(file, result, 'utf8', (err2) => {
       if (err2) return console.log(err2);
       return null;
     });
@@ -46,9 +46,9 @@ const findReplace = (file, findReplaces) => {
   });
 };
 
-const fixDependencyErrors = packageFiles => {
+const fixDependencyErrors = (packageFiles) => {
   const findReplaces = [];
-  errors.forEach(error => {
+  errors.forEach((error) => {
     findReplaces.push({
       find: new RegExp(
         `\\"${error.dependency}\\"\\:[ ]+\\"\\^[0-9]+\\.[0-9]+\\.[0-9]+\\"`,
@@ -61,13 +61,13 @@ const fixDependencyErrors = packageFiles => {
     );
   });
 
-  packageFiles.forEach(file => {
+  packageFiles.forEach((file) => {
     findReplace(file, findReplaces);
   });
 };
 
 const checkBpkDependencyList = (dependencies, correctVersions, packageName) => {
-  Object.keys(dependencies).forEach(dependency => {
+  Object.keys(dependencies).forEach((dependency) => {
     if (Object.keys(correctVersions).indexOf(dependency) !== -1) {
       const dependencyVersion = dependencies[dependency];
       const correctDependencyVersion = `^${correctVersions[dependency]}`;
@@ -103,7 +103,7 @@ const checkBpkDependencies = (packageFile, correctVersions) => {
   }
 };
 
-const getLatestProductionVersion = version => {
+const getLatestProductionVersion = (version) => {
   if (version.includes('-alpha')) {
     return version.split('-alpha')[0];
   }
@@ -113,7 +113,7 @@ const getLatestProductionVersion = version => {
   return version;
 };
 
-const getBpkPackageVersions = packageFiles =>
+const getBpkPackageVersions = (packageFiles) =>
   packageFiles.reduce((acc, pkg) => {
     if (pkg === '' || !pkg.includes('bpk-')) {
       return acc;
@@ -133,7 +133,7 @@ let packageFiles = execSync(
   .toString()
   .split('\n');
 
-packageFiles = packageFiles.filter(s => s !== '');
+packageFiles = packageFiles.filter((s) => s !== '');
 const bpkPackageVersions = getBpkPackageVersions(packageFiles);
 
 if (
@@ -156,7 +156,7 @@ if (
   bpkPackageVersions['@skyscanner/bpk-foundations-web'] = foundationsVersion[0];
 }
 
-packageFiles.forEach(pf => {
+packageFiles.forEach((pf) => {
   checkBpkDependencies(pf, bpkPackageVersions);
 });
 
@@ -171,7 +171,7 @@ if (errors.length === 0) {
 } else {
   console.log('Some Backpack cross dependencies are outdated  😱');
   console.log('');
-  errors.forEach(error => {
+  errors.forEach((error) => {
     console.log(
       `${error.packageName} depends on ${error.dependency} ${error.dependencyVersion}, it should be ${error.correctDependencyVersion}`,
     );

--- a/scripts/npm/check-owners.js
+++ b/scripts/npm/check-owners.js
@@ -60,19 +60,19 @@ const meta = require('../../meta.json');
 
 let failures = false;
 
-const owners = meta.maintainers.map(maintainer => maintainer.npm).sort();
+const owners = meta.maintainers.map((maintainer) => maintainer.npm).sort();
 
 const packageDone = () => {
   packagesDataFetched += 1;
   bar.update(packagesDataFetched);
 };
 
-const getPackageMaintainers = pkg =>
+const getPackageMaintainers = (pkg) =>
   new Promise((resolve, reject) => {
-    https.get(`https://registry.npmjs.org/${pkg}/`, res => {
+    https.get(`https://registry.npmjs.org/${pkg}/`, (res) => {
       let body = '';
       res.setEncoding('utf8');
-      res.on('data', d => {
+      res.on('data', (d) => {
         body += d;
       });
       res.on('error', reject);
@@ -83,7 +83,7 @@ const getPackageMaintainers = pkg =>
           packageDone();
           resolve({
             name: pkg,
-            maintainers: pkgData.maintainers.map(m => m.name),
+            maintainers: pkgData.maintainers.map((m) => m.name),
             new: false,
           });
         } else {
@@ -97,7 +97,7 @@ const getPackageMaintainers = pkg =>
     });
   });
 
-const verifyMaintainers = data => {
+const verifyMaintainers = (data) => {
   if (data.new) {
     console.log(
       `${data.name} ⁇\n  Package does not seem to be in NPM registry (yet)`,
@@ -106,7 +106,7 @@ const verifyMaintainers = data => {
   }
 
   const sortedMaintainers = data.maintainers
-    .filter(m => !DEARLY_DEPARTED.includes(m))
+    .filter((m) => !DEARLY_DEPARTED.includes(m))
     .sort();
 
   if (sortedMaintainers.join('') === owners.join('')) {
@@ -127,18 +127,18 @@ console.log(`Maintainers are:\n  ${owners.join('\n  ')}\n`);
 const privatePackages = ['bpk-component-boilerplate'];
 
 readdir('packages/')
-  .then(packages => packages.filter(i => !privatePackages.includes(i)))
-  .then(packages => {
+  .then((packages) => packages.filter((i) => !privatePackages.includes(i)))
+  .then((packages) => {
     bar.start(packages.length, 0);
     return packages;
   })
-  .then(packages => Promise.all(packages.map(getPackageMaintainers)))
-  .then(packages => {
+  .then((packages) => Promise.all(packages.map(getPackageMaintainers)))
+  .then((packages) => {
     bar.stop();
     console.log('');
     return packages;
   })
-  .then(maintainers => maintainers.forEach(verifyMaintainers))
+  .then((maintainers) => maintainers.forEach(verifyMaintainers))
   .then(() => {
     if (failures) {
       console.log(
@@ -150,7 +150,7 @@ readdir('packages/')
       process.exit(0);
     }
   })
-  .catch(error => {
+  .catch((error) => {
     console.error(
       'An unknown error occured. Please check your network connection and try again.',
     );

--- a/scripts/npm/check-react-versions.js
+++ b/scripts/npm/check-react-versions.js
@@ -27,7 +27,7 @@ const reactVersionErrors = [];
 
 console.log('Checking React versions...');
 
-reactLibs.forEach(lib => {
+reactLibs.forEach((lib) => {
   if (reactDeps[lib] !== skyscannerStandard) {
     reactVersionErrors.push(
       `Your version of ${lib} ${reactDeps[lib]} does not match the company version ${skyscannerStandard}`,

--- a/scripts/npm/create-component.js
+++ b/scripts/npm/create-component.js
@@ -47,7 +47,7 @@ _.mixin({
 });
 
 // Util to recursively make dirs
-const mkdirp = dir =>
+const mkdirp = (dir) =>
   path
     .resolve(dir)
     .split(path.sep)
@@ -104,7 +104,7 @@ const createComponent = async (err, { name }) => {
     `!**/node_modules/**`,
   ]);
 
-  const processBoilerPlateFiles = boilerPlateFilePath => {
+  const processBoilerPlateFiles = (boilerPlateFilePath) => {
     const newFilePath = boilerPlateFilePath
       .split('boilerplate')
       .join(name)
@@ -123,7 +123,7 @@ const createComponent = async (err, { name }) => {
     });
   };
 
-  const componentCreationProcess = async directoryAlreadyExists => {
+  const componentCreationProcess = async (directoryAlreadyExists) => {
     if (directoryAlreadyExists) {
       console.error(
         colors.red(
@@ -148,7 +148,7 @@ const createComponent = async (err, { name }) => {
       .split(STORYBOOK_CONFIG_SPLIT_POINT_1)[1]
       .split(STORYBOOK_CONFIG_SPLIT_POINT_2)[0]
       .split('\n')
-      .filter(s => !_.isEmpty(s));
+      .filter((s) => !_.isEmpty(s));
 
     storybookConfigContentImports.push(storybookImport);
 

--- a/scripts/npm/get-owners.js
+++ b/scripts/npm/get-owners.js
@@ -25,7 +25,7 @@
 
 const meta = require('../../meta.json');
 
-meta.maintainers.forEach(maintainer => {
+meta.maintainers.forEach((maintainer) => {
   if (maintainer.npm) {
     process.stdout.write(`${maintainer.npm}\n`);
   }

--- a/scripts/publish-process/add-missing-tags.js
+++ b/scripts/publish-process/add-missing-tags.js
@@ -32,13 +32,13 @@ const {
 } = require('./util');
 
 const getCommitHash = () =>
-  new Promise(resolve => {
+  new Promise((resolve) => {
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
     });
 
-    rl.question('Enter the hash of the commit to tag', answer => {
+    rl.question('Enter the hash of the commit to tag', (answer) => {
       if (!answer.match(GIT_HASH_REGEX)) {
         rl.close();
         resolve(getCommitHash());
@@ -55,7 +55,7 @@ const getPackagesForTagging = () => {
     execSync(`npx lerna changed -l --json`).toString(),
   );
   assert(lernaChanges, 'Could not retrieve lerna changes.');
-  return lernaChanges.map(c => ({ name: c.name, newVersion: c.version }));
+  return lernaChanges.map((c) => ({ name: c.name, newVersion: c.version }));
 };
 
 const cli = async () => {

--- a/scripts/publish-process/transform-bpk-imports.js
+++ b/scripts/publish-process/transform-bpk-imports.js
@@ -29,7 +29,7 @@ const updateImports = (file, dirs) =>
       }
       let result = data;
 
-      dirs.forEach(pkg => {
+      dirs.forEach((pkg) => {
         const split = result.split(`from '${pkg}`);
         if (split.length === 1) {
           return;
@@ -37,7 +37,7 @@ const updateImports = (file, dirs) =>
         result = split.join(`from '${pkg}-css`);
       });
 
-      fs.writeFile(file, result, 'utf8', err2 => {
+      fs.writeFile(file, result, 'utf8', (err2) => {
         if (err2) return reject(err2);
         return resolve();
       });
@@ -50,16 +50,16 @@ console.log('Crunching Backpack import paths...');
 const dirs = execSync('ls packages | grep -v "react-version-test.js"')
   .toString()
   .split('\n')
-  .filter(s => s !== '');
+  .filter((s) => s !== '');
 
 const jsFiles = execSync(
   'find packages -name "*.js" -o -name "*.jsx" | grep -v node_modules',
 )
   .toString()
   .split('\n')
-  .filter(s => s !== '');
+  .filter((s) => s !== '');
 
-const updatePromises = jsFiles.map(jF => updateImports(jF, dirs));
+const updatePromises = jsFiles.map((jF) => updateImports(jF, dirs));
 
 Promise.all(updatePromises).then(() => {
   // eslint-disable-next-line no-console

--- a/scripts/publish-process/transform-js-scss-css-imports.js
+++ b/scripts/publish-process/transform-js-scss-css-imports.js
@@ -28,7 +28,7 @@ const updateImports = (file, findReplaces) =>
         reject(err);
       }
       let result = data;
-      findReplaces.forEach(fr => {
+      findReplaces.forEach((fr) => {
         const splitFile = result.split(fr.find);
         if (splitFile.length === 1) {
           return;
@@ -36,7 +36,7 @@ const updateImports = (file, findReplaces) =>
         result = splitFile.join(fr.replace);
       });
 
-      fs.writeFile(file, result, 'utf8', err2 => {
+      fs.writeFile(file, result, 'utf8', (err2) => {
         if (err2) return reject(err2);
         return resolve();
       });
@@ -53,9 +53,9 @@ const jsFiles = execSync(
 )
   .toString()
   .split('\n')
-  .filter(s => s !== '');
+  .filter((s) => s !== '');
 
-const updatePromises = jsFiles.map(jF => updateImports(jF, findReplaces));
+const updatePromises = jsFiles.map((jF) => updateImports(jF, findReplaces));
 
 Promise.all(updatePromises).then(() => {
   // eslint-disable-next-line no-console

--- a/scripts/publish-process/update-changelog.js
+++ b/scripts/publish-process/update-changelog.js
@@ -33,13 +33,14 @@ const createTimestamp = () => {
   return `# ${year}-${month}-${day}`;
 };
 
-const insertEntriesIntoChangelog = (changelogContents, changesToInsert) => {
-  return `${createTimestamp()}
+const insertEntriesIntoChangelog = (
+  changelogContents,
+  changesToInsert,
+) => `${createTimestamp()}
 
 ${changesToInsert}
 
 ${changelogContents}`;
-};
 
 const cli = () => {
   console.log(

--- a/scripts/publish-process/util.js
+++ b/scripts/publish-process/util.js
@@ -61,7 +61,7 @@ const assert = (condition, message) => {
 const getCurrentPackageMeta = () => {
   const packages = JSON.parse(execSync(`npx lerna ls -l --json`).toString());
   assert(packages && packages.map, 'Failed to get current package meta');
-  return packages.map(p => ({
+  return packages.map((p) => ({
     name: p.name,
     private: p.private,
     path: p.location,
@@ -70,7 +70,7 @@ const getCurrentPackageMeta = () => {
 };
 
 const createGitTags = (changes, commitHash = '') => {
-  changes.forEach(c => {
+  changes.forEach((c) => {
     const tagMessage = `${c.name}@${c.newVersion}`;
     const command = `git tag -a ${tagMessage} ${commitHash} -m ${tagMessage}`;
     if (verbose) {
@@ -85,32 +85,32 @@ const createGitTags = (changes, commitHash = '') => {
   });
 };
 
-const publishPackageToNPM = packageName =>
-  new Promise(resolve => {
+const publishPackageToNPM = (packageName) =>
+  new Promise((resolve) => {
     exec(`(cd packages/${packageName} && npm publish)`, null, () => {
       publishDone();
       resolve();
     });
   });
 
-const publishPackagesToNPM = changes =>
-  new Promise(resolve => {
+const publishPackagesToNPM = (changes) =>
+  new Promise((resolve) => {
     bar.start(changes.length, 0);
-    const tasks = changes.map(c => publishPackageToNPM(c.name));
+    const tasks = changes.map((c) => publishPackageToNPM(c.name));
 
-    Promise.all(tasks).then(result => {
+    Promise.all(tasks).then((result) => {
       bar.stop();
       resolve(result);
     });
   });
 
-const updateDependencies = dependencies => {
+const updateDependencies = (dependencies) => {
   if (!dependencies) {
     return;
   }
   const dependencyList = {};
 
-  Object.keys(dependencies).forEach(depName => {
+  Object.keys(dependencies).forEach((depName) => {
     const depValue = dependencies[depName];
     if (depName.match('bpk-*')) {
       const newName = `${depName}-css`;
@@ -125,7 +125,7 @@ const updateDependencies = dependencies => {
 };
 
 const appendToPackageName = (c, text) =>
-  new Promise(resolve => {
+  new Promise((resolve) => {
     const packageJsonFilePath = path.join(c.path, 'package.json');
     const appendedName = `${c.name}-${text}`;
     const packageJsonData = JSON.parse(
@@ -149,10 +149,10 @@ const appendToPackageName = (c, text) =>
   });
 
 const appendToPackageNames = (changes, text) =>
-  new Promise(resolve => {
-    const tasks = changes.map(c => appendToPackageName(c, text));
+  new Promise((resolve) => {
+    const tasks = changes.map((c) => appendToPackageName(c, text));
 
-    Promise.all(tasks).then(result => {
+    Promise.all(tasks).then((result) => {
       resolve(result);
     });
   });


### PR DESCRIPTION
Upgrading eslint-config-skyscanner to the latest version to bring in newer TS linters to help prepare for migration to Typescript types.