### PR TITLE
[KOA-4993]: Migrate from recompose

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+- bpk-react-utils:
+  - Migrated from deprecated `recompose` library and function `wrapDisplayName`to support React 17+. Created localised version to support same functionality.

--- a/packages/bpk-animate-height/package-lock.json
+++ b/packages/bpk-animate-height/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-animate-height",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-accordion/package-lock.json
+++ b/packages/bpk-component-accordion/package-lock.json
@@ -1,24 +1,28 @@
 {
 	"name": "bpk-component-accordion",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@skyscanner/bpk-foundations-common": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
-			"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
 		"@skyscanner/bpk-foundations-web": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
 			"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
+			"dev": true,
 			"requires": {
 				"@skyscanner/bpk-foundations-common": "^2.2.1",
 				"color": "^3.0.0"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-common": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
+					"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
+					"dev": true,
+					"requires": {
+						"color": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@skyscanner/bpk-svgs": {
@@ -33,6 +37,25 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-common": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
+					"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
+					"requires": {
+						"color": "^3.0.0"
+					}
+				},
+				"@skyscanner/bpk-foundations-web": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
+					"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-aria-live/package-lock.json
+++ b/packages/bpk-component-aria-live/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-aria-live",
-	"version": "2.1.3",
+	"version": "2.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-autosuggest/package-lock.json
+++ b/packages/bpk-component-autosuggest/package-lock.json
@@ -1,75 +1,32 @@
 {
 	"name": "bpk-component-autosuggest",
-	"version": "6.1.2",
+	"version": "6.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@skyscanner/bpk-foundations-common": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
-			"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
-		"@skyscanner/bpk-foundations-web": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
-			"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
-			"requires": {
-				"@skyscanner/bpk-foundations-common": "^2.2.1",
-				"color": "^3.0.0"
-			}
-		},
 		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+			"version": "14.1.3",
+			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.3.tgz",
+			"integrity": "sha512-JHYsT4yZrdd0oBXX4GBvIZB0QHnh/Svk5Z40co6WREFWFbv+2qnOpyJB0T1hhOmQvM3nPXFhxQtJD5nOS+lEuA=="
 		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
 			"integrity": "sha512-/xeikqxn+KaxuNkHDxC5odJ6H+Z0N7seFGhpddWgvh0UN/orc82e3VO6HS9YNtbG5dVBe2TqOSAcaZAfGUiY9g==",
 			"requires": {
-				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-web": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-5.3.0.tgz",
+					"integrity": "sha512-kU9acWxema8v0n29TXSOlNiOv2Y1bdfYL6oSkAnNCZAsJe4+KoTfe0Q2EYw9kbJzbw8PdVT1PqRA2YIZekh5jg==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				}
 			}
-		},
-		"color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"requires": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -148,14 +105,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
 			"integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
-		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			}
 		}
 	}
 }

--- a/packages/bpk-component-badge/package-lock.json
+++ b/packages/bpk-component-badge/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-badge",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-banner-alert/package-lock.json
+++ b/packages/bpk-component-banner-alert/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-banner-alert",
-	"version": "6.1.2",
+	"version": "6.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -29,11 +29,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -41,6 +36,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-barchart/package-lock.json
+++ b/packages/bpk-component-barchart/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-barchart",
-	"version": "4.2.2",
+	"version": "4.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-blockquote/package-lock.json
+++ b/packages/bpk-component-blockquote/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-blockquote",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-boilerplate/package-lock.json
+++ b/packages/bpk-component-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-boilerplate",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-breadcrumb/package-lock.json
+++ b/packages/bpk-component-breadcrumb/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-breadcrumb",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-breakpoint/package-lock.json
+++ b/packages/bpk-component-breakpoint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-breakpoint",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-button/package-lock.json
+++ b/packages/bpk-component-button/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-button",
-	"version": "5.1.1",
+	"version": "6.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-calendar/package-lock.json
+++ b/packages/bpk-component-calendar/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-calendar",
-	"version": "11.1.3",
+	"version": "11.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-card/package-lock.json
+++ b/packages/bpk-component-card/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-card",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-checkbox/package-lock.json
+++ b/packages/bpk-component-checkbox/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-checkbox",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-chip/package-lock.json
+++ b/packages/bpk-component-chip/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-chip",
-	"version": "5.2.2",
+	"version": "5.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-close-button/package-lock.json
+++ b/packages/bpk-component-close-button/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-close-button",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-code/package-lock.json
+++ b/packages/bpk-component-code/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-code",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-content-container/package-lock.json
+++ b/packages/bpk-component-content-container/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-content-container",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-datatable/package-lock.json
+++ b/packages/bpk-component-datatable/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-datatable",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -12,27 +12,26 @@
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
-		"@skyscanner/bpk-foundations-common": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
-			"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
 		"@skyscanner/bpk-foundations-web": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
 			"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
