### PR TITLE
[SHIBA-1308]: aria-live changed for bpk-component-nudger

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Fixed**
+- `bpk-component-nudger`
+  - Changed `aria-live` from assertive to polite.

--- a/packages/bpk-component-nudger/src/BpkConfigurableNudger.js
+++ b/packages/bpk-component-nudger/src/BpkConfigurableNudger.js
@@ -105,7 +105,7 @@ const BpkConfigurableNudger = <T>(props: Props<T>) => {
       {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'. */}
       <input
         type="text"
-        aria-live="assertive"
+        aria-live="polite"
         readOnly
         value={formatValue(value)}
         id={id}

--- a/packages/bpk-component-nudger/src/__snapshots__/BpkNudger-test.js.snap
+++ b/packages/bpk-component-nudger/src/__snapshots__/BpkNudger-test.js.snap
@@ -29,7 +29,7 @@ exports[`BpkNudger should render as a configurable nudger correctly 1`] = `
       </span>
     </button>
     <input
-      aria-live="assertive"
+      aria-live="polite"
       class="bpk-nudger__input"
       id="nudger"
       readonly=""
@@ -92,7 +92,7 @@ exports[`BpkNudger should render as an on dark nudger correctly 1`] = `
       </span>
     </button>
     <input
-      aria-live="assertive"
+      aria-live="polite"
       class="bpk-nudger__input bpk-nudger__input--numeric bpk-nudger__input--secondary-on-dark"
       id="nudger"
       readonly=""
@@ -155,7 +155,7 @@ exports[`BpkNudger should render correctly 1`] = `
       </span>
     </button>
     <input
-      aria-live="assertive"
+      aria-live="polite"
       class="bpk-nudger__input bpk-nudger__input--numeric"
       id="nudger"
       readonly=""
@@ -218,7 +218,7 @@ exports[`BpkNudger should render correctly with a "className" attribute 1`] = `
       </span>
     </button>
     <input
-      aria-live="assertive"
+      aria-live="polite"
       class="bpk-nudger__input bpk-nudger__input--numeric"
       id="nudger"
       readonly=""
@@ -282,7 +282,7 @@ exports[`BpkNudger should render correctly with a value < min 1`] = `
       </span>
     </button>
     <input
-      aria-live="assertive"
+      aria-live="polite"
       class="bpk-nudger__input bpk-nudger__input--numeric"
       id="nudger"
       readonly=""
@@ -345,7 +345,7 @@ exports[`BpkNudger should render correctly with a value = max 1`] = `
       </span>
     </button>
     <input
-      aria-live="assertive"
+      aria-live="polite"
       class="bpk-nudger__input bpk-nudger__input--numeric"
       id="nudger"
       readonly=""
@@ -410,7 +410,7 @@ exports[`BpkNudger should render correctly with a value = min 1`] = `
       </span>
     </button>
     <input
-      aria-live="assertive"
+      aria-live="polite"
       class="bpk-nudger__input bpk-nudger__input--numeric"
       id="nudger"
       readonly=""
@@ -473,7 +473,7 @@ exports[`BpkNudger should render correctly with a value > max 1`] = `
       </span>
     </button>
     <input
-      aria-live="assertive"
+      aria-live="polite"
       class="bpk-nudger__input bpk-nudger__input--numeric"
       id="nudger"
       readonly=""


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

[Ticket](https://gojira.skyscanner.net/browse/SHIBA-1308)
[Slack Thread](https://skyscanner.slack.com/archives/C03RSTQLM5Y/p1659602802992139)

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
