### PR TITLE
[KOA-4879]: Deprecate bpk-heading-6 mixin

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Changed:**
+  - bpk-mixins:
+    - Deprecated `bpk-heading-6` mixin.

--- a/packages/bpk-mixins/src/mixins/_typography.scss
+++ b/packages/bpk-mixins/src/mixins/_typography.scss
@@ -688,8 +688,12 @@ $bpk-spacing-v2: true;
 ///   .selector {
 ///     @include bpk-heading-6();
 ///   }
+///
+/// @deprecated Use `bpk-heading-5` instead.
 
 @mixin bpk-heading-6 {
+  @warn 'bpk-heading-6 is deprecated. Use `bpk-heading-5` instead.';
+
   margin-top: $bpk-heading-margin-top;
   margin-bottom: $bpk-heading-margin-bottom;
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

As part of KOA-4879 we want to deprecate `heading-6` mixin as its a duplicate of `heading-5` and doesn't exist in the new typography system.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [ ] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
