### PR TITLE
[NO JIRA] Fix import order

### DIFF
--- a/packages/bpk-component-aria-live/src/BpkAriaLive.tsx
+++ b/packages/bpk-component-aria-live/src/BpkAriaLive.tsx
@@ -17,9 +17,9 @@
  */
 
 import React from 'react';
+import type { ReactElement } from 'react';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import { cssModules } from 'bpk-react-utils';
-import type { ReactElement } from 'react';
 
 import STYLES from './BpkAriaLive.module.scss';
 


### PR DESCRIPTION
As we are temporarily shipping backpack as both a single package and individual packages, we change the import paths and order during the release process. Due to the `@ts-expect-error` comment in the import files, there is an extra empty line unnecessarily added in between the `react` imports which breaks the linting.