### PR TITLE
[NO JIRA]: Removing old native folder

### DIFF
--- a/native/README.md
+++ b/native/README.md
@@ -1,5 +1,0 @@
-Looking for Backpack for React Native?
-
-It's moved to its own repo: https://github.com/Skyscanner/backpack-react-native.
-
-Sorry for the inconvenience!


### PR DESCRIPTION
This folder had been introduced 3 years ago when we split out our mobile native code to separate repos. I think given its been 3 years now people are familiar with where this is located and we can safely remove this folder and the one file to tidy up the repo.
