### PR TITLE
[BD-6042] Fixed the indicator style when scrollLeft is a decimal value

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -871,3 +871,5 @@ Storyshots
 mapOptionStyles
 googleMapsApiKey
 preventGoogleFontsLoading
+scrollLeft
+scrollerEl

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+bpk-component-mobile-scroll-container
+- Fixed indicator style when scrollLeft of scrollerEl is a decimal value.

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
@@ -52,7 +52,7 @@ const computeScrollIndicatorClassName = (
   const { offsetWidth, scrollLeft, scrollWidth } = scrollerEl;
 
   const rtl = isRTL();
-  const scrollValue = rtl ? -scrollLeft : scrollLeft;
+  const scrollValue = rtl ? -Math.ceil(scrollLeft) : Math.ceil(scrollLeft);
   const showLeadingIndicator = scrollValue > 0;
   const showTrailingIndicator = scrollValue < scrollWidth - offsetWidth;
   const showLeftIndicator = rtl ? showTrailingIndicator : showLeadingIndicator;

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
@@ -52,7 +52,7 @@ const computeScrollIndicatorClassName = (
   const { offsetWidth, scrollLeft, scrollWidth } = scrollerEl;
 
   const rtl = isRTL();
-  const scrollValue = rtl ? -Math.ceil(scrollLeft) : Math.ceil(scrollLeft);
+  const scrollValue = rtl ? -Math.floor(scrollLeft) : Math.ceil(scrollLeft);
   const showLeadingIndicator = scrollValue > 0;
   const showTrailingIndicator = scrollValue < scrollWidth - offsetWidth;
   const showLeftIndicator = rtl ? showTrailingIndicator : showLeadingIndicator;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
## Context

### [BD-6042](https://gojira.skyscanner.net/browse/BD-6042)

### Why Are We Making This Change?
<!--- This could be to improve conversion, facilitate another feature or just to make the code cleaner -->
<!--- It is unlikely that the reviewer will know why a feature is being added, this will help the reviewer confirm that the change is correct -->
We found that due to [the problem of `scrollLeft` itself](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft) - **On systems using display scaling, scrollLeft may give you a decimal value** 
This will affect the logic of calculating whether the indicator is displayed or not in `BpkMobileScrollContainer`.

### What Predictions Do We Have About When This Goes Live? 
<!--- How do we know that the feature is working in production? -->
<!--- In some cases, such as a code refactor there will be no user change -->
<!--- In most cases, we will be making a user facing change that should have some measurable impact -->
<!--- This could be one of the following 3 things-->
<!--- User Actions, such as clicks on a certain button -->
<!--- Error rates, 4XX or 5XX -->
<!--- Latency -->
- Indicator will be calculated correctly when scrollLeft gets a decimal value.
<!--- If the change is measurable, do we have a graph or mixpanel event that monitors it?-->
<!--- In some cases we may need an alert as well, or send some kind of message if something goes wrong with this feature -->

<!--- In either case please create / link to the relevant graph or alert where we will see this change -->

<!--- If you have any doubts about this ask on the accom-web-contrib channel -->

### Change Description
<!--- Provide a short bullet point list of the code changes that have gone into this PR-->
<!--- You do not need to provide excessive detail here, the code should be as clear as possible on what is happening -->
<!--- e.g - Deleted module X -->
<!---     - Replaced module X with Y -->
<!---     - Refactored Z to take new parameter -->
- Take the ceil value of `scrollLeft`

### Screenshots
<!--- Add here if this pull request introduces any visual changes -->
<!--- You could convert the video to gif to easy understand the change https://ezgif.com/video-to-gif --->

<!-- If side by side this formatting helps -->
To better show the difference, I change the indicator styles temporarily.
Problems will probably occur when:
1. Screen zoomed
2. The width of the container of BpkMobileScrollContainer is decimal.

When the problem occurs, we see that showTrailingIndicator will **always have a true value even the list have meet the end**.


| Before                        | After                         |
| ----------------------------- | ----------------------------- |
| <img src="https://user-images.githubusercontent.com/86780745/168571066-6e58fc78-9d46-4ecc-bc0a-2c02d4662033.gif" width=300/> | <img src="https://user-images.githubusercontent.com/86780745/168571019-834c15f3-445e-4f68-899e-d47e0876409b.gif" width=300 /> |

#### Arabic

| Before                        | After                         |
| ----------------------------- | ----------------------------- |
| <img src="https://user-images.githubusercontent.com/86780745/168575505-cb594bd0-e76f-4fc1-adf8-81556eb322c5.gif" width=300/> | <img src="https://user-images.githubusercontent.com/86780745/168575474-99f75ce5-89ce-446b-ad18-d5929d00bdbb.gif" width=300 /> |


Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
