### PR TITLE
New portal implementation for Modal, Dialog and Drawer

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,18 @@
+**Breaking:**
+
+- bpk-react-utils:
+  - Upgraded `Portal` to use the native React Portal implementation.
+  - Removed usage of `unstable_renderSubtreeIntoContainer` as this has been deprecated in the latest version.
+  - Removed usage of `findDOMNode` which has been deprecated in strict mode, and should only be used as an escape hatch in legacy edge cases. (possibly with tooltips and popovers)
+  - Removed `unmountComponentAtNode` as we now unmount by removing the portal from the `renderTarget`.
+  - Introduced `PortalV1` to support legacy usage during the transition and will throw a warning if used to move to the latest version.
+
+- bpk-component-datepicker:
+- bpk-component-tooltip:
+- bpk-component-popover:
+  - Migrated to `PortalV1` - to continue using the old portal implementation, as we are breaking the task down, but in a future implementation will be migrated to the new portal system.
+
+- bpk-component-drawer:
+- bpk-component-dialog:
+- bpk-component-modal:
+  - Migrated to the new native portal implementation. Which should now mean that context is available from the parent component to the child pop-up components.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,18 +1,19 @@
 **Breaking:**
 
-- bpk-react-utils:
+`@skyscanner/backpack-web`<br />
+`bpk-react-utils`
   - Upgraded `Portal` to use the native React Portal implementation.
   - Removed usage of `unstable_renderSubtreeIntoContainer` as this has been deprecated in the latest version.
   - Removed usage of `findDOMNode` which has been deprecated in strict mode, and should only be used as an escape hatch in legacy edge cases. (possibly with tooltips and popovers)
   - Removed `unmountComponentAtNode` as we now unmount by removing the portal from the `renderTarget`.
   - Introduced `PortalV1` to support legacy usage during the transition and will throw a warning if used to move to the latest version.
 
-- bpk-component-datepicker:
-- bpk-component-tooltip:
-- bpk-component-popover:
+`bpk-component-datepicker`<br /> 
+`bpk-component-tooltip`<br /> 
+`bpk-component-popover`
   - Migrated to `PortalV1` - to continue using the old portal implementation, as we are breaking the task down, but in a future implementation will be migrated to the new portal system.
 
-- bpk-component-drawer:
-- bpk-component-dialog:
-- bpk-component-modal:
+`bpk-component-drawer`<br /> 
+`bpk-component-dialog`<br />
+`bpk-component-modal`
   - Migrated to the new native portal implementation. Which should now mean that context is available from the parent component to the child pop-up components.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,12 +8,16 @@
   - Removed `unmountComponentAtNode` as we now unmount by removing the portal from the `renderTarget`.
   - Introduced `PortalV1` to support legacy usage during the transition and will throw a warning if used to move to the latest version.
 
+`bpk-component-drawer`<br /> 
+`bpk-component-dialog`<br />
+`bpk-component-modal`
+  - Migrated to the new native portal implementation. Which should now mean that context is available from the parent component to the child pop-up components.
+
+**Updated:**
+
 `bpk-component-datepicker`<br /> 
 `bpk-component-tooltip`<br /> 
 `bpk-component-popover`
   - Migrated to `PortalV1` - to continue using the old portal implementation, as we are breaking the task down, but in a future implementation will be migrated to the new portal system.
 
-`bpk-component-drawer`<br /> 
-`bpk-component-dialog`<br />
-`bpk-component-modal`
-  - Migrated to the new native portal implementation. Which should now mean that context is available from the parent component to the child pop-up components.
+

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -22,7 +22,7 @@ import { createPopper, basePlacements } from '@popperjs/core';
 import PropTypes from 'prop-types';
 import React, { Component, type Node } from 'react';
 import focusStore from 'a11y-focus-store';
-import { Portal, cssModules } from 'bpk-react-utils';
+import { PortalV1, cssModules } from 'bpk-react-utils';
 
 import keyboardFocusScope from './keyboardFocusScope';
 import STYLES from './BpkPopover.module.scss';
@@ -216,7 +216,7 @@ class BpkPopoverPortal extends Component<Props> {
     }
 
     return (
-      <Portal
+      <PortalV1
         beforeClose={this.beforeClose}
         className={classNames.join(' ')}
         isOpen={isOpen}
@@ -228,7 +228,7 @@ class BpkPopoverPortal extends Component<Props> {
       >
         {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'. */}
         <BpkPopover onClose={this.onClose} {...rest} />
-      </Portal>
+      </PortalV1>
     );
   }
 }

--- a/packages/bpk-component-popover/src/__snapshots__/BpkPopoverPortal-test.js.snap
+++ b/packages/bpk-component-popover/src/__snapshots__/BpkPopoverPortal-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BpkPopoverPortal Custom Portal props should render correctly with portalClassName added to portal component 1`] = `
-<Portal
+<PortalV1
   beforeClose={[Function]}
   className="bpk-popover-portal my-custom-classname"
   closeOnEscPressed={true}
@@ -33,11 +33,11 @@ exports[`BpkPopoverPortal Custom Portal props should render correctly with porta
       My popover content
     </div>
   </BpkPopover>
-</Portal>
+</PortalV1>
 `;
 
 exports[`BpkPopoverPortal Custom Portal props should render correctly with portalStyle added to portal component 1`] = `
-<Portal
+<PortalV1
   beforeClose={[Function]}
   className="bpk-popover-portal"
   closeOnEscPressed={true}
@@ -73,7 +73,7 @@ exports[`BpkPopoverPortal Custom Portal props should render correctly with porta
       My popover content
     </div>
   </BpkPopover>
-</Portal>
+</PortalV1>
 `;
 
 exports[`BpkPopoverPortal should not render anything if target is a function 1`] = `<DocumentFragment />`;

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal-test.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal-test.js
@@ -27,13 +27,12 @@ jest.mock('bpk-react-utils', () => {
 
   return {
     ...original,
-    Portal: 'Portal',
+    PortalV1: 'PortalV1',
   };
 });
 
-/* eslint-disable import/first */
+// eslint-disable-next-line import/first
 import BpkTooltipPortal from './BpkTooltipPortal';
-/* eslint-enable */
 
 describe('BpkTooltipPortal', () => {
   it('should render correctly', () => {

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -21,7 +21,7 @@
 import { createPopper, basePlacements } from '@popperjs/core';
 import PropTypes from 'prop-types';
 import React, { Component, type Node, type Element } from 'react';
-import { Portal, cssModules } from 'bpk-react-utils';
+import { PortalV1, cssModules } from 'bpk-react-utils';
 
 import BpkTooltip, {
   propTypes as tooltipPropTypes,
@@ -195,7 +195,7 @@ class BpkTooltipPortal extends Component<Props, State> {
     }
 
     return renderPortal ? (
-      <Portal
+      <PortalV1
         target={targetWithAccessibilityProps}
         targetRef={(targetRef) => {
           this.targetRef = targetRef;
@@ -211,7 +211,7 @@ class BpkTooltipPortal extends Component<Props, State> {
         <BpkTooltip padded={padded} {...rest}>
           {children}
         </BpkTooltip>
-      </Portal>
+      </PortalV1>
     ) : (
       targetWithAccessibilityProps
     );

--- a/packages/bpk-component-tooltip/src/__snapshots__/BpkTooltipPortal-test.js.snap
+++ b/packages/bpk-component-tooltip/src/__snapshots__/BpkTooltipPortal-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BpkTooltipPortal should render correctly 1`] = `
 <DocumentFragment>
-  <portal
+  <portalv1
     class="bpk-tooltip-portal"
     target="[object Object]"
   >
@@ -24,13 +24,13 @@ exports[`BpkTooltipPortal should render correctly 1`] = `
         My tooltip content
       </div>
     </section>
