### PR TITLE
[no jira]: Fix image background

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,9 @@
 - `BpkDataTable`:
     - Fixed warnings about props not being recognised.
 
+- `BpkImage`:
+  - Fixed an issue where if the image didn't fit the full size of the container and dark background was shown behind the image.
+
 **Changed:**
   - `BpkInput`
     - Update placeholder state color.

--- a/packages/bpk-component-image/src/BpkImage.module.scss
+++ b/packages/bpk-component-image/src/BpkImage.module.scss
@@ -53,7 +53,7 @@
 }
 
 @mixin bpk-image--no-background {
-  background-color: $bpk-surface-contrast-day;
+  background-color: transparent;
 }
 
 @mixin bpk-image {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

This PR fixes an issue that was introduced during the colour refresh. At the time I was confused to what this was and how it worked but now reverted to its previous setting.

The idea behind the change is for setting 'no background' (transparent) when the image being supplied to the component didn't fully fill the container. E.g. rounded images or images of say cars.

An example can be seen below on the car hire page - in this instance it has been overriden to restore previous functionality.

![Screenshot 2023-02-14 at 16 35 45](https://user-images.githubusercontent.com/8831547/218799769-3695c0c7-a753-441c-a48c-bc5a7c0ba7ed.png)

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
