### PR TITLE
[KOA-5596]: Group 3 semantic token update

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,11 @@
+**Changed:**
+
+- bpk-component-graphic-promotion<br />
+- bpk-component-image<br />
+- bpk-component-rating<br />
+- bpk-component-skip-link<br />
+  - Changed components to use semantic tokens.
+
+- bpk-component-progress:
+  - Migrated to semantic colours
+  - Removed `stepColor` prop as not being used and shouldn't be customised.

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.module.scss
@@ -75,10 +75,10 @@
   max-width: 76.5rem;
   margin-right: auto;
   margin-left: auto;
-  background-color: $bpk-color-sky-blue;
+  background-color: $bpk-surface-contrast-day;
   background-position: center;
   background-size: cover;
-  color: $bpk-color-white;
+  color: $bpk-text-on-dark-day;
   box-shadow: none;
 
   @include bpk-breakpoint-small-tablet {

--- a/packages/bpk-component-image/src/BpkImage.module.scss
+++ b/packages/bpk-component-image/src/BpkImage.module.scss
@@ -53,7 +53,7 @@
 }
 
 @mixin bpk-image--no-background {
-  background-color: transparent;
+  background-color: $bpk-surface-contrast-day;
 }
 
 @mixin bpk-image {
@@ -61,7 +61,7 @@
   display: block;
   max-width: 100%;
   transition: background-color $bpk-duration-base ease-in-out;
-  background-color: $bpk-color-sky-gray-tint-06;
+  background-color: $bpk-surface-highlight-day;
   overflow: hidden;
   transition-delay: $bpk-duration-base;
 }

