### PR TITLE
[KOA-5029]: Upgrade web to Node 14

### DIFF
--- a/.naverc
+++ b/.naverc
@@ -1,1 +1,1 @@
-lts/carbon
+lts/fermium

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/erbium
+lts/fermium

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,14 +27,14 @@ Conventions and squad decisions are kept in the [decisions folder](/decisions). 
 
 Backpack is developed using Node, using the following versions:
 
-* `LTS/Erbium` (Node ^12.13.0)
-* `^6.12.0` (npm)
+* `LTS/Fermium` (Node ^14.19.1)
+* `^6.14.16` (npm)
 
 This is enforced using a pre-install hook that calls out to [ensure-node-env](https://github.com/Skyscanner/ensure-node-env).
 
 If you use [nvm](https://github.com/creationix/nvm) or [nave](https://github.com/isaacs/nave) to manage your Node environment, Backpack has built-in support for these. Just run `nvm use` or `nave auto` to install the correct Node version.
 
-To install npm, use `npm install --global npm@^6.12.0`.
+To install npm, use `npm install --global npm@^6.14.16`.
 
 ### Android, iOS and React Native
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "node": "^12.13.0",
-    "npm": "^6.12.0"
+    "node": "^14.19.1",
+    "npm": "^6.14.16"
   },
   "repository": {
     "type": "git",
@@ -47,7 +47,6 @@
     "lint:scss:fix": "stylelint 'packages/**/*.scss' --syntax scss --fix",
     "lint-staged": "lint-staged",
     "postinstall": "npm run bootstrap",
-    "preinstall": "npx ensure-node-env",
     "prettier": "prettier --config .prettierrc --write \"**/*.js\"",
     "publish": "npm run check-pristine && npm run check-owners && npm run build && git pull --rebase && npm run test && lerna publish && npm run publish:css",
     "publish:css": "node ./scripts/publish-process/transform-js-scss-css-imports.js && node ./scripts/publish-process/transform-bpk-imports.js && node ./scripts/publish-process/publish-css-tagged-packages.js && git reset --hard HEAD",

--- a/packages/bpk-animate-height/package-lock.json
+++ b/packages/bpk-animate-height/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-animate-height",
-	"version": "4.1.5",
+	"version": "4.1.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-accordion/package-lock.json
+++ b/packages/bpk-component-accordion/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-accordion",
-	"version": "5.0.5",
+	"version": "5.0.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-aria-live/package-lock.json
+++ b/packages/bpk-component-aria-live/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-aria-live",
-	"version": "2.1.9",
+	"version": "2.1.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-autosuggest/package-lock.json
+++ b/packages/bpk-component-autosuggest/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-autosuggest",
-	"version": "6.1.7",
+	"version": "6.1.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-banner-alert/package-lock.json
+++ b/packages/bpk-component-banner-alert/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-banner-alert",
-	"version": "6.1.7",
+	"version": "6.1.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-calendar/package-lock.json
+++ b/packages/bpk-component-calendar/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-calendar",
-	"version": "11.1.9",
+	"version": "11.1.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-checkbox/package-lock.json
+++ b/packages/bpk-component-checkbox/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-checkbox",
-	"version": "4.1.7",
+	"version": "4.1.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-chip/package-lock.json
+++ b/packages/bpk-component-chip/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-chip",
-	"version": "5.2.7",
+	"version": "5.2.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-datepicker/package-lock.json
+++ b/packages/bpk-component-datepicker/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-datepicker",
-	"version": "15.2.9",
+	"version": "15.2.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-drawer/package-lock.json
+++ b/packages/bpk-component-drawer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-drawer",
-	"version": "4.1.6",
+	"version": "4.1.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-fieldset/package-lock.json
+++ b/packages/bpk-component-fieldset/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-fieldset",
-	"version": "4.1.9",
+	"version": "4.1.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-form-validation/package-lock.json
+++ b/packages/bpk-component-form-validation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-form-validation",
-	"version": "4.2.7",
+	"version": "4.2.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-input/package-lock.json
+++ b/packages/bpk-component-input/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-input",
-	"version": "6.1.7",
+	"version": "6.1.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-map/package-lock.json
+++ b/packages/bpk-component-map/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-map",
-	"version": "5.2.7",
+	"version": "6.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-modal/package-lock.json
+++ b/packages/bpk-component-modal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-modal",
-	"version": "3.1.7",
+	"version": "3.1.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-navigation-bar/package-lock.json
+++ b/packages/bpk-component-navigation-bar/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-navigation-bar",
-	"version": "3.1.7",
+	"version": "3.1.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-navigation-stack/package-lock.json
+++ b/packages/bpk-component-navigation-stack/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-navigation-stack",
-	"version": "3.1.7",
+	"version": "3.1.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-pagination/package-lock.json
+++ b/packages/bpk-component-pagination/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-pagination",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-phone-input/package-lock.json
+++ b/packages/bpk-component-phone-input/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-phone-input",
-	"version": "7.1.9",
+	"version": "7.1.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-popover/package-lock.json
+++ b/packages/bpk-component-popover/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-popover",
-	"version": "4.1.7",
+	"version": "4.1.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-radio/package-lock.json
+++ b/packages/bpk-component-radio/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-radio",
-	"version": "3.1.6",
+	"version": "3.1.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-rtl-toggle/package-lock.json
+++ b/packages/bpk-component-rtl-toggle/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-rtl-toggle",
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-scrollable-calendar/package-lock.json
+++ b/packages/bpk-component-scrollable-calendar/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-scrollable-calendar",
-	"version": "6.1.9",
+	"version": "6.1.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-component-switch/package-lock.json
+++ b/packages/bpk-component-switch/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bpk-component-switch",
-	"version": "2.1.6",
+	"version": "2.1.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Upgrades Backpack Web to Node 14 as an interim step to move to a supported Node version.

Follow up work will be completed to upgrade libraries and implementations to fully support Node 16 as currently upgrading to Node 16 causes test failures and has some bugs in npm v8 which is a large task.

So we will break this down in order to support it properly and not make a large PRs that might be unstable or less easy to manage