+			"dev": true,
 			"requires": {
 				"@skyscanner/bpk-foundations-common": "^2.2.1",
 				"color": "^3.0.0"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-common": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
+					"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
+					"dev": true,
+					"requires": {
+						"color": "^3.0.0"
+					}
+				}
 			}
-		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
 		},
 		"bpk-mixins": {
 			"version": "28.0.0",
@@ -41,6 +40,30 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-common": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
+					"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
+					"requires": {
+						"color": "^3.0.0"
+					}
+				},
+				"@skyscanner/bpk-foundations-web": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
+					"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				},
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"clsx": {

--- a/packages/bpk-component-datepicker/package-lock.json
+++ b/packages/bpk-component-datepicker/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-datepicker",
-	"version": "15.2.3",
+	"version": "15.2.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-description-list/package-lock.json
+++ b/packages/bpk-component-description-list/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-description-list",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-dialog/package-lock.json
+++ b/packages/bpk-component-dialog/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpk-component-dialog",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -21,11 +21,6 @@
         "color": "^3.0.0"
       }
     },
-    "@skyscanner/bpk-svgs": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-      "integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-    },
     "bpk-mixins": {
       "version": "28.0.0",
       "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
       "requires": {
         "@skyscanner/bpk-foundations-web": "^6.0.0",
         "@skyscanner/bpk-svgs": "^14.1.4"
+      },
+      "dependencies": {
+        "@skyscanner/bpk-svgs": {
+          "version": "14.1.4",
+          "resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+          "integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+        }
       }
     },
     "color": {

--- a/packages/bpk-component-drawer/package-lock.json
+++ b/packages/bpk-component-drawer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-drawer",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -29,11 +29,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -41,6 +36,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-fieldset/package-lock.json
+++ b/packages/bpk-component-fieldset/package-lock.json
@@ -1,75 +1,32 @@
 {
 	"name": "bpk-component-fieldset",
-	"version": "4.1.3",
+	"version": "4.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@skyscanner/bpk-foundations-common": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
-			"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
-		"@skyscanner/bpk-foundations-web": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
-			"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
-			"requires": {
-				"@skyscanner/bpk-foundations-common": "^2.2.1",
-				"color": "^3.0.0"
-			}
-		},
 		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+			"version": "14.1.3",
+			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.3.tgz",
+			"integrity": "sha512-JHYsT4yZrdd0oBXX4GBvIZB0QHnh/Svk5Z40co6WREFWFbv+2qnOpyJB0T1hhOmQvM3nPXFhxQtJD5nOS+lEuA=="
 		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
 			"integrity": "sha512-/xeikqxn+KaxuNkHDxC5odJ6H+Z0N7seFGhpddWgvh0UN/orc82e3VO6HS9YNtbG5dVBe2TqOSAcaZAfGUiY9g==",
 			"requires": {
-				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-web": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-5.3.0.tgz",
+					"integrity": "sha512-kU9acWxema8v0n29TXSOlNiOv2Y1bdfYL6oSkAnNCZAsJe4+KoTfe0Q2EYw9kbJzbw8PdVT1PqRA2YIZekh5jg==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				}
 			}
-		},
-		"color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"requires": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -103,14 +60,6 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			}
 		}
 	}
 }

