### PR TITLE
[KOA-4879]: Deprecate heading component

### DIFF
--- a/packages/bpk-component-heading/README.md
+++ b/packages/bpk-component-heading/README.md
@@ -1,3 +1,4 @@
+# This component has been deprecated, please use bpk-component-text instead to apply heading styles
 # bpk-component-heading
 
 > Backpack heading component.

--- a/packages/bpk-component-heading/package.json
+++ b/packages/bpk-component-heading/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.1",
   "description": "Backpack heading component.",
   "license": "Apache-2.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git@github.com:Skyscanner/backpack.git"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

This PR adds missing deprecation work when this component was previously deprecated back in 2017!

- Adds deprecation note to BpkHeading component README.
- Sets the package to `private` so that the component is ignored during publish.

The code will then probably be removed when we ship Backpack as a single package