### PR TITLE
[NO-JIRA] - Remove Key Index from Calendar

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Fixed**
+- `bpk-component-calendar`
+  - Remove prop index from `DateType`.

--- a/packages/bpk-component-calendar/src/custom-proptypes.js
+++ b/packages/bpk-component-calendar/src/custom-proptypes.js
@@ -60,8 +60,8 @@ const SelectionConfigurationSingle = PropTypes.shape({
 
 const SelectionConfigurationRange = PropTypes.shape({
   type: PropTypes.oneOf([CALENDAR_SELECTION_TYPE.range]),
-  startDate: DateType('selectionConfiguration'),
-  endDate: DateType('selectionConfiguration'),
+  startDate: DateType(),
+  endDate: DateType(),
 });
 
 const SelectionConfiguration = PropTypes.oneOfType([

--- a/packages/bpk-component-calendar/src/custom-proptypes.js
+++ b/packages/bpk-component-calendar/src/custom-proptypes.js
@@ -20,8 +20,8 @@ import PropTypes from 'prop-types';
 
 import { isBefore, isSameDay } from './date-utils';
 
-const DateType = (key) => (props) => {
-  const { endDate, startDate } = props[key];
+const DateType = () => (props) => {
+  const { endDate, startDate } = props;
 
   // No range selected
   if (!startDate && !endDate) {
@@ -30,9 +30,7 @@ const DateType = (key) => (props) => {
 
   // End date without a start date is not allowed
   if (!startDate && endDate) {
-    return new Error(
-      `Cannot specify \`endDate\` without \`startDate\` in ${key}.`,
-    );
+    return new Error(`Cannot specify \`endDate\` without \`startDate\`.`);
   }
 
   // Start date without an end date is always valid
@@ -43,7 +41,7 @@ const DateType = (key) => (props) => {
   // Start date cannot be after end date
   if (isBefore(endDate, startDate) && !isSameDay(endDate, startDate)) {
     return new Error(
-      `Start date \`${startDate}\` cannot be after end date \`${endDate}\` in \`props.${key}\`.`,
+      `Start date \`${startDate}\` cannot be after end date \`${endDate}\`.`,
     );
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Removing the key as it's being used as an index to retrieve the selectionConfiguration props, however the props are being passed as an object and being destructured so each individual property are accessible.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