--- a/packages/bpk-component-flare/package-lock.json
+++ b/packages/bpk-component-flare/package-lock.json
@@ -1,75 +1,32 @@
 {
 	"name": "bpk-component-flare",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@skyscanner/bpk-foundations-common": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
-			"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
-		"@skyscanner/bpk-foundations-web": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
-			"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
-			"requires": {
-				"@skyscanner/bpk-foundations-common": "^2.2.1",
-				"color": "^3.0.0"
-			}
-		},
 		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+			"version": "14.1.3",
+			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.3.tgz",
+			"integrity": "sha512-JHYsT4yZrdd0oBXX4GBvIZB0QHnh/Svk5Z40co6WREFWFbv+2qnOpyJB0T1hhOmQvM3nPXFhxQtJD5nOS+lEuA=="
 		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
 			"integrity": "sha512-/xeikqxn+KaxuNkHDxC5odJ6H+Z0N7seFGhpddWgvh0UN/orc82e3VO6HS9YNtbG5dVBe2TqOSAcaZAfGUiY9g==",
 			"requires": {
-				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-web": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-5.3.0.tgz",
+					"integrity": "sha512-kU9acWxema8v0n29TXSOlNiOv2Y1bdfYL6oSkAnNCZAsJe4+KoTfe0Q2EYw9kbJzbw8PdVT1PqRA2YIZekh5jg==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				}
 			}
-		},
-		"color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"requires": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -103,14 +60,6 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			}
 		}
 	}
 }

--- a/packages/bpk-component-form-validation/package-lock.json
+++ b/packages/bpk-component-form-validation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-form-validation",
-	"version": "4.2.2",
+	"version": "4.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-graphic-promotion/package-lock.json
+++ b/packages/bpk-component-graphic-promotion/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpk-component-graphic-promotion",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -21,11 +21,6 @@
         "color": "^3.0.0"
       }
     },