-  </portal>
+  </portalv1>
 </DocumentFragment>
 `;
 
 exports[`BpkTooltipPortal should render correctly with a custom portal className 1`] = `
 <DocumentFragment>
-  <portal
+  <portalv1
     class="bpk-tooltip-portal my-custom-class"
     target="[object Object]"
   >
@@ -52,13 +52,13 @@ exports[`BpkTooltipPortal should render correctly with a custom portal className
         My tooltip content
       </div>
     </section>
-  </portal>
+  </portalv1>
 </DocumentFragment>
 `;
 
 exports[`BpkTooltipPortal should render correctly with a custom tooltip className 1`] = `
 <DocumentFragment>
-  <portal
+  <portalv1
     class="bpk-tooltip-portal"
     target="[object Object]"
   >
@@ -80,13 +80,13 @@ exports[`BpkTooltipPortal should render correctly with a custom tooltip classNam
         My tooltip content
       </div>
     </section>
-  </portal>
+  </portalv1>
 </DocumentFragment>
 `;
 
 exports[`BpkTooltipPortal should render correctly with custom portal style 1`] = `
 <DocumentFragment>
-  <portal
+  <portalv1
     class="bpk-tooltip-portal"
     style="color: rgb(209, 67, 91);"
     target="[object Object]"
@@ -109,6 +109,6 @@ exports[`BpkTooltipPortal should render correctly with custom portal style 1`] =
         My tooltip content
       </div>
     </section>
-  </portal>
+  </portalv1>
 </DocumentFragment>
 `;

--- a/packages/bpk-react-utils/index.js
+++ b/packages/bpk-react-utils/index.js
@@ -20,6 +20,7 @@
 
 import wrapDisplayName from './src/wrapDisplayName';
 import Portal from './src/Portal';
+import PortalV1 from './src/Portal-v1';
 import TransitionInitialMount from './src/TransitionInitialMount';
 import cssModules from './src/cssModules';
 import deprecated from './src/deprecated';
@@ -33,6 +34,7 @@ import isRTL from './src/isRTL';
 
 export {
   Portal,
+  PortalV1,
   TransitionInitialMount,
   cssModules,
   deprecated,
@@ -45,6 +47,7 @@ export {
 };
 export default {
   Portal,
+  PortalV1,
   TransitionInitialMount,
   cssModules,
   deprecated,

--- a/packages/bpk-react-utils/src/Portal-test.js
+++ b/packages/bpk-react-utils/src/Portal-test.js
@@ -22,7 +22,7 @@ import { render, waitFor, fireEvent } from '@testing-library/react';
 import Portal from './Portal';
 
 const KEYCODES = {
-  ESCAPE: '27',
+  ESCAPE: 'Escape',
 };
 
 describe('Portal', () => {
@@ -443,7 +443,7 @@ describe('Portal', () => {
     expect(onCloseSpy).toHaveBeenCalledTimes(0);
 
     const event = new KeyboardEvent('keydown', {
-      keyCode: KEYCODES.ESCAPE,
+      key: KEYCODES.ESCAPE,
     });
 
     document.dispatchEvent(event);
@@ -486,7 +486,7 @@ describe('Portal', () => {
     expect(onCloseSpy).toHaveBeenCalledTimes(0);
 
     const event = new KeyboardEvent('keydown', {
-      keyCode: KEYCODES.ESCAPE,
+      key: KEYCODES.ESCAPE,
     });
 
     document.dispatchEvent(event);

--- a/packages/bpk-react-utils/src/Portal-test.js
+++ b/packages/bpk-react-utils/src/Portal-test.js
@@ -16,437 +16,754 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import { mount } from 'enzyme';
-import { render } from '@testing-library/react';
-import { render as reactDomRender, unmountComponentAtNode } from 'react-dom';
+import React, { useState, useEffect } from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 
 import Portal from './Portal';
 
 const KEYCODES = {
-  ESCAPE: 27,
+  ESCAPE: '27',
 };
 
 describe('Portal', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+  });
+
   it('should render correctly with no target', () => {
-    const { asFragment } = render(
-      <Portal isOpen={false}>
+    const { container } = render(
+      <Portal isOpen={false} onClose={jest.fn()}>
         <div>My portal content</div>
       </Portal>,
     );
-    expect(asFragment()).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('should render correctly with target', () => {
-    const { asFragment } = render(
-      <Portal isOpen={false} target={<div>Target</div>}>
+    const target = document.createElement('div');
+    const { container } = render(
+      <Portal isOpen={false} target={target} onClose={jest.fn()}>
         <div>My portal content</div>
       </Portal>,
     );
 
-    expect(asFragment()).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('should render correctly with renderTarget', () => {
-    const div = document.createElement('div');
-    const { asFragment } = render(
-      <Portal isOpen renderTarget={() => div}>
+    const renderTarget = document.createElement('div');
+    const { container } = render(
+      <Portal isOpen renderTarget={renderTarget} onClose={jest.fn()}>
         <div>My portal content</div>
       </Portal>,
     );
 
-    expect(asFragment()).toMatchSnapshot();
-    expect(div).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
+    expect(renderTarget).toMatchSnapshot();
   });
 
   it('should render with a custom style property', () => {
-    const customStyle = { color: 'red' }; // eslint-disable-line backpack/use-tokens
+    const renderTarget = document.createElement('div');
+    const customStyle = {
+      // eslint-disable-next-line backpack/use-tokens
+      color: 'red',
+    };
 
-    const portal = mount(
-      <Portal isOpen style={customStyle}>
-        <div>My portal content</div>
-      </Portal>,
-    );
-
-    expect(portal.instance().portalElement.style.color).toEqual(
-      customStyle.color,
-    );
-  });
-
-  it('should render with a custom className property', () => {
-    const customClassname = 'my-custom-classname';
-
-    const portal = mount(
-      <Portal isOpen className={customClassname}>
-        <div>My portal content</div>
-      </Portal>,
-    );
-
-    expect(
-      portal.instance().portalElement.classList.contains(customClassname),
-    ).toBe(true);
-  });
-
-  it('should render portal children to document.body', () => {
-    mount(
-      <Portal isOpen>
-        <div>My portal content</div>
-      </Portal>,
-    );
-
-    expect(document.body.lastChild.textContent).toEqual('My portal content');
-  });
-
-  it('should remove portal children from document.body on close', () => {
-    const div = document.createElement('div');
-    div.appendChild(document.createTextNode('Not a portal'));
-    document.body.appendChild(div);
-
-    expect(document.body.lastChild.textContent).toEqual('Not a portal');
-
-    const portal = mount(
-      <Portal isOpen>
-        <div>My portal content</div>
-      </Portal>,
-    );
-
-    expect(document.body.lastChild.textContent).toEqual('My portal content');
-
-    portal.setProps({ isOpen: false }).update();
-
-    expect(document.body.lastChild.textContent).toEqual('Not a portal');
-  });
-
-  it('should not remove portal children if render target no longer exists', () => {
-    const div = document.createElement('div');
-    div.id = 'render-target';
-    document.body.appendChild(div);
-
-    const portal = mount(
+    render(
       <Portal
         isOpen
-        renderTarget={() => document.getElementById('render-target')}
+        style={customStyle}
+        renderTarget={renderTarget}
+        onClose={jest.fn()}
       >
         <div>My portal content</div>
       </Portal>,
     );
+    const portalElement = renderTarget.firstChild;
 
-    expect(document.body.lastChild.textContent).toEqual('My portal content');
+    if (!portalElement || !(portalElement instanceof HTMLElement)) {
+      throw new Error('portalElement not defined or is of wrong type');
+    }
 
-    document.body.removeChild(div);
-
-    expect(() => {
-      portal.setProps({ isOpen: false }).update();
-    }).not.toThrow();
+    expect(portalElement.style.color).toEqual(customStyle.color);
   });
 
-  it('should call the onClose handler on click outside', () => {
-    const onCloseSpy = jest.fn();
+  it('should render with a custom className property', () => {
+    const renderTarget = document.createElement('div');
+    const customClassname = 'my-custom-classname';
+    render(
+      <Portal
+        isOpen
+        className={customClassname}
+        renderTarget={renderTarget}
+        onClose={jest.fn()}
+      >
+        <div>My portal content</div>
+      </Portal>,
+    );
+    const portalElement = renderTarget.firstChild;
 
-    const portal = mount(
-      <Portal isOpen onClose={onCloseSpy} target={<div>target</div>}>
+    if (!portalElement || !(portalElement instanceof HTMLElement)) {
+      throw new Error('portalElement not defined or is of wrong type');
+    }
+
+    expect(portalElement.classList.contains(customClassname)).toBe(true);
+  });
+
+  it('should render portal children to document.body', () => {
+    render(
+      <Portal isOpen onClose={jest.fn()}>
         <div>My portal content</div>
       </Portal>,
     );
 
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    expect(document.body && document.body.textContent).toEqual(
+      'My portal content',
+    );
+  });
 
-    portal.instance().onDocumentMouseDown({
-      button: 1,
-    });
-    portal.instance().onDocumentMouseUp({
-      button: 1,
-    });
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+  it('should remove portal children from document.body on close', () => {
+    const renderTarget = document.createElement('div');
+    const text = document.createElement('h1');
+    text.textContent = 'Not a portal';
+    renderTarget.appendChild(text);
 
-    portal.instance().onDocumentMouseDown({
-      button: 0,
-      target: portal.instance().getTargetElement(),
-    });
-    portal.instance().onDocumentMouseUp({
-      button: 0,
-      target: portal.instance().getTargetElement(),
-    });
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    expect(renderTarget).toMatchInlineSnapshot(`
+      <div>
+        <h1>
+          Not a portal
+        </h1>
+      </div>
+    `);
 
-    portal.instance().onDocumentMouseDown({
-      button: 0,
-      target: portal.instance().portalElement,
-    });
-    portal.instance().onDocumentMouseUp({
-      button: 0,
-      target: portal.instance().portalElement,
-    });
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    const { rerender } = render(
+      <Portal isOpen renderTarget={renderTarget} onClose={jest.fn()}>
+        <div>My portal content</div>
+      </Portal>,
+    );
 
-    portal.instance().onDocumentMouseDown({
-      button: 0,
-    });
-    portal.instance().onDocumentMouseUp({
-      button: 0,
-    });
-    expect(onCloseSpy.mock.calls.length).toEqual(1);
+    expect(renderTarget).toMatchInlineSnapshot(`
+      <div>
+        <h1>
+          Not a portal
+        </h1>
+        <div>
+          <div>
+            My portal content
+          </div>
+        </div>
+      </div>
+    `);
+
+    rerender(
+      <Portal isOpen={false} renderTarget={renderTarget} onClose={jest.fn()}>
+        <div>My portal content</div>
+      </Portal>,
+    );
+
+    expect(renderTarget).toMatchInlineSnapshot(`
+      <div>
+        <h1>
+          Not a portal
+        </h1>
+      </div>
+    `);
+  });
+
+  it('should not remove portal children if render target no longer exists', () => {
+    const { body } = document;
+
+    if (!body) {
+      throw new Error('failed to setup test');
+    }
+
+    const renderTarget = document.createElement('div');
+    renderTarget.id = 'render-target';
+    body.appendChild(renderTarget);
+    const { baseElement, container, rerender } = render(
+      <Portal isOpen renderTarget={renderTarget} onClose={jest.fn()}>
+        <div>My portal content</div>
+      </Portal>,
+    );
+
+    expect(container.firstChild).toBe(null);
+    expect(baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div
+          id="render-target"
+        >
+          <div>
+            <div>
+              My portal content
+            </div>
+          </div>
+        </div>
+        <div />
+      </body>
+    `);
+
+    body.removeChild(renderTarget);
+    rerender(
+      <Portal isOpen={false} renderTarget={renderTarget} onClose={jest.fn()}>
+        <div>My portal content</div>
+      </Portal>,
+    );
+
+    expect(baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div />
+      </body>
+    `);
+  });
+
+  it('should call the onClose handler on click outside', async () => {
+    const renderTarget = document.createElement('div');
+    const target = document.createElement('div');
+    const onCloseSpy = jest.fn();
+    const { getByText } = render(
+      <>
+        <h1>My other content</h1>
+        <Portal
+          isOpen
+          onClose={onCloseSpy}
+          target={target}
+          renderTarget={renderTarget}
+        >
+          <div>My portal content</div>
+        </Portal>
+      </>,
+    );
+
+    // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'where' implicitly has an 'any' type.
+    const click = (where, right, drag = false) => {
+      fireEvent(
+        where,
+        new MouseEvent('mousedown', {
+          bubbles: true,
+          cancelable: true,
+          button: right ? 2 : 0,
+        }),
+      );
+
+      if (drag) {
+        fireEvent(
+          where,
+          new MouseEvent('touchmove', {
+            bubbles: true,
+            cancelable: true,
+            button: right ? 2 : 0,
+          }),
+        );
+      }
+
+      fireEvent(
+        where,
+        new MouseEvent('mouseup', {
+          bubbles: true,
+          cancelable: true,
+          button: right ? 2 : 0,
+        }),
+      );
+    };
+
+    const outOfPortal = getByText('My other content');
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
+
+    click(outOfPortal, true);
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
+
+    click(target, false);
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
+
+    click(renderTarget, false);
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
+
+    click(outOfPortal, false, true);
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
+
+    click(outOfPortal, false);
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not have a race condition if the portal is opened then closed quickly', async () => {
+    const renderTarget = document.createElement('div');
+    const target = document.createElement('div');
+    const onCloseSpy = jest.fn();
+
+    const MyApp = () => {
+      const [visible, setVisible] = useState(true);
+      useEffect(() => {
+        setVisible(false);
+      }, []);
+      return (
+        <>
+          <h1>My other content</h1>
+          {visible && (
+            <Portal
+              isOpen
+              onClose={onCloseSpy}
+              target={target}
+              renderTarget={renderTarget}
+            >
+              <div>My portal content</div>
+            </Portal>
+          )}
+        </>
+      );
+    };
+
+    const { getByText } = render(<MyApp />);
+
+    // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'where' implicitly has an 'any' type.
+    const click = (where) => {
+      fireEvent(
+        where,
+        new MouseEvent('mousedown', {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+        }),
+      );
+      fireEvent(
+        where,
+        new MouseEvent('mouseup', {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+        }),
+      );
+    };
+
+    const outOfPortal = getByText('My other content');
+    click(outOfPortal);
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
   });
 
   it('should propagate the click event to the onClose handler', () => {
+    const target = document.createElement('div');
     const onCloseSpy = jest.fn();
-
-    const portal = mount(
-      <Portal isOpen onClose={onCloseSpy} target={<div>target</div>}>
-        <div>My portal content</div>
-      </Portal>,
+    const { getByText } = render(
+      <>
+        <h1>My other content</h1>
+        <Portal isOpen onClose={onCloseSpy} target={target}>
+          <div>My portal content</div>
+        </Portal>
+      </>,
     );
 
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    const outOfPortal = getByText('My other content');
 
-    const event = {
-      button: 0,
-    };
-    portal.instance().onDocumentMouseDown(event);
-    portal.instance().onDocumentMouseUp(event);
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
 
-    expect(onCloseSpy.mock.calls[0][0]).toEqual(event);
-    expect(onCloseSpy.mock.calls[0][1]).toEqual({ source: 'DOCUMENT_CLICK' });
+    fireEvent(
+      outOfPortal,
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      outOfPortal,
+      new MouseEvent('mouseup', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      }),
+    );
+
+    expect(onCloseSpy.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          MouseEvent {
+            "isTrusted": false,
+          },
+          Object {
+            "source": "DOCUMENT_CLICK",
+          },
+        ],
+      ]
+    `);
   });
 
   it('should call the onClose handler on escape key', () => {
-    const mountPoint = document.createElement('div');
-    document.body.appendChild(mountPoint);
-
+    const target = document.createElement('div');
     const onCloseSpy = jest.fn();
-
-    reactDomRender(
-      <Portal isOpen onClose={onCloseSpy} target={<div>target</div>}>
+    render(
+      <Portal isOpen onClose={onCloseSpy} target={target}>
         <div>My portal content</div>
       </Portal>,
-      mountPoint,
     );
 
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    const event = new KeyboardEvent('keydown', {
+      key: KEYCODES.ESCAPE,
+    });
+
     document.dispatchEvent(event);
 
-    expect(onCloseSpy.mock.calls.length).toEqual(1);
+    expect(onCloseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call targetRef with the target', () => {
+    const target = document.createElement('div');
+    const targetRef = jest.fn();
+    render(
+      <Portal isOpen target={target} targetRef={targetRef}>
+        <div>My portal content</div>
+      </Portal>,
+    );
+
+    expect(targetRef).toHaveBeenCalledWith(target);
   });
 
   it('should not close on escape key if closeOnEscPressed is false', () => {
-    const mountPoint = document.createElement('div');
-    document.body.appendChild(mountPoint);
-
+    const target = document.createElement('div');
     const onCloseSpy = jest.fn();
-
-    reactDomRender(
+    render(
       <Portal
         isOpen
         onClose={onCloseSpy}
-        target={<div>target</div>}
+        target={target}
         closeOnEscPressed={false}
       >
         <div>My portal content</div>
       </Portal>,
-      mountPoint,
     );
 
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    const event = new KeyboardEvent('keydown', {
+      keyCode: KEYCODES.ESCAPE,
+    });
+
     document.dispatchEvent(event);
 
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
   });
 
   it('should propagate the escape key event to the onClose handler', () => {
-    const mountPoint = document.createElement('div');
-    document.body.appendChild(mountPoint);
-
+    const target = document.createElement('div');
     const onCloseSpy = jest.fn();
-
-    reactDomRender(
-      <Portal isOpen onClose={onCloseSpy} target={<div>target</div>}>
+    render(
+      <Portal isOpen onClose={onCloseSpy} target={target}>
         <div>My portal content</div>
       </Portal>,
-      mountPoint,
     );
 
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    const event = new KeyboardEvent('keydown', {
+      key: KEYCODES.ESCAPE,
+    });
+
     document.dispatchEvent(event);
 
     expect(onCloseSpy.mock.calls[0][0]).toEqual(event);
-    expect(onCloseSpy.mock.calls[0][1]).toEqual({ source: 'ESCAPE' });
+    expect(onCloseSpy.mock.calls[0][1]).toEqual({
+      source: 'ESCAPE',
+    });
   });
 
   it('should not call the onClose handler on escape key if portal is closed', () => {
-    const mountPoint = document.createElement('div');
-    document.body.appendChild(mountPoint);
-
+    const target = document.createElement('div');
     const onCloseSpy = jest.fn();
-
-    reactDomRender(
-      <Portal isOpen={false} onClose={onCloseSpy} target={<div>target</div>}>
+    render(
+      <Portal isOpen={false} onClose={onCloseSpy} target={target}>
         <div>My portal content</div>
       </Portal>,
-      mountPoint,
     );
 
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    const event = new KeyboardEvent('keydown', {
+      keyCode: KEYCODES.ESCAPE,
+    });
+
     document.dispatchEvent(event);
 
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
   });
 
   it('should not call the onClose handler again on escape key if portal is unmounted', () => {
-    const mountPoint = document.createElement('div');
-    document.body.appendChild(mountPoint);
-
+    const target = document.createElement('div');
     const onCloseSpy = jest.fn();
-
-    reactDomRender(
-      <Portal isOpen onClose={onCloseSpy} target={<div>target</div>}>
+    const { rerender } = render(
+      <Portal isOpen onClose={onCloseSpy} target={target}>
         <div>My portal content</div>
       </Portal>,
-      mountPoint,
     );
 
-    expect(onCloseSpy.mock.calls.length).toEqual(0);
+    expect(onCloseSpy).toHaveBeenCalledTimes(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
-    document.dispatchEvent(event);
-
-    expect(onCloseSpy.mock.calls.length).toEqual(1);
-
-    unmountComponentAtNode(mountPoint);
+    const event = new KeyboardEvent('keydown', {
+      key: KEYCODES.ESCAPE,
+    });
 
     document.dispatchEvent(event);
 
-    expect(onCloseSpy.mock.calls.length).toEqual(1);
+    expect(onCloseSpy).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Portal isOpen={false} onClose={onCloseSpy} target={target}>
+        <div>My portal content</div>
+      </Portal>,
+    );
+    document.dispatchEvent(event);
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should call the onRender handler when props are updated', () => {
     const onRenderSpy = jest.fn();
-
-    const portal = mount(
-      <Portal isOpen onRender={onRenderSpy}>
+    const { rerender } = render(
+      <Portal isOpen onRender={onRenderSpy} onClose={jest.fn()}>
         <div>My portal content</div>
       </Portal>,
     );
 
-    expect(onRenderSpy.mock.calls.length).toBe(1);
+    expect(onRenderSpy).toHaveBeenCalledTimes(1);
 
-    portal.setProps({ target: <div>target1</div> }).update();
-    expect(onRenderSpy.mock.calls.length).toBe(2);
+    rerender(
+      <Portal isOpen onRender={onRenderSpy} onClose={jest.fn()}>
+        <div>My portal content changed</div>
+      </Portal>,
+    );
 
-    portal.setProps({ target: <div>target2</div> }).update();
-    expect(onRenderSpy.mock.calls.length).toBe(3);
+    expect(onRenderSpy).toHaveBeenCalledTimes(2);
+
+    rerender(
+      <Portal isOpen onRender={onRenderSpy} onClose={jest.fn()}>
+        <div>My portal content changed again</div>
+      </Portal>,
+    );
+
+    expect(onRenderSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should call the onRender handler before the onOpen handler handler when props are updated', () => {
-    let order = 0;
-
-    const portal = mount(
+    const handler = jest.fn();
+    const { rerender } = render(
       <Portal
         isOpen={false}
-        onRender={() => {
-          order = 1;
-        }}
-        onOpen={() => {
-          order = 2;
-        }}
+        onRender={() => handler('onRender')}
+        onOpen={() => handler('onOpen')}
+        onClose={jest.fn()}
       >
         <div>My portal content</div>
       </Portal>,
     );
 
-    portal.setProps({ isOpen: true }).update();
-    expect(order).toBe(2);
+    expect(handler.mock.calls).toMatchInlineSnapshot('Array []');
+
+    jest.clearAllMocks();
+    rerender(
+      <Portal
+        isOpen
+        onRender={() => handler('onRender')}
+        onOpen={() => handler('onOpen')}
+        onClose={jest.fn()}
+      >
+        <div>My portal content</div>
+      </Portal>,
+    );
+
+    expect(handler.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "onRender",
+        ],
+        Array [
+          "onOpen",
+        ],
+      ]
+    `);
   });
 
   it('should call the onRender handler before the onOpen handler handler when component is mounted', () => {
-    let order = 0;
-
-    mount(
+    const handler = jest.fn();
+    render(
       <Portal
         isOpen
-        onRender={() => {
-          order = 1;
-        }}
-        onOpen={() => {
-          order = 2;
-        }}
+        onRender={() => handler('onRender')}
+        onOpen={() => handler('onOpen')}
+        onClose={jest.fn()}
       >
         <div>My portal content</div>
       </Portal>,
     );
 
-    expect(order).toBe(2);
+    expect(handler.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "onRender",
+        ],
+        Array [
+          "onOpen",
+        ],
+      ]
+    `);
   });
 
   it('should not call the onRender handler when isOpen is false', () => {
     const onRenderSpy = jest.fn();
-
-    const portal = mount(
-      <Portal isOpen={false} onRender={onRenderSpy}>
+    const { rerender } = render(
+      <Portal isOpen={false} onRender={onRenderSpy} onClose={jest.fn()}>
         <div>My portal content</div>
       </Portal>,
     );
 
-    expect(onRenderSpy.mock.calls.length).toBe(0);
+    expect(onRenderSpy).toHaveBeenCalledTimes(0);
 
-    portal.setProps({ isOpen: true }).update();
-    expect(onRenderSpy.mock.calls.length).toBe(1);
+    rerender(
+      <Portal isOpen onRender={onRenderSpy} onClose={jest.fn()}>
+        <div>My portal content</div>
+      </Portal>,
+    );
 
-    portal.setProps({ isOpen: false }).update();
-    expect(onRenderSpy.mock.calls.length).toBe(1);
+    expect(onRenderSpy).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Portal isOpen={false} onRender={onRenderSpy} onClose={jest.fn()}>
+        <div>My portal content</div>
+      </Portal>,
+    );
+
+    expect(onRenderSpy).toHaveBeenCalledTimes(1);
   });
 
   describe('lifecycle methods', () => {
-    let portal;
+    // @ts-expect-error ts-migrate(7034) FIXME: Variable 'rerender' implicitly has type 'any' in s... Remove this comment to see the full error message
+    let rerender;
+
     const openSpy = jest.fn();
-    const closeSpy = jest.fn();
-    const beforeCloseSpy = jest.fn();
-
-    beforeAll(() => {
-      Portal.prototype.open = openSpy;
-      Portal.prototype.close = closeSpy;
-
-      portal = mount(
-        <Portal isOpen>
-          <div>My portal content</div>
-        </Portal>,
-      );
-    });
+    const closeSpy = jest.fn((close) => close());
 
     describe('componentDidMount()', () => {
       it('should open the portal on mount', () => {
-        expect(openSpy.mock.calls.length).toEqual(1);
+        expect(openSpy).toHaveBeenCalledTimes(0);
+        expect(closeSpy).toHaveBeenCalledTimes(0);
+
+        ({ rerender } = render(
+          <Portal
+            isOpen
+            onOpen={openSpy}
+            beforeClose={closeSpy}
+            onClose={jest.fn()}
+          >
+            <div>My portal content</div>
+          </Portal>,
+        ));
+
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(closeSpy).toHaveBeenCalledTimes(0);
       });
     });
 
     describe('UNSAFE_componentWillReceiveProps()', () => {
       it('should close the portal when isOpen is removed', () => {
-        portal.setProps({ isOpen: false }).update();
-        expect(closeSpy.mock.calls.length).toEqual(1);
+        expect(openSpy).toHaveBeenCalledTimes(0);
+        expect(closeSpy).toHaveBeenCalledTimes(0);
+
+        // @ts-expect-error ts-migrate(7005) FIXME: Variable 'rerender' implicitly has an 'any' type.
+        rerender(
+          <Portal
+            isOpen={false}
+            onOpen={openSpy}
+            beforeClose={closeSpy}
+            onClose={jest.fn()}
+          >
+            <div>My portal content</div>
+          </Portal>,
+        );
+        waitFor(() => {
+          expect(openSpy).toHaveBeenCalledTimes(0);
+          expect(closeSpy).toHaveBeenCalledTimes(1);
+        });
       });
 
       it('should open the portal again when isOpen is added', () => {
-        portal.setProps({ isOpen: true }).update();
-        expect(openSpy.mock.calls.length).toEqual(2);
-      });
+        expect(openSpy).toHaveBeenCalledTimes(0);
+        expect(closeSpy).toHaveBeenCalledTimes(0);
 
-      it('should call beforeClose when isOpen is removed', () => {
-        portal
-          .setProps({ beforeClose: beforeCloseSpy, isOpen: false })
-          .update();
-        expect(beforeCloseSpy.mock.calls.length).toEqual(1);
+        // @ts-expect-error ts-migrate(7005) FIXME: Variable 'rerender' implicitly has an 'any' type.
+        rerender(
+          <Portal
+            isOpen
+            onOpen={openSpy}
+            beforeClose={closeSpy}
+            onClose={jest.fn()}
+          >
+            <div>My portal content</div>
+          </Portal>,
+        );
+
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(closeSpy).toHaveBeenCalledTimes(0);
       });
     });
+  });
 
-    // No tests for
-    // - renderPortal, as we'd have to mock react-dom render()
-    // - componentWillUnmount, as it takes forever and slows down the test suite immensely
+  it('should remove all items from the dom when unmounted', () => {
+    const { body } = document;
+
+    if (!body) {
+      throw new Error('failed to setup test');
+    }
+
+    const addEventListener = jest.spyOn(document, 'addEventListener');
+    const removeEventListener = jest.spyOn(document, 'removeEventListener');
+    const { baseElement, rerender } = render(
+      <Portal isOpen onClose={jest.fn()}>
+        <div>My portal content</div>
+      </Portal>,
+    );
+
+    expect(baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div />
+        <div>
+          <div>
+            My portal content
+          </div>
+        </div>
+      </body>
+    `);
+
+    rerender(<h1>My replacement content</h1>);
+
+    expect(baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <h1>
+            My replacement content
+          </h1>
+        </div>
+      </body>
+    `);
+
+    // The first two argments should be the same
+    addEventListener.mock.calls.forEach((_, index) => {
+      expect(addEventListener.mock.calls[index][0]).toEqual(
+        removeEventListener.mock.calls[index][0],
+      );
+      expect(addEventListener.mock.calls[index][1]).toEqual(
+        removeEventListener.mock.calls[index][1],
+      );
+    });
+
+    expect(addEventListener.mock.calls.length).toEqual(
+      removeEventListener.mock.calls.length,
+    );
+    expect(addEventListener.mock.calls.length).toEqual(6);
   });
 });

--- a/packages/bpk-react-utils/src/Portal-v1-test.js
+++ b/packages/bpk-react-utils/src/Portal-v1-test.js
@@ -24,7 +24,7 @@ import { render as reactDomRender, unmountComponentAtNode } from 'react-dom';
 import PortalV1 from './Portal-v1';
 
 const KEYCODES = {
-  ESCAPE: 27,
+  ESCAPE: 'Escape',
 };
 
 describe('Portal', () => {
@@ -224,7 +224,7 @@ describe('Portal', () => {
 
     expect(onCloseSpy.mock.calls.length).toEqual(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    const event = new KeyboardEvent('keydown', { key: KEYCODES.ESCAPE });
     document.dispatchEvent(event);
 
     expect(onCloseSpy.mock.calls.length).toEqual(1);
@@ -250,7 +250,7 @@ describe('Portal', () => {
 
     expect(onCloseSpy.mock.calls.length).toEqual(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    const event = new KeyboardEvent('keydown', { key: KEYCODES.ESCAPE });
     document.dispatchEvent(event);
 
     expect(onCloseSpy.mock.calls.length).toEqual(0);
@@ -271,7 +271,7 @@ describe('Portal', () => {
 
     expect(onCloseSpy.mock.calls.length).toEqual(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    const event = new KeyboardEvent('keydown', { key: KEYCODES.ESCAPE });
     document.dispatchEvent(event);
 
     expect(onCloseSpy.mock.calls[0][0]).toEqual(event);
@@ -293,7 +293,7 @@ describe('Portal', () => {
 
     expect(onCloseSpy.mock.calls.length).toEqual(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    const event = new KeyboardEvent('keydown', { key: KEYCODES.ESCAPE });
     document.dispatchEvent(event);
 
     expect(onCloseSpy.mock.calls.length).toEqual(0);
@@ -314,7 +314,7 @@ describe('Portal', () => {
 
     expect(onCloseSpy.mock.calls.length).toEqual(0);
 
-    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    const event = new KeyboardEvent('keydown', { key: KEYCODES.ESCAPE });
     document.dispatchEvent(event);
 
     expect(onCloseSpy.mock.calls.length).toEqual(1);

--- a/packages/bpk-react-utils/src/Portal-v1-test.js
+++ b/packages/bpk-react-utils/src/Portal-v1-test.js
@@ -1,0 +1,452 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import { render as reactDomRender, unmountComponentAtNode } from 'react-dom';
+
+import PortalV1 from './Portal-v1';
+
+const KEYCODES = {
+  ESCAPE: 27,
+};
+
+describe('Portal', () => {
+  it('should render correctly with no target', () => {
+    const { asFragment } = render(
+      <PortalV1 isOpen={false}>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with target', () => {
+    const { asFragment } = render(
+      <PortalV1 isOpen={false} target={<div>Target</div>}>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with renderTarget', () => {
+    const div = document.createElement('div');
+    const { asFragment } = render(
+      <PortalV1 isOpen renderTarget={() => div}>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+    expect(div).toMatchSnapshot();
+  });
+
+  it('should render with a custom style property', () => {
+    const customStyle = { color: 'red' }; // eslint-disable-line backpack/use-tokens
+
+    const portal = mount(
+      <PortalV1 isOpen style={customStyle}>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(portal.instance().portalElement.style.color).toEqual(
+      customStyle.color,
+    );
+  });
+
+  it('should render with a custom className property', () => {
+    const customClassname = 'my-custom-classname';
+
+    const portal = mount(
+      <PortalV1 isOpen className={customClassname}>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(
+      portal.instance().portalElement.classList.contains(customClassname),
+    ).toBe(true);
+  });
+
+  it('should render portal children to document.body', () => {
+    mount(
+      <PortalV1 isOpen>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(document.body.lastChild.textContent).toEqual('My portal content');
+  });
+
+  it('should remove portal children from document.body on close', () => {
+    const div = document.createElement('div');
+    div.appendChild(document.createTextNode('Not a portal'));
+    document.body.appendChild(div);
+
+    expect(document.body.lastChild.textContent).toEqual('Not a portal');
+
+    const portal = mount(
+      <PortalV1 isOpen>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(document.body.lastChild.textContent).toEqual('My portal content');
+
+    portal.setProps({ isOpen: false }).update();
+
+    expect(document.body.lastChild.textContent).toEqual('Not a portal');
+  });
+
+  it('should not remove portal children if render target no longer exists', () => {
+    const div = document.createElement('div');
+    div.id = 'render-target';
+    document.body.appendChild(div);
+
+    const portal = mount(
+      <PortalV1
+        isOpen
+        renderTarget={() => document.getElementById('render-target')}
+      >
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(document.body.lastChild.textContent).toEqual('My portal content');
+
+    document.body.removeChild(div);
+
+    expect(() => {
+      portal.setProps({ isOpen: false }).update();
+    }).not.toThrow();
+  });
+
+  it('should call the onClose handler on click outside', () => {
+    const onCloseSpy = jest.fn();
+
+    const portal = mount(
+      <PortalV1 isOpen onClose={onCloseSpy} target={<div>target</div>}>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    portal.instance().onDocumentMouseDown({
+      button: 1,
+    });
+    portal.instance().onDocumentMouseUp({
+      button: 1,
+    });
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    portal.instance().onDocumentMouseDown({
+      button: 0,
+      target: portal.instance().getTargetElement(),
+    });
+    portal.instance().onDocumentMouseUp({
+      button: 0,
+      target: portal.instance().getTargetElement(),
+    });
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    portal.instance().onDocumentMouseDown({
+      button: 0,
+      target: portal.instance().portalElement,
+    });
+    portal.instance().onDocumentMouseUp({
+      button: 0,
+      target: portal.instance().portalElement,
+    });
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    portal.instance().onDocumentMouseDown({
+      button: 0,
+    });
+    portal.instance().onDocumentMouseUp({
+      button: 0,
+    });
+    expect(onCloseSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('should propagate the click event to the onClose handler', () => {
+    const onCloseSpy = jest.fn();
+
+    const portal = mount(
+      <PortalV1 isOpen onClose={onCloseSpy} target={<div>target</div>}>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    const event = {
+      button: 0,
+    };
+    portal.instance().onDocumentMouseDown(event);
+    portal.instance().onDocumentMouseUp(event);
+
+    expect(onCloseSpy.mock.calls[0][0]).toEqual(event);
+    expect(onCloseSpy.mock.calls[0][1]).toEqual({ source: 'DOCUMENT_CLICK' });
+  });
+
+  it('should call the onClose handler on escape key', () => {
+    const mountPoint = document.createElement('div');
+    document.body.appendChild(mountPoint);
+
+    const onCloseSpy = jest.fn();
+
+    reactDomRender(
+      <PortalV1 isOpen onClose={onCloseSpy} target={<div>target</div>}>
+        <div>My portal content</div>
+      </PortalV1>,
+      mountPoint,
+    );
+
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    document.dispatchEvent(event);
+
+    expect(onCloseSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('should not close on escape key if closeOnEscPressed is false', () => {
+    const mountPoint = document.createElement('div');
+    document.body.appendChild(mountPoint);
+
+    const onCloseSpy = jest.fn();
+
+    reactDomRender(
+      <PortalV1
+        isOpen
+        onClose={onCloseSpy}
+        target={<div>target</div>}
+        closeOnEscPressed={false}
+      >
+        <div>My portal content</div>
+      </PortalV1>,
+      mountPoint,
+    );
+
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    document.dispatchEvent(event);
+
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+  });
+
+  it('should propagate the escape key event to the onClose handler', () => {
+    const mountPoint = document.createElement('div');
+    document.body.appendChild(mountPoint);
+
+    const onCloseSpy = jest.fn();
+
+    reactDomRender(
+      <PortalV1 isOpen onClose={onCloseSpy} target={<div>target</div>}>
+        <div>My portal content</div>
+      </PortalV1>,
+      mountPoint,
+    );
+
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    document.dispatchEvent(event);
+
+    expect(onCloseSpy.mock.calls[0][0]).toEqual(event);
+    expect(onCloseSpy.mock.calls[0][1]).toEqual({ source: 'ESCAPE' });
+  });
+
+  it('should not call the onClose handler on escape key if portal is closed', () => {
+    const mountPoint = document.createElement('div');
+    document.body.appendChild(mountPoint);
+
+    const onCloseSpy = jest.fn();
+
+    reactDomRender(
+      <PortalV1 isOpen={false} onClose={onCloseSpy} target={<div>target</div>}>
+        <div>My portal content</div>
+      </PortalV1>,
+      mountPoint,
+    );
+
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    document.dispatchEvent(event);
+
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+  });
+
+  it('should not call the onClose handler again on escape key if portal is unmounted', () => {
+    const mountPoint = document.createElement('div');
+    document.body.appendChild(mountPoint);
+
+    const onCloseSpy = jest.fn();
+
+    reactDomRender(
+      <PortalV1 isOpen onClose={onCloseSpy} target={<div>target</div>}>
+        <div>My portal content</div>
+      </PortalV1>,
+      mountPoint,
+    );
+
+    expect(onCloseSpy.mock.calls.length).toEqual(0);
+
+    const event = new KeyboardEvent('keydown', { keyCode: KEYCODES.ESCAPE });
+    document.dispatchEvent(event);
+
+    expect(onCloseSpy.mock.calls.length).toEqual(1);
+
+    unmountComponentAtNode(mountPoint);
+
+    document.dispatchEvent(event);
+
+    expect(onCloseSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('should call the onRender handler when props are updated', () => {
+    const onRenderSpy = jest.fn();
+
+    const portal = mount(
+      <PortalV1 isOpen onRender={onRenderSpy}>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(onRenderSpy.mock.calls.length).toBe(1);
+
+    portal.setProps({ target: <div>target1</div> }).update();
+    expect(onRenderSpy.mock.calls.length).toBe(2);
+
+    portal.setProps({ target: <div>target2</div> }).update();
+    expect(onRenderSpy.mock.calls.length).toBe(3);
+  });
+
+  it('should call the onRender handler before the onOpen handler handler when props are updated', () => {
+    let order = 0;
+
+    const portal = mount(
+      <PortalV1
+        isOpen={false}
+        onRender={() => {
+          order = 1;
+        }}
+        onOpen={() => {
+          order = 2;
+        }}
+      >
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    portal.setProps({ isOpen: true }).update();
+    expect(order).toBe(2);
+  });
+
+  it('should call the onRender handler before the onOpen handler handler when component is mounted', () => {
+    let order = 0;
+
+    mount(
+      <PortalV1
+        isOpen
+        onRender={() => {
+          order = 1;
+        }}
+        onOpen={() => {
+          order = 2;
+        }}
+      >
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(order).toBe(2);
+  });
+
+  it('should not call the onRender handler when isOpen is false', () => {
+    const onRenderSpy = jest.fn();
+
+    const portal = mount(
+      <PortalV1 isOpen={false} onRender={onRenderSpy}>
+        <div>My portal content</div>
+      </PortalV1>,
+    );
+
+    expect(onRenderSpy.mock.calls.length).toBe(0);
+
+    portal.setProps({ isOpen: true }).update();
+    expect(onRenderSpy.mock.calls.length).toBe(1);
+
+    portal.setProps({ isOpen: false }).update();
+    expect(onRenderSpy.mock.calls.length).toBe(1);
+  });
+
+  describe('lifecycle methods', () => {
+    let portal;
+    const openSpy = jest.fn();
+    const closeSpy = jest.fn();
+    const beforeCloseSpy = jest.fn();
+
+    beforeAll(() => {
+      PortalV1.prototype.open = openSpy;
+      PortalV1.prototype.close = closeSpy;
+
+      portal = mount(
+        <PortalV1 isOpen>
+          <div>My portal content</div>
+        </PortalV1>,
+      );
+    });
+
+    describe('componentDidMount()', () => {
+      it('should open the portal on mount', () => {
+        expect(openSpy.mock.calls.length).toEqual(1);
+      });
+    });
+
+    describe('UNSAFE_componentWillReceiveProps()', () => {
+      it('should close the portal when isOpen is removed', () => {
+        portal.setProps({ isOpen: false }).update();
+        expect(closeSpy.mock.calls.length).toEqual(1);
+      });
+
+      it('should open the portal again when isOpen is added', () => {
+        portal.setProps({ isOpen: true }).update();
+        expect(openSpy.mock.calls.length).toEqual(2);
+      });
+
+      it('should call beforeClose when isOpen is removed', () => {
+        portal
+          .setProps({ beforeClose: beforeCloseSpy, isOpen: false })
+          .update();
+        expect(beforeCloseSpy.mock.calls.length).toEqual(1);
+      });
+    });
+
+    // No tests for
+    // - renderPortal, as we'd have to mock react-dom render()
+    // - componentWillUnmount, as it takes forever and slows down the test suite immensely
+  });
+});

--- a/packages/bpk-react-utils/src/Portal-v1.js
+++ b/packages/bpk-react-utils/src/Portal-v1.js
@@ -26,7 +26,7 @@ import assign from 'object-assign';
 import PropTypes from 'prop-types';
 
 const KEYCODES = {
-  ESCAPE: 27,
+  ESCAPE: 'Escape',
 };
 
 class PortalV1 extends Component {
@@ -118,7 +118,7 @@ class PortalV1 extends Component {
 
   onDocumentKeyDown(event) {
     if (
-      event.keyCode === KEYCODES.ESCAPE &&
+      event.key === KEYCODES.ESCAPE &&
       this.props.isOpen &&
       this.props.closeOnEscPressed
     ) {

--- a/packages/bpk-react-utils/src/Portal.js
+++ b/packages/bpk-react-utils/src/Portal.js
@@ -22,7 +22,7 @@ import assign from 'object-assign';
 import PropTypes from 'prop-types';
 
 const KEYCODES = {
-  ESCAPE: '27',
+  ESCAPE: 'Escape',
 };
 
 class Portal extends Component {

--- a/packages/bpk-react-utils/src/__snapshots__/Portal-test.js.snap
+++ b/packages/bpk-react-utils/src/__snapshots__/Portal-test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Portal should render correctly with no target 1`] = `<DocumentFragment />`;
+exports[`Portal should render correctly with no target 1`] = `<div />`;
 
-exports[`Portal should render correctly with renderTarget 1`] = `<DocumentFragment />`;
+exports[`Portal should render correctly with renderTarget 1`] = `<div />`;
 
 exports[`Portal should render correctly with renderTarget 2`] = `
 <div>
@@ -14,10 +14,4 @@ exports[`Portal should render correctly with renderTarget 2`] = `
 </div>
 `;
 
-exports[`Portal should render correctly with target 1`] = `
-<DocumentFragment>
-  <div>
-    Target
-  </div>
-</DocumentFragment>
-`;
+exports[`Portal should render correctly with target 1`] = `<div />`;

--- a/packages/bpk-react-utils/src/__snapshots__/Portal-v1-test.js.snap
+++ b/packages/bpk-react-utils/src/__snapshots__/Portal-v1-test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Portal should render correctly with no target 1`] = `<DocumentFragment />`;
+
+exports[`Portal should render correctly with renderTarget 1`] = `<DocumentFragment />`;
+
+exports[`Portal should render correctly with renderTarget 2`] = `
+<div>
+  <div>
+    <div>
+      My portal content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Portal should render correctly with target 1`] = `
+<DocumentFragment>
+  <div>
+    Target
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Migrated popup components to native React portal implementation. Components migrated Dialog, Drawer and Modal.

For interactive components Tooltip and Popover (by extension Datepicker) migrated to remain using the previous implementation exposed through PortalV1 - this is due to a bit more of the complexities of the component which will be resolved through separate PRs to follow.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
