### PR TITLE
[NO-JIRA] Add a11y props to BpkList

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -215,6 +215,7 @@ z-index
 
 # a11y terms
 aria-describedby
+aria-labelledby
 tablist
 
 # Locales
@@ -260,6 +261,7 @@ animateOnLeave
 animationDuration
 appearActiveClassName
 appearClassName
+ariaLabelledby
 aspectRatio
 bannerStyle
 BarChart

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -49,3 +49,5 @@
   - Changed calendar to semantic colours:
     - Changed navigation icon colours
     - Changed date range selection background colour
+- bpk-component-list:
+  - Now accepts `ariaLabel`, `ariaLabelledby` and `title` properties.

--- a/packages/bpk-component-list/README.md
+++ b/packages/bpk-component-list/README.md
@@ -34,11 +34,14 @@ export default () => (
 
 ### BpkList
 
-| Property  | PropType | Required | Default Value |
-| --------- | -------- | -------- | ------------- |
-| children  | -        | true     | -             |
-| ordered   | bool     | false    | false         |
-| className | string   | false    | null          |
+| Property       | PropType | Required | Default Value |
+| -------------- | -------- | -------- | ------------- |
+| children       | -        | true     | -             |
+| ordered        | bool     | false    | false         |
+| className      | string   | false    | null          |
+| ariaLabel      | string   | false    | null          |
+| ariaLabelledby | string   | false    | null          |
+| title          | string   | false    | null          |
 
 ### BpkListItem
 

--- a/packages/bpk-component-list/src/BpkList-test.js
+++ b/packages/bpk-component-list/src/BpkList-test.js
@@ -19,7 +19,7 @@
 /* @flow strict */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import BpkList from './BpkList';
 
@@ -49,5 +49,41 @@ describe('BpkList', () => {
       </BpkList>,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should apply the ariaLabel prop correctly', () => {
+    render(
+      <BpkList ariaLabel="nice accessible label">
+        <li>list item</li>
+      </BpkList>,
+    );
+
+    expect(screen.getByRole('list')).toHaveAttribute(
+      'aria-label',
+      'nice accessible label',
+    );
+  });
+
+  it('should apply the ariaLabelledby prop correctly', () => {
+    render(
+      <BpkList ariaLabelledby="an id">
+        <li>list item</li>
+      </BpkList>,
+    );
+
+    expect(screen.getByRole('list')).toHaveAttribute(
+      'aria-labelledby',
+      'an id',
+    );
+  });
+
+  it('should apply the title prop correctly', () => {
+    render(
+      <BpkList title="element title">
+        <li>list item</li>
+      </BpkList>,
+    );
+
+    expect(screen.getByRole('list')).toHaveAttribute('title', 'element title');
   });
 });

--- a/packages/bpk-component-list/src/BpkList-test.js
+++ b/packages/bpk-component-list/src/BpkList-test.js
@@ -20,6 +20,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import BpkList from './BpkList';
 

--- a/packages/bpk-component-list/src/BpkList.js
+++ b/packages/bpk-component-list/src/BpkList.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import PropTypes, { string } from 'prop-types';
+import PropTypes from 'prop-types';
 import React, { type Node } from 'react';
 import { cssModules } from 'bpk-react-utils';
 

--- a/packages/bpk-component-list/src/BpkList.js
+++ b/packages/bpk-component-list/src/BpkList.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import PropTypes from 'prop-types';
+import PropTypes, { string } from 'prop-types';
 import React, { type Node } from 'react';
 import { cssModules } from 'bpk-react-utils';
 
@@ -30,15 +30,28 @@ type Props = {
   children: Node,
   ordered: boolean,
   className: ?string,
+  ariaLabel: ?string,
+  ariaLabelledby: ?string,
+  title: ?string,
 };
 
 const BpkList = (props: Props) => {
-  const { children, className, ordered } = props;
+  const { ariaLabel, ariaLabelledby, children, className, ordered, title } =
+    props;
 
   const TagName: any = ordered ? 'ol' : 'ul';
   const classNames: string = getClassName('bpk-list', className);
 
-  return <TagName className={classNames}>{children}</TagName>;
+  return (
+    <TagName
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
+      title={title}
+      className={classNames}
+    >
+      {children}
+    </TagName>
+  );
 };
 
 BpkList.propTypes = {
@@ -53,6 +66,9 @@ BpkList.propTypes = {
 BpkList.defaultProps = {
   ordered: false,
   className: null,
+  ariaLabel: null,
+  ariaLabelledby: null,
+  title: null,
 };
 
 export default BpkList;


### PR DESCRIPTION
Updates BpkList component to accept `ariaLabel`, `ariaLabelledby` and `title` props.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