-    "@skyscanner/bpk-svgs": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-      "integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-    },
     "bpk-mixins": {
       "version": "28.0.0",
       "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
       "requires": {
         "@skyscanner/bpk-foundations-web": "^6.0.0",
         "@skyscanner/bpk-svgs": "^14.1.4"
+      },
+      "dependencies": {
+        "@skyscanner/bpk-svgs": {
+          "version": "14.1.4",
+          "resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+          "integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+        }
       }
     },
     "color": {

--- a/packages/bpk-component-grid-toggle/package-lock.json
+++ b/packages/bpk-component-grid-toggle/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-grid-toggle",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-grid/package-lock.json
+++ b/packages/bpk-component-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-grid",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-horizontal-nav/package-lock.json
+++ b/packages/bpk-component-horizontal-nav/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-horizontal-nav",
-	"version": "5.1.2",
+	"version": "5.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-icon/package-lock.json
+++ b/packages/bpk-component-icon/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpk-component-icon",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/bpk-component-image/package-lock.json
+++ b/packages/bpk-component-image/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-image",
-	"version": "5.1.2",
+	"version": "5.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -29,11 +29,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -41,6 +36,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-infinite-scroll/package-lock.json
+++ b/packages/bpk-component-infinite-scroll/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-infinite-scroll",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-input/package-lock.json
+++ b/packages/bpk-component-input/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-input",
-	"version": "6.1.2",
+	"version": "6.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-label/package-lock.json
+++ b/packages/bpk-component-label/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-label",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-link/package-lock.json
+++ b/packages/bpk-component-link/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-link",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-list/package-lock.json
+++ b/packages/bpk-component-list/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-list",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-loading-button/package-lock.json
+++ b/packages/bpk-component-loading-button/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-loading-button",
-	"version": "4.1.2",
+	"version": "5.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-map/package-lock.json
+++ b/packages/bpk-component-map/package-lock.json
@@ -1,26 +1,9 @@
 {
 	"name": "bpk-component-map",
-	"version": "5.2.2",
+	"version": "5.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@skyscanner/bpk-foundations-common": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
-			"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
-		"@skyscanner/bpk-foundations-web": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
-			"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
-			"requires": {
-				"@skyscanner/bpk-foundations-common": "^2.2.1",
-				"color": "^3.0.0"
-			}
-		},
 		"@skyscanner/bpk-svgs": {
 			"version": "14.1.4",
 			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
@@ -45,8 +28,18 @@
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
 			"integrity": "sha512-/xeikqxn+KaxuNkHDxC5odJ6H+Z0N7seFGhpddWgvh0UN/orc82e3VO6HS9YNtbG5dVBe2TqOSAcaZAfGUiY9g==",
 			"requires": {
-				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-web": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-5.3.0.tgz",
+					"integrity": "sha512-kU9acWxema8v0n29TXSOlNiOv2Y1bdfYL6oSkAnNCZAsJe4+KoTfe0Q2EYw9kbJzbw8PdVT1PqRA2YIZekh5jg==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				}
 			}
 		},
 		"can-use-dom": {
@@ -58,37 +51,6 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
 			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-		},
-		"color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"requires": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
 		},
 		"core-js": {
 			"version": "2.5.7",
@@ -149,11 +111,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -276,14 +233,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			}
 		},
 		"symbol-observable": {
 			"version": "1.2.0",

--- a/packages/bpk-component-mobile-scroll-container/package-lock.json
+++ b/packages/bpk-component-mobile-scroll-container/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-mobile-scroll-container",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-modal/package-lock.json
+++ b/packages/bpk-component-modal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-modal",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-navigation-bar/package-lock.json
+++ b/packages/bpk-component-navigation-bar/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-navigation-bar",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-navigation-stack/package-lock.json
+++ b/packages/bpk-component-navigation-stack/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-navigation-stack",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -29,11 +29,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -41,6 +36,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-nudger/package-lock.json
+++ b/packages/bpk-component-nudger/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-nudger",
-	"version": "5.1.2",
+	"version": "6.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-overlay/package-lock.json
+++ b/packages/bpk-component-overlay/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-overlay",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-pagination/package-lock.json
+++ b/packages/bpk-component-pagination/package-lock.json
@@ -1,75 +1,32 @@
 {
 	"name": "bpk-component-pagination",
-	"version": "3.1.2",
+	"version": "4.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@skyscanner/bpk-foundations-common": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
-			"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
-		"@skyscanner/bpk-foundations-web": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
-			"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
-			"requires": {
-				"@skyscanner/bpk-foundations-common": "^2.2.1",
-				"color": "^3.0.0"
-			}
-		},
 		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+			"version": "14.1.3",
+			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.3.tgz",
+			"integrity": "sha512-JHYsT4yZrdd0oBXX4GBvIZB0QHnh/Svk5Z40co6WREFWFbv+2qnOpyJB0T1hhOmQvM3nPXFhxQtJD5nOS+lEuA=="
 		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
 			"integrity": "sha512-/xeikqxn+KaxuNkHDxC5odJ6H+Z0N7seFGhpddWgvh0UN/orc82e3VO6HS9YNtbG5dVBe2TqOSAcaZAfGUiY9g==",
 			"requires": {
-				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-web": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-5.3.0.tgz",
+					"integrity": "sha512-kU9acWxema8v0n29TXSOlNiOv2Y1bdfYL6oSkAnNCZAsJe4+KoTfe0Q2EYw9kbJzbw8PdVT1PqRA2YIZekh5jg==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				}
 			}
-		},
-		"color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"requires": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -103,14 +60,6 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			}
 		}
 	}
 }

