### PR TITLE
[LEOP-269] node16 support in bpk-mixins

### DIFF
--- a/packages/bpk-mixins/package.json
+++ b/packages/bpk-mixins/package.json
@@ -18,7 +18,7 @@
     "@skyscanner/bpk-svgs": "^14.0.19"
   },
   "peerDependencies": {
-    "node-sass": "^4.12.0"
+    "node-sass": "^4.12.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "bpk-react-utils": "^4.0.2"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

After this change, bpk-mixins will be supported node12 above,
not so familiar with backpack dependency, I expect I don't need to change  "node-sass": "^4.14.1", in backpack, as bpk-component depends on bpk-mixins , not depend on node-sass directly, correct me if I am wrong

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
