### PR TITLE
[KOA-5063]: Add new smaller switch, semantic tokens and type deprecation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,3 +17,9 @@
 - bpk-component-content-cards<br />
 - bpk-component-graphic-promotion
   - Disabled recent Typescript changes due to incompatibility for non Typescript projects
+
+**Changed:**
+
+- bpk-component-switch:
+  - Added new `small` variant using a `boolean` to enable the small size.
+  - Deprecated `type` property as we no longer use/support `event` type switch and only have one style.

--- a/examples/bpk-component-switch/examples.js
+++ b/examples/bpk-component-switch/examples.js
@@ -19,22 +19,23 @@
 
 import React from 'react';
 
-import BpkSwitch, { SWITCH_TYPES } from '../../packages/bpk-component-switch';
+import BpkSwitch from '../../packages/bpk-component-switch';
 
 const DefaultExample = ({ ...rest }: {}) => (
   <BpkSwitch {...rest} label="Backpack" />
 );
-const EventExample = ({ ...rest }: {}) => (
-  <BpkSwitch {...rest} label="Backpack" type={SWITCH_TYPES.event} />
+
+const SmallExample = ({ ...rest }: {}) => (
+  <BpkSwitch small {...rest} label="Backpack" />
 );
 
 const MixedExample = () => (
   <div>
     <DefaultExample />
-    <EventExample />
+    <SmallExample />
     <DefaultExample checked />
-    <EventExample checked />
+    <SmallExample checked />
   </div>
 );
 
-export { DefaultExample, EventExample, MixedExample };
+export { DefaultExample, SmallExample, MixedExample };

--- a/examples/bpk-component-switch/stories.js
+++ b/examples/bpk-component-switch/stories.js
@@ -19,9 +19,9 @@
 
 import { storiesOf } from '@storybook/react';
 
-import { DefaultExample, EventExample, MixedExample } from './examples';
+import { DefaultExample, SmallExample, MixedExample } from './examples';
 
 storiesOf('bpk-component-switch', module)
   .add('Default', DefaultExample)
-  .add('Event', EventExample)
+  .add('Small', SmallExample)
   .add('Visual test', MixedExample);

--- a/packages/bpk-component-switch/README.md
+++ b/packages/bpk-component-switch/README.md
@@ -28,7 +28,7 @@ export default () => (
 | --------- | -------- | -------- | ------------- |
 | label     | Node     | true     | -             |
 | className | string   | false    | null          |
-| type      | oneOf(SWITCH_TYPES.primary, SWITCH_TYPES.event) | false | SWITCH_TYPES.primary
+| small     | boolean  | false    | false         |
 
 This component uses a hidden [`<input type="checkbox" />`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox), so it supports all the same properties as it (for example `checked`).
 

--- a/packages/bpk-component-switch/src/BpkSwitch-test.js
+++ b/packages/bpk-component-switch/src/BpkSwitch-test.js
@@ -20,7 +20,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import BpkSwitch, { SWITCH_TYPES } from './BpkSwitch';
+import BpkSwitch from './BpkSwitch';
 
 describe('BpkSwitch', () => {
   it('should render correctly', () => {
@@ -28,10 +28,8 @@ describe('BpkSwitch', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render event type', () => {
-    const { asFragment } = render(
-      <BpkSwitch label="Switch" type={SWITCH_TYPES.event} />,
-    );
+  it('should render small switch', () => {
+    const { asFragment } = render(<BpkSwitch label="Switch" small />);
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/packages/bpk-component-switch/src/BpkSwitch.js
+++ b/packages/bpk-component-switch/src/BpkSwitch.js
@@ -19,7 +19,7 @@
 
 import PropTypes from 'prop-types';
 import React, { type Node } from 'react';
-import { cssModules } from 'bpk-react-utils';
+import { cssModules, deprecated } from 'bpk-react-utils';
 
 import STYLES from './BpkSwitch.module.scss';
 
@@ -32,11 +32,6 @@ export const SWITCH_TYPES = {
 
 export type SwitchTypeValue = $Values<typeof SWITCH_TYPES>;
 
-const switchTypeClassNames = {
-  [SWITCH_TYPES.primary]: getClassName('bpk-switch__switch--primary'),
-  [SWITCH_TYPES.event]: getClassName('bpk-switch__switch--event'),
-};
-
 export type Props = {
   label: Node,
   type: SwitchTypeValue,
@@ -44,12 +39,13 @@ export type Props = {
 };
 
 const BpkSwitch = (props: Props) => {
-  const { className, label, type, ...rest } = props;
+  const { className, label, small, type, ...rest } = props;
 
-  const switchClassNames = [
-    getClassName('bpk-switch__switch'),
-    switchTypeClassNames[type],
-  ];
+  const switchClassNames = getClassName(
+    'bpk-switch__switch',
+    `bpk-switch__switch--${type}`,
+    small && 'bpk-switch__switch--small',
+  );
 
   return (
     <label className={getClassName('bpk-switch', className)}>
@@ -63,20 +59,25 @@ const BpkSwitch = (props: Props) => {
       <span aria-hidden className={getClassName('bpk-switch__label')}>
         {label}
       </span>
-      <span aria-hidden className={switchClassNames.join(' ')} />
+      <span aria-hidden className={switchClassNames} />
     </label>
   );
 };
 
 BpkSwitch.propTypes = {
   label: PropTypes.node.isRequired,
-  type: PropTypes.oneOf([SWITCH_TYPES.primary, SWITCH_TYPES.event]),
+  type: deprecated(
+    PropTypes.oneOf([SWITCH_TYPES.primary, SWITCH_TYPES.event]),
+    'This property is deprecated and only one type supported, please remove your usage of this property',
+  ),
   className: PropTypes.string,
+  small: PropTypes.boolean,
 };
 
 BpkSwitch.defaultProps = {
   className: null,
   type: SWITCH_TYPES.primary,
+  small: false,
 };
 
 export default BpkSwitch;

--- a/packages/bpk-component-switch/src/BpkSwitch.module.scss
+++ b/packages/bpk-component-switch/src/BpkSwitch.module.scss
@@ -20,18 +20,14 @@
 
 $bpk-spacing-v2: true;
 
-$primary-on-color: $bpk-color-sky-blue;
-$event-on-color: $bpk-color-abisko;
-$off-color: $bpk-color-sky-gray-tint-06;
-$handle-color: $bpk-color-white;
-
 $height: bpk-spacing-xl();
 $width: bpk-spacing-sm() * 13;
 $border-width: $bpk-one-pixel-rem * 2;
 
 .bpk-switch {
   position: relative;
-  display: inline-block;
+  display: flex;
+  align-items: center;
 
   // Checkbox is invisible so the switch element can be the visual element.
   &__checkbox {
@@ -43,12 +39,13 @@ $border-width: $bpk-one-pixel-rem * 2;
         @include bpk-themeable-property(
           background,
           --bpk-switch-checked-color,
-          $primary-on-color
+          $bpk-core-accent-day
         );
       }
 
+      // This is now deprecated and will be removed in the future.
       &--event {
-        background: $event-on-color;
+        background: $bpk-color-abisko;
       }
 
       &::before {
@@ -71,7 +68,7 @@ $border-width: $bpk-one-pixel-rem * 2;
     height: $height;
     transition: background $bpk-duration-sm linear;
     border-radius: $height / 2;
-    background: $off-color;
+    background: $bpk-surface-highlight-day;
     cursor: pointer;
 
     // The 'handle'.
@@ -85,9 +82,19 @@ $border-width: $bpk-one-pixel-rem * 2;
       height: $height - ($border-width * 2);
       transition: left $bpk-duration-sm ease-out;
       border-radius: 50%;
-      background: $handle-color;
+      background: $bpk-text-on-dark-day;
 
       @include bpk-box-shadow-sm;
+    }
+
+    &--small {
+      width: bpk-spacing-xxl();
+      height: bpk-spacing-sm() * 5;
+
+      &::before {
+        width: bpk-spacing-base();
+        height: bpk-spacing-base();
+      }
     }
   }
 }

--- a/packages/bpk-component-switch/src/__snapshots__/BpkSwitch-test.js.snap
+++ b/packages/bpk-component-switch/src/__snapshots__/BpkSwitch-test.js.snap
@@ -49,7 +49,7 @@ exports[`BpkSwitch should render correctly when checked 1`] = `
 </DocumentFragment>
 `;
 
-exports[`BpkSwitch should render event type 1`] = `
+exports[`BpkSwitch should render small switch 1`] = `
 <DocumentFragment>
   <label
     class="bpk-switch"
@@ -67,7 +67,7 @@ exports[`BpkSwitch should render event type 1`] = `
     </span>
     <span
       aria-hidden="true"
-      class="bpk-switch__switch bpk-switch__switch--event"
+      class="bpk-switch__switch bpk-switch__switch--primary bpk-switch__switch--small"
     />
   </label>
 </DocumentFragment>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

New small variant added to Backpack 

![Screenshot 2022-09-02 at 15 11 10](https://user-images.githubusercontent.com/8831547/188167716-28e61627-c369-4f0e-818c-67f4aaaf02c8.png)
![Screenshot 2022-09-02 at 15 11 15](https://user-images.githubusercontent.com/8831547/188167717-67f6f916-dc64-4a24-a324-3b265bf478fc.png)

Also in this PR:
- Migrated to semantic tokens
- Deprecated Event type switch as this is no longer a supported design pattern

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