--- a/packages/bpk-component-progress/README.md
+++ b/packages/bpk-component-progress/README.md
@@ -49,7 +49,6 @@ const Steps = () => (
 | onComplete               | func                          | false    | null          |
 | onCompleteTransitionEnd  | func                          | false    | null          |
 | stepped                  | bool                          | false    | false         |
-| stepColor                | string                        | false    | `colorWhite`    |
 
 ## Theme props
 

--- a/packages/bpk-component-progress/src/BpkProgress-test.js
+++ b/packages/bpk-component-progress/src/BpkProgress-test.js
@@ -50,13 +50,6 @@ describe('BpkProgress', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render correctly with a "stepColor" attribute', () => {
-    const { asFragment } = render(
-      <BpkProgress min={0} max={9} value={2} stepped stepColor="blue" />,
-    );
-    expect(asFragment()).toMatchSnapshot();
-  });
-
   it('should render correctly with "small" and "stepped" attributes', () => {
     const { asFragment } = render(
       <BpkProgress min={0} max={9} value={2} small stepped />,

--- a/packages/bpk-component-progress/src/BpkProgress.js
+++ b/packages/bpk-component-progress/src/BpkProgress.js
@@ -20,7 +20,6 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { colorWhite } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 import clamp from 'lodash.clamp';
 import { cssModules } from 'bpk-react-utils';
 
@@ -31,16 +30,15 @@ const getClassName = cssModules(STYLES);
 const isTransitionEndSupported = () =>
   !!(typeof window !== 'undefined' && 'TransitionEvent' in window);
 
-const renderSteps = (numberOfSteps, stepColor) => {
+const renderSteps = (numberOfSteps) => {
   const steps = [];
   for (let i = 1; i <= numberOfSteps; i += 1) {
     const left = `${100 * (i / (numberOfSteps + 1))}%`;
-    const backgroundColor = stepColor;
     steps.push(
       <div
         key={`bpk-progress__step-${i}`}
         className={getClassName('bpk-progress__step')}
-        style={{ left, backgroundColor }}
+        style={{ left }}
       />,
     );
   }
@@ -52,7 +50,6 @@ type Props = {
   min: number,
   value: number,
   stepped: boolean,
-  stepColor: string,
   small: boolean,
   className: ?string,
   onComplete: ?() => mixed,
@@ -66,7 +63,6 @@ class BpkProgress extends Component<Props> {
     min: PropTypes.number.isRequired,
     value: PropTypes.number.isRequired,
     stepped: PropTypes.bool,
-    stepColor: PropTypes.string,
     small: PropTypes.bool,
     className: PropTypes.string,
     onComplete: PropTypes.func,
@@ -77,7 +73,6 @@ class BpkProgress extends Component<Props> {
   static defaultProps = {
     className: null,
     stepped: false,
-    stepColor: colorWhite,
     small: false,
     onComplete: () => null,
     onCompleteTransitionEnd: () => null,
@@ -113,23 +108,21 @@ class BpkProgress extends Component<Props> {
       max,
       min,
       small,
-      stepColor,
       stepped,
       value,
       ...rest
     } = this.props;
-    const classNames = [getClassName('bpk-progress')];
-    if (className) {
-      classNames.push(className);
-    }
-    if (small) {
-      classNames.push(getClassName('bpk-progress--small'));
-    }
 
-    const valueClassName = [getClassName('bpk-progress__value')];
-    if (stepped) {
-      valueClassName.push(getClassName('bpk-progress__value--stepped'));
-    }
+    const classNames = getClassName(
+      'bpk-progress',
+      className,
+      small && 'bpk-progress--small',
+    );
+
+    const valueClassName = getClassName(
+      'bpk-progress__value',
+      stepped && 'bpk-progress__value--stepped',
+    );
 
     const adjustedValue = clamp(value, min, max);
     const percentage = 100 * (adjustedValue / (max - min));
@@ -141,7 +134,7 @@ class BpkProgress extends Component<Props> {
     return (
       // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
       <div
-        className={classNames.join(' ')}
+        className={classNames}
         role="progressbar"
         aria-valuetext={getValueText ? getValueText(value, min, max) : null}
         aria-valuenow={value}
@@ -151,11 +144,11 @@ class BpkProgress extends Component<Props> {
         {...rest}
       >
         <div
-          className={valueClassName.join(' ')}
+          className={valueClassName}
           style={{ width: `${percentage}%` }}
           onTransitionEnd={this.handleCompleteTransitionEnd}
         />
-        {renderSteps(numberOfSteps, stepColor)}
+        {renderSteps(numberOfSteps)}
       </div>
     );
   }

--- a/packages/bpk-component-progress/src/BpkProgress.module.scss
+++ b/packages/bpk-component-progress/src/BpkProgress.module.scss
@@ -24,7 +24,7 @@ $bpk-spacing-v2: true;
   position: relative;
   height: bpk-spacing-base();
   border-radius: $bpk-border-radius-pill;
-  background-color: $bpk-color-sky-gray-tint-06;
+  background-color: $bpk-surface-highlight-day;
   overflow: hidden;
 
   &--small {
@@ -46,7 +46,7 @@ $bpk-spacing-v2: true;
     @include bpk-themeable-property(
       background-color,
       --bpk-progress-bar-fill-color,
-      $bpk-color-sky-blue
+      $bpk-core-accent-day
     );
 
     &--stepped {
@@ -59,6 +59,6 @@ $bpk-spacing-v2: true;
     top: 0;
     bottom: 0;
     width: 2 * $bpk-one-pixel-rem;
-    background: $bpk-color-white;
+    background: $bpk-canvas-day;
   }
 }

--- a/packages/bpk-component-progress/src/__snapshots__/BpkProgress-test.js.snap
+++ b/packages/bpk-component-progress/src/__snapshots__/BpkProgress-test.js.snap
@@ -34,35 +34,35 @@ exports[`BpkProgress should render correctly with "small" and "stepped" attribut
     />
     <div
       class="bpk-progress__step"
-      style="left: 11.11111111111111%; background-color: rgb(255, 255, 255);"
+      style="left: 11.11111111111111%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 22.22222222222222%; background-color: rgb(255, 255, 255);"
+      style="left: 22.22222222222222%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 33.33333333333333%; background-color: rgb(255, 255, 255);"
+      style="left: 33.33333333333333%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 44.44444444444444%; background-color: rgb(255, 255, 255);"
+      style="left: 44.44444444444444%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 55.55555555555556%; background-color: rgb(255, 255, 255);"
+      style="left: 55.55555555555556%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 66.66666666666666%; background-color: rgb(255, 255, 255);"
+      style="left: 66.66666666666666%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 77.77777777777779%; background-color: rgb(255, 255, 255);"
+      style="left: 77.77777777777779%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 88.88888888888889%; background-color: rgb(255, 255, 255);"
+      style="left: 88.88888888888889%;"
     />
   </div>
 </DocumentFragment>
@@ -104,56 +104,6 @@ exports[`BpkProgress should render correctly with a "small" attribute 1`] = `
 </DocumentFragment>
 `;
 
-exports[`BpkProgress should render correctly with a "stepColor" attribute 1`] = `
-<DocumentFragment>
-  <div
-    aria-valuemax="9"
-    aria-valuemin="0"
-    aria-valuenow="2"
-    class="bpk-progress"
-    role="progressbar"
-    tabindex="0"
-  >
-    <div
-      class="bpk-progress__value bpk-progress__value--stepped"
-      style="width: 22.22222222222222%;"
-    />
-    <div
-      class="bpk-progress__step"
-      style="left: 11.11111111111111%; background-color: blue;"
-    />
-    <div
-      class="bpk-progress__step"
-      style="left: 22.22222222222222%; background-color: blue;"
-    />
-    <div
-      class="bpk-progress__step"
-      style="left: 33.33333333333333%; background-color: blue;"
-    />
-    <div
-      class="bpk-progress__step"
-      style="left: 44.44444444444444%; background-color: blue;"
-    />
-    <div
-      class="bpk-progress__step"
-      style="left: 55.55555555555556%; background-color: blue;"
-    />
-    <div
-      class="bpk-progress__step"
-      style="left: 66.66666666666666%; background-color: blue;"
-    />
-    <div
-      class="bpk-progress__step"
-      style="left: 77.77777777777779%; background-color: blue;"
-    />
-    <div
-      class="bpk-progress__step"
-      style="left: 88.88888888888889%; background-color: blue;"
-    />
-  </div>
-</DocumentFragment>
-`;
-
 exports[`BpkProgress should render correctly with a "stepped" attribute 1`] = `
 <DocumentFragment>
   <div
@@ -170,35 +120,35 @@ exports[`BpkProgress should render correctly with a "stepped" attribute 1`] = `
     />
     <div
       class="bpk-progress__step"
-      style="left: 11.11111111111111%; background-color: rgb(255, 255, 255);"
+      style="left: 11.11111111111111%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 22.22222222222222%; background-color: rgb(255, 255, 255);"
+      style="left: 22.22222222222222%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 33.33333333333333%; background-color: rgb(255, 255, 255);"
+      style="left: 33.33333333333333%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 44.44444444444444%; background-color: rgb(255, 255, 255);"
+      style="left: 44.44444444444444%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 55.55555555555556%; background-color: rgb(255, 255, 255);"
+      style="left: 55.55555555555556%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 66.66666666666666%; background-color: rgb(255, 255, 255);"
+      style="left: 66.66666666666666%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 77.77777777777779%; background-color: rgb(255, 255, 255);"
+      style="left: 77.77777777777779%;"
     />
     <div
       class="bpk-progress__step"
-      style="left: 88.88888888888889%; background-color: rgb(255, 255, 255);"
+      style="left: 88.88888888888889%;"
     />
   </div>
 </DocumentFragment>

--- a/packages/bpk-component-rating/src/BpkRating.module.scss
+++ b/packages/bpk-component-rating/src/BpkRating.module.scss
@@ -34,7 +34,7 @@ $bpk-spacing-v2: true;
     padding-right: bpk-spacing-md();
     justify-content: center;
     align-items: baseline;
-    color: $bpk-color-sky-gray;
+    color: $bpk-text-primary-day;
 
     @include bpk-rtl {
       padding-right: 0;
@@ -55,7 +55,7 @@ $bpk-spacing-v2: true;
   }
 
   &__scale {
-    color: $bpk-color-sky-gray-tint-02;
+    color: $bpk-text-secondary-day;
   }
 
   &__title {
@@ -66,7 +66,7 @@ $bpk-spacing-v2: true;
 
   &__subtitle {
     padding-left: bpk-spacing-md();
-    color: $bpk-color-sky-gray-tint-02;
+    color: $bpk-text-secondary-day;
 
     @include bpk-rtl {
       padding-right: bpk-spacing-md();

--- a/packages/bpk-component-skip-link/src/BpkSkipLink.module.scss
+++ b/packages/bpk-component-skip-link/src/BpkSkipLink.module.scss
@@ -23,8 +23,7 @@
   padding: $bpk-spacing-sm;
   transition: opacity $bpk-duration-sm ease-in-out;
   border-radius: $bpk-border-radius-sm;
-  background-color: $bpk-color-panjin;
-  color: $bpk-color-white;
+  color: $bpk-text-on-dark-day;
   font-weight: bold;
   text-decoration: none;
   opacity: 0;
@@ -38,7 +37,7 @@
   @include bpk-themeable-property(
     background-color,
     --bpk-skip-link-background-color,
-    $bpk-color-panjin
+    $bpk-status-danger-spot-day
   );
 
   &:focus-within,


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

**Changed:**

- bpk-component-graphic-promotion, bpk-component-image, bpk-component-rating, bpk-component-skip-link
  - Changed components to use semantic tokens.

- bpk-component-progress:
  - Migrated to semantic colours
  - Removed `stepColor` prop as not being used and shouldn't be customised.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
