### PR TITLE
[NO JIRA]: Update disabled input cursor for the BpkCheckbox and BpkRadio components

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -29,3 +29,6 @@
 
   - `BpkCheckbox`
     - Update disabled input cursor to inherit `not-allowed` style
+
+  - `BpkRadio`
+    - Update disabled input cursor to inherit `not-allowed` style

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,7 @@
     ```
     ```javascript
     // myJsFile.js
-    
+
     import BpkText, { TEXT_STYLES } from '@skyscanner/backpack-web/bpk-component-text';
 
     <BpkText tagName="h1" textStyle={TEXT_STYLES.heading1} className='myTextClass'>
@@ -23,6 +23,9 @@
 **Patched:**
   - `BpkContentCards`
     - Fix headline vertical spacing
-  
+
   - `BpkCalendar`
     - Swap calendar tokens for semantic tokens
+
+  - `BpkCheckbox`
+    - Update disabled input cursor to inherit `not-allowed` style

--- a/packages/bpk-component-checkbox/src/BpkCheckbox.module.scss
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.module.scss
@@ -49,6 +49,11 @@ $bpk-spacing-v2: true;
 
   &__input {
     @include bpk-checkbox__input;
+  }
+
+    &--disabled {
+      cursor: inherit;
+    }
 
     &-indeterminate {
       &::before {

--- a/packages/bpk-component-checkbox/src/BpkCheckbox.module.scss
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.module.scss
@@ -49,7 +49,6 @@ $bpk-spacing-v2: true;
 
   &__input {
     @include bpk-checkbox__input;
-  }
 
     &--disabled {
       cursor: inherit;

--- a/packages/bpk-component-checkbox/src/BpkCheckbox.module.scss
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.module.scss
@@ -50,10 +50,6 @@ $bpk-spacing-v2: true;
   &__input {
     @include bpk-checkbox__input;
 
-    &--disabled {
-      cursor: inherit;
-    }
-
     &-indeterminate {
       &::before {
         position: absolute;
@@ -65,6 +61,10 @@ $bpk-spacing-v2: true;
         border-radius: $bpk-border-size-lg;
         background-color: $bpk-surface-default-day;
       }
+    }
+
+    &:disabled {
+      cursor: inherit;
     }
 
     &-white {

--- a/packages/bpk-component-radio/src/BpkRadio.module.scss
+++ b/packages/bpk-component-radio/src/BpkRadio.module.scss
@@ -50,6 +50,8 @@ $bpk-radio-size: bpk-spacing-lg() - ($bpk-one-pixel-rem * 4);
       }
 
       &:disabled {
+        cursor: inherit;
+
         + .bpk-radio__circle {
           display: block;
           background: $bpk-text-disabled-day;

--- a/packages/bpk-component-radio/src/BpkRadio.module.scss
+++ b/packages/bpk-component-radio/src/BpkRadio.module.scss
@@ -44,14 +44,16 @@ $bpk-radio-size: bpk-spacing-lg() - ($bpk-one-pixel-rem * 4);
   &__input {
     @include bpk-radio__input;
 
+    &:disabled {
+      cursor: inherit;
+    }
+
     &:checked {
       + .bpk-radio__circle {
         display: block;
       }
 
       &:disabled {
-        cursor: inherit;
-
         + .bpk-radio__circle {
           display: block;
           background: $bpk-text-disabled-day;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Updating the cursor of the disabled input in the `BpkCheckbox` and `BpkRadio` components to use the `not-allowed` style, as having it on the parent `<label>` wasn't enough for full coverage of the element when hovering over it, though because the label has the style, simply inheriting the value is enough to solve the issue.

[Context and video](https://skyscanner.slack.com/archives/C0JHPDSSU/p1671114670988229?thread_ts=1671114550.335799&cid=C0JHPDSSU) with the before and after example of the change. You can also see the issue in the [Backpack docs](https://backpack.github.io/components/checkbox/?platform=web) for the components.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
