### PR TITLE
[no-jira]: Fixing changes from recent react import change

### DIFF
--- a/examples/bpk-component-autosuggest/examples.js
+++ b/examples/bpk-component-autosuggest/examples.js
@@ -18,6 +18,8 @@
 
 /* @flow strict */
 
+import { Component } from 'react';
+
 import { withRtlSupport } from '../../packages/bpk-component-icon';
 import FlightIcon from '../../packages/bpk-component-icon/lg/flight';
 import BpkAutosuggest, {

--- a/examples/bpk-component-chip/examples.js
+++ b/examples/bpk-component-chip/examples.js
@@ -19,6 +19,7 @@
 /* @flow strict */
 
 // eslint-disable-next-line max-classes-per-file
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { cssModules } from '../../packages/bpk-react-utils';

--- a/packages/bpk-component-content-cards/src/BpkContentCard.js
+++ b/packages/bpk-component-content-cards/src/BpkContentCard.js
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkText from '../../bpk-component-text';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import { cssModules } from '../../bpk-react-utils';

--- a/packages/bpk-component-content-cards/src/BpkContentCards.js
+++ b/packages/bpk-component-content-cards/src/BpkContentCards.js
@@ -17,6 +17,7 @@
  */
 /* eslint react/no-array-index-key: 0 */
 
+// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkText from '../../bpk-component-text';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import { cssModules } from '../../bpk-react-utils';


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

We recently completed #2727 to follow the new React standards and remove React imports, however it was found that some of the automated scripts messed two of the examples of our components so don't render anymore in storybook.

This PR fixes to include the correct imports for usage and restores the lost stories, it also adds back some removed comments for our temp TS disabling

Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
