### PR TITLE
Updating READMEs since solely single package publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > Backpack is a collection of design resources, reusable components and guidelines for creating Skyscanner's products.
 
+[![npm version](https://badge.fury.io/js/@skyscanner%2Fbackpack-web.svg)](https://badge.fury.io/js/@skyscanner%2Fbackpack-web)
 [![Build Status](https://github.com/Skyscanner/backpack/workflows/Backpack%20CI/badge.svg)](https://github.com/Skyscanner/backpack/actions)
 
 ## Quick links
@@ -11,10 +12,10 @@
 
 ## Usage
 
-### Installing packages
+### Installation
 
 ```sh
-npm install [package-name] --save-dev
+npm install --save @skyscanner/backpack-web
 ```
 
 ## Contributing
@@ -23,71 +24,73 @@ To contribute please see [contributing.md](CONTRIBUTING.md).
 
 ## List of packages
 
-| Component                                                                                  | Version                                                                                                                                             |
-| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`bpk-component-accordion`](/packages/bpk-component-accordion)                             | [![npm version](https://badge.fury.io/js/bpk-component-accordion.svg)](http://badge.fury.io/js/bpk-component-accordion)                             |
-| [`bpk-component-autosuggest`](/packages/bpk-component-autosuggest)                         | [![npm version](https://badge.fury.io/js/bpk-component-autosuggest.svg)](http://badge.fury.io/js/bpk-component-autosuggest)                         |
-| [`bpk-component-badge`](/packages/bpk-component-badge)                                     | [![npm version](https://badge.fury.io/js/bpk-component-badge.svg)](http://badge.fury.io/js/bpk-component-badge)                                     |
-| [`bpk-component-banner-alert`](/packages/bpk-component-banner-alert)                       | [![npm version](https://badge.fury.io/js/bpk-component-banner-alert.svg)](http://badge.fury.io/js/bpk-component-banner-alert)                       |
-| [`bpk-component-barchart`](/packages/bpk-component-barchart)                               | [![npm version](https://badge.fury.io/js/bpk-component-barchart.svg)](http://badge.fury.io/js/bpk-component-barchart)                               |
-| [`bpk-component-blockquote`](/packages/bpk-component-blockquote)                           | [![npm version](https://badge.fury.io/js/bpk-component-blockquote.svg)](http://badge.fury.io/js/bpk-component-blockquote)                           |
-| [`bpk-component-breadcrumb`](/packages/bpk-component-breadcrumb)                           | [![npm version](https://badge.fury.io/js/bpk-component-breadcrumb.svg)](http://badge.fury.io/js/bpk-component-breadcrumb)                           |
-| [`bpk-component-breakpoint`](/packages/bpk-component-breakpoint)                           | [![npm version](https://badge.fury.io/js/bpk-component-breakpoint.svg)](http://badge.fury.io/js/bpk-component-breakpoint)                           |
-| [`bpk-component-button`](/packages/bpk-component-button)                                   | [![npm version](https://badge.fury.io/js/bpk-component-button.svg)](http://badge.fury.io/js/bpk-component-button)                                   |
-| [`bpk-component-calendar`](/packages/bpk-component-calendar)                               | [![npm version](https://badge.fury.io/js/bpk-component-calendar.svg)](http://badge.fury.io/js/bpk-component-calendar)                               |
-| [`bpk-component-card`](/packages/bpk-component-card)                                       | [![npm version](https://badge.fury.io/js/bpk-component-card.svg)](http://badge.fury.io/js/bpk-component-card)                                       |
-| [`bpk-component-checkbox`](/packages/bpk-component-checkbox)                               | [![npm version](https://badge.fury.io/js/bpk-component-checkbox.svg)](http://badge.fury.io/js/bpk-component-checkbox)                               |
-| [`bpk-component-chip`](/packages/bpk-component-chip)                                       | [![npm version](https://badge.fury.io/js/bpk-component-chip.svg)](http://badge.fury.io/js/bpk-component-chip)                                       |
-| [`bpk-component-close-button`](/packages/bpk-component-close-button)                       | [![npm version](https://badge.fury.io/js/bpk-component-close-button.svg)](http://badge.fury.io/js/bpk-component-close-button)                       |
-| [`bpk-component-code`](/packages/bpk-component-code)                                       | [![npm version](https://badge.fury.io/js/bpk-component-code.svg)](http://badge.fury.io/js/bpk-component-code)                                       |
-| [`bpk-component-content-container`](/packages/bpk-component-content-container)             | [![npm version](https://badge.fury.io/js/bpk-component-content-container.svg)](http://badge.fury.io/js/bpk-component-content-container)             |
-| [`bpk-component-datatable`](/packages/bpk-component-datatable)                             | [![npm version](https://badge.fury.io/js/bpk-component-datatable.svg)](http://badge.fury.io/js/bpk-component-datatable)                             |
-| [`bpk-component-datepicker`](/packages/bpk-component-datepicker)                           | [![npm version](https://badge.fury.io/js/bpk-component-datepicker.svg)](http://badge.fury.io/js/bpk-component-datepicker)                           |
-| [`bpk-component-description-list`](/packages/bpk-component-description-list)               | [![npm version](https://badge.fury.io/js/bpk-component-description-list.svg)](http://badge.fury.io/js/bpk-component-description-list)               |
-| [`bpk-component-dialog`](/packages/bpk-component-dialog)                                   | [![npm version](https://badge.fury.io/js/bpk-component-dialog.svg)](http://badge.fury.io/js/bpk-component-dialog)                                   |
-| [`bpk-component-drawer`](/packages/bpk-component-drawer)                                   | [![npm version](https://badge.fury.io/js/bpk-component-drawer.svg)](http://badge.fury.io/js/bpk-component-drawer)                                   |
-| [`bpk-component-fieldset`](/packages/bpk-component-fieldset)                               | [![npm version](https://badge.fury.io/js/bpk-component-fieldset.svg)](http://badge.fury.io/js/bpk-component-fieldset)                               |
-| [`bpk-component-form-validation`](/packages/bpk-component-form-validation)                 | [![npm version](https://badge.fury.io/js/bpk-component-form-validation.svg)](http://badge.fury.io/js/bpk-component-form-validation)                 |
-| [`bpk-component-graphic-promotion`](/packages/bpk-component-graphic-promotion)                     | [![npm version](https://badge.fury.io/js/bpk-component-graphic-promotion.svg)](http://badge.fury.io/js/bpk-component-graphic-promotion)                     |
-| [`bpk-component-grid`](/packages/bpk-component-grid)                                       | [![npm version](https://badge.fury.io/js/bpk-component-grid.svg)](http://badge.fury.io/js/bpk-component-grid)                                       |
-| [`bpk-component-grid-toggle`](/packages/bpk-component-grid-toggle)                         | [![npm version](https://badge.fury.io/js/bpk-component-grid-toggle.svg)](http://badge.fury.io/js/bpk-component-grid-toggle)                         |
-| [`bpk-component-horizontal-nav`](/packages/bpk-component-horizontal-nav)                   | [![npm version](https://badge.fury.io/js/bpk-component-horizontal-nav.svg)](http://badge.fury.io/js/bpk-component-horizontal-nav)                   |
-| [`bpk-component-icon`](/packages/bpk-component-icon)                                       | [![npm version](https://badge.fury.io/js/bpk-component-icon.svg)](http://badge.fury.io/js/bpk-component-icon)                                       |
-| [`bpk-component-image`](/packages/bpk-component-image)                                     | [![npm version](https://badge.fury.io/js/bpk-component-image.svg)](http://badge.fury.io/js/bpk-component-image)                                     |
-| [`bpk-component-infinite-scroll`](/packages/bpk-component-infinite-scroll)                 | [![npm version](https://badge.fury.io/js/bpk-component-infinite-scroll.svg)](http://badge.fury.io/js/bpk-component-infinite-scroll)                 |
-| [`bpk-component-input`](/packages/bpk-component-input)                                     | [![npm version](https://badge.fury.io/js/bpk-component-input.svg)](http://badge.fury.io/js/bpk-component-input)                                     |
-| [`bpk-component-label`](/packages/bpk-component-label)                                     | [![npm version](https://badge.fury.io/js/bpk-component-label.svg)](http://badge.fury.io/js/bpk-component-label)                                     |
-| [`bpk-component-link`](/packages/bpk-component-link)                                       | [![npm version](https://badge.fury.io/js/bpk-component-link.svg)](http://badge.fury.io/js/bpk-component-link)                                       |
-| [`bpk-component-list`](/packages/bpk-component-list)                                       | [![npm version](https://badge.fury.io/js/bpk-component-list.svg)](http://badge.fury.io/js/bpk-component-list)                                       |
-| [`bpk-component-loading-button`](/packages/bpk-component-loading-button)                   | [![npm version](https://badge.fury.io/js/bpk-component-loading-button.svg)](http://badge.fury.io/js/bpk-component-loading-button)                   |
-| [`bpk-component-mobile-scroll-container`](/packages/bpk-component-mobile-scroll-container) | [![npm version](https://badge.fury.io/js/bpk-component-mobile-scroll-container.svg)](http://badge.fury.io/js/bpk-component-mobile-scroll-container) |
-| [`bpk-component-modal`](/packages/bpk-component-modal)                                     | [![npm version](https://badge.fury.io/js/bpk-component-modal.svg)](http://badge.fury.io/js/bpk-component-modal)                                     |
-| [`bpk-component-navigation-bar`](/packages/bpk-component-navigation-bar)                   | [![npm version](https://badge.fury.io/js/bpk-component-navigation-bar.svg)](http://badge.fury.io/js/bpk-component-navigation-bar)                   |
-| [`bpk-component-nudger`](/packages/bpk-component-nudger)                                   | [![npm version](https://badge.fury.io/js/bpk-component-nudger.svg)](http://badge.fury.io/js/bpk-component-nudger)                                   |
-| [`bpk-component-pagination`](/packages/bpk-component-pagination)                           | [![npm version](https://badge.fury.io/js/bpk-component-pagination.svg)](http://badge.fury.io/js/bpk-component-pagination)                           |
-| [`bpk-component-panel`](/packages/bpk-component-panel)                                     | [![npm version](https://badge.fury.io/js/bpk-component-panel.svg)](http://badge.fury.io/js/bpk-component-panel)                                     |
-| [`bpk-component-phone-input`](/packages/bpk-component-phone-input)                         | [![npm version](https://badge.fury.io/js/bpk-component-phone-input.svg)](http://badge.fury.io/js/bpk-component-phone-input)                         |
-| [`bpk-component-popover`](/packages/bpk-component-popover)                                 | [![npm version](https://badge.fury.io/js/bpk-component-popover.svg)](http://badge.fury.io/js/bpk-component-popover)                                 |
-| [`bpk-component-progress`](/packages/bpk-component-progress)                               | [![npm version](https://badge.fury.io/js/bpk-component-progress.svg)](http://badge.fury.io/js/bpk-component-progress)                               |
-| [`bpk-component-radio`](/packages/bpk-component-radio)                                     | [![npm version](https://badge.fury.io/js/bpk-component-radio.svg)](http://badge.fury.io/js/bpk-component-radio)                                     |
-| [`bpk-component-rtl-toggle`](/packages/bpk-component-rtl-toggle)                           | [![npm version](https://badge.fury.io/js/bpk-component-rtl-toggle.svg)](http://badge.fury.io/js/bpk-component-rtl-toggle)                           |
-| [`bpk-component-section-list`](/packages/bpk-component-section-list)                       | [![npm version](https://badge.fury.io/js/bpk-component-section-list.svg)](http://badge.fury.io/js/bpk-component-section-list)                       |
-| [`bpk-component-select`](/packages/bpk-component-select)                                   | [![npm version](https://badge.fury.io/js/bpk-component-select.svg)](http://badge.fury.io/js/bpk-component-select)                                   |
-| [`bpk-component-slider`](/packages/bpk-component-slider)                                   | [![npm version](https://badge.fury.io/js/bpk-component-slider.svg)](http://badge.fury.io/js/bpk-component-slider)                                   |
-| [`bpk-component-spinner`](/packages/bpk-component-spinner)                                 | [![npm version](https://badge.fury.io/js/bpk-component-spinner.svg)](http://badge.fury.io/js/bpk-component-spinner)                                 |
-| [`bpk-component-star-rating`](/packages/bpk-component-star-rating)                         | [![npm version](https://badge.fury.io/js/bpk-component-star-rating.svg)](http://badge.fury.io/js/bpk-component-star-rating)                         |
-| [`bpk-component-switch`](/packages/bpk-component-switch)                                   | [![npm version](https://badge.fury.io/js/bpk-component-switch.svg)](http://badge.fury.io/js/bpk-component-switch)                         |
-| [`bpk-component-table`](/packages/bpk-component-table)                                     | [![npm version](https://badge.fury.io/js/bpk-component-table.svg)](http://badge.fury.io/js/bpk-component-table)                                     |
-| [`bpk-component-text`](/packages/bpk-component-text)                                       | [![npm version](https://badge.fury.io/js/bpk-component-text.svg)](http://badge.fury.io/js/bpk-component-text)                                       |
-| [`bpk-component-textarea`](/packages/bpk-component-textarea)                               | [![npm version](https://badge.fury.io/js/bpk-component-textarea.svg)](http://badge.fury.io/js/bpk-component-textarea)                               |
-| [`bpk-theming`](/packages/bpk-theming)                                                     | [![npm version](https://badge.fury.io/js/bpk-theming.svg)](http://badge.fury.io/js/bpk-theming)                                                     |
-| [`bpk-component-ticket`](/packages/bpk-component-ticket)                                   | [![npm version](https://badge.fury.io/js/bpk-component-ticket.svg)](http://badge.fury.io/js/bpk-component-ticket)                                   |
-| [`bpk-component-tooltip`](/packages/bpk-component-tooltip)                                 | [![npm version](https://badge.fury.io/js/bpk-component-tooltip.svg)](http://badge.fury.io/js/bpk-component-tooltip)                                 |
-| [`bpk-react-utils`](/packages/bpk-react-utils)                                             | [![npm version](https://badge.fury.io/js/bpk-react-utils.svg)](http://badge.fury.io/js/bpk-react-utils)                                             |
+[`bpk-animate-height`](/packages/bpk-animate-height)
+[`bpk-component-accordion`](/packages/bpk-component-accordion)
+[`bpk-component-autosuggest`](/packages/bpk-component-autosuggest)
+[`bpk-component-badge`](/packages/bpk-component-badge)
+[`bpk-component-banner-alert`](/packages/bpk-component-banner-alert)
+[`bpk-component-barchart`](/packages/bpk-component-barchart)
+[`bpk-component-blockquote`](/packages/bpk-component-blockquote)
+[`bpk-component-breadcrumb`](/packages/bpk-component-breadcrumb)
+[`bpk-component-breakpoint`](/packages/bpk-component-breakpoint)
+[`bpk-component-button`](/packages/bpk-component-button)
+[`bpk-component-calendar`](/packages/bpk-component-calendar)
+[`bpk-component-card`](/packages/bpk-component-card)
+[`bpk-component-checkbox`](/packages/bpk-component-checkbox)
+[`bpk-component-chip`](/packages/bpk-component-chip)
+[`bpk-component-close-button`](/packages/bpk-component-close-button)
+[`bpk-component-code`](/packages/bpk-component-code)
+[`bpk-component-content-container`](/packages/bpk-component-content-container)
+[`bpk-component-datatable`](/packages/bpk-component-datatable)
+[`bpk-component-datepicker`](/packages/bpk-component-datepicker)
+[`bpk-component-description-list`](/packages/bpk-component-description-list)
+[`bpk-component-dialog`](/packages/bpk-component-dialog)
+[`bpk-component-drawer`](/packages/bpk-component-drawer)
+[`bpk-component-fieldset`](/packages/bpk-component-fieldset)
+[`bpk-component-form-validation`](/packages/bpk-component-form-validation)
+[`bpk-component-graphic-promotion`](/packages/bpk-component-graphic-promotion)
+[`bpk-component-grid`](/packages/bpk-component-grid)
+[`bpk-component-grid-toggle`](/packages/bpk-component-grid-toggle)
+[`bpk-component-horizontal-nav`](/packages/bpk-component-horizontal-nav)
+[`bpk-component-icon`](/packages/bpk-component-icon)
+[`bpk-component-image`](/packages/bpk-component-image)
+[`bpk-component-infinite-scroll`](/packages/bpk-component-infinite-scroll)
+[`bpk-component-input`](/packages/bpk-component-input)
+[`bpk-component-label`](/packages/bpk-component-label)
+[`bpk-component-link`](/packages/bpk-component-link)
+[`bpk-component-list`](/packages/bpk-component-list)
+[`bpk-component-loading-button`](/packages/bpk-component-loading-button)
+[`bpk-component-mobile-scroll-container`](/packages/bpk-component-mobile-scroll-container)
+[`bpk-component-modal`](/packages/bpk-component-modal)
+[`bpk-component-navigation-bar`](/packages/bpk-component-navigation-bar)
+[`bpk-component-nudger`](/packages/bpk-component-nudger)
+[`bpk-component-page-indicator`](/packages/bpk-component-page-indicator)
+[`bpk-component-pagination`](/packages/bpk-component-pagination)
+[`bpk-component-panel`](/packages/bpk-component-panel)
+[`bpk-component-phone-input`](/packages/bpk-component-phone-input)
+[`bpk-component-popover`](/packages/bpk-component-popover)
+[`bpk-component-progress`](/packages/bpk-component-progress)
+[`bpk-component-radio`](/packages/bpk-component-radio)
+[`bpk-component-rtl-toggle`](/packages/bpk-component-rtl-toggle)
+[`bpk-component-section-list`](/packages/bpk-component-section-list)
+[`bpk-component-select`](/packages/bpk-component-select)
+[`bpk-component-slider`](/packages/bpk-component-slider)
+[`bpk-component-spinner`](/packages/bpk-component-spinner)
+[`bpk-component-star-rating`](/packages/bpk-component-star-rating)
+[`bpk-component-switch`](/packages/bpk-component-switch)
+[`bpk-component-table`](/packages/bpk-component-table)
+[`bpk-component-text`](/packages/bpk-component-text)
+[`bpk-component-textarea`](/packages/bpk-component-textarea)
+[`bpk-theming`](/packages/bpk-theming)
+[`bpk-component-ticket`](/packages/bpk-component-ticket)
+[`bpk-component-tooltip`](/packages/bpk-component-tooltip)
+[`bpk-react-utils`](/packages/bpk-react-utils)
 
 ## List of external packages
 
 These components are part of Backpack and are utilised by the components but live in the Foundations repository.
+
+These are installed separately and installation information can be found in the [`Backpack Foundations repo`](https://github.com/Skyscanner/backpack-foundations)
 
 | Component                                                                                                                      | Version                                                                                                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/packages/README.md
+++ b/packages/README.md
@@ -2,8 +2,8 @@
 
 > Backpack is a collection of design resources, reusable components and guidelines for creating Skyscanner's products.
 
+[![npm version](https://badge.fury.io/js/@skyscanner%2Fbackpack-web.svg)](https://badge.fury.io/js/@skyscanner%2Fbackpack-web)
 [![Build Status](https://github.com/Skyscanner/backpack/workflows/Backpack%20CI/badge.svg)](https://github.com/Skyscanner/backpack/actions)
-
 
 ## Quick links
 
@@ -12,10 +12,10 @@
 
 ## Usage
 
-### Installing packages
+### Installation
 
 ```sh
-npm install [package-name] --save-dev
+npm install --save @skyscanner/backpack-web
 ```
 
 ## Contributing
@@ -24,71 +24,73 @@ To contribute please see [contributing.md](CONTRIBUTING.md).
 
 ## List of packages
 
-| Component                                                                                  | Version                                                                                                                                             |
-| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`bpk-component-accordion`](/packages/bpk-component-accordion)                             | [![npm version](https://badge.fury.io/js/bpk-component-accordion.svg)](http://badge.fury.io/js/bpk-component-accordion)                             |
-| [`bpk-component-autosuggest`](/packages/bpk-component-autosuggest)                         | [![npm version](https://badge.fury.io/js/bpk-component-autosuggest.svg)](http://badge.fury.io/js/bpk-component-autosuggest)                         |
-| [`bpk-component-badge`](/packages/bpk-component-badge)                                     | [![npm version](https://badge.fury.io/js/bpk-component-badge.svg)](http://badge.fury.io/js/bpk-component-badge)                                     |
-| [`bpk-component-banner-alert`](/packages/bpk-component-banner-alert)                       | [![npm version](https://badge.fury.io/js/bpk-component-banner-alert.svg)](http://badge.fury.io/js/bpk-component-banner-alert)                       |
-| [`bpk-component-barchart`](/packages/bpk-component-barchart)                               | [![npm version](https://badge.fury.io/js/bpk-component-barchart.svg)](http://badge.fury.io/js/bpk-component-barchart)                               |
-| [`bpk-component-blockquote`](/packages/bpk-component-blockquote)                           | [![npm version](https://badge.fury.io/js/bpk-component-blockquote.svg)](http://badge.fury.io/js/bpk-component-blockquote)                           |
-| [`bpk-component-breadcrumb`](/packages/bpk-component-breadcrumb)                           | [![npm version](https://badge.fury.io/js/bpk-component-breadcrumb.svg)](http://badge.fury.io/js/bpk-component-breadcrumb)                           |
-| [`bpk-component-breakpoint`](/packages/bpk-component-breakpoint)                           | [![npm version](https://badge.fury.io/js/bpk-component-breakpoint.svg)](http://badge.fury.io/js/bpk-component-breakpoint)                           |
-| [`bpk-component-button`](/packages/bpk-component-button)                                   | [![npm version](https://badge.fury.io/js/bpk-component-button.svg)](http://badge.fury.io/js/bpk-component-button)                                   |
-| [`bpk-component-calendar`](/packages/bpk-component-calendar)                               | [![npm version](https://badge.fury.io/js/bpk-component-calendar.svg)](http://badge.fury.io/js/bpk-component-calendar)                               |
-| [`bpk-component-card`](/packages/bpk-component-card)                                       | [![npm version](https://badge.fury.io/js/bpk-component-card.svg)](http://badge.fury.io/js/bpk-component-card)                                       |
-| [`bpk-component-checkbox`](/packages/bpk-component-checkbox)                               | [![npm version](https://badge.fury.io/js/bpk-component-checkbox.svg)](http://badge.fury.io/js/bpk-component-checkbox)                               |
-| [`bpk-component-chip`](/packages/bpk-component-chip)                                       | [![npm version](https://badge.fury.io/js/bpk-component-chip.svg)](http://badge.fury.io/js/bpk-component-chip)                                       |
-| [`bpk-component-close-button`](/packages/bpk-component-close-button)                       | [![npm version](https://badge.fury.io/js/bpk-component-close-button.svg)](http://badge.fury.io/js/bpk-component-close-button)                       |
-| [`bpk-component-code`](/packages/bpk-component-code)                                       | [![npm version](https://badge.fury.io/js/bpk-component-code.svg)](http://badge.fury.io/js/bpk-component-code)                                       |
-| [`bpk-component-content-container`](/packages/bpk-component-content-container)             | [![npm version](https://badge.fury.io/js/bpk-component-content-container.svg)](http://badge.fury.io/js/bpk-component-content-container)             |
-| [`bpk-component-datatable`](/packages/bpk-component-datatable)                             | [![npm version](https://badge.fury.io/js/bpk-component-datatable.svg)](http://badge.fury.io/js/bpk-component-datatable)                             |
-| [`bpk-component-datepicker`](/packages/bpk-component-datepicker)                           | [![npm version](https://badge.fury.io/js/bpk-component-datepicker.svg)](http://badge.fury.io/js/bpk-component-datepicker)                           |
-| [`bpk-component-description-list`](/packages/bpk-component-description-list)               | [![npm version](https://badge.fury.io/js/bpk-component-description-list.svg)](http://badge.fury.io/js/bpk-component-description-list)               |
-| [`bpk-component-dialog`](/packages/bpk-component-dialog)                                   | [![npm version](https://badge.fury.io/js/bpk-component-dialog.svg)](http://badge.fury.io/js/bpk-component-dialog)                                   |
-| [`bpk-component-drawer`](/packages/bpk-component-drawer)                                   | [![npm version](https://badge.fury.io/js/bpk-component-drawer.svg)](http://badge.fury.io/js/bpk-component-drawer)                                   |
-| [`bpk-component-fieldset`](/packages/bpk-component-fieldset)                               | [![npm version](https://badge.fury.io/js/bpk-component-fieldset.svg)](http://badge.fury.io/js/bpk-component-fieldset)                               |
-| [`bpk-component-form-validation`](/packages/bpk-component-form-validation)                 | [![npm version](https://badge.fury.io/js/bpk-component-form-validation.svg)](http://badge.fury.io/js/bpk-component-form-validation)                 |
-| [`bpk-component-graphic-promotion`](/packages/bpk-component-graphic-promotion)                     | [![npm version](https://badge.fury.io/js/bpk-component-graphic-promotion.svg)](http://badge.fury.io/js/bpk-component-graphic-promotion)                     |
-| [`bpk-component-grid`](/packages/bpk-component-grid)                                       | [![npm version](https://badge.fury.io/js/bpk-component-grid.svg)](http://badge.fury.io/js/bpk-component-grid)                                       |
-| [`bpk-component-grid-toggle`](/packages/bpk-component-grid-toggle)                         | [![npm version](https://badge.fury.io/js/bpk-component-grid-toggle.svg)](http://badge.fury.io/js/bpk-component-grid-toggle)                         |
-| [`bpk-component-horizontal-nav`](/packages/bpk-component-horizontal-nav)                   | [![npm version](https://badge.fury.io/js/bpk-component-horizontal-nav.svg)](http://badge.fury.io/js/bpk-component-horizontal-nav)                   |
-| [`bpk-component-icon`](/packages/bpk-component-icon)                                       | [![npm version](https://badge.fury.io/js/bpk-component-icon.svg)](http://badge.fury.io/js/bpk-component-icon)                                       |
-| [`bpk-component-image`](/packages/bpk-component-image)                                     | [![npm version](https://badge.fury.io/js/bpk-component-image.svg)](http://badge.fury.io/js/bpk-component-image)                                     |
-| [`bpk-component-infinite-scroll`](/packages/bpk-component-infinite-scroll)                 | [![npm version](https://badge.fury.io/js/bpk-component-infinite-scroll.svg)](http://badge.fury.io/js/bpk-component-infinite-scroll)                 |
-| [`bpk-component-input`](/packages/bpk-component-input)                                     | [![npm version](https://badge.fury.io/js/bpk-component-input.svg)](http://badge.fury.io/js/bpk-component-input)                                     |
-| [`bpk-component-label`](/packages/bpk-component-label)                                     | [![npm version](https://badge.fury.io/js/bpk-component-label.svg)](http://badge.fury.io/js/bpk-component-label)                                     |
-| [`bpk-component-link`](/packages/bpk-component-link)                                       | [![npm version](https://badge.fury.io/js/bpk-component-link.svg)](http://badge.fury.io/js/bpk-component-link)                                       |
-| [`bpk-component-list`](/packages/bpk-component-list)                                       | [![npm version](https://badge.fury.io/js/bpk-component-list.svg)](http://badge.fury.io/js/bpk-component-list)                                       |
-| [`bpk-component-loading-button`](/packages/bpk-component-loading-button)                   | [![npm version](https://badge.fury.io/js/bpk-component-loading-button.svg)](http://badge.fury.io/js/bpk-component-loading-button)                   |
-| [`bpk-component-mobile-scroll-container`](/packages/bpk-component-mobile-scroll-container) | [![npm version](https://badge.fury.io/js/bpk-component-mobile-scroll-container.svg)](http://badge.fury.io/js/bpk-component-mobile-scroll-container) |
-| [`bpk-component-modal`](/packages/bpk-component-modal)                                     | [![npm version](https://badge.fury.io/js/bpk-component-modal.svg)](http://badge.fury.io/js/bpk-component-modal)                                     |
-| [`bpk-component-navigation-bar`](/packages/bpk-component-navigation-bar)                   | [![npm version](https://badge.fury.io/js/bpk-component-navigation-bar.svg)](http://badge.fury.io/js/bpk-component-navigation-bar)                   |
-| [`bpk-component-nudger`](/packages/bpk-component-nudger)                                   | [![npm version](https://badge.fury.io/js/bpk-component-nudger.svg)](http://badge.fury.io/js/bpk-component-nudger)                                   |
-| [`bpk-component-pagination`](/packages/bpk-component-pagination)                           | [![npm version](https://badge.fury.io/js/bpk-component-pagination.svg)](http://badge.fury.io/js/bpk-component-pagination)                           |
-| [`bpk-component-panel`](/packages/bpk-component-panel)                                     | [![npm version](https://badge.fury.io/js/bpk-component-panel.svg)](http://badge.fury.io/js/bpk-component-panel)                                     |
-| [`bpk-component-phone-input`](/packages/bpk-component-phone-input)                         | [![npm version](https://badge.fury.io/js/bpk-component-phone-input.svg)](http://badge.fury.io/js/bpk-component-phone-input)                         |
-| [`bpk-component-popover`](/packages/bpk-component-popover)                                 | [![npm version](https://badge.fury.io/js/bpk-component-popover.svg)](http://badge.fury.io/js/bpk-component-popover)                                 |
-| [`bpk-component-progress`](/packages/bpk-component-progress)                               | [![npm version](https://badge.fury.io/js/bpk-component-progress.svg)](http://badge.fury.io/js/bpk-component-progress)                               |
-| [`bpk-component-radio`](/packages/bpk-component-radio)                                     | [![npm version](https://badge.fury.io/js/bpk-component-radio.svg)](http://badge.fury.io/js/bpk-component-radio)                                     |
-| [`bpk-component-rtl-toggle`](/packages/bpk-component-rtl-toggle)                           | [![npm version](https://badge.fury.io/js/bpk-component-rtl-toggle.svg)](http://badge.fury.io/js/bpk-component-rtl-toggle)                           |
-| [`bpk-component-section-list`](/packages/bpk-component-section-list)                       | [![npm version](https://badge.fury.io/js/bpk-component-section-list.svg)](http://badge.fury.io/js/bpk-component-section-list)                       |
-| [`bpk-component-select`](/packages/bpk-component-select)                                   | [![npm version](https://badge.fury.io/js/bpk-component-select.svg)](http://badge.fury.io/js/bpk-component-select)                                   |
-| [`bpk-component-slider`](/packages/bpk-component-slider)                                   | [![npm version](https://badge.fury.io/js/bpk-component-slider.svg)](http://badge.fury.io/js/bpk-component-slider)                                   |
-| [`bpk-component-spinner`](/packages/bpk-component-spinner)                                 | [![npm version](https://badge.fury.io/js/bpk-component-spinner.svg)](http://badge.fury.io/js/bpk-component-spinner)                                 |
-| [`bpk-component-star-rating`](/packages/bpk-component-star-rating)                         | [![npm version](https://badge.fury.io/js/bpk-component-star-rating.svg)](http://badge.fury.io/js/bpk-component-star-rating)                         |
-| [`bpk-component-switch`](/packages/bpk-component-switch)                                   | [![npm version](https://badge.fury.io/js/bpk-component-switch.svg)](http://badge.fury.io/js/bpk-component-switch)                         |
-| [`bpk-component-table`](/packages/bpk-component-table)                                     | [![npm version](https://badge.fury.io/js/bpk-component-table.svg)](http://badge.fury.io/js/bpk-component-table)                                     |
-| [`bpk-component-text`](/packages/bpk-component-text)                                       | [![npm version](https://badge.fury.io/js/bpk-component-text.svg)](http://badge.fury.io/js/bpk-component-text)                                       |
-| [`bpk-component-textarea`](/packages/bpk-component-textarea)                               | [![npm version](https://badge.fury.io/js/bpk-component-textarea.svg)](http://badge.fury.io/js/bpk-component-textarea)                               |
-| [`bpk-theming`](/packages/bpk-theming)                                                     | [![npm version](https://badge.fury.io/js/bpk-theming.svg)](http://badge.fury.io/js/bpk-theming)                                                     |
-| [`bpk-component-ticket`](/packages/bpk-component-ticket)                                   | [![npm version](https://badge.fury.io/js/bpk-component-ticket.svg)](http://badge.fury.io/js/bpk-component-ticket)                                   |
-| [`bpk-component-tooltip`](/packages/bpk-component-tooltip)                                 | [![npm version](https://badge.fury.io/js/bpk-component-tooltip.svg)](http://badge.fury.io/js/bpk-component-tooltip)                                 |
-| [`bpk-react-utils`](/packages/bpk-react-utils)                                             | [![npm version](https://badge.fury.io/js/bpk-react-utils.svg)](http://badge.fury.io/js/bpk-react-utils)                                             |
+[`bpk-animate-height`](/packages/bpk-animate-height)
+[`bpk-component-accordion`](/packages/bpk-component-accordion)
+[`bpk-component-autosuggest`](/packages/bpk-component-autosuggest)
+[`bpk-component-badge`](/packages/bpk-component-badge)
+[`bpk-component-banner-alert`](/packages/bpk-component-banner-alert)
+[`bpk-component-barchart`](/packages/bpk-component-barchart)
+[`bpk-component-blockquote`](/packages/bpk-component-blockquote)
+[`bpk-component-breadcrumb`](/packages/bpk-component-breadcrumb)
+[`bpk-component-breakpoint`](/packages/bpk-component-breakpoint)
+[`bpk-component-button`](/packages/bpk-component-button)
+[`bpk-component-calendar`](/packages/bpk-component-calendar)
+[`bpk-component-card`](/packages/bpk-component-card)
+[`bpk-component-checkbox`](/packages/bpk-component-checkbox)
+[`bpk-component-chip`](/packages/bpk-component-chip)
+[`bpk-component-close-button`](/packages/bpk-component-close-button)
+[`bpk-component-code`](/packages/bpk-component-code)
+[`bpk-component-content-container`](/packages/bpk-component-content-container)
+[`bpk-component-datatable`](/packages/bpk-component-datatable)
+[`bpk-component-datepicker`](/packages/bpk-component-datepicker)
+[`bpk-component-description-list`](/packages/bpk-component-description-list)
+[`bpk-component-dialog`](/packages/bpk-component-dialog)
+[`bpk-component-drawer`](/packages/bpk-component-drawer)
+[`bpk-component-fieldset`](/packages/bpk-component-fieldset)
+[`bpk-component-form-validation`](/packages/bpk-component-form-validation)
+[`bpk-component-graphic-promotion`](/packages/bpk-component-graphic-promotion)
+[`bpk-component-grid`](/packages/bpk-component-grid)
+[`bpk-component-grid-toggle`](/packages/bpk-component-grid-toggle)
+[`bpk-component-horizontal-nav`](/packages/bpk-component-horizontal-nav)
+[`bpk-component-icon`](/packages/bpk-component-icon)
+[`bpk-component-image`](/packages/bpk-component-image)
+[`bpk-component-infinite-scroll`](/packages/bpk-component-infinite-scroll)
+[`bpk-component-input`](/packages/bpk-component-input)
+[`bpk-component-label`](/packages/bpk-component-label)
+[`bpk-component-link`](/packages/bpk-component-link)
+[`bpk-component-list`](/packages/bpk-component-list)
+[`bpk-component-loading-button`](/packages/bpk-component-loading-button)
+[`bpk-component-mobile-scroll-container`](/packages/bpk-component-mobile-scroll-container)
+[`bpk-component-modal`](/packages/bpk-component-modal)
+[`bpk-component-navigation-bar`](/packages/bpk-component-navigation-bar)
+[`bpk-component-nudger`](/packages/bpk-component-nudger)
+[`bpk-component-page-indicator`](/packages/bpk-component-page-indicator)
+[`bpk-component-pagination`](/packages/bpk-component-pagination)
+[`bpk-component-panel`](/packages/bpk-component-panel)
+[`bpk-component-phone-input`](/packages/bpk-component-phone-input)
+[`bpk-component-popover`](/packages/bpk-component-popover)
+[`bpk-component-progress`](/packages/bpk-component-progress)
+[`bpk-component-radio`](/packages/bpk-component-radio)
+[`bpk-component-rtl-toggle`](/packages/bpk-component-rtl-toggle)
+[`bpk-component-section-list`](/packages/bpk-component-section-list)
+[`bpk-component-select`](/packages/bpk-component-select)
+[`bpk-component-slider`](/packages/bpk-component-slider)
+[`bpk-component-spinner`](/packages/bpk-component-spinner)
+[`bpk-component-star-rating`](/packages/bpk-component-star-rating)
+[`bpk-component-switch`](/packages/bpk-component-switch)
+[`bpk-component-table`](/packages/bpk-component-table)
+[`bpk-component-text`](/packages/bpk-component-text)
+[`bpk-component-textarea`](/packages/bpk-component-textarea)
+[`bpk-theming`](/packages/bpk-theming)
+[`bpk-component-ticket`](/packages/bpk-component-ticket)
+[`bpk-component-tooltip`](/packages/bpk-component-tooltip)
+[`bpk-react-utils`](/packages/bpk-react-utils)
 
 ## List of external packages
 
 These components are part of Backpack and are utilised by the components but live in the Foundations repository.
+
+These are installed separately and installation information can be found in the [`Backpack Foundations repo`](https://github.com/Skyscanner/backpack-foundations)
 
 | Component                                                                                                                      | Version                                                                                                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -98,4 +100,5 @@ These components are part of Backpack and are utilised by the components but liv
 | [`@skyscanner/bpk-foundations-web`](https://github.com/Skyscanner/backpack-foundations/tree/main/packages/bpk-foundations-web) | [![npm version](https://badge.fury.io/js/%40skyscanner%2Fbpk-foundations-web.svg)](https://badge.fury.io/js/%40skyscanner%2Fbpk-foundations-web) |
 
 ## Contact
+
 - backpack@skyscanner.net

--- a/packages/bpk-animate-height/README.md
+++ b/packages/bpk-animate-height/README.md
@@ -9,14 +9,12 @@ More information on the easing values can be found at [http://easings.net/](http
 
 ## Installation
 
-```sh
-npm install bpk-animate-height --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
-import AnimateHeight from 'bpk-animate-height';
+import AnimateHeight from '@skyscanner/backpack-web/bpk-animate-height';
 import React, { Component } from 'react';
 
 class AnimateHeightContainer extends Component {

--- a/packages/bpk-component-accordion/README.md
+++ b/packages/bpk-component-accordion/README.md
@@ -4,9 +4,7 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-accordion --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
@@ -16,7 +14,7 @@ The `withSingleItemAccordionState` higher-order component is used to limit one s
 
 ```js
 import React from 'react';
-import { BpkAccordion, BpkAccordionItem, withSingleItemAccordionState } from 'bpk-component-accordion';
+import { BpkAccordion, BpkAccordionItem, withSingleItemAccordionState } from '@skyscanner/backpack-web/bpk-component-accordion';
 
 const SingleItemAccordion = withSingleItemAccordionState(BpkAccordion);
 
@@ -41,7 +39,7 @@ The `withAccordionItemState` higher-order component is used to allow multiple it
 
 ```js
 import React from 'react';
-import { BpkAccordion, BpkAccordionItem, withAccordionItemState } from 'bpk-component-accordion';
+import { BpkAccordion, BpkAccordionItem, withAccordionItemState } from '@skyscanner/backpack-web/bpk-component-accordion';
 
 const StatefulAccordionItem = withAccordionItemState(BpkAccordionItem);
 
@@ -66,9 +64,9 @@ export default () => (
 
 ```js
 import React from 'react';
-import { BpkAccordion, BpkAccordionItem } from 'bpk-component-accordion';
-import { withAlignment } from 'bpk-component-icon';
-import StopsIcon from 'bpk-component-icon/sm/stops';
+import { BpkAccordion, BpkAccordionItem } from '@skyscanner/backpack-web/bpk-component-accordion';
+import { withAlignment } from '@skyscanner/backpack-web/bpk-component-icon';
+import StopsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/stops';
 import { lineHeightBase, iconSizeSm, colorPanjin } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 const AlignedStopsIcon = withAlignment(StopsIcon, lineHeightBase, iconSizeSm);

--- a/packages/bpk-component-aria-live/README.md
+++ b/packages/bpk-component-aria-live/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-aria-live --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```tsx
 import React from 'react';
-import BpkAriaLive, { ARIA_LIVE_POLITENESS_SETTINGS } from 'bpk-component-aria-live';
+import BpkAriaLive, { ARIA_LIVE_POLITENESS_SETTINGS } from '@skyscanner/backpack-web/bpk-component-aria-live';
 
 export default () => (
   <>

--- a/packages/bpk-component-autosuggest/README.md
+++ b/packages/bpk-component-autosuggest/README.md
@@ -4,18 +4,16 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-autosuggest --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkLabel from 'bpk-component-label';
-import { withRtlSupport } from 'bpk-component-icon';
-import FlightIcon from 'bpk-component-icon/lg/flight';
-import BpkAutosuggest, { BpkAutosuggestSuggestion } from 'bpk-component-autosuggest';
+import BpkLabel from '@skyscanner/backpack-web/bpk-component-label';
+import { withRtlSupport } from '@skyscanner/backpack-web/bpk-component-icon';
+import FlightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flight';
+import BpkAutosuggest, { BpkAutosuggestSuggestion } from '@skyscanner/backpack-web/bpk-component-autosuggest';
 
 const BpkFlightIcon = withRtlSupport(FlightIcon);
 

--- a/packages/bpk-component-badge/README.md
+++ b/packages/bpk-component-badge/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-badge --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkBadge, { BADGE_TYPES } from 'bpk-component-badge';
+import BpkBadge, { BADGE_TYPES } from '@skyscanner/backpack-web/bpk-component-badge';
 
 export default () => (
   <BpkBadge

--- a/packages/bpk-component-banner-alert/README.md
+++ b/packages/bpk-component-banner-alert/README.md
@@ -4,9 +4,7 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-banner-alert --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
@@ -14,7 +12,7 @@ npm install bpk-component-banner-alert --save-dev
 
 ```js
 import React from 'react';
-import BpkBannerAlert, { ALERT_TYPES } from 'bpk-component-banner-alert';
+import BpkBannerAlert, { ALERT_TYPES } from '@skyscanner/backpack-web/bpk-component-banner-alert';
 
 export default () => (
   <BpkBannerAlert
@@ -28,7 +26,7 @@ export default () => (
 
 ```js
 import React, { Component } from 'react';
-import { ALERT_TYPES, BpkBannerAlertDismissable } from 'bpk-component-banner-alert';
+import { ALERT_TYPES, BpkBannerAlertDismissable } from '@skyscanner/backpack-web/bpk-component-banner-alert';
 
 class DismissableBpkBannerAlert extends Component {
   constructor() {
@@ -68,7 +66,7 @@ export default () => (
 
 ```js
 import React, { Component } from 'react';
-import { ALERT_TYPES, withBannerAlertState, BpkBannerAlertDismissable, BpkBannerAlertExpandable } from 'bpk-component-banner-alert';
+import { ALERT_TYPES, withBannerAlertState, BpkBannerAlertDismissable, BpkBannerAlertExpandable } from '@skyscanner/backpack-web/bpk-component-banner-alert';
 
 const BannerAlertDismissableState = withBannerAlertState(BpkBannerAlertDismissable);
 const BannerAlertExpandableState = withBannerAlertState(BpkBannerAlertExpandable);

--- a/packages/bpk-component-barchart/README.md
+++ b/packages/bpk-component-barchart/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-barchart --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkBarchart from 'bpk-component-barchart';
+import BpkBarchart from '@skyscanner/backpack-web/bpk-component-barchart';
 
 const priceData = [
   {

--- a/packages/bpk-component-blockquote/README.md
+++ b/packages/bpk-component-blockquote/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-blockquote --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkBlockquote from 'bpk-component-blockquote';
+import BpkBlockquote from '@skyscanner/backpack-web/bpk-component-blockquote';
 
 export default () => (
   <BpkBlockquote extraSpace>

--- a/packages/bpk-component-boilerplate/README.md
+++ b/packages/bpk-component-boilerplate/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-boilerplate --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkBoilerplate from 'bpk-component-code';
+import BpkBoilerplate from '@skyscanner/backpack-web/bpk-component-code';
 
 export default () => <BpkBoilerplate />;
 ```

--- a/packages/bpk-component-breadcrumb/README.md
+++ b/packages/bpk-component-breadcrumb/README.md
@@ -4,14 +4,12 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-breadcrumb --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 ```js
 import React, { Component } from 'react';
-import BpkBreadcrumb, { BpkBreadcrumbItem } from 'bpk-component-breadcrumb';
+import BpkBreadcrumb, { BpkBreadcrumbItem } from '@skyscanner/backpack-web/bpk-component-breadcrumb';
 
 
 export default class App extends Component {

--- a/packages/bpk-component-breakpoint/README.md
+++ b/packages/bpk-component-breakpoint/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-breakpoint --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkBreakpoint, { BREAKPOINTS } from 'bpk-component-breakpoint';
+import BpkBreakpoint, { BREAKPOINTS } from '@skyscanner/backpack-web/bpk-component-breakpoint';
 
 export default () => (
   <BpkBreakpoint query={BREAKPOINTS.MOBILE}>

--- a/packages/bpk-component-button/README.md
+++ b/packages/bpk-component-button/README.md
@@ -4,17 +4,15 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-button --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import { withButtonAlignment, withRtlSupport } from 'bpk-component-icon';
-import ArrowIcon from 'bpk-component-icon/sm/long-arrow-right';
-import BpkButton from 'bpk-component-button';
+import { withButtonAlignment, withRtlSupport } from '@skyscanner/backpack-web/bpk-component-icon';
+import ArrowIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/long-arrow-right';
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
 
 const AlignedArrowIcon = withButtonAlignment(withRtlSupport(ArrowIcon));
 

--- a/packages/bpk-component-calendar/README.md
+++ b/packages/bpk-component-calendar/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-calendar --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkCalendar from 'bpk-component-calendar';
-import BpkInput, { INPUT_TYPES } from 'bpk-component-input';
+import BpkCalendar from '@skyscanner/backpack-web/bpk-component-calendar';
+import BpkInput, { INPUT_TYPES } from '@skyscanner/backpack-web/bpk-component-input';
 import format from 'date-fns/format';
 
 const formatDateFull = date => format(date, 'EEEE, do MMMM yyyy');

--- a/packages/bpk-component-card/README.md
+++ b/packages/bpk-component-card/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-card --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkCard from 'bpk-component-card';
+import BpkCard from '@skyscanner/backpack-web/bpk-component-card';
 
 export default () => (
   <BpkCard>

--- a/packages/bpk-component-checkbox/README.md
+++ b/packages/bpk-component-checkbox/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-checkbox --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkCheckbox from 'bpk-component-checkbox';
+import BpkCheckbox from '@skyscanner/backpack-web/bpk-component-checkbox';
 
 export default () => (
   <BpkCheckbox

--- a/packages/bpk-component-chip/README.md
+++ b/packages/bpk-component-chip/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-chip --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkSelectableChip, { BpkDismissibleChip, CHIP_TYPES } from 'bpk-component-chip';
-import BeachIconSm from 'bpk-component-icon/sm/beach';
+import BpkSelectableChip, { BpkDismissibleChip, CHIP_TYPES } from '@skyscanner/backpack-web/bpk-component-chip';
+import BeachIconSm from '@skyscanner/backpack-web/bpk-component-icon/sm/beach';
 
 export default () => (
 

--- a/packages/bpk-component-close-button/README.md
+++ b/packages/bpk-component-close-button/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-close-button --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkCloseButton from 'bpk-component-close-button';
+import BpkCloseButton from '@skyscanner/backpack-web/bpk-component-close-button';
 
 export default () => (
   <BpkCloseButton label="Close" onClick={() => console.log('click')} />

--- a/packages/bpk-component-code/README.md
+++ b/packages/bpk-component-code/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-code --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import { BpkCode, BpkCodeBlock } from 'bpk-component-code';
-import BpkText from 'bpk-component-text';
+import { BpkCode, BpkCodeBlock } from '@skyscanner/backpack-web/bpk-component-code';
+import BpkText from '@skyscanner/backpack-web/bpk-component-text';
 
 const codeBlock = `import React from 'react';
 import ReactDOM from 'react-dom';

--- a/packages/bpk-component-content-cards/README.md
+++ b/packages/bpk-component-content-cards/README.md
@@ -7,9 +7,7 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-content-cards --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 

--- a/packages/bpk-component-content-container/README.md
+++ b/packages/bpk-component-content-container/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-content-container --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkContentContainer from 'bpk-component-content-container';
+import BpkContentContainer from '@skyscanner/backpack-web/bpk-component-content-container';
 
 export default () => (
   <BpkContentContainer>

--- a/packages/bpk-component-datatable/README.md
+++ b/packages/bpk-component-datatable/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-datatable --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import { BpkDataTable, BpkDataTableColumn } from 'bpk-component-datatable';
+import { BpkDataTable, BpkDataTableColumn } from '@skyscanner/backpack-web/bpk-component-datatable';
 
 const rows = [
   { name: 'Jose', description: 'Software Engineer' },
@@ -42,7 +40,7 @@ By default `BpkDataTable` sorts the column using the value of `dataKey`. For use
 
 ```js
 import React from 'react';
-import { BpkDataTable, BpkDataTableColumn } from 'bpk-component-datatable';
+import { BpkDataTable, BpkDataTableColumn } from '@skyscanner/backpack-web/bpk-component-datatable';
 
 const complexRows = [
     {

--- a/packages/bpk-component-datepicker/README.md
+++ b/packages/bpk-component-datepicker/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-datepicker --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkDatepicker, { CALENDAR_SELECTION_TYPE } from 'bpk-component-datepicker';
+import BpkDatepicker, { CALENDAR_SELECTION_TYPE } from '@skyscanner/backpack-web/bpk-component-datepicker';
 import format from 'date-fns/format';
 
 const formatDate = date => format(date, 'dd/MM/yyyy');
@@ -74,7 +72,7 @@ By default `BpkCalendar` is used but the calendar component is fully configurabl
 
 ```js
 import React, { Component } from 'react';
-import BpkDatepicker from 'bpk-component-datepicker';
+import BpkDatepicker from '@skyscanner/backpack-web/bpk-component-datepicker';
 import {
   BpkCalendarNav,
   BpkCalendarGridHeader,
@@ -82,7 +80,7 @@ import {
   BpkCalendarDate,
   withCalendarState,
   composeCalendar,
-} from 'bpk-component-calendar';
+} from '@skyscanner/backpack-web/bpk-component-calendar';
 import { colorSagano } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 const ColoredCalendarDate = props =>

--- a/packages/bpk-component-description-list/README.md
+++ b/packages/bpk-component-description-list/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-description-list --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import { BpkDescriptionList, BpkDescriptionTerm, BpkDescriptionDetails } from 'bpk-component-description-list';
+import { BpkDescriptionList, BpkDescriptionTerm, BpkDescriptionDetails } from '@skyscanner/backpack-web/bpk-component-description-list';
 
 export default () => (
   <BpkDescriptionList>

--- a/packages/bpk-component-dialog/README.md
+++ b/packages/bpk-component-dialog/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-dialog --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkDialog from 'bpk-component-dialog';
-import BpkButton from 'bpk-component-button';
+import BpkDialog from '@skyscanner/backpack-web/bpk-component-dialog';
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
 
 class App extends Component {
   constructor() {

--- a/packages/bpk-component-drawer/README.md
+++ b/packages/bpk-component-drawer/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-drawer --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkDrawer from 'bpk-component-drawer';
-import BpkButton from 'bpk-component-button';
+import BpkDrawer from '@skyscanner/backpack-web/bpk-component-drawer';
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
 
 class App extends Component {
   constructor() {

--- a/packages/bpk-component-fieldset/README.md
+++ b/packages/bpk-component-fieldset/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-fieldset --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkFieldset from 'bpk-component-fieldset';
-import BpkInput, { INPUT_TYPES } from 'bpk-component-input';
+import BpkFieldset from '@skyscanner/backpack-web/bpk-component-fieldset';
+import BpkInput, { INPUT_TYPES } from '@skyscanner/backpack-web/bpk-component-input';
 
 class FieldsetContainer extends Component {
   constructor(props) {

--- a/packages/bpk-component-flare/README.md
+++ b/packages/bpk-component-flare/README.md
@@ -4,9 +4,7 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-flare --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
@@ -16,7 +14,7 @@ Note that the default background color is white. You will need to apply a custom
 
 ```js
 import React from 'react';
-import { BpkContentBubble } from 'bpk-component-flare';
+import { BpkContentBubble } from '@skyscanner/backpack-web/bpk-component-flare';
 
 export default MyComponent = () => (
   <div>

--- a/packages/bpk-component-floating-notification/README.md
+++ b/packages/bpk-component-floating-notification/README.md
@@ -2,15 +2,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-floating-notification --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkFloatingNotification from 'bpk-component-floating-notification';
+import BpkFloatingNotification from '@skyscanner/backpack-web/bpk-component-floating-notification';
 import BpkIconHeart from '../../packages/bpk-component-icon/sm/heart';
 
 export default () => (

--- a/packages/bpk-component-form-validation/README.md
+++ b/packages/bpk-component-form-validation/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-form-validation --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkFormValidation from 'bpk-component-form-validation';
+import BpkFormValidation from '@skyscanner/backpack-web/bpk-component-form-validation';
 
 export default () => (
   <BpkFormValidation id="my-form-validation" expanded>

--- a/packages/bpk-component-graphic-promotion/README.md
+++ b/packages/bpk-component-graphic-promotion/README.md
@@ -2,15 +2,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-graphic-promotion --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```tsx
 import React from 'react';
-import BpkGraphicPromo from 'bpk-component-graphic-promotion';
+import BpkGraphicPromo from '@skyscanner/backpack-web/bpk-component-graphic-promotion';
 
 export default () => (
   <BpkGraphicPromo

--- a/packages/bpk-component-grid-toggle/README.md
+++ b/packages/bpk-component-grid-toggle/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-grid-toggle --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkGridToggle from 'bpk-component-grid-toggle';
+import BpkGridToggle from '@skyscanner/backpack-web/bpk-component-grid-toggle';
 
 export default () => (
   <BpkGridToggle />

--- a/packages/bpk-component-grid/README.md
+++ b/packages/bpk-component-grid/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-grid --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import { BpkGridContainer, BpkGridRow, BpkGridColumn } from 'bpk-component-grid';
+import { BpkGridContainer, BpkGridRow, BpkGridColumn } from '@skyscanner/backpack-web/bpk-component-grid';
 
 export default () => (
   <BpkGridContainer>

--- a/packages/bpk-component-horizontal-nav/README.md
+++ b/packages/bpk-component-horizontal-nav/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-horizontal-nav --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkHorizontalNav, { BpkHorizontalNavItem } from 'bpk-component-horizontal-nav';
+import BpkHorizontalNav, { BpkHorizontalNavItem } from '@skyscanner/backpack-web/bpk-component-horizontal-nav';
 
 export default class App extends Component {
   constructor() {

--- a/packages/bpk-component-icon/README.md
+++ b/packages/bpk-component-icon/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-icon --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Basic usage
 
 ```js
 import React from 'react';
-import BpkSmallFlightIcon from 'bpk-component-icon/sm/flight';
-import BpkLargeAccessibilityIcon from 'bpk-component-icon/lg/accessibility';
+import BpkSmallFlightIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flight';
+import BpkLargeAccessibilityIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/accessibility';
 
 import './icons.scss';
 
@@ -42,10 +40,10 @@ export default () => (
 
 ```js
 import React from 'react';
-import BpkButton from 'bpk-component-button';
-import BpkSmallFlightIcon from 'bpk-component-icon/sm/flight';
-import BpkLargeAccessibilityIcon from 'bpk-component-icon/lg/accessibility';
-import { withButtonAlignment, withLargeButtonAlignment } from 'bpk-component-icon';
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
+import BpkSmallFlightIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flight';
+import BpkLargeAccessibilityIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/accessibility';
+import { withButtonAlignment, withLargeButtonAlignment } from '@skyscanner/backpack-web/bpk-component-icon';
 
 const AlignedBpkSmallFlightIcon = withButtonAlignment(BpkSmallFlightIcon);
 const AlignedBpkLargeAccessibilityIcon = withLargeButtonAlignment(BpkLargeAccessibilityIcon);
@@ -66,8 +64,8 @@ export default () => (
 
 ```js
 import React from 'react';
-import BpkSmallFlightIcon from 'bpk-component-icon/sm/flight';
-import { withRtlSupport } from 'bpk-component-icon';
+import BpkSmallFlightIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flight';
+import { withRtlSupport } from '@skyscanner/backpack-web/bpk-component-icon';
 
 import './icons.scss';
 

--- a/packages/bpk-component-image/README.md
+++ b/packages/bpk-component-image/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-image --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkImage from 'bpk-component-image';
+import BpkImage from '@skyscanner/backpack-web/bpk-component-image';
 import { breakpointDesktop, breakpointTablet } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 export default () => (
@@ -34,7 +32,7 @@ The `BpkImage` component will only load images if `inView` is true.
 Using this HOC can make pages load faster and prevent data being used to display images which are never seen by the user.
 
 ```js
-import BpkImage, { withLazyLoading, withLoadingBehavior } from 'bpk-component-image';
+import BpkImage, { withLazyLoading, withLoadingBehavior } from '@skyscanner/backpack-web/bpk-component-image';
 import { breakpointDesktop, breakpointTablet } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 // Support for SSR
@@ -58,7 +56,7 @@ export default () => (
 When the `loading` prop is set true, a spinner will be displayed. When this changes to false, the spinner will fade away and the loaded image and content will fade into view.
 
 ```js
-import BpkImage, { BpkBackgroundImage, withLazyLoading, withLoadingBehavior } from 'bpk-component-image';
+import BpkImage, { BpkBackgroundImage, withLazyLoading, withLoadingBehavior } from '@skyscanner/backpack-web/bpk-component-image';
 import { breakpointDesktop, breakpointTablet } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 const FadingImage = withLoadingBehavior(BpkImage);
@@ -90,7 +88,7 @@ export default () => (
 Combining `withLazyLoading` and `withLoadingBehavior` gives us a lazily loaded image that will show a spinner while the image loads.
 
 ```js
-import BpkImage, { withLazyLoading, withLoadingBehavior } from 'bpk-component-image';
+import BpkImage, { withLazyLoading, withLoadingBehavior } from '@skyscanner/backpack-web/bpk-component-image';
 import { breakpointDesktop, breakpointTablet } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 const documentIfExists = typeof window !== 'undefined' ? document : null;

--- a/packages/bpk-component-infinite-scroll/README.md
+++ b/packages/bpk-component-infinite-scroll/README.md
@@ -4,20 +4,18 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-infinite-scroll --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
 import PropTypes from 'prop-types';
-import BpkButton from 'bpk-component-button';
-import BpkSpinner, { SPINNER_TYPES } from 'bpk-component-spinner';
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
+import BpkSpinner, { SPINNER_TYPES } from '@skyscanner/backpack-web/bpk-component-spinner';
 import withInfiniteScroll, {
   ArrayDataSource,
-} from 'bpk-component-infinite-scroll';
+} from '@skyscanner/backpack-web/bpk-component-infinite-scroll';
 
 const SomeList = ({ elements }) => (
   <div id="list">
@@ -108,7 +106,7 @@ its data.
 ```js
 import React from 'react';
 import PropTypes from 'prop-types';
-import withInfiniteScroll, { DataSource } from 'bpk-component-infinite-scroll';
+import withInfiniteScroll, { DataSource } from '@skyscanner/backpack-web/bpk-component-infinite-scroll';
 
 const SomeList = ({ elements }) => (
   <div id="list">

--- a/packages/bpk-component-input/README.md
+++ b/packages/bpk-component-input/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-input --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkInput, { INPUT_TYPES, CLEAR_BUTTON_MODES } from 'bpk-component-input';
+import BpkInput, { INPUT_TYPES, CLEAR_BUTTON_MODES } from '@skyscanner/backpack-web/bpk-component-input';
 
 export default () => (
   <BpkInput
@@ -75,8 +73,8 @@ You can still attach custom handlers for these events as they will still be call
 
 ```js
 import React from 'react';
-import BpkInput, { withOpenEvents } from 'bpk-component-input';
-import BpkPopover from 'bpk-component-popover';
+import BpkInput, { withOpenEvents } from '@skyscanner/backpack-web/bpk-component-input';
+import BpkPopover from '@skyscanner/backpack-web/bpk-component-popover';
 
 const EnhancedInput = withOpenEvents(BpkInput);
 

--- a/packages/bpk-component-label/README.md
+++ b/packages/bpk-component-label/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-label --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkLabel from 'bpk-component-label';
+import BpkLabel from '@skyscanner/backpack-web/bpk-component-label';
 
 export default () => (
   <BpkLabel htmlFor="origin">Origin</BpkLabel>

--- a/packages/bpk-component-link/README.md
+++ b/packages/bpk-component-link/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-link --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkLink, { BpkButtonLink } from 'bpk-component-link';
+import BpkLink, { BpkButtonLink } from '@skyscanner/backpack-web/bpk-component-link';
 
 export default () => (
   <div>

--- a/packages/bpk-component-list/README.md
+++ b/packages/bpk-component-list/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-list --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import { BpkList, BpkListItem } from 'bpk-component-list';
+import { BpkList, BpkListItem } from '@skyscanner/backpack-web/bpk-component-list';
 
 export default () => (
   <BpkList>

--- a/packages/bpk-component-loading-button/README.md
+++ b/packages/bpk-component-loading-button/README.md
@@ -4,17 +4,15 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-loading-button --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkLoadingButton from 'bpk-component-loading-button';
-import BaggageIcon from 'bpk-component-icon/sm/baggage';
-import { withButtonAlignment, withRtlSupport } from 'bpk-component-icon';
+import BpkLoadingButton from '@skyscanner/backpack-web/bpk-component-loading-button';
+import BaggageIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baggage';
+import { withButtonAlignment, withRtlSupport } from '@skyscanner/backpack-web/bpk-component-icon';
 
 const AlignedBaggageIcon = withButtonAlignment(withRtlSupport(BaggageIcon));
 const icon = <AlignedBaggageIcon />;

--- a/packages/bpk-component-map/README.md
+++ b/packages/bpk-component-map/README.md
@@ -6,21 +6,19 @@ Requires **React 16.8+**
 
 ## Installation
 
-```sh
-npm install bpk-component-map --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkText from 'bpk-component-text';
-import { withRtlSupport } from 'bpk-component-icon';
-import LandmarkIconSm from 'bpk-component-icon/sm/landmark';
+import BpkText from '@skyscanner/backpack-web/bpk-component-text';
+import { withRtlSupport } from '@skyscanner/backpack-web/bpk-component-icon';
+import LandmarkIconSm from '@skyscanner/backpack-web/bpk-component-icon/sm/landmark';
 import BpkMap, {
   BpkIconMarker,
   BpkOverlayView,
-} from 'bpk-component-map';
+} from '@skyscanner/backpack-web/bpk-component-map';
 
 const AlignedLandmarkIconSm = withRtlSupport(LandmarkIconSm);
 
@@ -64,7 +62,7 @@ Price markers are used to display clickable prices on a map.
 
 ```js
 import React from 'react';
-import BpkMap, { BpkPriceMarker, PRICE_MARKER_STATUSES } from 'bpk-component-map';
+import BpkMap, { BpkPriceMarker, PRICE_MARKER_STATUSES } from '@skyscanner/backpack-web/bpk-component-map';
 
 export default () => (
   <BpkMap
@@ -106,7 +104,7 @@ If you intend to include multiple maps on one page, it's better to load the Goog
 
 ```js
 import React from 'react';
-import BpkMap, { withGoogleMapsScript } from 'bpk-component-map';
+import BpkMap, { withGoogleMapsScript } from '@skyscanner/backpack-web/bpk-component-map';
 
 const BpkMapWithScript = withGoogleMapsScript(BpkMap);
 

--- a/packages/bpk-component-mobile-scroll-container/README.md
+++ b/packages/bpk-component-mobile-scroll-container/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-mobile-scroll-container --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import { cssModules } from 'bpk-react-utils';
-import BpkMobileScrollContainer from 'bpk-component-mobile-scroll-container';
+import { cssModules } from '@skyscanner/backpack-web/bpk-react-utils';
+import BpkMobileScrollContainer from '@skyscanner/backpack-web/bpk-component-mobile-scroll-container';
 
 import STYLES from './MyComponent.scss';
 

--- a/packages/bpk-component-modal/README.md
+++ b/packages/bpk-component-modal/README.md
@@ -4,17 +4,15 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-modal --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkModal from 'bpk-component-modal';
-import BpkButton from 'bpk-component-button';
-import { BpkNavigationBarButtonLink } from 'bpk-component-navigation-bar';
+import BpkModal from '@skyscanner/backpack-web/bpk-component-modal';
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
+import { BpkNavigationBarButtonLink } from '@skyscanner/backpack-web/bpk-component-navigation-bar';
 
 class App extends Component {
   constructor() {

--- a/packages/bpk-component-navigation-bar/README.md
+++ b/packages/bpk-component-navigation-bar/README.md
@@ -4,9 +4,7 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-navigation-bar --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
@@ -14,10 +12,10 @@ npm install bpk-component-navigation-bar --save-dev
 
 ```js
 import React from 'react';
-import ArrowIcon from 'bpk-component-icon/sm/long-arrow-left';
-import { withRtlSupport } from 'bpk-component-icon';
+import ArrowIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/long-arrow-left';
+import { withRtlSupport } from '@skyscanner/backpack-web/bpk-component-icon';
 
-import BpkNavigationBar, { BpkNavigationBarIconButton, BpkNavigationBarButtonLink } from 'bpk-component-navigation-bar';
+import BpkNavigationBar, { BpkNavigationBarIconButton, BpkNavigationBarButtonLink } from '@skyscanner/backpack-web/bpk-component-navigation-bar';
 
 const ArrowIconWithRtl = withRtlSupport(ArrowIcon);
 
@@ -58,8 +56,8 @@ export default () => (
 
 ```js
 import React from 'react';
-import ArrowIcon from 'bpk-component-icon/sm/long-arrow-left';
-import { BpkNavigationBarIconButton } from 'bpk-component-navigation-bar';
+import ArrowIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/long-arrow-left';
+import { BpkNavigationBarIconButton } from '@skyscanner/backpack-web/bpk-component-navigation-bar';
 
 export default () => (
   <BpkNavigationBarIconButton
@@ -89,7 +87,7 @@ export default () => (
 
 ```js
 import React from 'react';
-import { BpkNavigationBarButtonLink } from 'bpk-component-navigation-bar';
+import { BpkNavigationBarButtonLink } from '@skyscanner/backpack-web/bpk-component-navigation-bar';
 
 export default () => (
   <BpkNavigationBarButtonLink onClick={() => {}}>

--- a/packages/bpk-component-nudger/README.md
+++ b/packages/bpk-component-nudger/README.md
@@ -4,9 +4,7 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-nudger --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
@@ -14,8 +12,8 @@ npm install bpk-component-nudger --save-dev
 
 ```js
 import React, { Component } from 'react';
-import BpkLabel from 'bpk-component-label';
-import BpkNudger from 'bpk-component-nudger';
+import BpkLabel from '@skyscanner/backpack-web/bpk-component-label';
+import BpkNudger from '@skyscanner/backpack-web/bpk-component-nudger';
 
 class App extends Component {
   constructor() {
@@ -53,8 +51,8 @@ class App extends Component {
 
 ```js
 import React, { Component } from 'react';
-import BpkLabel from 'bpk-component-label';
-import { BpkConfigurableNudger } from 'bpk-component-nudger';
+import BpkLabel from '@skyscanner/backpack-web/bpk-component-label';
+import { BpkConfigurableNudger } from '@skyscanner/backpack-web/bpk-component-nudger';
 
 const options = ['economy', 'premium', 'business', 'first'];
 

--- a/packages/bpk-component-overlay/README.md
+++ b/packages/bpk-component-overlay/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-overlay --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkText from 'bpk-component-text';
-import BpkOverlay, { BORDER_RADIUS_STYLES, OVERLAY_TYPES } from 'bpk-component-overlay';
+import BpkText from '@skyscanner/backpack-web/bpk-component-text';
+import BpkOverlay, { BORDER_RADIUS_STYLES, OVERLAY_TYPES } from '@skyscanner/backpack-web/bpk-component-overlay';
 
 export default () => (
   <div>

--- a/packages/bpk-component-page-indicator/README.md
+++ b/packages/bpk-component-page-indicator/README.md
@@ -4,9 +4,7 @@
 
 ## Installation
 
-```sh
-npm install @skyscanner/backpack-web --save
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 

--- a/packages/bpk-component-pagination/README.md
+++ b/packages/bpk-component-pagination/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-pagination --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkPagination from 'bpk-component-pagination';
+import BpkPagination from '@skyscanner/backpack-web/bpk-component-pagination';
 
 const Pagination = () => (
   <BpkPagination

--- a/packages/bpk-component-panel/README.md
+++ b/packages/bpk-component-panel/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-panel --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkPanel from 'bpk-component-panel';
+import BpkPanel from '@skyscanner/backpack-web/bpk-component-panel';
 
 export default () => (
   <BpkPanel>

--- a/packages/bpk-component-phone-input/README.md
+++ b/packages/bpk-component-phone-input/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-phone-input --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkPhoneInput from 'bpk-component-phone-input';
-import BpkImage from 'bpk-component-image';
+import BpkPhoneInput from '@skyscanner/backpack-web/bpk-component-phone-input';
+import BpkImage from '@skyscanner/backpack-web/bpk-component-image';
 
 const DIALING_CODE_TO_ID_MAP = {
   '44': 'uk',

--- a/packages/bpk-component-popover/README.md
+++ b/packages/bpk-component-popover/README.md
@@ -4,17 +4,15 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-popover --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkButton from 'bpk-component-button';
-import BpkPopover from 'bpk-component-popover';
-import BpkText from 'bpk-component-text';
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
+import BpkPopover from '@skyscanner/backpack-web/bpk-component-popover';
+import BpkText from '@skyscanner/backpack-web/bpk-component-text';
 
 class App extends Component {
   constructor() {

--- a/packages/bpk-component-price/README.md
+++ b/packages/bpk-component-price/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-price --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkPrice, { SIZES, ALIGNS } from 'bpk-component-price';
+import BpkPrice, { SIZES, ALIGNS } from '@skyscanner/backpack-web/bpk-component-price';
 
 export default () => (
   <BpkPrice

--- a/packages/bpk-component-progress/README.md
+++ b/packages/bpk-component-progress/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-progress --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkProgress from 'bpk-component-progress';
+import BpkProgress from '@skyscanner/backpack-web/bpk-component-progress';
 
 const Progress = () => (
   <BpkProgress

--- a/packages/bpk-component-radio/README.md
+++ b/packages/bpk-component-radio/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-radio --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkRadio from 'bpk-component-radio';
+import BpkRadio from '@skyscanner/backpack-web/bpk-component-radio';
 
 export default () => (
   <BpkRadio

--- a/packages/bpk-component-rating/README.md
+++ b/packages/bpk-component-rating/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-rating --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkRating, { RATING_SIZES, RATING_SCALES } from 'bpk-component-rating';
+import BpkRating, { RATING_SIZES, RATING_SCALES } from '@skyscanner/backpack-web/bpk-component-rating';
 
 export default () => (
   <BpkRating

--- a/packages/bpk-component-rtl-toggle/README.md
+++ b/packages/bpk-component-rtl-toggle/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-rtl-toggle --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkRtlToggle from 'bpk-component-rtl-toggle';
+import BpkRtlToggle from '@skyscanner/backpack-web/bpk-component-rtl-toggle';
 
 export default () => (
   <BpkRtlToggle />

--- a/packages/bpk-component-scrollable-calendar/README.md
+++ b/packages/bpk-component-scrollable-calendar/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-scrollable-calendar --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import { DateUtils } from 'bpk-component-calendar';
-import BpkScrollableCalendar, { CALENDAR_SELECTION_TYPE } from 'bpk-component-scrollable-calendar';
+import { DateUtils } from '@skyscanner/backpack-web/bpk-component-calendar';
+import BpkScrollableCalendar, { CALENDAR_SELECTION_TYPE } from '@skyscanner/backpack-web/bpk-component-scrollable-calendar';
 import format from 'date-fns/format';
 
 const formatDateFull = date => format(date, 'EEEE, do MMMM yyyy');

--- a/packages/bpk-component-section-list/README.md
+++ b/packages/bpk-component-section-list/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-section-list --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkSectionList, { BpkSectionListSection, BpkSectionListItem } from 'bpk-component-section-list';
+import BpkSectionList, { BpkSectionListSection, BpkSectionListItem } from '@skyscanner/backpack-web/bpk-component-section-list';
 
 export default () => (
   <BpkSectionList>

--- a/packages/bpk-component-select/README.md
+++ b/packages/bpk-component-select/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-select --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkSelect from 'bpk-component-select';
+import BpkSelect from '@skyscanner/backpack-web/bpk-component-select';
 
 export default () => (
   <BpkSelect

--- a/packages/bpk-component-skip-link/README.md
+++ b/packages/bpk-component-skip-link/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-skip-link --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkSkipLink from 'bpk-component-skip-link';
+import BpkSkipLink from '@skyscanner/backpack-web/bpk-component-skip-link';
 
 export default () => <BpkSkipLink href="#main" label="Skip to main content" />;
 ```

--- a/packages/bpk-component-slider/README.md
+++ b/packages/bpk-component-slider/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-slider --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkSlider from 'bpk-component-slider';
+import BpkSlider from '@skyscanner/backpack-web/bpk-component-slider';
 
 const Slider = () => (
   <BpkSlider

--- a/packages/bpk-component-spinner/README.md
+++ b/packages/bpk-component-spinner/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-spinner --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import { BpkSpinner, BpkLargeSpinner, BpkExtraLargeSpinner, SPINNER_TYPES } from 'bpk-component-spinner';
+import { BpkSpinner, BpkLargeSpinner, BpkExtraLargeSpinner, SPINNER_TYPES } from '@skyscanner/backpack-web/bpk-component-spinner';
 
 export default () => (
   <div>

--- a/packages/bpk-component-split-input/README.md
+++ b/packages/bpk-component-split-input/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-split-input --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkSplitInput, { INPUT_TYPES } from 'bpk-component-split-input';
+import BpkSplitInput, { INPUT_TYPES } from '@skyscanner/backpack-web/bpk-component-split-input';
 
 export default () => (
   <BpkSplitInput

--- a/packages/bpk-component-star-rating/README.md
+++ b/packages/bpk-component-star-rating/README.md
@@ -4,9 +4,7 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-star-rating --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
@@ -17,7 +15,7 @@ import BpkStarRating, {
   STAR_TYPES,
   BpkInteractiveStarRating,
   withInteractiveStarRatingState
-} from 'bpk-component-star-rating';
+} from '@skyscanner/backpack-web/bpk-component-star-rating';
 
 const InteractiveStarRating = withInteractiveStarRatingState(BpkInteractiveStarRating);
 

--- a/packages/bpk-component-switch/README.md
+++ b/packages/bpk-component-switch/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-switch --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkSwitch from 'bpk-component-switch';
+import BpkSwitch from '@skyscanner/backpack-web/bpk-component-switch';
 
 export default () => (
   <div>

--- a/packages/bpk-component-table/README.md
+++ b/packages/bpk-component-table/README.md
@@ -4,9 +4,7 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-table --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
@@ -19,7 +17,7 @@ import {
   BpkTableRow,
   BpkTableCell,
   BpkTableHeadCell,
-} from 'bpk-component-table';
+} from '@skyscanner/backpack-web/bpk-component-table';
 
 export default () => (
   <BpkTable>

--- a/packages/bpk-component-text/README.md
+++ b/packages/bpk-component-text/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-text --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```javascript
 import React from 'react';
-import BpkText, { TEXT_STYLES } from 'bpk-component-text';
+import BpkText, { TEXT_STYLES } from '@skyscanner/backpack-web/bpk-component-text';
 
 export default () => (
   <BpkText tagName="h1" textStyle={TEXT_STYLES.subheading}>My heading</BpkText>
@@ -25,8 +23,8 @@ When using the same style in many places repeating the `textStyle` and `tagName`
 
 ```javascript
 import React from 'react';
-import BpkText from 'bpk-component-text';
-import { withDefaultProps } from 'bpk-react-utils';
+import BpkText from '@skyscanner/backpack-web/bpk-component-text';
+import { withDefaultProps } from '@skyscanner/backpack-web/bpk-react-utils';
 
 const LargeParagraph = withDefaultProps(BpkText, { textStyle: 'bodyLongform', tagName: 'p' });
 const TinySpan = withDefaultProps(BpkText, { textStyle: 'caption', tagName: 'span' });
@@ -56,7 +54,7 @@ Heading `textStyle` should not be confused with heading `tagName` that provide s
 
 ```javascript
 import React from 'react';
-import BpkText, { TEXT_STYLES } from 'bpk-component-text';
+import BpkText, { TEXT_STYLES } from '@skyscanner/backpack-web/bpk-component-text';
 
 export default () => (
   <BpkText tagName="h1" textStyle={TEXT_STYLES.heading1}>My heading</BpkText>

--- a/packages/bpk-component-textarea/README.md
+++ b/packages/bpk-component-textarea/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-textarea --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkTextarea from 'bpk-component-textarea';
+import BpkTextarea from '@skyscanner/backpack-web/bpk-component-textarea';
 
 export default () => (
   <BpkTextarea

--- a/packages/bpk-component-theme-toggle/README.md
+++ b/packages/bpk-component-theme-toggle/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-theme-toggle --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkThemeToggle from 'bpk-component-theme-toggle';
+import BpkThemeToggle from '@skyscanner/backpack-web/bpk-component-theme-toggle';
 
 export default () => (
   <BpkThemeToggle />
@@ -23,8 +21,8 @@ export default () => (
 
 ```js
 import React from 'react';
-import { updateOnThemeChange } from 'bpk-component-theme-toggle';
-import BpkThemeProvider from 'bpk-theming';
+import { updateOnThemeChange } from '@skyscanner/backpack-web/bpk-component-theme-toggle';
+import BpkThemeProvider from '@skyscanner/backpack-web/bpk-theming';
 
 const EnhancedThemeProvider = updateOnThemeChange(BpkThemeProvider);
 ```

--- a/packages/bpk-component-ticket/README.md
+++ b/packages/bpk-component-ticket/README.md
@@ -4,15 +4,13 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-ticket --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React from 'react';
-import BpkTicket from 'bpk-component-ticket';
+import BpkTicket from '@skyscanner/backpack-web/bpk-component-ticket';
 
 export default () => (
   <BpkTicket stub="Lorem ipsum dolor sit amet.">

--- a/packages/bpk-component-tooltip/README.md
+++ b/packages/bpk-component-tooltip/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-component-tooltip --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
 import React, { Component } from 'react';
-import BpkText from 'bpk-component-text';
-import BpkTooltip from 'bpk-component-tooltip';
+import BpkText from '@skyscanner/backpack-web/bpk-component-text';
+import BpkTooltip from '@skyscanner/backpack-web/bpk-component-tooltip';
 
 const App = () => (
   const targetRef = useRef(null);

--- a/packages/bpk-react-utils/README.md
+++ b/packages/bpk-react-utils/README.md
@@ -4,9 +4,7 @@
 
 ## Installation
 
-```sh
-npm install bpk-react-utils --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Portal.js
 
@@ -16,9 +14,9 @@ it's necessary in overcoming z-index issues when absolutely positioning elements
 ### Usage
 
 ```js
-import { Portal } from 'bpk-react-utils';
-import BpkButton from 'bpk-component-button';
-import { BpkCode } from 'bpk-component-code';
+import { Portal } from '@skyscanner/backpack-web/bpk-react-utils';
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
+import { BpkCode } from '@skyscanner/backpack-web/bpk-component-code';
 import React, { Component } from 'react';
 
 class MyComponent extends Component {
@@ -81,7 +79,7 @@ A helpful utility which permits backwards compatibility with hard coded classes 
 
 ```js
 import React from 'react';
-import { cssModules } from 'bpk-react-utils';
+import { cssModules } from '@skyscanner/backpack-web/bpk-react-utils';
 
 import STYLES from './MyComponent.scss';
 
@@ -119,7 +117,7 @@ Without CSS modules:
 The returned function accepts multiple class names and ignores values other than strings. e.g:
 
 ```js
-import { cssModules } from 'bpk-react-utils';
+import { cssModules } from '@skyscanner/backpack-web/bpk-react-utils';
 
 import STYLES from './MyComponent.scss';
 
@@ -143,7 +141,7 @@ components initial mount. All you need to provide is two class names and a timeo
 
 ```js
 import React from 'react';
-import { TransitionInitialMount } from 'bpk-react-utils';
+import { TransitionInitialMount } from '@skyscanner/backpack-web/bpk-react-utils';
 
 const MyComponent = (props) => (
   <TransitionInitialMount
@@ -190,7 +188,7 @@ Returns true if the browser is showing content right-to-left.
 
 ```js
 import React from 'react';
-import { isRTL } from 'bpk-react-utils';
+import { isRTL } from '@skyscanner/backpack-web/bpk-react-utils';
 
 if (isRTL()) {
   // do RTL stuff
@@ -207,7 +205,7 @@ Returns true if the device is an iPhone.
 
 ```js
 import React from 'react';
-import { isDeviceIphone } from 'bpk-react-utils';
+import { isDeviceIphone } from '@skyscanner/backpack-web/bpk-react-utils';
 
 if (isDeviceIphone()) {
   // do iPhone specific stuff
@@ -224,7 +222,7 @@ Returns true if the device is an iPad.
 
 ```js
 import React from 'react';
-import { isDeviceIpad } from 'bpk-react-utils';
+import { isDeviceIpad } from '@skyscanner/backpack-web/bpk-react-utils';
 
 if (isDeviceIpad()) {
   // do iPad specific stuff
@@ -241,7 +239,7 @@ Returns true if the platform is iOS (iPhone/iPad).
 
 ```js
 import React from 'react';
-import { isDeviceIos } from 'bpk-react-utils';
+import { isDeviceIos } from '@skyscanner/backpack-web/bpk-react-utils';
 
 if (isDeviceIos()) {
   // do iOS specific stuff

--- a/packages/bpk-scrim-utils/README.md
+++ b/packages/bpk-scrim-utils/README.md
@@ -4,12 +4,10 @@
 
 ## Installation
 
-```sh
-npm install bpk-scrim-utils --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ```js
-import { withScrim } from 'bpk-scrim-utils';
+import { withScrim } from '@skyscanner/backpack-web/bpk-scrim-utils';
 
 const Box = props => (
   <div ref={props.dialogRef}>

--- a/packages/bpk-storybook-utils/README.md
+++ b/packages/bpk-storybook-utils/README.md
@@ -4,9 +4,7 @@ This package contains convenience utilities for use with storybook.
 
 ## Installation
 
-```sh
-npm install bpk-storybook-utils --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Included utilities
 
@@ -18,7 +16,7 @@ This makes it possible to use the `action` both within and without environments 
 #### Usage
 
 ```js
-import { action } from 'bpk-storybook-utils';
+import { action } from '@skyscanner/backpack-web/bpk-storybook-utils';
 
 ...
 
@@ -32,7 +30,7 @@ Adds a dark background, useful for displaying components that don't appear on a 
 #### Usage
 
 ```js
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
+import { BpkDarkExampleWrapper } from '@skyscanner/backpack-web/bpk-storybook-utils';
 
 ...
 

--- a/packages/bpk-theming/README.md
+++ b/packages/bpk-theming/README.md
@@ -4,16 +4,14 @@
 
 ## Installation
 
-```sh
-npm install bpk-theming --save-dev
-```
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
 
 ## Usage
 
 ```js
-import BpkThemeProvider from 'bpk-theming';
+import BpkThemeProvider from '@skyscanner/backpack-web/bpk-theming';
 
-import BpkLink, { themeAttributes as linkThemeAttributes } from 'bpk-component-link';
+import BpkLink, { themeAttributes as linkThemeAttributes } from '@skyscanner/backpack-web/bpk-component-link';
 
 const theme = {
   linkColor: '#c00',


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Now we have shifted to only publishing the single package, we need to update the READMEs across the board to reflect this change.

This PR does this.

Root package and packages/package.json file - we shift to :

- Noting just the single version badge at the top of the file
- Update installation instructions to just be the single package
- Remove links to each npm package badges as we no longer publish to them
- Also added a missing `bpk-animate-height` link as it was never there

For each component README:
- Update the installation step to point to the main repo (as we do for Backpack React Native)
- Update our example code for imports to point at the single package import