### PR TITLE
[ST-4451]: Add contentId to Graphic Promotion component

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -286,6 +286,7 @@ collapseDelay
 color
 compareValues
 containerClassName
+contentId
 cornerStyle
 CORNER_STYLES.sm
 CORNER_STYLES.lg

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Added:**
+
+- `bpk-component-graphic-promotion`: `3.1.2` => `3.1.3`
+  - Added optional property `contentId`, to apply a HTML attribute `id` to the `div` containing the main content of the Graphic Promotion.

--- a/examples/bpk-component-graphic-promotion/examples.js
+++ b/examples/bpk-component-graphic-promotion/examples.js
@@ -25,6 +25,7 @@ import { cssModules } from '../../packages/bpk-react-utils';
 
 import STYLES from './examples.module.scss';
 
+const contentId = 'graphic-promo-content';
 const getClassName = cssModules(STYLES);
 const sponsor = {
   label: 'Sponsored',
@@ -50,6 +51,7 @@ const style = {
 
 const DefaultExample = () => (
   <BpkGraphicPromo
+    contentId={contentId}
     tagline={tagline}
     headline={headline}
     subheading={subheading}

--- a/packages/bpk-component-graphic-promotion/README.md
+++ b/packages/bpk-component-graphic-promotion/README.md
@@ -14,6 +14,7 @@ import BpkGraphicPromo from 'bpk-component-graphic-promotion';
 
 export default () => (
   <BpkGraphicPromo
+    contentId="graphic-promo-1"
     tagline="Tagline"
     headline="Ride your wave"
     subheading="Portugal and 6 more countries have just been added to the UK travel green list"
@@ -34,6 +35,7 @@ export default () => (
 
 | Property         | PropType          | Required | Default Value |
 | ---------------- | ----------------- | -------- | ------------- |
+| contentId        | string            | false    | null          |
 | buttonText       | string            | true     | -             |
 | headline         | string            | true     | -             |
 | invertVertically | bool              | true     | -             |

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.js
@@ -44,6 +44,7 @@ export const TEXT_ALIGN = {
 
 export type Props = {
   className: ?string,
+  contentId: ?string,
   tagline: ?string,
   headline: string,
   subheading: ?string,
@@ -86,6 +87,7 @@ const BpkGraphicPromo = (props: Props) => {
   const {
     buttonText,
     className,
+    contentId,
     headline,
     invertVertically,
     onClick,
@@ -127,7 +129,7 @@ const BpkGraphicPromo = (props: Props) => {
       onClick={onClickWrapper}
       onKeyDown={onKeyWrapper}
     >
-      <div className={containerClasses} aria-hidden>
+      <div id={contentId} className={containerClasses} aria-hidden>
         <div className={getTextClasses('bpk-graphic-promo__sponsor-content')}>
           {sponsor && (
             <>


### PR DESCRIPTION
This adds an optional property to the Graphic Promotion component, to attach an 'id' to the 'div' wrapping the main content, rather than the top level containing 'div'. This is to uniquely identify the main content, to be used for purposes outside of Backpack.

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
