### PR TITLE
[BD-6033] Fixed `preventGoogleFontsLoading` making Google Maps cannot be interactive

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+- bpk-component-map:
+  - Fixed `preventGoogleFontsLoading` defaulting to `true` make Google Maps cannot be interactive

--- a/packages/bpk-component-map/README.md
+++ b/packages/bpk-component-map/README.md
@@ -154,7 +154,7 @@ When using `withGoogleMapsScript`, some additional props are available:
 | googleMapsApiKey          | string   | true     | -                                 |
 | libraries                 | array    | false    | ['geometry', 'drawing', 'places'] |
 | loadingElement            | node     | false    | BpkSpinner                        |
-| preventGoogleFontsLoading | bool     | false    | true                              |
+| preventGoogleFontsLoading | bool     | false    | false                             |
 
 ### BpkIconMarker
 

--- a/packages/bpk-component-map/src/withGoogleMapsScript.js
+++ b/packages/bpk-component-map/src/withGoogleMapsScript.js
@@ -70,7 +70,7 @@ function withGoogleMapsScript(Component: ComponentType<any>) {
 
   WithGoogleMapsScript.defaultProps = {
     loadingElement: <DefaultLoadingElement />,
-    preventGoogleFontsLoading: true,
+    preventGoogleFontsLoading: false,
     libraries: ['geometry', 'drawing', 'places'],
   };
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

When `preventGoogleFontsLoading` is set to `true`, Google Maps will not be able to interact, such as the markers cannot be clicked, because the whole layout is masked by a mask, so it is better to update the default value to `false` to avoid the confusion, because most of the case we want to interact on Google Maps instead of a static map

Related to the PR https://github.com/Skyscanner/backpack/pull/2423

![image](https://user-images.githubusercontent.com/29422130/167128218-eb85b310-d057-4b26-ba6a-5f4aac93f2ed.png)

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
