### PR TITLE
Fix bpk switch deprecated type presence

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Patched:**
+  - `BpkSwitch`
+    - Fix deprecation message caused by default "type" set

--- a/packages/bpk-component-switch/src/BpkSwitch.js
+++ b/packages/bpk-component-switch/src/BpkSwitch.js
@@ -40,12 +40,12 @@ export type Props = {
 };
 
 const BpkSwitch = (props: Props) => {
-  const { className, label, small, ...rest } = props;
-  const type = props.type || SWITCH_TYPES.primary;
+  const { className, label, small, type, ...rest } = props;
+  const resolvedType = type || SWITCH_TYPES.primary;
 
   const switchClassNames = getClassName(
     'bpk-switch__switch',
-    `bpk-switch__switch--${type}`,
+    `bpk-switch__switch--${resolvedType}`,
     small && 'bpk-switch__switch--small',
   );
 
@@ -78,6 +78,7 @@ BpkSwitch.propTypes = {
 
 BpkSwitch.defaultProps = {
   className: null,
+  type: null,
   small: false,
 };
 

--- a/packages/bpk-component-switch/src/BpkSwitch.js
+++ b/packages/bpk-component-switch/src/BpkSwitch.js
@@ -40,7 +40,8 @@ export type Props = {
 };
 
 const BpkSwitch = (props: Props) => {
-  const { className, label, small, type, ...rest } = props;
+  const { className, label, small, ...rest } = props;
+  const type = props.type || SWITCH_TYPES.primary;
 
   const switchClassNames = getClassName(
     'bpk-switch__switch',
@@ -77,7 +78,6 @@ BpkSwitch.propTypes = {
 
 BpkSwitch.defaultProps = {
   className: null,
-  type: SWITCH_TYPES.primary,
   small: false,
 };
 


### PR DESCRIPTION
This deprecated 'type' property has a default value set which causes a lot of warnings even in the case when 'type' property is not set in the code.
The idea is to remove default value from prototype and move it to the code to prevent these warnings.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
