### PR TITLE
ST-4126 clickable graphic promo

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,5 +5,9 @@
 
 **Fixed:**
 
+- bpk-component-graphic-promotion
+  - Made entire card clickable on all platforms
+  - Updated tests and storybook examples for component
+
 - `@skyscanner/backpack-web`
   - Added missing dependencies `@skyscanner/bpk-svgs`, `@react-google-maps/api`, `@popperjs/core` 

--- a/examples/bpk-component-graphic-promotion/examples.js
+++ b/examples/bpk-component-graphic-promotion/examples.js
@@ -33,7 +33,7 @@ const sponsor = {
 };
 const buttonText = 'Discover more';
 const onClick = () => {
-  window.location.href = 'https://www.skyscanner.net';
+  window.open('https://www.skyscanner.net');
 };
 
 const tagline = 'Travel tips';

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo-test.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo-test.js
@@ -104,7 +104,7 @@ describe('BpkGraphicPromo', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should redirect us to link when card is clicked on mobile', () => {
+  it('should redirect us to link when card is clicked', () => {
     render(<BpkGraphicPromo {...props} />);
 
     const graphicPromo = document.getElementsByClassName(

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -30,8 +30,6 @@
   box-shadow: none;
 
   @include breakpoint-landscape {
-    pointer-events: none;
-
     &__sponsor-label {
       margin-bottom: bpk-spacing-sm();
 
@@ -237,8 +235,6 @@
   }
 
   &__cta {
-    pointer-events: auto;
-
     @include breakpoint-landscape {
       margin-top: bpk-spacing-xl();
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
[ST-4126](https://gojira.skyscanner.net/browse/ST-4326)
Whole promo card is now clickable on all platforms

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
