### PR TITLE
[BD-6043] Fix rating RTL issue with additional padding

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+- bpk-component-rating:
+   - Fixed an RTL issue where the value had additional padding.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,4 +1,4 @@
 **Fixed:**
 
 - bpk-component-rating:
-   - Fixed an RTL issue where the value had additional padding.
+   - Fixed RTL issue where the value had additional padding.

--- a/packages/bpk-component-rating/src/BpkRating.module.scss
+++ b/packages/bpk-component-rating/src/BpkRating.module.scss
@@ -37,6 +37,7 @@ $bpk-spacing-v2: true;
     color: $bpk-color-sky-gray;
 
     @include bpk-rtl {
+      padding-right: 0;
       padding-left: bpk-spacing-md();
     }
   }
@@ -69,6 +70,7 @@ $bpk-spacing-v2: true;
 
     @include bpk-rtl {
       padding-right: bpk-spacing-md();
+      padding-left: 0;
     }
 
     &--large {
@@ -77,6 +79,7 @@ $bpk-spacing-v2: true;
 
       @include bpk-rtl {
         padding-right: 0;
+        padding-left: 0;
       }
     }
   }


### PR DESCRIPTION
##  Context
Subject: New design for ReviewRating to backpack `bpk-component-rating`
Ticket:  https://gojira.skyscanner.net/browse/BD-6043
UX:  [figma](https://www.figma.com/file/irZ3YBx8vOm16ICkAr7mB3/Backpack?node-id=7986%3A7553)
Confluence:  [Backpack Rating component](https://confluence.skyscannertools.net/display/BD/Rating+component)
Visual link: https://backpack.github.io/storybook-prs/2430/?path=/story/bpk-component-rating--visual-test

## Why Are We Making This Change?
- There is a RTL issue for rating value has additional padding


## Change Description
 - Fix rating RTL issue with additional padding
 - Update UNRELEASED.md


### Screenshots
<!--- You could convert the video to gif to easy understand the change https://ezgif.com/video-to-gif --->

| Before                        | After                         |
| ----------------------------- | ----------------------------- |
| <img src="https://user-images.githubusercontent.com/33623220/170219040-e003b9b4-5c40-4ed1-86dd-1ed169fd6899.png" width=400/> | <img src="https://user-images.githubusercontent.com/33623220/170219340-9d16b44d-abe3-400d-8e92-67a34a2fd4b6.png" width=400 /> |


## Checklist

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
