### PR TITLE
[ST-4405] Fix accessibility issues in Graphic Promo.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+`bpk-component-graphic-promotion`
+- Fixed accessibility errors.

--- a/packages/bpk-component-graphic-promotion/package-lock.json
+++ b/packages/bpk-component-graphic-promotion/package-lock.json
@@ -1,21 +1,29 @@
 {
   "name": "bpk-component-graphic-promotion",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.18.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.18.3.tgz",
+      "integrity": "sha1-x7ZUtX9vY89/i0GKycoEQIxFefQ=",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@skyscanner/bpk-foundations-common": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.3.0.tgz",
-      "integrity": "sha512-AiuhJ9Ko+8dgxKUGxLUY0/jeBHKTOAHuu93ULA00OKOGWP+3SplGkwUQpwhv07EdSUKAS8R1u0CMnduxshvfBg==",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-2.3.0.tgz",
+      "integrity": "sha1-uWdmfDwIQqFhRqlHRTgDyh0QmDg=",
       "requires": {
         "color": "^3.0.0"
       }
     },
     "@skyscanner/bpk-foundations-web": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-8.0.0.tgz",
-      "integrity": "sha512-WGfiU1DoEv7EhH80h9spYPmLFPDlFFATFWoRbRWDmxkEZHxrV3f6oRUM5S7AIudZfk2Afi2Dg96N1IZRHt6geQ==",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-8.0.0.tgz",
+      "integrity": "sha1-0wbakJ2cFh4hg7CfDbWVT3lBDQE=",
       "requires": {
         "@skyscanner/bpk-foundations-common": "^2.3.0",
         "color": "^3.0.0"
@@ -23,22 +31,51 @@
     },
     "@skyscanner/bpk-svgs": {
       "version": "14.1.9",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.9.tgz",
-      "integrity": "sha512-g7GZYf6tuXsOk7zp7eHxzSFB+4uqGAVYqTv7eOyzl1RZA8dW52/dFK6ghPnM8/UwipQWqm3WVBAIv85lY0exHQ=="
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-svgs/-/bpk-svgs-14.1.9.tgz",
+      "integrity": "sha1-MCLKlMltk4nWnNbTWy63MGqiT+0="
+    },
+    "bpk-component-button": {
+      "version": "6.2.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bpk-component-button/-/bpk-component-button-6.2.5.tgz",
+      "integrity": "sha1-gHthniQ9fPvSaEr0mTOWIZIscFg=",
+      "requires": {
+        "bpk-mixins": "^31.1.1",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "bpk-component-text": {
+      "version": "7.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bpk-component-text/-/bpk-component-text-7.0.4.tgz",
+      "integrity": "sha1-rfU8inU+H56hBeoyQFAUAFJX39M=",
+      "requires": {
+        "bpk-mixins": "^31.1.1",
+        "bpk-react-utils": "^4.1.2",
+        "prop-types": "^15.7.2"
+      }
     },
     "bpk-mixins": {
       "version": "31.1.1",
-      "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-31.1.1.tgz",
-      "integrity": "sha512-XfmzgtaMTpPmjW3UkS8Wbm9qyS0Qp6iizKV5zCJj82DLWnXBeh2Bwcgz9T1DfoYOw6c7Glo8aNoH4pPTqd7apg==",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bpk-mixins/-/bpk-mixins-31.1.1.tgz",
+      "integrity": "sha1-qJWi46FQUSccf5zCNjjvNtZ9QQU=",
       "requires": {
         "@skyscanner/bpk-foundations-web": "^8.0.0",
         "@skyscanner/bpk-svgs": "^14.1.9"
       }
     },
+    "bpk-react-utils": {
+      "version": "4.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bpk-react-utils/-/bpk-react-utils-4.1.2.tgz",
+      "integrity": "sha1-JcVhnhsxAqVGNoyxFVmslty4mG8=",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^2.5.3"
+      }
+    },
     "color": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color/-/color-3.2.1.tgz",
+      "integrity": "sha1-NUTcGYyvRJDD7MmnkLVP6f9F4WQ=",
       "requires": {
         "color-convert": "^1.9.3",
         "color-string": "^1.6.0"
@@ -46,61 +83,96 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "requires": {
         "color-name": "1.1.3"
       }
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha1-RGf5FG8Db4Vbdk37W/hYK/NCx6Q=",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
     },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha1-6bNpcA+Vn2Ls3lprq95LzNkWmvg=",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "is-arrayish": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM="
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.8.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha1-TxonOv38jzSIqMUWv9p4+HI1I2I="
+    },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha1-35zbAleWIRFRpDbGmo87l7WwfI0=",
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha1-iSV0Kpj/2QgUmI11Zq0wyjsmO1I="
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"

