### PR TITLE
[ST-4398] Add trigger button to Floating Notification component Storybook

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -355,6 +355,7 @@ onClick
 onClose
 onDialingCodePress
 onDismiss
+onExit
 onItemPress
 onLoad
 onMonthChange

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,3 +4,6 @@
 
 - bpk-component-split-input:
   - Replace deprecated spacing tokens with new tokens. There are no visual changes as the new tokens have the exact values.
+
+- bpk-component-floating-notification: `1.0.0` => `1.1.0`
+  - Added new prop `onExit` which executes a function after the component has finished the exit animation.

--- a/examples/bpk-component-floating-notification/examples.js
+++ b/examples/bpk-component-floating-notification/examples.js
@@ -37,14 +37,12 @@ const AlertContainer = ({ children }: Props): Node => {
       <BpkButton
         onClick={() => {
           setShowAlert(true);
-          setTimeout(() => {
-            setShowAlert(false);
-          }, 4800);
         }}
       >
         Trigger alert
       </BpkButton>
-      {showAlert && children}
+      {showAlert &&
+        React.cloneElement(children, { onExit: () => setShowAlert(false) })}
     </>
   );
 };
@@ -56,40 +54,50 @@ const DefaultExample = () => (
 );
 
 const IconExample = () => (
-  <BpkFloatingNotification icon={BpkIconHeart} text="Saved" />
+  <AlertContainer>
+    <BpkFloatingNotification icon={BpkIconHeart} text="Saved" />
+  </AlertContainer>
 );
 
 const CtaExample = () => (
-  <BpkFloatingNotification ctaText="View" text="Saved" />
+  <AlertContainer>
+    <BpkFloatingNotification ctaText="View" text="Saved" />
+  </AlertContainer>
 );
 
 const CtaIconLongTextExample = () => (
-  <BpkFloatingNotification
-    ctaText="View"
-    icon={BpkIconHeart}
-    text="Killer Combo saved to New York and Miami 🎉"
-  />
+  <AlertContainer>
+    <BpkFloatingNotification
+      ctaText="View"
+      icon={BpkIconHeart}
+      text="Killer Combo saved to New York and Miami 🎉"
+    />
+  </AlertContainer>
 );
 
 const CtaIconLongTextDarkModeExample = () => (
-  <BpkFloatingNotification
-    ctaText="View"
-    type={TYPE.dark}
-    icon={BpkIconInformationCircle}
-    text="Killer Combo saved to New York and Miami 🎉"
-  />
+  <AlertContainer>
+    <BpkFloatingNotification
+      ctaText="View"
+      type={TYPE.dark}
+      icon={BpkIconInformationCircle}
+      text="Killer Combo saved to New York and Miami 🎉"
+    />
+  </AlertContainer>
 );
 
 const VisualTestExample = () => (
-  <BpkFloatingNotification
-    animateOnEnter
-    animateOnExit
-    ctaText="View"
-    hideAfter={5000}
-    icon={BpkIconInformationCircle}
-    text="Killer Combo saved to New York and Miami 🎉"
-    type={TYPE.dark}
-  />
+  <AlertContainer>
+    <BpkFloatingNotification
+      animateOnEnter
+      animateOnExit
+      ctaText="View"
+      hideAfter={5000}
+      icon={BpkIconInformationCircle}
+      text="Killer Combo saved to New York and Miami 🎉"
+      type={TYPE.dark}
+    />
+  </AlertContainer>
 );
 
 export {

--- a/examples/bpk-component-floating-notification/examples.js
+++ b/examples/bpk-component-floating-notification/examples.js
@@ -16,15 +16,44 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState, Node } from 'react';
 
 import BpkFloatingNotification, {
   TYPE,
 } from '../../packages/bpk-component-floating-notification';
 import BpkIconHeart from '../../packages/bpk-component-icon/sm/heart';
 import BpkIconInformationCircle from '../../packages/bpk-component-icon/sm/information-circle';
+import BpkButton from '../../packages/bpk-component-button';
 
