### PR TITLE
Add support for Mobile/Tablet/Desktop images for BpkGraphicPromo

### DIFF
--- a/examples/bpk-component-graphic-promotion/examples.js
+++ b/examples/bpk-component-graphic-promotion/examples.js
@@ -18,16 +18,13 @@
 
 import React from 'react';
 
+import STYLES from './examples.module.scss';
+
 import BpkGraphicPromo, {
   TEXT_ALIGN,
 } from '../../packages/bpk-component-graphic-promotion';
-
-const backgroundImageDesktop =
-  'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=2096px:800px&quality=90';
-const backgroundImageTablet =
-  'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=820px:1180px&quality=90';
-const backgroundImageMobile =
-  'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=390:844px&quality=90';
+import { cssModules } from '../../packages/bpk-react-utils';
+const getClassName = cssModules(STYLES);
 const sponsor = {
   label: 'Sponsored',
   logo: 'https://js.skyscnr.com/sttc/bpk-content/skyland-a76916b4.png',
@@ -41,18 +38,22 @@ const onClick = () => {
 const tagline = 'Travel tips';
 const headline = 'Three Peaks Challenge';
 const subheading = 'How to complete the climb in 3 days';
+const style = {
+  '--background-image-mobile': 'url(\'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=390:844px&quality=90\')',
+  '--background-image-tablet': 'url(\'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=820px:1180px&quality=90\')',
+  '--background-image-desktop': 'url(\'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=2096px:800px&quality=90\')',
+};
 
 const DefaultExample = () => (
   <BpkGraphicPromo
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    backgroundImageDesktop={backgroundImageDesktop}
-    backgroundImageMobile={backgroundImageMobile}
-    backgroundImageTablet={backgroundImageTablet}
     sponsor={sponsor}
     buttonText={buttonText}
     onClick={onClick}
+    className={getClassName(STYLES.graphicPromo)}
+    style={style}
     textAlign={TEXT_ALIGN.start}
   />
 );
@@ -62,12 +63,11 @@ const CenterAlignedExample = () => (
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    backgroundImageDesktop={backgroundImageDesktop}
-    backgroundImageTablet={backgroundImageTablet}
-    backgroundImageMobile={backgroundImageMobile}
     sponsor={sponsor}
     buttonText={buttonText}
     onClick={onClick}
+    className={getClassName(STYLES.graphicPromo)}
+    style={style}
     textAlign={TEXT_ALIGN.center}
   />
 );
@@ -77,12 +77,11 @@ const RightAlignedExample = () => (
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    backgroundImageDesktop={backgroundImageDesktop}
-    backgroundImageTablet={backgroundImageTablet}
-    backgroundImageMobile={backgroundImageMobile}
     sponsor={sponsor}
     buttonText={buttonText}
     onClick={onClick}
+    className={getClassName(STYLES.graphicPromo)}
+    style={style}
     textAlign={TEXT_ALIGN.end}
   />
 );
@@ -92,12 +91,11 @@ const InvertedPortraitExample = () => (
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    backgroundImageDesktop={backgroundImageDesktop}
-    backgroundImageTablet={backgroundImageTablet}
-    backgroundImageMobile={backgroundImageMobile}
     sponsor={sponsor}
     buttonText={buttonText}
     onClick={onClick}
+    className={getClassName(STYLES.graphicPromo)}
+    style={style}
     textAlign={TEXT_ALIGN.start}
     invertVertically
   />
@@ -106,11 +104,10 @@ const InvertedPortraitExample = () => (
 const MinimalisticExample = () => (
   <BpkGraphicPromo
     headline={headline}
-    backgroundImageDesktop={backgroundImageDesktop}
-    backgroundImageTablet={backgroundImageTablet}
-    backgroundImageMobile={backgroundImageMobile}
     sponsor={sponsor}
     buttonText={buttonText}
+    className={getClassName(STYLES.graphicPromo)}
+    style={style}
     onClick={onClick}
     textAlign={TEXT_ALIGN.start}
   />
@@ -121,10 +118,9 @@ const NonSponsoredExample = () => (
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    backgroundImageDesktop={backgroundImageDesktop}
-    backgroundImageTablet={backgroundImageTablet}
-    backgroundImageMobile={backgroundImageMobile}
     buttonText={buttonText}
+    className={getClassName(STYLES.graphicPromo)}
+    style={style}
     onClick={onClick}
     textAlign={TEXT_ALIGN.start}
   />

--- a/examples/bpk-component-graphic-promotion/examples.js
+++ b/examples/bpk-component-graphic-promotion/examples.js
@@ -18,12 +18,13 @@
 
 import React from 'react';
 
-import STYLES from './examples.module.scss';
-
 import BpkGraphicPromo, {
   TEXT_ALIGN,
 } from '../../packages/bpk-component-graphic-promotion';
 import { cssModules } from '../../packages/bpk-react-utils';
+
+import STYLES from './examples.module.scss';
+
 const getClassName = cssModules(STYLES);
 const sponsor = {
   label: 'Sponsored',
@@ -39,9 +40,12 @@ const tagline = 'Travel tips';
 const headline = 'Three Peaks Challenge';
 const subheading = 'How to complete the climb in 3 days';
 const style = {
-  '--background-image-mobile': 'url(\'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=390:844px&quality=90\')',
-  '--background-image-tablet': 'url(\'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=820px:1180px&quality=90\')',
-  '--background-image-desktop': 'url(\'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=2096px:800px&quality=90\')',
+  '--background-image-mobile':
+    "url('https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=390:844px&quality=90')",
+  '--background-image-tablet':
+    "url('https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=820px:1180px&quality=90')",
+  '--background-image-desktop':
+    "url('https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=2096px:800px&quality=90')",
 };
 
 const DefaultExample = () => (

--- a/examples/bpk-component-graphic-promotion/examples.js
+++ b/examples/bpk-component-graphic-promotion/examples.js
@@ -22,8 +22,12 @@ import BpkGraphicPromo, {
   TEXT_ALIGN,
 } from '../../packages/bpk-component-graphic-promotion';
 
-const image =
-  'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=1048px:400px&quality=90';
+const backgroundImageDesktop =
+  'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=2096px:800px&quality=90';
+const backgroundImageTablet =
+  'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=820px:1180px&quality=90';
+const backgroundImageMobile =
+  'https://content.skyscnr.com/m/31ebf33b07194794/original/Hiker-looking-out-over-mountain.jpg?crop=390:844px&quality=90';
 const sponsor = {
   label: 'Sponsored',
   logo: 'https://js.skyscnr.com/sttc/bpk-content/skyland-a76916b4.png',
@@ -43,7 +47,9 @@ const DefaultExample = () => (
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    image={image}
+    backgroundImageDesktop={backgroundImageDesktop}
+    backgroundImageMobile={backgroundImageMobile}
+    backgroundImageTablet={backgroundImageTablet}
     sponsor={sponsor}
     buttonText={buttonText}
     onClick={onClick}
@@ -56,7 +62,9 @@ const CenterAlignedExample = () => (
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    image={image}
+    backgroundImageDesktop={backgroundImageDesktop}
+    backgroundImageTablet={backgroundImageTablet}
+    backgroundImageMobile={backgroundImageMobile}
     sponsor={sponsor}
     buttonText={buttonText}
     onClick={onClick}
@@ -69,7 +77,9 @@ const RightAlignedExample = () => (
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    image={image}
+    backgroundImageDesktop={backgroundImageDesktop}
+    backgroundImageTablet={backgroundImageTablet}
+    backgroundImageMobile={backgroundImageMobile}
     sponsor={sponsor}
     buttonText={buttonText}
     onClick={onClick}
@@ -82,7 +92,9 @@ const InvertedPortraitExample = () => (
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    image={image}
+    backgroundImageDesktop={backgroundImageDesktop}
+    backgroundImageTablet={backgroundImageTablet}
+    backgroundImageMobile={backgroundImageMobile}
     sponsor={sponsor}
     buttonText={buttonText}
     onClick={onClick}
@@ -94,7 +106,9 @@ const InvertedPortraitExample = () => (
 const MinimalisticExample = () => (
   <BpkGraphicPromo
     headline={headline}
-    image={image}
+    backgroundImageDesktop={backgroundImageDesktop}
+    backgroundImageTablet={backgroundImageTablet}
+    backgroundImageMobile={backgroundImageMobile}
     sponsor={sponsor}
     buttonText={buttonText}
     onClick={onClick}
@@ -107,7 +121,9 @@ const NonSponsoredExample = () => (
     tagline={tagline}
     headline={headline}
     subheading={subheading}
-    image={image}
+    backgroundImageDesktop={backgroundImageDesktop}
+    backgroundImageTablet={backgroundImageTablet}
+    backgroundImageMobile={backgroundImageMobile}
     buttonText={buttonText}
     onClick={onClick}
     textAlign={TEXT_ALIGN.start}

--- a/examples/bpk-component-graphic-promotion/examples.module.scss
+++ b/examples/bpk-component-graphic-promotion/examples.module.scss
@@ -1,0 +1,19 @@
+$breakpoint-landscape-desktop-min: 50.01rem;
+$breakpoint-landscape-tablet-max: 50rem;
+$breakpoint-landscape-tablet-min: 43.76rem;
+$breakpoint-portrait-large-max: 43.75rem;
+
+.graphicPromo {
+  @media (max-width: $breakpoint-portrait-large-max) {
+    background-image: var(--background-image-mobile);
+  }
+
+  @media (min-width: $breakpoint-landscape-tablet-min) and (max-width: $breakpoint-landscape-tablet-max) {
+    background-image: var(--background-image-tablet);;
+  }
+
+  @media (min-width: $breakpoint-landscape-desktop-min) {
+    background-image: var(--background-image-desktop);
+  }
+}
+

--- a/packages/bpk-component-graphic-promotion/package-lock.json
+++ b/packages/bpk-component-graphic-promotion/package-lock.json
@@ -1,9 +1,17 @@
 {
   "name": "bpk-component-graphic-promotion",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.17.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.17.9.tgz",
+      "integrity": "sha1-0Z+/gC0BqMts8FOmTkctQsQ0unI=",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@skyscanner/bpk-foundations-common": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.2.1.tgz",
@@ -21,6 +29,71 @@
         "color": "^3.0.0"
       }
     },
+    "bpk-component-button": {
+      "version": "6.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bpk-component-button/-/bpk-component-button-6.0.1.tgz",
+      "integrity": "sha1-PijyWsQxQHidQ9GZk/CORisZzog=",
+      "requires": {
+        "bpk-mixins": "^28.0.0",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.8.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.13.1"
+          }
+        }
+      }
+    },
+    "bpk-component-card": {
+      "version": "4.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bpk-component-card/-/bpk-component-card-4.1.4.tgz",
+      "integrity": "sha1-a/6m4I35rRILdTYFKud9b9ymCww=",
+      "requires": {
+        "bpk-mixins": "^28.0.0",
+        "bpk-react-utils": "^4.1.1",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.8.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.13.1"
+          }
+        }
+      }
+    },
+    "bpk-component-text": {
+      "version": "6.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bpk-component-text/-/bpk-component-text-6.1.4.tgz",
+      "integrity": "sha1-fnGBG6jX8iYwM8Kn4xZ6o+0qi6Q=",
+      "requires": {
+        "bpk-mixins": "^28.0.0",
+        "bpk-react-utils": "^4.1.1",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.8.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.13.1"
+          }
+        }
+      }
+    },
     "bpk-mixins": {
       "version": "28.0.0",
       "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-28.0.0.tgz",
@@ -34,6 +107,28 @@
           "version": "14.1.4",
           "resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.4.tgz",
           "integrity": "sha512-TPpF2BhKr/B74RMeHEKT9IIeDwI9B1wXjkGKNGHaOsRO5jUNvak7e0kq8bIQsgcC4HsAnTJhJm/wwyEJy25UIQ=="
+        }
+      }
+    },
+    "bpk-react-utils": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bpk-react-utils/-/bpk-react-utils-4.1.1.tgz",
+      "integrity": "sha1-64bOvdlBnpvHYEVGK+ttzatQ8BQ=",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^2.5.3"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.8.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.13.1"
+          }
         }
       }
     },
@@ -68,6 +163,14 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha1-6bNpcA+Vn2Ls3lprq95LzNkWmvg=",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -99,6 +202,32 @@
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha1-TxonOv38jzSIqMUWv9p4+HI1I2I="
+    },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha1-35zbAleWIRFRpDbGmo87l7WwfI0=",
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha1-iSV0Kpj/2QgUmI11Zq0wyjsmO1I="
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -43,9 +43,6 @@ export type Props = {
   tagline: ?string,
   headline: string,
   subheading: ?string,
-  backgroundImageMobile: string,
-  backgroundImageTablet: string,
-  backgroundImageDesktop: string,
   sponsor: ?{
     label: string,
     logo: string,
@@ -56,6 +53,7 @@ export type Props = {
   invertVertically: boolean,
   textAlign: TEXT_ALIGN,
   textColor: TEXT_COLORS,
+  style: string,
 };
 
 const constructAriaLabel = ({
@@ -83,9 +81,6 @@ const constructAriaLabel = ({
 
 const BpkGraphicPromo = (props: Props) => {
   const {
-    backgroundImageDesktop,
-    backgroundImageMobile,
-    backgroundImageTablet,
     buttonText,
     className,
     headline,
@@ -96,6 +91,7 @@ const BpkGraphicPromo = (props: Props) => {
     tagline,
     textAlign,
     textColor,
+    style
   } = props;
 
   // FIXME: Use useCallback() here when React is updated.
@@ -118,9 +114,7 @@ const BpkGraphicPromo = (props: Props) => {
       className={cardClasses}
       style={{
         color: textColor,
-        '--background-image-mobile': `url(${backgroundImageMobile})`,
-        '--background-image-tablet': `url(${backgroundImageTablet})`,
-        '--background-image-desktop': `url(${backgroundImageDesktop})`,
+        ...style
       }}
       onClick={onClickWrapper}
       aria-label={constructAriaLabel(props)}

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -87,11 +87,11 @@ const BpkGraphicPromo = (props: Props) => {
     invertVertically,
     onClick,
     sponsor,
+    style,
     subheading,
     tagline,
     textAlign,
     textColor,
-    style
   } = props;
 
   // FIXME: Use useCallback() here when React is updated.
@@ -114,7 +114,7 @@ const BpkGraphicPromo = (props: Props) => {
       className={cardClasses}
       style={{
         color: textColor,
-        ...style
+        ...style,
       }}
       onClick={onClickWrapper}
       aria-label={constructAriaLabel(props)}
@@ -179,9 +179,6 @@ BpkGraphicPromo.propTypes = {
   tagline: PropTypes.string,
   headline: PropTypes.string.isRequired,
   subheading: PropTypes.string,
-  backgroundImageMobile: PropTypes.string.isRequired,
-  backgroundImageTablet: PropTypes.string.isRequired,
-  backgroundImageDesktop: PropTypes.string.isRequired,
   sponsor: PropTypes.shape({
     label: PropTypes.string,
     logo: PropTypes.string,
@@ -192,6 +189,7 @@ BpkGraphicPromo.propTypes = {
   invertVertically: PropTypes.bool,
   textAlign: PropTypes.oneOf(Object.values(TEXT_ALIGN)).isRequired,
   textColor: PropTypes.oneOf(Object.values(TEXT_COLORS)),
+  style: PropTypes.string,
 };
 
 BpkGraphicPromo.defaultProps = {
@@ -201,6 +199,7 @@ BpkGraphicPromo.defaultProps = {
   sponsor: null,
   invertVertically: false,
   textColor: TEXT_COLORS.white,
+  style: {},
 };
 
 export default BpkGraphicPromo;

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -43,7 +43,9 @@ export type Props = {
   tagline: ?string,
   headline: string,
   subheading: ?string,
-  image: string,
+  backgroundImageMobile: string,
+  backgroundImageTablet: string,
+  backgroundImageDesktop: string,
   sponsor: ?{
     label: string,
     logo: string,
@@ -81,10 +83,12 @@ const constructAriaLabel = ({
 
 const BpkGraphicPromo = (props: Props) => {
   const {
+    backgroundImageDesktop,
+    backgroundImageMobile,
+    backgroundImageTablet,
     buttonText,
     className,
     headline,
-    image,
     invertVertically,
     onClick,
     sponsor,
@@ -109,11 +113,15 @@ const BpkGraphicPromo = (props: Props) => {
 
   const getTextClasses = (baseClass: string) =>
     getClassName(baseClass, `${baseClass}--${textAlign}`);
-
   return (
     <BpkCard
       className={cardClasses}
-      style={{ backgroundImage: `url(${image})`, color: textColor }}
+      style={{
+        color: textColor,
+        '--background-image-mobile': `url(${backgroundImageMobile})`,
+        '--background-image-tablet': `url(${backgroundImageTablet})`,
+        '--background-image-desktop': `url(${backgroundImageDesktop})`,
+      }}
       onClick={onClickWrapper}
       aria-label={constructAriaLabel(props)}
       padded={false}
@@ -177,7 +185,9 @@ BpkGraphicPromo.propTypes = {
   tagline: PropTypes.string,
   headline: PropTypes.string.isRequired,
   subheading: PropTypes.string,
-  image: PropTypes.string.isRequired,
+  backgroundImageMobile: PropTypes.string.isRequired,
+  backgroundImageTablet: PropTypes.string.isRequired,
+  backgroundImageDesktop: PropTypes.string.isRequired,
   sponsor: PropTypes.shape({
     label: PropTypes.string,
     logo: PropTypes.string,

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -31,6 +31,14 @@
   @include breakpoint-landscape {
     pointer-events: none;
 
+    @include breakpoint-landscape-desktop {
+      background-image: var(--background-image-desktop);
+    }
+
+    @include breakpoint-landscape-tablet {
+      background-image: var(--background-image-tablet);
+    }
+
     &__sponsor-label {
       margin-bottom: bpk-spacing-sm();
 
@@ -67,6 +75,7 @@
   }
 
   @include breakpoint-portrait-large {
+    background-image: var(--background-image-mobile);
     &__sponsor-label {
       margin-bottom: bpk-spacing-md();
 
@@ -91,6 +100,8 @@
   }
 
   @include breakpoint-portrait-medium {
+    background-image: var(--background-image-mobile);
+
     &__sponsor-label {
       margin-bottom: bpk-spacing-md();
 
@@ -115,6 +126,7 @@
   }
 
   @include breakpoint-portrait-small {
+    background-image: var(--background-image-mobile);
     &__sponsor-label {
       margin-bottom: bpk-spacing-sm();
 

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -31,14 +31,6 @@
   @include breakpoint-landscape {
     pointer-events: none;
 
-    @include breakpoint-landscape-desktop {
-      background-image: var(--background-image-desktop);
-    }
-
-    @include breakpoint-landscape-tablet {
-      background-image: var(--background-image-tablet);
-    }
-
     &__sponsor-label {
       margin-bottom: bpk-spacing-sm();
 
@@ -75,7 +67,6 @@
   }
 
   @include breakpoint-portrait-large {
-    background-image: var(--background-image-mobile);
     &__sponsor-label {
       margin-bottom: bpk-spacing-md();
 
@@ -100,8 +91,6 @@
   }
 
   @include breakpoint-portrait-medium {
-    background-image: var(--background-image-mobile);
-
     &__sponsor-label {
       margin-bottom: bpk-spacing-md();
 
@@ -126,7 +115,6 @@
   }
 
   @include breakpoint-portrait-small {
-    background-image: var(--background-image-mobile);
     &__sponsor-label {
       margin-bottom: bpk-spacing-sm();
 


### PR DESCRIPTION
This change allows different images to be loaded depending on the viewport width.

# Screenshots
## Desktop
![Screenshot 2022-04-12 at 12 39 41](https://user-images.githubusercontent.com/38808938/162952499-d39fd12b-a16f-424b-b3b2-4480126ba501.png)
## Tablet
![Screenshot 2022-04-12 at 12 39 53](https://user-images.githubusercontent.com/38808938/162952525-352fad1d-d949-42bd-bd23-27c62733d4e2.png)
## Mobile
![Screenshot 2022-04-12 at 12 40 06](https://user-images.githubusercontent.com/38808938/162952575-fbd378b8-8113-4f16-88f1-49ae98d1286f.png)


Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