--- a/packages/bpk-component-graphic-promotion/package.json
+++ b/packages/bpk-component-graphic-promotion/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "bpk-component-button": "^6.2.5",
-    "bpk-component-card": "^4.1.11",
     "bpk-component-text": "^7.0.4",
     "bpk-mixins": "^31.1.1",
     "bpk-react-utils": "^4.1.2",

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -99,18 +99,13 @@ const BpkGraphicPromo = (props: Props) => {
     textAlign,
   } = props;
 
-  const onClickWrapper = React.useCallback(
-    (event: React.MouseEvent<HTMLElement>) => {
-      event.stopPropagation();
-      onClick();
-    },
-    [onClick],
-  );
-  const onKeyWrapper = React.useCallback(
-    (event: React.KeyboardEvent<HTMLElement>) =>
-      isAccessibilityClick(event) && onClick(),
-    [onClick],
-  );
+  // FIXME: Use useCallback() here when React is updated.
+  const onClickWrapper = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    onClick();
+  };
+  const onKeyWrapper = (event: React.KeyboardEvent<HTMLElement>) =>
+    isAccessibilityClick(event) && onClick();
 
   const cardClasses = getClassName(
     getCardClassName('bpk-card'),

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -22,11 +22,13 @@ import React from 'react';
 import { cssModules } from 'bpk-react-utils';
 import BpkText from 'bpk-component-text';
 import BpkButton from 'bpk-component-button';
-import BpkCard from 'bpk-component-card';
 
-import STYLES from './BpkGraphicPromo.module.scss';
+import CARD_STYLES from '../../bpk-component-card/src/BpkCard.module.scss';
 
-const getClassName = cssModules(STYLES);
+import GP_STYLES from './BpkGraphicPromo.module.scss';
+
+const getClassName = cssModules(GP_STYLES);
+const getCardClassName = cssModules(CARD_STYLES);
 
 export const TEXT_ALIGN = {
   start: 'start',
@@ -94,7 +96,11 @@ const BpkGraphicPromo = (props: Props) => {
     onClick();
   };
 
-  const cardClasses = getClassName('bpk-graphic-promo', className);
+  const cardClasses = getClassName(
+    getCardClassName('bpk-card'),
+    'bpk-graphic-promo',
+    className,
+  );
   const containerClasses = getClassName(
     'bpk-graphic-promo__container',
     `bpk-graphic-promo__container--${textAlign}`,
@@ -104,12 +110,13 @@ const BpkGraphicPromo = (props: Props) => {
   const getTextClasses = (baseClass: string) =>
     getClassName(baseClass, `${baseClass}--${textAlign}`);
   return (
-    <BpkCard
+    <div
       className={cardClasses}
       style={style}
       onClick={onClickWrapper}
+      role="link"
       aria-label={constructAriaLabel(props)}
-      padded={false}
+      tabIndex={0}
     >
       <div className={containerClasses} aria-hidden>
         <div className={getTextClasses('bpk-graphic-promo__sponsor-content')}>
@@ -162,7 +169,7 @@ const BpkGraphicPromo = (props: Props) => {
           </BpkButton>
         </div>
       </div>
-    </BpkCard>
+    </div>
   );
 };
 

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -23,9 +23,9 @@ import { cssModules } from 'bpk-react-utils';
 import BpkText from 'bpk-component-text';
 import BpkButton from 'bpk-component-button';
 
-import GP_STYLES from './BpkGraphicPromo.module.scss';
+import STYLES from './BpkGraphicPromo.module.scss';
 
-const getClassName = cssModules(GP_STYLES);
+const getClassName = cssModules(STYLES);
 
 const ACCESSIBILITY_KEYS = {
   Enter: 13 /* Enter */,

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -100,17 +100,15 @@ const BpkGraphicPromo = (props: Props) => {
   } = props;
 
   const onClickWrapper = React.useCallback(
-    (
-      event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
-    ) => {
-      if (event.type === 'click') {
-        event.stopPropagation();
-      } else if (!isAccessibilityClick(event)) {
-        return;
-      }
-
+    (event: React.MouseEvent<HTMLElement>) => {
+      event.stopPropagation();
       onClick();
     },
+    [onClick],
+  );
+  const onKeyWrapper = React.useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) =>
+      isAccessibilityClick(event) && onClick(),
     [onClick],
   );
 
@@ -139,7 +137,7 @@ const BpkGraphicPromo = (props: Props) => {
       aria-label={constructAriaLabel(props)}
       tabIndex={0}
       onClick={onClickWrapper}
-      onKeyDown={onClickWrapper}
+      onKeyDown={onKeyWrapper}
     >
       <div className={containerClasses} aria-hidden>
         <div className={getTextClasses('bpk-graphic-promo__sponsor-content')}>

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -92,18 +92,20 @@ const BpkGraphicPromo = (props: Props) => {
     textAlign,
   } = props;
 
-  // FIXME: Use useCallback() here when React is updated.
-  const onClickWrapper = (
-    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
-  ) => {
-    if (event.type === 'click') {
-      event.stopPropagation();
-    } else if (!ACCESSIBILITY_KEYS.includes(event.keyCode || event.which)) {
-      return;
-    }
+  const onClickWrapper = React.useCallback(
+    (
+      event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    ) => {
+      if (event.type === 'click') {
+        event.stopPropagation();
+      } else if (!ACCESSIBILITY_KEYS.includes(event.keyCode || event.which)) {
+        return;
+      }
 
-    onClick();
-  };
+      onClick();
+    },
+    [onClick],
+  );
 
   const cardClasses = getClassName(
     getCardClassName('bpk-card'),

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -30,7 +30,7 @@ import GP_STYLES from './BpkGraphicPromo.module.scss';
 const getClassName = cssModules(GP_STYLES);
 const getCardClassName = cssModules(CARD_STYLES);
 
-const ACCESSIBILITY_KEYS = [13, 32];
+const ACCESSIBILITY_KEYS = [13 /* Enter */, 32 /* Space */];
 
 export const TEXT_ALIGN = {
   start: 'start',

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -23,12 +23,9 @@ import { cssModules } from 'bpk-react-utils';
 import BpkText from 'bpk-component-text';
 import BpkButton from 'bpk-component-button';
 
-import CARD_STYLES from '../../bpk-component-card/src/BpkCard.module.scss';
-
 import GP_STYLES from './BpkGraphicPromo.module.scss';
 
 const getClassName = cssModules(GP_STYLES);
-const getCardClassName = cssModules(CARD_STYLES);
 
 const ACCESSIBILITY_KEYS = {
   Enter: 13 /* Enter */,
@@ -107,11 +104,7 @@ const BpkGraphicPromo = (props: Props) => {
   const onKeyWrapper = (event: React.KeyboardEvent<HTMLElement>) =>
     isAccessibilityClick(event) && onClick();
 
-  const cardClasses = getClassName(
-    getCardClassName('bpk-card'),
-    'bpk-graphic-promo',
-    className,
-  );
+  const cardClasses = getClassName('bpk-graphic-promo', className);
   const containerClasses = getClassName(
     'bpk-graphic-promo__container',
     `bpk-graphic-promo__container--${textAlign}`,

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -123,7 +123,7 @@ const BpkGraphicPromo = (props: Props) => {
 
   return (
     // The card appears as a single component for the screen reader; its children are hidden. The card handles mouse
-    // clicks and key presses (Enter) for the whole component, as described here:
+    // clicks and key presses (Enter/Space) for the whole component, as described here:
     // https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets
     <div
       className={cardClasses}

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -30,6 +30,8 @@ import GP_STYLES from './BpkGraphicPromo.module.scss';
 const getClassName = cssModules(GP_STYLES);
 const getCardClassName = cssModules(CARD_STYLES);
 
+const ACCESSIBILITY_KEYS = [13, 32];
+
 export const TEXT_ALIGN = {
   start: 'start',
   center: 'center',
@@ -91,8 +93,15 @@ const BpkGraphicPromo = (props: Props) => {
   } = props;
 
   // FIXME: Use useCallback() here when React is updated.
-  const onClickWrapper = (event: React.MouseEvent<HTMLElement>) => {
-    event.stopPropagation();
+  const onClickWrapper = (
+    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+  ) => {
+    if (event.type === 'click') {
+      event.stopPropagation();
+    } else if (!ACCESSIBILITY_KEYS.includes(event.keyCode || event.which)) {
+      return;
+    }
+
     onClick();
   };
 
@@ -109,14 +118,19 @@ const BpkGraphicPromo = (props: Props) => {
 
   const getTextClasses = (baseClass: string) =>
     getClassName(baseClass, `${baseClass}--${textAlign}`);
+
   return (
+    // The card appears as a single component for the screen reader; its children are hidden. The card handles mouse
+    // clicks and key presses (Enter) for the whole component, as described here:
+    // https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets
     <div
       className={cardClasses}
       style={style}
-      onClick={onClickWrapper}
       role="link"
       aria-label={constructAriaLabel(props)}
       tabIndex={0}
+      onClick={onClickWrapper}
+      onKeyDown={onClickWrapper}
     >
       <div className={containerClasses} aria-hidden>
         <div className={getTextClasses('bpk-graphic-promo__sponsor-content')}>

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -104,7 +104,7 @@ const BpkGraphicPromo = (props: Props) => {
   const onKeyWrapper = (event: React.KeyboardEvent<HTMLElement>) =>
     isAccessibilityClick(event) && onClick();
 
-  const cardClasses = getClassName('bpk-graphic-promo', className);
+  const cardClasses = getClassName('bpk-card', 'bpk-graphic-promo', className);
   const containerClasses = getClassName(
     'bpk-graphic-promo__container',
     `bpk-graphic-promo__container--${textAlign}`,

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -30,7 +30,10 @@ import GP_STYLES from './BpkGraphicPromo.module.scss';
 const getClassName = cssModules(GP_STYLES);
 const getCardClassName = cssModules(CARD_STYLES);
 
-const ACCESSIBILITY_KEYS = [13 /* Enter */, 32 /* Space */];
+const ACCESSIBILITY_KEYS = {
+  Enter: 13 /* Enter */,
+  Space: 32 /* Space */,
+};
 
 export const TEXT_ALIGN = {
   start: 'start',
@@ -98,7 +101,11 @@ const BpkGraphicPromo = (props: Props) => {
     ) => {
       if (event.type === 'click') {
         event.stopPropagation();
-      } else if (!ACCESSIBILITY_KEYS.includes(event.keyCode || event.which)) {
+      } else if (
+        !Object.values(ACCESSIBILITY_KEYS).includes(
+          event.keyCode || event.which,
+        )
+      ) {
         return;
       }
 

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -35,6 +35,10 @@ const ACCESSIBILITY_KEYS = {
   Space: 32 /* Space */,
 };
 
+const isAccessibilityClick = (event: React.KeyboardEvent<HTMLElement>) =>
+  Object.keys(ACCESSIBILITY_KEYS).includes(event.key) ||
+  Object.values(ACCESSIBILITY_KEYS).includes(event.keyCode || event.which);
+
 export const TEXT_ALIGN = {
   start: 'start',
   center: 'center',
@@ -101,11 +105,7 @@ const BpkGraphicPromo = (props: Props) => {
     ) => {
       if (event.type === 'click') {
         event.stopPropagation();
-      } else if (
-        !Object.values(ACCESSIBILITY_KEYS).includes(
-          event.keyCode || event.which,
-        )
-      ) {
+      } else if (!isAccessibilityClick(event)) {
         return;
       }
 

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -29,6 +29,8 @@
   color: $bpk-color-white;
   box-shadow: none;
 
+  @include bpk-card;
+
   @include breakpoint-landscape {
     &__sponsor-label {
       margin-bottom: bpk-spacing-sm();

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -19,6 +19,10 @@
 @import '~bpk-mixins/index';
 @import './custom-breakpoints.module';
 
+.bpk-card {
+  @include bpk-card;
+}
+
 .bpk-graphic-promo {
   max-width: 65.5rem;
   margin-right: auto;
@@ -28,8 +32,6 @@
   background-size: cover;
   color: $bpk-color-white;
   box-shadow: none;
-
-  @include bpk-card;
 
   @include breakpoint-landscape {
     &__sponsor-label {

--- a/packages/bpk-component-graphic-promotion/src/__snapshots__/BpkGraphicPromo-test.js.snap
+++ b/packages/bpk-component-graphic-promotion/src/__snapshots__/BpkGraphicPromo-test.js.snap
@@ -4,7 +4,7 @@ exports[`BpkGraphicPromo should display the tagline and no sponsor for non-spons
 <DocumentFragment>
   <div
     aria-label="Tagline. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-graphic-promo"
+    class="bpk-card bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -50,7 +50,7 @@ exports[`BpkGraphicPromo should not display tagline or subheading when not provi
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Learn more"
-    class="bpk-graphic-promo"
+    class="bpk-card bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -97,7 +97,7 @@ exports[`BpkGraphicPromo should render correctly when centre aligned 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-graphic-promo"
+    class="bpk-card bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -149,7 +149,7 @@ exports[`BpkGraphicPromo should render correctly when inverted portrait 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-graphic-promo"
+    class="bpk-card bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -201,7 +201,7 @@ exports[`BpkGraphicPromo should render correctly when right aligned 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-graphic-promo"
+    class="bpk-card bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -253,7 +253,7 @@ exports[`BpkGraphicPromo should render correctly with all properties set 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-graphic-promo"
+    class="bpk-card bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -305,7 +305,7 @@ exports[`BpkGraphicPromo should support arbitrary props 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-graphic-promo"
+    class="bpk-card bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -357,7 +357,7 @@ exports[`BpkGraphicPromo should support custom class names 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-graphic-promo custom-classname"
+    class="bpk-card bpk-graphic-promo custom-classname"
     role="link"
     tabindex="0"
   >

--- a/packages/bpk-component-graphic-promotion/src/__snapshots__/BpkGraphicPromo-test.js.snap
+++ b/packages/bpk-component-graphic-promotion/src/__snapshots__/BpkGraphicPromo-test.js.snap
@@ -4,7 +4,7 @@ exports[`BpkGraphicPromo should display the tagline and no sponsor for non-spons
 <DocumentFragment>
   <div
     aria-label="Tagline. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-card bpk-graphic-promo"
+    class="bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -50,7 +50,7 @@ exports[`BpkGraphicPromo should not display tagline or subheading when not provi
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Learn more"
-    class="bpk-card bpk-graphic-promo"
+    class="bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -97,7 +97,7 @@ exports[`BpkGraphicPromo should render correctly when centre aligned 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-card bpk-graphic-promo"
+    class="bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -149,7 +149,7 @@ exports[`BpkGraphicPromo should render correctly when inverted portrait 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-card bpk-graphic-promo"
+    class="bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -201,7 +201,7 @@ exports[`BpkGraphicPromo should render correctly when right aligned 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-card bpk-graphic-promo"
+    class="bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -253,7 +253,7 @@ exports[`BpkGraphicPromo should render correctly with all properties set 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-card bpk-graphic-promo"
+    class="bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -305,7 +305,7 @@ exports[`BpkGraphicPromo should support arbitrary props 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-card bpk-graphic-promo"
+    class="bpk-graphic-promo"
     role="link"
     tabindex="0"
   >
@@ -357,7 +357,7 @@ exports[`BpkGraphicPromo should support custom class names 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-card bpk-graphic-promo custom-classname"
+    class="bpk-graphic-promo custom-classname"
     role="link"
     tabindex="0"
   >

--- a/packages/bpk-component-graphic-promotion/src/__snapshots__/BpkGraphicPromo-test.js.snap
+++ b/packages/bpk-component-graphic-promotion/src/__snapshots__/BpkGraphicPromo-test.js.snap
@@ -5,7 +5,7 @@ exports[`BpkGraphicPromo should display the tagline and no sponsor for non-spons
   <div
     aria-label="Tagline. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    role="button"
+    role="link"
     tabindex="0"
   >
     <div
@@ -51,7 +51,7 @@ exports[`BpkGraphicPromo should not display tagline or subheading when not provi
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Learn more"
     class="bpk-card bpk-graphic-promo"
-    role="button"
+    role="link"
     tabindex="0"
   >
     <div
@@ -98,7 +98,7 @@ exports[`BpkGraphicPromo should render correctly when centre aligned 1`] = `
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    role="button"
+    role="link"
     tabindex="0"
   >
     <div
@@ -150,7 +150,7 @@ exports[`BpkGraphicPromo should render correctly when inverted portrait 1`] = `
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    role="button"
+    role="link"
     tabindex="0"
   >
     <div
@@ -202,7 +202,7 @@ exports[`BpkGraphicPromo should render correctly when right aligned 1`] = `
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    role="button"
+    role="link"
     tabindex="0"
   >
     <div
@@ -254,7 +254,7 @@ exports[`BpkGraphicPromo should render correctly with all properties set 1`] = `
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    role="button"
+    role="link"
     tabindex="0"
   >
     <div
@@ -306,7 +306,7 @@ exports[`BpkGraphicPromo should support arbitrary props 1`] = `
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    role="button"
+    role="link"
     tabindex="0"
   >
     <div
@@ -358,7 +358,7 @@ exports[`BpkGraphicPromo should support custom class names 1`] = `
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo custom-classname"
-    role="button"
+    role="link"
     tabindex="0"
   >
     <div

--- a/packages/bpk-component-graphic-promotion/src/accessibility-test.js
+++ b/packages/bpk-component-graphic-promotion/src/accessibility-test.js
@@ -41,7 +41,7 @@ const subheading =
 describe('BpkGraphicPromo accessibility tests', () => {
   // TODO: Temporarily disabling tests due to a newer version of jest-axe which causes tests to fail when using nested interactive elements
 
-  it.skip('should not have programmatically-detectable accessibility issues', async () => {
+  it('should not have programmatically-detectable accessibility issues', async () => {
     const { container } = render(
       <BpkGraphicPromo
         className="test"
@@ -59,7 +59,7 @@ describe('BpkGraphicPromo accessibility tests', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it.skip('should not have programmatically-detectable accessibility issues in centre aligned', async () => {
+  it('should not have programmatically-detectable accessibility issues in centre aligned', async () => {
     const { container } = render(
       <BpkGraphicPromo
         tagline={tagline}
@@ -76,7 +76,7 @@ describe('BpkGraphicPromo accessibility tests', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it.skip('should not have programmatically-detectable accessibility issues in right aligned', async () => {
+  it('should not have programmatically-detectable accessibility issues in right aligned', async () => {
     const { container } = render(
       <BpkGraphicPromo
         tagline={tagline}
@@ -93,7 +93,7 @@ describe('BpkGraphicPromo accessibility tests', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it.skip('should not have programmatically-detectable accessibility issues in inverted portrait', async () => {
+  it('should not have programmatically-detectable accessibility issues in inverted portrait', async () => {
     const { container } = render(
       <BpkGraphicPromo
         tagline={tagline}
@@ -111,7 +111,7 @@ describe('BpkGraphicPromo accessibility tests', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it.skip('should not have programmatically-detectable accessibility issues when optional text is missing', async () => {
+  it('should not have programmatically-detectable accessibility issues when optional text is missing', async () => {
     const { container } = render(
       <BpkGraphicPromo
         headline={headline}
@@ -126,7 +126,7 @@ describe('BpkGraphicPromo accessibility tests', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it.skip('should not have programmatically-detectable accessibility issues in non-sponsored', async () => {
+  it('should not have programmatically-detectable accessibility issues in non-sponsored', async () => {
     const { container } = render(
       <BpkGraphicPromo
         tagline={tagline}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

[ST-4405](https://gojira.skyscanner.net/browse/ST-4405)

Graphic Promo had accessibility issues with the button nested inside an `a` tag. We need both the button and the whole card to be clickable. For accessibility users, however, we treat the whole card as one item and use `aria-hidden` to hide its contents from the screen reader.

Unfortunately, an update to `axe` seems to have broken our current implementation. Axe throws accessibility errors, which we are fixing in this PR by making the card a `div` that uses the styles of Skyscanner's card component. The `div` is clickable and can be focused on using Tab; Enter and Space click the link

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] ~`README.md`~
- [x] Tests
- [ ] ~Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)~