-const DefaultExample = () => <BpkFloatingNotification text="Saved" />;
+type Props = {
+  children: Node,
+};
+
+const AlertContainer = ({ children }: Props): Node => {
+  const [showAlert, setShowAlert] = useState(false);
+
+  return (
+    <>
+      <BpkButton
+        onClick={() => {
+          setShowAlert(true);
+          setTimeout(() => {
+            setShowAlert(false);
+          }, 4800);
+        }}
+      >
+        Trigger alert
+      </BpkButton>
+      {showAlert && children}
+    </>
+  );
+};
+
+const DefaultExample = () => (
+  <AlertContainer>
+    <BpkFloatingNotification text="Saved" />
+  </AlertContainer>
+);
 
 const IconExample = () => (
   <BpkFloatingNotification icon={BpkIconHeart} text="Saved" />

--- a/packages/bpk-component-floating-notification/README.md
+++ b/packages/bpk-component-floating-notification/README.md
@@ -35,6 +35,7 @@ export default () => (
 | hideAfter      | number       | false    | 4000          |
 | icon           | ReactElement | false    | null          |
 | onClick        | func         | false    | null          |
+| onExit         | func         | false    | null          |
 | text           | string       | true     | -             |
 | type           | oneOf(TYPE)  | false    | TYPE.light    |
 
@@ -45,6 +46,10 @@ export default () => (
 This prop controls the amount of time that the notification stays visible before the exit animation begins.
 
 The default value is 4 seconds (4000 milliseconds).
+
+#### onExit
+
+Execute a function after the component has finished the exit animation.
 
 #### type
 

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification-test.js
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification-test.js
@@ -104,4 +104,13 @@ describe('BpkFloatingNotification', () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it('should do function when unmounted (exited)', () => {
+    const onExit = jest.fn();
+    render(<BpkFloatingNotification onExit={onExit} {...props} />);
+
+    setTimeout(() => {
+      expect(onExit).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
@@ -41,6 +41,7 @@ type Props = {
   hideAfter: ?number,
   icon: ?() => ReactElement,
   onClick: ?() => void,
+  onExit: ?() => void,
   text: string,
   type: ?TYPE,
 };
@@ -56,6 +57,7 @@ const BpkFloatingNotification = (props: Props) => {
     hideAfter,
     icon: Icon,
     onClick,
+    onExit,
     text,
     type,
     ...rest
@@ -99,6 +101,7 @@ const BpkFloatingNotification = (props: Props) => {
       appear={animateOnEnter}
       exit={animateOnExit}
       unmountOnExit
+      onExited={onExit}
     >
       <div className={classNames} {...rest} role="alert">
         {Icon && (
@@ -131,6 +134,7 @@ BpkFloatingNotification.propTypes = {
   hideAfter: PropTypes.number,
   icon: PropTypes.ReactElement,
   onClick: PropTypes.func,
+  onExit: PropTypes.func,
   text: PropTypes.string.isRequired,
   type: PropTypes.oneOf(Object.values(TYPE)),
 };
@@ -143,6 +147,7 @@ BpkFloatingNotification.defaultProps = {
   hideAfter: 4000,
   icon: null,
   onClick: null,
+  onExit: null,
   type: TYPE.light,
 };
 

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
@@ -100,7 +100,7 @@ const BpkFloatingNotification = (props: Props) => {
       exit={animateOnExit}
       unmountOnExit
     >
-      <div className={classNames} {...rest}>
+      <div className={classNames} {...rest} role="alert">
         {Icon && (
           <div className={iconClassNames}>
             <Icon />

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
@@ -33,7 +33,7 @@ export const TYPE = {
   dark: 'dark',
 };
 
-export type Props = {
+type Props = {
   animateOnEnter: ?boolean,
   animateOnExit: ?boolean,
   className: ?string,

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
@@ -103,7 +103,7 @@ const BpkFloatingNotification = (props: Props) => {
       unmountOnExit
       onExited={onExit}
     >
-      <div className={classNames} role="alert" {...rest}>
+      <div className={classNames} {...rest}>
         {Icon && (
           <div className={iconClassNames}>
             <Icon />

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.js
@@ -103,7 +103,7 @@ const BpkFloatingNotification = (props: Props) => {
       unmountOnExit
       onExited={onExit}
     >
-      <div className={classNames} {...rest} role="alert">
+      <div className={classNames} role="alert" {...rest}>
         {Icon && (
           <div className={iconClassNames}>
             <Icon />

--- a/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.js.snap
+++ b/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.js.snap
@@ -4,6 +4,7 @@ exports[`BpkFloatingNotification should render correctly 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
@@ -18,6 +19,7 @@ exports[`BpkFloatingNotification should render correctly in dark mode (prop) 1`]
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--dark bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
@@ -32,6 +34,7 @@ exports[`BpkFloatingNotification should render correctly with CTA text 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
@@ -52,6 +55,7 @@ exports[`BpkFloatingNotification should render correctly with CTA text in dark m
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--dark bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
@@ -72,6 +76,7 @@ exports[`BpkFloatingNotification should render correctly with icon prop 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alert"
   >
     <div
       class="bpk-floating-notification__icon"
@@ -101,6 +106,7 @@ exports[`BpkFloatingNotification should render correctly with icon prop in dark 
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--dark bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alert"
   >
     <div
       class="bpk-floating-notification__icon bpk-floating-notification__icon--dark"
@@ -130,6 +136,7 @@ exports[`BpkFloatingNotification should support arbitrary props 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alert"
     testid="123"
   >
     <p
@@ -145,6 +152,7 @@ exports[`BpkFloatingNotification should support custom class names 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification custom-classname bpk-floating-notification--appear bpk-floating-notification--appear-active"
+    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"

--- a/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.js.snap
+++ b/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.js.snap
@@ -4,7 +4,6 @@ exports[`BpkFloatingNotification should render correctly 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
-    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
@@ -19,7 +18,6 @@ exports[`BpkFloatingNotification should render correctly in dark mode (prop) 1`]
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--dark bpk-floating-notification--appear bpk-floating-notification--appear-active"
-    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
@@ -34,7 +32,6 @@ exports[`BpkFloatingNotification should render correctly with CTA text 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
-    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
@@ -55,7 +52,6 @@ exports[`BpkFloatingNotification should render correctly with CTA text in dark m
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--dark bpk-floating-notification--appear bpk-floating-notification--appear-active"
-    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"
@@ -76,7 +72,6 @@ exports[`BpkFloatingNotification should render correctly with icon prop 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
-    role="alert"
   >
     <div
       class="bpk-floating-notification__icon"
@@ -106,7 +101,6 @@ exports[`BpkFloatingNotification should render correctly with icon prop in dark 
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--dark bpk-floating-notification--appear bpk-floating-notification--appear-active"
-    role="alert"
   >
     <div
       class="bpk-floating-notification__icon bpk-floating-notification__icon--dark"
@@ -136,7 +130,6 @@ exports[`BpkFloatingNotification should support arbitrary props 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
-    role="alert"
     testid="123"
   >
     <p
@@ -152,7 +145,6 @@ exports[`BpkFloatingNotification should support custom class names 1`] = `
 <DocumentFragment>
   <div
     class="bpk-floating-notification custom-classname bpk-floating-notification--appear bpk-floating-notification--appear-active"
-    role="alert"
   >
     <p
       class="bpk-text bpk-text--body-default bpk-floating-notification__text"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

# Changes

- Added a new prop `onExit` which takes in a function to execute after the exit animation of the floating notification component has finished
- Added "Trigger alert" button to the Storybook examples so that users can replay the animation

![image](https://user-images.githubusercontent.com/64750210/178249863-5ae5ef6b-4087-4f2d-a4cd-e4f2209c58c5.png)

# Checklist

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
  - Follow up ticket [TICKET GOES HERE]