### PR TITLE
Fix BpkPagination throwing a warning caused by incorrect BpkButton prop

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -73,6 +73,7 @@ BpkContentBubble
 BpkFlareBar
 
 BpkPanel
+BpkPagination
 
 BpkPhoneNumberInput
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,1 @@
+Fixed warning message when using BpkPagination in bpk-component-pagination

--- a/packages/bpk-component-pagination/src/BpkPaginationPage.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationPage.js
@@ -37,7 +37,7 @@ const BpkPaginationPage = (props) => {
   return (
     <BpkButton
       primaryOnDark={!isSelected}
-      primary={isSelected}
+      primaryOnLight={isSelected}
       onClick={onSelect}
       className={classNames.join(' ')}
       aria-label={pageLabel(page, isSelected)}

--- a/packages/bpk-component-pagination/src/BpkPaginationPage.js
+++ b/packages/bpk-component-pagination/src/BpkPaginationPage.js
@@ -37,7 +37,6 @@ const BpkPaginationPage = (props) => {
   return (
     <BpkButton
       primaryOnDark={!isSelected}
-      primaryOnLight={isSelected}
       onClick={onSelect}
       className={classNames.join(' ')}
       aria-label={pageLabel(page, isSelected)}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

`primary` is not a valid `BpkButton` field so I switched it to `primaryOnLight`. This was spamming the console wherever we use a `BpkPagination` component and it was making our danger checks fail, preventing us from merging PRs.

Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