--- a/packages/bpk-component-panel/package-lock.json
+++ b/packages/bpk-component-panel/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-panel",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-phone-input/package-lock.json
+++ b/packages/bpk-component-phone-input/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-phone-input",
-	"version": "7.1.3",
+	"version": "7.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-popover/package-lock.json
+++ b/packages/bpk-component-popover/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-popover",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-progress/package-lock.json
+++ b/packages/bpk-component-progress/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-progress",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-radio/package-lock.json
+++ b/packages/bpk-component-radio/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-radio",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-rating/package-lock.json
+++ b/packages/bpk-component-rating/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-rating",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-rtl-toggle/package-lock.json
+++ b/packages/bpk-component-rtl-toggle/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-rtl-toggle",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-scrollable-calendar/package-lock.json
+++ b/packages/bpk-component-scrollable-calendar/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-scrollable-calendar",
-	"version": "6.1.3",
+	"version": "6.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -30,9 +30,9 @@
 			}
 		},
 		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+			"version": "14.1.3",
+			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.3.tgz",
+			"integrity": "sha512-JHYsT4yZrdd0oBXX4GBvIZB0QHnh/Svk5Z40co6WREFWFbv+2qnOpyJB0T1hhOmQvM3nPXFhxQtJD5nOS+lEuA=="
 		},
 		"bpk-mixins": {
 			"version": "28.0.0",
@@ -41,6 +41,25 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-common": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
+					"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
+					"requires": {
+						"color": "^3.0.0"
+					}
+				},
+				"@skyscanner/bpk-foundations-web": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-5.3.0.tgz",
+					"integrity": "sha512-kU9acWxema8v0n29TXSOlNiOv2Y1bdfYL6oSkAnNCZAsJe4+KoTfe0Q2EYw9kbJzbw8PdVT1PqRA2YIZekh5jg==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				}
 			}
 		},
 		"clsx": {
@@ -91,8 +110,8 @@
 		},
 		"is-arrayish": {
 			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+			"resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM="
 		},
 		"js-tokens": {
 			"version": "4.0.0",

--- a/packages/bpk-component-section-list/package-lock.json
+++ b/packages/bpk-component-section-list/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-section-list",
-	"version": "3.2.2",
+	"version": "3.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-select/package-lock.json
+++ b/packages/bpk-component-select/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-select",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-skip-link/package-lock.json
+++ b/packages/bpk-component-skip-link/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-skip-link",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-slider/package-lock.json
+++ b/packages/bpk-component-slider/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpk-component-slider",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/bpk-component-spinner/package-lock.json
+++ b/packages/bpk-component-spinner/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-spinner",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-star-rating/package-lock.json
+++ b/packages/bpk-component-star-rating/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-star-rating",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,11 +21,6 @@
 				"color": "^3.0.0"
 			}
 		},
-		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
-		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -33,6 +28,13 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-svgs": {
+					"version": "14.1.4",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
+					"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-switch/package-lock.json
+++ b/packages/bpk-component-switch/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-switch",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-table/package-lock.json
+++ b/packages/bpk-component-table/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-table",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-text/package-lock.json
+++ b/packages/bpk-component-text/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-text",
-	"version": "6.1.2",
+	"version": "6.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-textarea/package-lock.json
+++ b/packages/bpk-component-textarea/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-textarea",
-	"version": "4.2.1",
+	"version": "4.2.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-theme-toggle/package-lock.json
+++ b/packages/bpk-component-theme-toggle/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-theme-toggle",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -22,9 +22,9 @@
 			}
 		},
 		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+			"version": "14.1.3",
