### PR TITLE
[NO-JIRA] Fix broken list key prop in BpkContentCards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 **Changed:**
 
   bpk-component-navigation-bar: 4.0.3 => 4.1.0 <br />
-    - Update component to semantic colours.
+    - Update component to semantic colours. <br />
   bpk-component-horizontal-nav: 6.0.3 => 6.1.0 <br />
-  - Migrated component to semantic colour tokens.
+    - Migrated component to semantic colour tokens. <br />
+  bpk-component-content-cards: 1.0.2 => 1.0.3 <br />
+    - Fix broken list key props in cards array <br />
 
 **Breaking:**
 

--- a/packages/bpk-component-content-cards/src/BpkContentCards.js
+++ b/packages/bpk-component-content-cards/src/BpkContentCards.js
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint react/no-array-index-key: 0 */
 
 import React from 'react';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
@@ -54,10 +55,9 @@ const BpkContentCards = ({ cards, heading }: Props) => {
         {heading}
       </BpkText>
       <div role="list" className={getClassName('bpk-content-cards--layout')}>
-        {cards.map((card) => (
-          <div role="listitem">
+        {cards.map((card, index) => (
+          <div role="listitem" key={index}>
             <BpkContentCard
-              key={card.image.url}
               card={card}
               layout={cards.length === 1 ? 'HORIZONTAL' : 'VERTICAL'}
             />


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

When using the `bpk-component-content-cards` component in [Banana](https://github.skyscannertools.net/dingo/banana/pull/5834/#issuecomment-844446) I noticed that there was an error in the console that `Each child in a list should have a unique "key" prop` and I realised we didn't set up the key prop correctly in the BpkContentCards component so this PR fixes that.

<img width="500" src="https://user-images.githubusercontent.com/58072716/189103715-ce144c70-d5d2-4843-afee-333eb79a1325.png">


Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
