### PR TITLE
ST-4162: center graphic promo text

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,5 +5,8 @@
 
 **Fixed:**
 
+- bpk-component-graphic-promotion
+  - Ensured text is centered correctly despite margins
+
 - `@skyscanner/backpack-web`
   - Added missing dependencies `@skyscanner/bpk-svgs`, `@react-google-maps/api`, `@popperjs/core` 

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -152,10 +152,6 @@
 
       &--center {
         align-items: center;
-
-        > * {
-          @include bpk-margin-trailing(bpk-spacing-lg());
-        }
       }
 
       &--end {
@@ -176,6 +172,10 @@
 
       @include bpk-margin-leading(bpk-spacing-xxxl(), false);
       @include bpk-margin-trailing(bpk-spacing-xxl(), false);
+
+      &--center > * {
+        @include bpk-margin-trailing(bpk-spacing-lg());
+      }
     }
 
     @include breakpoint-landscape-tablet {
@@ -183,6 +183,10 @@
 
       @include bpk-margin-leading(bpk-spacing-xxl(), false);
       @include bpk-margin-trailing(bpk-spacing-xl(), false);
+
+      &--center > * {
+        @include bpk-margin-trailing(bpk-spacing-md());
+      }
     }
 
     @include breakpoint-portrait-large {

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -152,6 +152,10 @@
 
       &--center {
         align-items: center;
+
+        > * {
+          margin-left: -0.75rem;
+        }
       }
 
       &--end {

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -173,6 +173,7 @@
       @include bpk-margin-leading(bpk-spacing-xxxl(), false);
       @include bpk-margin-trailing(bpk-spacing-xxl(), false);
 
+      /* adjusting for 1.5rem different between margins */
       &--center > * {
         @include bpk-margin-trailing(bpk-spacing-lg());
       }
@@ -184,6 +185,7 @@
       @include bpk-margin-leading(bpk-spacing-xxl(), false);
       @include bpk-margin-trailing(bpk-spacing-xl(), false);
 
+      /* adjusting for 0.5rem different between margins */
       &--center > * {
         @include bpk-margin-trailing(bpk-spacing-md());
       }

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -154,7 +154,7 @@
         align-items: center;
 
         > * {
-          @include bpk-margin-trailing(bpk-spacing-lg() / 2);
+          @include bpk-margin-trailing(bpk-spacing-lg());
         }
       }
 

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -154,7 +154,7 @@
         align-items: center;
 
         > * {
-          margin-left: -0.75rem;
+          @include bpk-margin-trailing(bpk-spacing-lg() / 2);
         }
       }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

[ST-4162](https://gojira.skyscanner.net/browse/ST-4162)
Centred text on the centred graphic promo to the exact centre ignoring margins.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
