### PR TITLE
[LOOM-582] Remove display: none attribute from AnimateHeight

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,8 @@
 **Changed:**
 
 - `@skyscanner/backpack-web`:
+  - `AnimateHeight`:
+    - Updated page to not set `display: none` any more.
   - `BpkPagination`:
     - Updated component to the new design of the component to align with our brand.
   - `BpkTooltip`:

--- a/packages/bpk-animate-height/README.md
+++ b/packages/bpk-animate-height/README.md
@@ -2,8 +2,7 @@
 
 > Animate height using CSS transitions.
 
-Note: This was forked from https://github.com/Stanko/react-animate-height. We have added functionality to
-set the display property of the container to `display: none;` when the height is equal to 0.
+Note: This was forked from https://github.com/Stanko/react-animate-height.
 
 More information on the easing values can be found at [http://easings.net/](http://easings.net/)
 

--- a/packages/bpk-animate-height/src/AnimateHeight.js
+++ b/packages/bpk-animate-height/src/AnimateHeight.js
@@ -45,19 +45,12 @@ class AnimateHeight extends Component {
     };
   }
 
-  componentDidMount() {
-    if (this.contentElement && this.props.height === 0) {
-      this.contentElement.style.display = 'none';
-    }
-  }
-
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { height } = this.props;
 
     // Check if 'height' prop has changed
     if (this.contentElement && nextProps.height !== height) {
       // Cache content height
-      this.contentElement.style.display = '';
       this.contentElement.style.overflow = this.props.transitionOverflow;
       const contentHeight = this.contentElement.offsetHeight;
       this.contentElement.style.overflow = '';
@@ -118,9 +111,6 @@ class AnimateHeight extends Component {
   }
 
   onTransitionEnd = () => {
-    if (this.contentElement && this.props.height === 0) {
-      this.contentElement.style.display = 'none';
-    }
     if (this.props.onAnimationComplete) {
       this.props.onAnimationComplete();
     }

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -52,9 +52,7 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
       <div
         style="height: 0px; overflow: hidden; transition: height 200ms ease;"
       >
-        <div
-          style="display: none;"
-        >
+        <div>
           My accordion content
         </div>
       </div>
@@ -115,9 +113,7 @@ exports[`BpkAccordionItem should render correctly 1`] = `
       <div
         style="height: 0px; overflow: hidden; transition: height 200ms ease;"
       >
-        <div
-          style="display: none;"
-        >
+        <div>
           My accordion content
         </div>
       </div>
@@ -179,9 +175,7 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
       <div
         style="height: 0px; overflow: hidden; transition: height 200ms ease;"
       >
-        <div
-          style="display: none;"
-        >
+        <div>
           My accordion content
         </div>
       </div>
@@ -303,9 +297,7 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
       <div
         style="height: 0px; overflow: hidden; transition: height 200ms ease;"
       >
-        <div
-          style="display: none;"
-        >
+        <div>
           My accordion content
         </div>
       </div>
@@ -366,9 +358,7 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
       <div
         style="height: 0px; overflow: hidden; transition: height 200ms ease;"
       >
-        <div
-          style="display: none;"
-        >
+        <div>
           My accordion content
         </div>
       </div>
@@ -441,9 +431,7 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
       <div
         style="height: 0px; overflow: hidden; transition: height 200ms ease;"
       >
-        <div
-          style="display: none;"
-        >
+        <div>
           My accordion content
         </div>
       </div>

--- a/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
@@ -52,9 +52,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
       <div
         style="height: 0px; overflow: hidden; transition: height 200ms ease;"
       >
-        <div
-          style="display: none;"
-        >
+        <div>
           My accordion content
         </div>
       </div>
@@ -115,9 +113,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
       <div
         style="height: 0px; overflow: hidden; transition: height 200ms ease;"
       >
-        <div
-          style="display: none;"
-        >
+        <div>
           My accordion content
         </div>
       </div>

--- a/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.js.snap
+++ b/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.js.snap
@@ -43,9 +43,7 @@ exports[`BpkBannerAlert should render correctly 1`] = `
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />

--- a/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlertDismissable-test.js.snap
+++ b/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlertDismissable-test.js.snap
@@ -66,9 +66,7 @@ exports[`BpkBannerAlertDismissable should render correctly 1`] = `
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />

--- a/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlertInner-test.js.snap
+++ b/packages/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlertInner-test.js.snap
@@ -43,9 +43,7 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -101,9 +99,7 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -159,9 +155,7 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -217,9 +211,7 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -275,9 +267,7 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -333,9 +323,7 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -391,9 +379,7 @@ exports[`BpkBannerAlertInner should render correctly with "type" attribute equal
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -449,9 +435,7 @@ exports[`BpkBannerAlertInner should render correctly with a custom banner-alert 
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -508,9 +492,7 @@ exports[`BpkBannerAlertInner should render correctly with a custom class name 1`
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -599,9 +581,7 @@ exports[`BpkBannerAlertInner should render correctly with a element based messag
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               >
@@ -682,9 +662,7 @@ exports[`BpkBannerAlertInner should render correctly with animateOnLeave 1`] = `
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -740,9 +718,7 @@ exports[`BpkBannerAlertInner should render correctly with arbitrary props 1`] = 
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -826,9 +802,7 @@ exports[`BpkBannerAlertInner should render correctly with child nodes 1`] = `
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               >
@@ -909,9 +883,7 @@ exports[`BpkBannerAlertInner should render correctly with dismissable option 1`]
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />

--- a/packages/bpk-component-banner-alert/src/__snapshots__/withBannerAlertState-test.js.snap
+++ b/packages/bpk-component-banner-alert/src/__snapshots__/withBannerAlertState-test.js.snap
@@ -66,9 +66,7 @@ exports[`withBannerAlertState(BpkBannerAlertDismissable) should render correctly
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               />
@@ -152,9 +150,7 @@ exports[`withBannerAlertState(BpkBannerAlertExpandable) should render correctly 
           <div
             style="height: 0px; overflow: hidden; transition: height 200ms ease;"
           >
-            <div
-              style="display: none;"
-            >
+            <div>
               <div
                 class="bpk-banner-alert__children-container"
               >

--- a/packages/bpk-component-fieldset/src/__snapshots__/BpkFieldset-test.js.snap
+++ b/packages/bpk-component-fieldset/src/__snapshots__/BpkFieldset-test.js.snap
@@ -185,9 +185,7 @@ exports[`BpkFieldset should render correctly with checkbox component 1`] = `
     <div
       style="height: 0px; overflow: visible; transition: height 200ms ease;"
     >
-      <div
-        style="display: none;"
-      >
+      <div>
         <div
           class="bpk-form-validation__container"
         >
@@ -252,9 +250,7 @@ exports[`BpkFieldset should render correctly with checkbox component and "requir
     <div
       style="height: 0px; overflow: visible; transition: height 200ms ease;"
     >
-      <div
-        style="display: none;"
-      >
+      <div>
         <div
           class="bpk-form-validation__container"
         >
@@ -311,9 +307,7 @@ exports[`BpkFieldset should render correctly with input component 1`] = `
     <div
       style="height: 0px; overflow: visible; transition: height 200ms ease;"
     >
-      <div
-        style="display: none;"
-      >
+      <div>
         <div
           class="bpk-form-validation__container"
         >
@@ -377,9 +371,7 @@ exports[`BpkFieldset should render correctly with input component and "descripti
     <div
       style="height: 0px; overflow: visible; transition: height 200ms ease;"
     >
-      <div
-        style="display: none;"
-      >
+      <div>
         <div
           class="bpk-form-validation__container"
         >
@@ -436,9 +428,7 @@ exports[`BpkFieldset should render correctly with input component and "disabled"
     <div
       style="height: 0px; overflow: visible; transition: height 200ms ease;"
     >
-      <div
-        style="display: none;"
-      >
+      <div>
         <div
           class="bpk-form-validation__container"
         >
@@ -500,9 +490,7 @@ exports[`BpkFieldset should render correctly with input component and "required"
     <div
       style="height: 0px; overflow: visible; transition: height 200ms ease;"
     >
-      <div
-        style="display: none;"
-      >
+      <div>
         <div
           class="bpk-form-validation__container"
         >
@@ -559,9 +547,7 @@ exports[`BpkFieldset should render correctly with input component and "valid" at
     <div
       style="height: 0px; overflow: visible; transition: height 200ms ease;"
     >
-      <div
-        style="display: none;"
-      >
+      <div>
         <div
           class="bpk-form-validation__container"
         >
@@ -700,9 +686,7 @@ exports[`BpkFieldset should render correctly with select component 1`] = `
     <div
       style="height: 0px; overflow: visible; transition: height 200ms ease;"
     >
-      <div
-        style="display: none;"
-      >
+      <div>
         <div
           class="bpk-form-validation__container"
         >
@@ -788,9 +772,7 @@ exports[`BpkFieldset should render correctly with select component and "required
     <div
       style="height: 0px; overflow: visible; transition: height 200ms ease;"
     >
-      <div
-        style="display: none;"
-      >
+      <div>
         <div
           class="bpk-form-validation__container"
         >

--- a/packages/bpk-component-form-validation/src/__snapshots__/BpkFormValidation-test.js.snap
+++ b/packages/bpk-component-form-validation/src/__snapshots__/BpkFormValidation-test.js.snap
@@ -42,9 +42,7 @@ exports[`BpkFormValidation should render correctly with "expanded" equal to fals
   <div
     style="height: 0px; overflow: visible; transition: height 200ms ease;"
   >
-    <div
-      style="display: none;"
-    >
+    <div>
       <div
         class="bpk-form-validation__container"
       >


### PR DESCRIPTION
This PR removes all instances of the `style` attribute `display` being set in the `AnimateHeight` package

Previously `display: none` was being set by `AnimateHeight` when an element was being hidden (i.e `height` being set to 0)

Due to this, Banana were using a custom `Accordion` component with its own `AnimateHeight` package, so that `display: none` wasn't being set on hidden accordion elements in the footer for SEO reasons

With this change Banana will no longer need to use a custom implementation of the `Accordion` component and they can fall in line with the Backpack component

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