+			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.3.tgz",
+			"integrity": "sha512-JHYsT4yZrdd0oBXX4GBvIZB0QHnh/Svk5Z40co6WREFWFbv+2qnOpyJB0T1hhOmQvM3nPXFhxQtJD5nOS+lEuA=="
 		},
 		"bpk-mixins": {
 			"version": "28.0.0",
@@ -33,6 +33,17 @@
 			"requires": {
 				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-web": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-5.3.0.tgz",
+					"integrity": "sha512-kU9acWxema8v0n29TXSOlNiOv2Y1bdfYL6oSkAnNCZAsJe4+KoTfe0Q2EYw9kbJzbw8PdVT1PqRA2YIZekh5jg==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				}
 			}
 		},
 		"color": {

--- a/packages/bpk-component-ticket/package-lock.json
+++ b/packages/bpk-component-ticket/package-lock.json
@@ -1,75 +1,32 @@
 {
 	"name": "bpk-component-ticket",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@skyscanner/bpk-foundations-common": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
-			"integrity": "sha512-vJ038Ee3il8bXlRleKqh1bVvp2ORSSAEcfSgxABhOsNanB1kABQkt589fBkqB6CQOQhTlIYYKYIESQSjo5+ZzA==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
-		"@skyscanner/bpk-foundations-web": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-6.0.0.tgz",
-			"integrity": "sha512-CRiGrUnGvQhP2XEHWnckGoFdTjvFg03hviV2rh3BxGSw9RuqN5x8K/OT6lJvuaqSVVbsQM4p/CshhQQQLKHLFA==",
-			"requires": {
-				"@skyscanner/bpk-foundations-common": "^2.2.1",
-				"color": "^3.0.0"
-			}
-		},
 		"@skyscanner/bpk-svgs": {
-			"version": "14.1.4",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
-			"integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+			"version": "14.1.3",
+			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.3.tgz",
+			"integrity": "sha512-JHYsT4yZrdd0oBXX4GBvIZB0QHnh/Svk5Z40co6WREFWFbv+2qnOpyJB0T1hhOmQvM3nPXFhxQtJD5nOS+lEuA=="
 		},
 		"bpk-mixins": {
 			"version": "28.0.0",
 			"resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
 			"integrity": "sha512-/xeikqxn+KaxuNkHDxC5odJ6H+Z0N7seFGhpddWgvh0UN/orc82e3VO6HS9YNtbG5dVBe2TqOSAcaZAfGUiY9g==",
 			"requires": {
-				"@skyscanner/bpk-foundations-web": "^6.0.0",
 				"@skyscanner/bpk-svgs": "^14.1.4"
+			},
+			"dependencies": {
+				"@skyscanner/bpk-foundations-web": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-5.3.0.tgz",
+					"integrity": "sha512-kU9acWxema8v0n29TXSOlNiOv2Y1bdfYL6oSkAnNCZAsJe4+KoTfe0Q2EYw9kbJzbw8PdVT1PqRA2YIZekh5jg==",
+					"requires": {
+						"@skyscanner/bpk-foundations-common": "^2.2.1",
+						"color": "^3.0.0"
+					}
+				}
 			}
-		},
-		"color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"requires": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -103,14 +60,6 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			}
 		}
 	}
 }

--- a/packages/bpk-component-tooltip/package-lock.json
+++ b/packages/bpk-component-tooltip/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-tooltip",
-	"version": "6.1.2",
+	"version": "6.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-react-utils/index.js
+++ b/packages/bpk-react-utils/index.js
@@ -18,8 +18,7 @@
 
 /* @flow strict */
 
-import wrapDisplayName from 'recompose/wrapDisplayName';
-
+import wrapDisplayName from './src/wrapDisplayName';
 import Portal from './src/Portal';
 import TransitionInitialMount from './src/TransitionInitialMount';
 import cssModules from './src/cssModules';

--- a/packages/bpk-react-utils/package-lock.json
+++ b/packages/bpk-react-utils/package-lock.json
@@ -4,29 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@babel/runtime": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-			"integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-			"requires": {
-				"regenerator-runtime": "^0.12.0"
-			}
-		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
-		"change-emitter": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-		},
 		"dom-helpers": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
@@ -50,55 +27,6 @@
 				}
 			}
 		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
-			}
-		},
-		"hoist-non-react-statics": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			}
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
-			}
-		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -112,27 +40,10 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
-			}
-		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "~2.0.3"
-			}
 		},
 		"prop-types": {
 			"version": "15.8.1",
@@ -164,49 +75,6 @@
 				"prop-types": "^15.6.2",
 				"react-lifecycles-compat": "^3.0.4"
 			}
