### PR TITLE
[NO-JIRA]: Update default overlay styles

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -384,8 +384,9 @@ overlayStyle
 overlayType
 overlayLevel
 OVERLAY_TYPES
-OVERLAY_TYPES.tint
+OVERLAY_TYPES.solid
 OVERLAY_LEVELS
+OVERLAY_LEVELS.low
 pageCount
 popperModifiers
 portalStyle

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,5 @@
+`@skyscanner/backpack-web`
+
+**Changed:**
+  - `BpkOverlay`
+    - Updated the default type to `solid` and the default level to `low`, as per design requirements.

--- a/packages/bpk-component-overlay/README.md
+++ b/packages/bpk-component-overlay/README.md
@@ -47,5 +47,5 @@ export default () => (
 | borderRadiusStyle (deprecated) | BORDER_RADIUS_STYLES | false | BORDER_RADIUS_STYLES.none |
 | className | string | false | null |
 | foregroundContent | Node | false | null |
-| overlayType | oneOf(OVERLAY_TYPES) | false | null |
-| overlayLevel | oneOf(OVERLAY_LEVELS) | false | null |
+| overlayType | oneOf(OVERLAY_TYPES) | false | OVERLAY_TYPES.solid |
+| overlayLevel | oneOf(OVERLAY_LEVELS) | false | OVERLAY_LEVELS.low |

--- a/packages/bpk-component-overlay/src/BpkOverlay.js
+++ b/packages/bpk-component-overlay/src/BpkOverlay.js
@@ -102,8 +102,8 @@ BpkOverlay.defaultProps = {
   borderRadiusStyle: null,
   className: null,
   foregroundContent: null,
-  overlayType: null,
-  overlayLevel: null,
+  overlayType: OVERLAY_TYPES.solid,
+  overlayLevel: OVERLAY_LEVELS.low,
 };
 
 export default BpkOverlay;

--- a/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.js.snap
+++ b/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.js.snap
@@ -9,7 +9,7 @@ exports[`BpkOverlay should render correctly 1`] = `
       Backpack
     </span>
     <div
-      class="bpk-overlay__overlay"
+      class="bpk-overlay__overlay bpk-overlay__overlay--solid-low"
     />
   </div>
 </DocumentFragment>
@@ -24,7 +24,7 @@ exports[`BpkOverlay should render correctly with foregroundContent 1`] = `
       Backpack
     </span>
     <div
-      class="bpk-overlay__overlay"
+      class="bpk-overlay__overlay bpk-overlay__overlay--solid-low"
     >
       <span>
         Skyscanner
@@ -404,7 +404,7 @@ exports[`BpkOverlay should support arbitrary props 1`] = `
       Backpack
     </span>
     <div
-      class="bpk-overlay__overlay"
+      class="bpk-overlay__overlay bpk-overlay__overlay--solid-low"
     />
   </div>
 </DocumentFragment>
@@ -419,7 +419,7 @@ exports[`BpkOverlay should support custom class names 1`] = `
       Backpack
     </span>
     <div
-      class="bpk-overlay__overlay"
+      class="bpk-overlay__overlay bpk-overlay__overlay--solid-low"
     />
   </div>
 </DocumentFragment>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

As part of discussions with design and how we will be expecting to use this, setting the default type to be `solid` with `low` style.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
