### PR TITLE
KOA-5436 Fix Popover and Tooltip "placement" propType

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,5 @@
+
+**Fixed:**
+`bpk-component-popover`
+`bpk-component-tooltip`
+  - Fix `placement` PropType

--- a/packages/bpk-component-popover/src/BpkPopoverPortal.js
+++ b/packages/bpk-component-popover/src/BpkPopoverPortal.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { createPopper, basePlacements } from '@popperjs/core';
+import { createPopper } from '@popperjs/core';
 import PropTypes from 'prop-types';
 import React, { Component, type Node } from 'react';
 import focusStore from 'a11y-focus-store';
@@ -50,7 +50,7 @@ export const propTypes = {
   target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
-  placement: PropTypes.oneOf(basePlacements),
+  placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
   portalStyle: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   portalClassName: PropTypes.string,
   renderTarget: PropTypes.func,

--- a/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
+++ b/packages/bpk-component-tooltip/src/BpkTooltipPortal.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { createPopper, basePlacements } from '@popperjs/core';
+import { createPopper } from '@popperjs/core';
 import PropTypes from 'prop-types';
 import React, { Component, type Node, type Element } from 'react';
 import { PortalV1, cssModules } from 'bpk-react-utils';
@@ -66,7 +66,7 @@ class BpkTooltipPortal extends Component<Props, State> {
     ariaLabel: PropTypes.string.isRequired,
     target: PropTypes.node.isRequired,
     children: PropTypes.node.isRequired,
-    placement: PropTypes.oneOf(basePlacements),
+    placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left', 'auto']),
     hideOnTouchDevices: PropTypes.bool,
     portalStyle: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     portalClassName: PropTypes.string,


### PR DESCRIPTION
It seems like `@popperjs/core` is not exporting `basePlacements`, so it's `undefined` and shows a warning in the tests. This is a screenshot of Backpack build itself:
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/7152781/181619973-4fffc8fd-28ef-4f93-a289-8a8f88660714.png">

The build for this pr doesn't contain this warning anymore.


Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
