### PR TITLE
KOA-5198: Tweak Graphic Promo tests

### DIFF
--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo-test.tsx
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo-test.tsx
@@ -41,6 +41,7 @@ const props: Props = {
     'Portugal and 6 more countries have just been added to the UK travel green list',
   tagline: 'Tagline',
   textAlign: TEXT_ALIGN.start,
+  contentId: 'mock-content-id',
 };
 
 describe('BpkGraphicPromo', () => {
@@ -122,9 +123,9 @@ describe('BpkGraphicPromo', () => {
     expect(props.onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should render correctly with a content ID', () => {
+  it('should render as expected without a content ID', () => {
     const { asFragment } = render(
-      <BpkGraphicPromo contentId="content-id" {...props} />,
+      <BpkGraphicPromo {...props} contentId={null} />,
     );
 
     expect(asFragment()).toMatchSnapshot();

--- a/packages/bpk-component-graphic-promotion/src/__snapshots__/BpkGraphicPromo-test.tsx.snap
+++ b/packages/bpk-component-graphic-promotion/src/__snapshots__/BpkGraphicPromo-test.tsx.snap
@@ -5,14 +5,14 @@ exports[`BpkGraphicPromo should display the tagline and no sponsor for non-spons
   <div
     aria-label="Tagline. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    id=""
+    id="mock-content-id"
     role="link"
     tabindex="0"
   >
     <div
       aria-hidden="true"
       class="bpk-graphic-promo__container bpk-graphic-promo__container--start"
-      id=""
+      id="mock-content-id__content"
     >
       <div
         class="bpk-graphic-promo__sponsor-content bpk-graphic-promo__sponsor-content--start"
@@ -53,14 +53,14 @@ exports[`BpkGraphicPromo should not display tagline or subheading when not provi
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Learn more"
     class="bpk-card bpk-graphic-promo"
-    id=""
+    id="mock-content-id"
     role="link"
     tabindex="0"
   >
     <div
       aria-hidden="true"
       class="bpk-graphic-promo__container bpk-graphic-promo__container--start"
-      id=""
+      id="mock-content-id__content"
     >
       <div
         class="bpk-graphic-promo__sponsor-content bpk-graphic-promo__sponsor-content--start"
@@ -97,7 +97,7 @@ exports[`BpkGraphicPromo should not display tagline or subheading when not provi
 </DocumentFragment>
 `;
 
-exports[`BpkGraphicPromo should render correctly when centre aligned 1`] = `
+exports[`BpkGraphicPromo should render as expected without a content ID 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
@@ -108,8 +108,62 @@ exports[`BpkGraphicPromo should render correctly when centre aligned 1`] = `
   >
     <div
       aria-hidden="true"
-      class="bpk-graphic-promo__container bpk-graphic-promo__container--center"
+      class="bpk-graphic-promo__container bpk-graphic-promo__container--start"
       id=""
+    >
+      <div
+        class="bpk-graphic-promo__sponsor-content bpk-graphic-promo__sponsor-content--start"
+      >
+        <span
+          class="bpk-text bpk-text--body-default bpk-graphic-promo__sponsor-label"
+        >
+          Sponsored
+        </span>
+        <img
+          alt="Airline Name"
+          class="bpk-graphic-promo__sponsor-logo"
+          src="path/to/logo.png"
+        />
+      </div>
+      <div
+        class="bpk-graphic-promo__promo-content bpk-graphic-promo__promo-content--start"
+      >
+        <h2
+          class="bpk-text bpk-text--body-default bpk-graphic-promo__headline"
+        >
+          Ride your wave
+        </h2>
+        <p
+          class="bpk-text bpk-text--body-default bpk-graphic-promo__subheading"
+        >
+          Portugal and 6 more countries have just been added to the UK travel green list
+        </p>
+        <button
+          class="bpk-button bpk-button--primary-on-dark bpk-graphic-promo__cta"
+          tabindex="-1"
+          type="button"
+        >
+          Learn more
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BpkGraphicPromo should render correctly when centre aligned 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
+    class="bpk-card bpk-graphic-promo"
+    id="mock-content-id"
+    role="link"
+    tabindex="0"
+  >
+    <div
+      aria-hidden="true"
+      class="bpk-graphic-promo__container bpk-graphic-promo__container--center"
+      id="mock-content-id__content"
     >
       <div
         class="bpk-graphic-promo__sponsor-content bpk-graphic-promo__sponsor-content--center"
@@ -156,14 +210,14 @@ exports[`BpkGraphicPromo should render correctly when inverted portrait 1`] = `
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    id=""
+    id="mock-content-id"
     role="link"
     tabindex="0"
   >
     <div
       aria-hidden="true"
       class="bpk-graphic-promo__container bpk-graphic-promo__container--start bpk-graphic-promo__container--inverted"
-      id=""
+      id="mock-content-id__content"
     >
       <div
         class="bpk-graphic-promo__sponsor-content bpk-graphic-promo__sponsor-content--start"
@@ -210,14 +264,14 @@ exports[`BpkGraphicPromo should render correctly when right aligned 1`] = `
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    id=""
+    id="mock-content-id"
     role="link"
     tabindex="0"
   >
     <div
       aria-hidden="true"
       class="bpk-graphic-promo__container bpk-graphic-promo__container--end"
-      id=""
+      id="mock-content-id__content"
     >
       <div
         class="bpk-graphic-promo__sponsor-content bpk-graphic-promo__sponsor-content--end"
@@ -259,73 +313,19 @@ exports[`BpkGraphicPromo should render correctly when right aligned 1`] = `
 </DocumentFragment>
 `;
 
-exports[`BpkGraphicPromo should render correctly with a content ID 1`] = `
-<DocumentFragment>
-  <div
-    aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
-    class="bpk-card bpk-graphic-promo"
-    id="content-id"
-    role="link"
-    tabindex="0"
-  >
-    <div
-      aria-hidden="true"
-      class="bpk-graphic-promo__container bpk-graphic-promo__container--start"
-      id="content-id__content"
-    >
-      <div
-        class="bpk-graphic-promo__sponsor-content bpk-graphic-promo__sponsor-content--start"
-      >
-        <span
-          class="bpk-text bpk-text--body-default bpk-graphic-promo__sponsor-label"
-        >
-          Sponsored
-        </span>
-        <img
-          alt="Airline Name"
-          class="bpk-graphic-promo__sponsor-logo"
-          src="path/to/logo.png"
-        />
-      </div>
-      <div
-        class="bpk-graphic-promo__promo-content bpk-graphic-promo__promo-content--start"
-      >
-        <h2
-          class="bpk-text bpk-text--body-default bpk-graphic-promo__headline"
-        >
-          Ride your wave
-        </h2>
-        <p
-          class="bpk-text bpk-text--body-default bpk-graphic-promo__subheading"
-        >
-          Portugal and 6 more countries have just been added to the UK travel green list
-        </p>
-        <button
-          class="bpk-button bpk-button--primary-on-dark bpk-graphic-promo__cta"
-          tabindex="-1"
-          type="button"
-        >
-          Learn more
-        </button>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`BpkGraphicPromo should render correctly with all properties set 1`] = `
 <DocumentFragment>
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo"
-    id=""
+    id="mock-content-id"
     role="link"
     tabindex="0"
   >
     <div
       aria-hidden="true"
       class="bpk-graphic-promo__container bpk-graphic-promo__container--start"
-      id=""
+      id="mock-content-id__content"
     >
       <div
         class="bpk-graphic-promo__sponsor-content bpk-graphic-promo__sponsor-content--start"
@@ -372,14 +372,14 @@ exports[`BpkGraphicPromo should support custom class names 1`] = `
   <div
     aria-label="Sponsored. Airline Name. Ride your wave. Portugal and 6 more countries have just been added to the UK travel green list. Learn more"
     class="bpk-card bpk-graphic-promo custom-classname"
-    id=""
+    id="mock-content-id"
     role="link"
     tabindex="0"
   >
     <div
       aria-hidden="true"
       class="bpk-graphic-promo__container bpk-graphic-promo__container--start"
-      id=""
+      id="mock-content-id__content"
     >
       <div
         class="bpk-graphic-promo__sponsor-content bpk-graphic-promo__sponsor-content--start"


### PR DESCRIPTION
In https://github.com/Skyscanner/backpack/pull/2535 it was requested that we set the contentId in tests by default.

This PR does so, and ensures we still have a test for when the contentId is not present (it is optional, with a default of null currently).

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md)) - **this bundles into an existing merged but not released change**
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
