### PR TITLE
[ST-4403] adds a11y to floating alert

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Fixed**
+- bpk-component-floating-notification
+  - adds a11y roles and attributes

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
@@ -100,7 +100,12 @@ const BpkFloatingNotification = (props: Props) => {
       exit={animateOnExit}
       unmountOnExit
     >
-      <div className={classNames} {...rest}>
+      <div
+        className={classNames}
+        {...rest}
+        role="alertdialog"
+        aria-describedby="dialogdesc"
+      >
         {Icon && (
           <div className={iconClassNames}>
             <Icon />
@@ -110,6 +115,7 @@ const BpkFloatingNotification = (props: Props) => {
           tagName="p"
           textStyle={TEXT_STYLES.bodyDefault}
           className={getClassName('bpk-floating-notification__text')}
+          id="dialogdesc"
         >
           {text}
         </BpkText>

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
@@ -105,6 +105,7 @@ const BpkFloatingNotification = (props: Props) => {
         {...rest}
         role="alertdialog"
         aria-describedby="dialogdesc"
+        aria-label="alert"
       >
         {Icon && (
           <div className={iconClassNames}>

--- a/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.js.snap
+++ b/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.js.snap
@@ -3,10 +3,14 @@
 exports[`BpkFloatingNotification should render correctly 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="dialogdesc"
+    aria-label="alert"
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alertdialog"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
+      id="dialogdesc"
     >
       Saved
     </p>
@@ -17,10 +21,14 @@ exports[`BpkFloatingNotification should render correctly 1`] = `
 exports[`BpkFloatingNotification should render correctly in dark mode (prop) 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="dialogdesc"
+    aria-label="alert"
     class="bpk-floating-notification bpk-floating-notification--dark bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alertdialog"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
+      id="dialogdesc"
     >
       Saved
     </p>
@@ -31,10 +39,14 @@ exports[`BpkFloatingNotification should render correctly in dark mode (prop) 1`]
 exports[`BpkFloatingNotification should render correctly with CTA text 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="dialogdesc"
+    aria-label="alert"
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alertdialog"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
+      id="dialogdesc"
     >
       Saved
     </p>
@@ -51,10 +63,14 @@ exports[`BpkFloatingNotification should render correctly with CTA text 1`] = `
 exports[`BpkFloatingNotification should render correctly with CTA text in dark mode 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="dialogdesc"
+    aria-label="alert"
     class="bpk-floating-notification bpk-floating-notification--dark bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alertdialog"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
+      id="dialogdesc"
     >
       Saved
     </p>
@@ -71,7 +87,10 @@ exports[`BpkFloatingNotification should render correctly with CTA text in dark m
 exports[`BpkFloatingNotification should render correctly with icon prop 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="dialogdesc"
+    aria-label="alert"
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alertdialog"
   >
     <div
       class="bpk-floating-notification__icon"
@@ -90,6 +109,7 @@ exports[`BpkFloatingNotification should render correctly with icon prop 1`] = `
     </div>
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
+      id="dialogdesc"
     >
       Saved
     </p>
@@ -100,7 +120,10 @@ exports[`BpkFloatingNotification should render correctly with icon prop 1`] = `
 exports[`BpkFloatingNotification should render correctly with icon prop in dark mode 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="dialogdesc"
+    aria-label="alert"
     class="bpk-floating-notification bpk-floating-notification--dark bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alertdialog"
   >
     <div
       class="bpk-floating-notification__icon bpk-floating-notification__icon--dark"
@@ -119,6 +142,7 @@ exports[`BpkFloatingNotification should render correctly with icon prop in dark 
     </div>
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
+      id="dialogdesc"
     >
       Saved
     </p>
@@ -129,11 +153,15 @@ exports[`BpkFloatingNotification should render correctly with icon prop in dark 
 exports[`BpkFloatingNotification should support arbitrary props 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="dialogdesc"
+    aria-label="alert"
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alertdialog"
     testid="123"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
+      id="dialogdesc"
     >
       Saved
     </p>
@@ -144,10 +172,14 @@ exports[`BpkFloatingNotification should support arbitrary props 1`] = `
 exports[`BpkFloatingNotification should support custom class names 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="dialogdesc"
+    aria-label="alert"
     class="bpk-floating-notification custom-classname bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alertdialog"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
+      id="dialogdesc"
     >
       Saved
     </p>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Updates bpk-component-floating-alert to be a11y compliant 

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [ ] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