-		},
-		"recompose": {
-			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-			"integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-			"requires": {
-				"@babel/runtime": "^7.0.0",
-				"change-emitter": "^0.1.2",
-				"fbjs": "^0.8.1",
-				"hoist-non-react-statics": "^2.3.1",
-				"react-lifecycles-compat": "^3.0.2",
-				"symbol-observable": "^1.0.4"
-			}
-		},
-		"regenerator-runtime": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-		},
-		"symbol-observable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-		},
-		"ua-parser-js": {
-			"version": "0.7.18",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
-		},
-		"whatwg-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
 		}
 	}
 }

--- a/packages/bpk-react-utils/package.json
+++ b/packages/bpk-react-utils/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.7.2",
-    "react-transition-group": "^2.5.3",
-    "recompose": "^0.30.0"
+    "react-transition-group": "^2.5.3"
   },
   "peerDependencies": {
     "react": "^16.3.0 || ^17.0.0",

--- a/packages/bpk-react-utils/src/withDefaultProps.js
+++ b/packages/bpk-react-utils/src/withDefaultProps.js
@@ -20,7 +20,8 @@
 
 import PropTypes from 'prop-types';
 import React, { type Node, type AbstractComponent } from 'react';
-import wrapDisplayName from 'recompose/wrapDisplayName';
+
+import wrapDisplayName from './wrapDisplayName';
 
 type Props = {
   children: ?Node,

--- a/packages/bpk-react-utils/src/wrapDisplayName-test.js
+++ b/packages/bpk-react-utils/src/wrapDisplayName-test.js
@@ -1,0 +1,39 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2022 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import wrapDisplayName from './wrapDisplayName';
+
+test('wrapDisplayName adds hoc name to component', () => {
+  const SimpleComponent = () => <div />;
+
+  expect(wrapDisplayName(SimpleComponent, 'wrappedName')).toBe(
+    'wrappedName(SimpleComponent)',
+  );
+});
+
+test('wrapDisplayName adds string hoc name to component', () => {
+  expect(wrapDisplayName('SomeString', 'wrappedName')).toBe(
+    'wrappedName(SomeString)',
+  );
+});
+
+test('wrapDisplayName returns undefined when no component is supplied', () => {
+  expect(wrapDisplayName(null, 'wrappedName')).toBe('wrappedName()');
+});

--- a/packages/bpk-react-utils/src/wrapDisplayName.js
+++ b/packages/bpk-react-utils/src/wrapDisplayName.js
@@ -1,0 +1,31 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2022 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const wrapDisplayName = (Component, hoc) => {
+  if (!Component) {
+    return `${hoc}()`;
+  }
+
+  if (typeof Component === 'string') {
+    return `${hoc}(${Component})`;
+  }
+
+  return `${hoc}(${Component.displayName || Component.name || 'Component'})`;
+};
+
+export default wrapDisplayName;

--- a/packages/bpk-scrim-utils/package-lock.json
+++ b/packages/bpk-scrim-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-scrim-utils",
-	"version": "5.1.0",
+	"version": "5.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-storybook-utils/package-lock.json
+++ b/packages/bpk-storybook-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpk-storybook-utils",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/bpk-theming/package-lock.json
+++ b/packages/bpk-theming/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-theming",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -514,19 +514,6 @@
         }
       }
     },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      }
-    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",

--- a/packages/package.json
+++ b/packages/package.json
@@ -30,6 +30,7 @@
     "date-fns": "^2.21.1",
     "d3-path": "^2.0.0",
     "d3-scale": "^4.0.2",
+    "date-fns": "^2.21.1",
     "intersection-observer": "^0.7.0",
     "lodash": "^4.17.20",
     "lodash.clamp": "^4.0.3",
@@ -41,8 +42,7 @@
     "react-responsive": "^6.1.2",
     "react-slider": "^1.3.1",
     "react-transition-group": "^2.5.3",
-    "react-virtualized": "^9.22.3",
-    "recompose": "^0.30.0"
+    "react-virtualized": "^9.22.3"
   },
   "peerDependencies": {
     "react": "^16.3.0 || ^17.0.0"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Migrates the `wrapDisplayName` function from using deprecated `recompose` library to a localised version that will enable migrations to React 17!

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
