### PR TITLE
[ST-4754] Remove the problematic component from Calendar.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,11 @@
 **Changed:**
 
 `bpk-component-button`: Cleaned up the onClick functionality to remove a wrapper that is no longer necessary
+
+**Fixed:**
+
+`BpkCalendarGrid`
+
+- Updated to remove a hidden component that was causing visual testing issues.
+- Removed `daysOfWeek` and `formatMonth` from the props, since they are no
+  longer needed.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,7 +2,7 @@
 
 `bpk-component-button`: Cleaned up the onClick functionality to remove a wrapper that is no longer necessary
 
-**Fixed:**
+**Breaking:**
 
 `BpkCalendarGrid`
 

--- a/examples/bpk-component-calendar/examples.js
+++ b/examples/bpk-component-calendar/examples.js
@@ -66,9 +66,7 @@ const CalendarGridExample = () => (
   <BpkCalendarGrid
     month={new Date()}
     weekStartsOn={1}
-    daysOfWeek={weekDays}
     onDateClick={action('Clicked day')}
-    formatMonth={formatMonth}
     formatDateFull={formatDateFull}
     DateComponent={BpkCalendarDate}
     preventKeyboardFocus

--- a/packages/bpk-component-calendar/README.md
+++ b/packages/bpk-component-calendar/README.md
@@ -11,11 +11,13 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 ```js
 import { Component } from 'react';
 import BpkCalendar from '@skyscanner/backpack-web/bpk-component-calendar';
-import BpkInput, { INPUT_TYPES } from '@skyscanner/backpack-web/bpk-component-input';
+import BpkInput, {
+  INPUT_TYPES,
+} from '@skyscanner/backpack-web/bpk-component-input';
 import format from 'date-fns/format';
 
-const formatDateFull = date => format(date, 'EEEE, do MMMM yyyy');
-const formatMonth = date => format(date, 'MMMM yyyy');
+const formatDateFull = (date) => format(date, 'EEEE, do MMMM yyyy');
+const formatMonth = (date) => format(date, 'MMMM yyyy');
 const daysOfWeek = [
   {
     name: 'Sunday',
@@ -27,14 +29,14 @@ const daysOfWeek = [
 ];
 
 export default class App extends Component {
-  constructor () {
+  constructor() {
     super();
 
     this.state = {
       selectionConfiguration: {
         type: CALENDAR_SELECTION_TYPE.single,
         date: null,
-        }
+      },
     };
   }
 
@@ -45,20 +47,20 @@ export default class App extends Component {
         date: date,
       },
     });
-  }
+  };
 
-  render () {
+  render() {
     return (
       <div>
         <BpkInput
-          id='dateInput'
+          id="dateInput"
           type={INPUT_TYPES.text}
-          name='date'
+          name="date"
           value={(this.state.selectionConfiguration.date || '').toString()}
-          placeholder='Departure date'
+          placeholder="Departure date"
         />
         <BpkCalendar
-          id='calendar'
+          id="calendar"
           onDateSelect={this.handleDateSelect}
           formatMonth={formatMonth}
           formatDateFull={formatDateFull}
@@ -70,7 +72,7 @@ export default class App extends Component {
           selectionConfiguration={this.state.selectionConfiguration}
         />
       </div>
-    )
+    );
   }
 }
 ```
@@ -95,12 +97,14 @@ The default export of this package uses the following set of components:
 Composition and state are implemented using the aforementioned higher-order components:
 
 ```js
-withCalendarState(composeCalendar(
-  BpkCalendarNav,
-  BpkCalendarGridHeader,
-  TransitioningBpkCalendarGrid,
-  BpkCalendarDate,
-))
+withCalendarState(
+  composeCalendar(
+    BpkCalendarNav,
+    BpkCalendarGridHeader,
+    TransitioningBpkCalendarGrid,
+    BpkCalendarDate,
+  ),
+);
 ```
 
 ### Building a custom calendar
@@ -108,45 +112,32 @@ withCalendarState(composeCalendar(
 A custom calendar can be created by swapping out any default component for an alternative:
 
 ```js
-composeCalendar(
-  MyNavigation,
-  MyHeader,
-  MyGrid,
-  MyDate,
-)
+composeCalendar(MyNavigation, MyHeader, MyGrid, MyDate);
 ```
 
 The navigation and header components are optional. If they are not needed, the arguments to `composeCalendar` should be set to `null`:
 
 ```js
-composeCalendar(
-  null,
-  null,
-  MyGrid,
-  MyDate,
-)
+composeCalendar(null, null, MyGrid, MyDate);
 ```
 
 In many cases, you might want to keep most of the components and replace only one or two:
 
 ```js
-composeCalendar(
-  BpkCalendarNav,
-  BpkCalendarGridHeader,
-  BpkCalendarGrid,
-  MyDate,
-)
+composeCalendar(BpkCalendarNav, BpkCalendarGridHeader, BpkCalendarGrid, MyDate);
 ```
 
 Finally, focus management and support for keyboard input can be added using `withCalendarState`:
 
 ```js
-withCalendarState(composeCalendar(
-  BpkCalendarNav,
-  BpkCalendarGridHeader,
-  BpkCalendarGrid,
-  MyDate,
-))
+withCalendarState(
+  composeCalendar(
+    BpkCalendarNav,
+    BpkCalendarGridHeader,
+    BpkCalendarGrid,
+    MyDate,
+  ),
+);
 ```
 
 > When implementing a replacement for any of the default calendar components, make sure it
@@ -155,32 +146,32 @@ withCalendarState(composeCalendar(
 
 ## Props
 
-| Property              | PropType             | Required            | Default Value    |
-| --------------------- | -------------------- | ------------------- | ---------------- |
-| daysOfWeek            | object               | true                | -                |
-| formatDateFull        | func                 | true                | -                |
-| formatMonth           | func                 | true                | -                |
-| id                    | string               | true                | -                |
-| weekStartsOn          | number               | true                | -                |
-| changeMonthLabel      | string               | if Nav !== null     | -                |
-| nextMonthLabel        | string               | if Nav !== null     | -                |
-| previousMonthLabel    | string               | if Nav !== null     | -                |
-| className             | string               | false               | null             |
-| fixedWidth            | bool                 | false               | true             |
-| gridClassName         | string               | false               | null             |
-| initiallyFocusedDate  | Date                 | false               | null             |
-| markOutsideDays       | bool                 | false               | true             |
-| markToday             | bool                 | false               | true             |
-| maxDate               | Date                 | false               | new Date() + 1 year |
-| minDate               | Date                 | false               | new Date()       |
-| onDateSelect          | func                 | false               | null             |
-| onMonthChange         | func                 | false               | null             |
-| selectionConfiguration| object               | false               | { type: CALENDAR_SELECTION_TYPE.single, date: null }  |
-| navProps              | object               | false               | null             |
-| headerProps           | object               | false               | null             |
-| gridProps             | object               | false               | null             |
-| dateProps             | object               | false               | null             |
-| weekDayKey            | string               | false               | nameAbbr         |
+| Property               | PropType | Required        | Default Value                                        |
+| ---------------------- | -------- | --------------- | ---------------------------------------------------- |
+| daysOfWeek             | object   | true            | -                                                    |
+| formatDateFull         | func     | true            | -                                                    |
+| formatMonth            | func     | true            | -                                                    |
+| id                     | string   | true            | -                                                    |
+| weekStartsOn           | number   | true            | -                                                    |
+| changeMonthLabel       | string   | if Nav !== null | -                                                    |
+| nextMonthLabel         | string   | if Nav !== null | -                                                    |
+| previousMonthLabel     | string   | if Nav !== null | -                                                    |
+| className              | string   | false           | null                                                 |
+| fixedWidth             | bool     | false           | true                                                 |
+| gridClassName          | string   | false           | null                                                 |
+| initiallyFocusedDate   | Date     | false           | null                                                 |
+| markOutsideDays        | bool     | false           | true                                                 |
+| markToday              | bool     | false           | true                                                 |
+| maxDate                | Date     | false           | new Date() + 1 year                                  |
+| minDate                | Date     | false           | new Date()                                           |
+| onDateSelect           | func     | false           | null                                                 |
+| onMonthChange          | func     | false           | null                                                 |
+| selectionConfiguration | object   | false           | { type: CALENDAR_SELECTION_TYPE.single, date: null } |
+| navProps               | object   | false           | null                                                 |
+| headerProps            | object   | false           | null                                                 |
+| gridProps              | object   | false           | null                                                 |
+| dateProps              | object   | false           | null                                                 |
+| weekDayKey             | string   | false           | nameAbbr                                             |
 
 Some of the more complex props and props for sub-components are detailed below.
 
@@ -189,18 +180,18 @@ Some of the more complex props and props for sub-components are detailed below.
 The BpkCalendarNav component is used to change the month that is being displayed by using
 buttons and a select box.
 
-| Property              | PropType             | Required | Default Value    |
-| --------------------- | -------------------- | -------- | ---------------- |
-| changeMonthLabel      | string               | true     | -                |
-| nextMonthLabel        | string               | true     | -                |
-| previousMonthLabel    | string               | true     | -                |
-| formatMonth           | func                 | true     | -                |
-| id                    | string               | true     | -                |
-| maxDate               | Date                 | true     | -                |
-| minDate               | Date                 | true     | -                |
-| month                 | Date                 | true     | -                |
-| onMonthChange         | func                 | false    | null             |
-| disabled              | bool                 | false    | false            |
+| Property           | PropType | Required | Default Value |
+| ------------------ | -------- | -------- | ------------- |
+| changeMonthLabel   | string   | true     | -             |
+| nextMonthLabel     | string   | true     | -             |
+| previousMonthLabel | string   | true     | -             |
+| formatMonth        | func     | true     | -             |
+| id                 | string   | true     | -             |
+| maxDate            | Date     | true     | -             |
+| minDate            | Date     | true     | -             |
+| month              | Date     | true     | -             |
+| onMonthChange      | func     | false    | null          |
+| disabled           | bool     | false    | false         |
 
 ### BpkCalendarGridHeader
 
@@ -208,55 +199,53 @@ The BpkCalendarGridHeader component displays the header of `BpkCalendarGrid`, li
 the days of the week. This is needed as a separate component, as the header should stay
 in place while the rest of the grid transitions when changing months.
 
-| Property              | PropType             | Required | Default Value    |
-| --------------------- | -------------------- | -------- | ---------------- |
-| daysOfWeek            | object               | true     | -                |
-| weekStartsOn          | number               | true     | -                |
-| className             | string               | false    | null             |
-| weekDayKey            | string               | false    | nameAbbr         |
+| Property     | PropType | Required | Default Value |
+| ------------ | -------- | -------- | ------------- |
+| daysOfWeek   | object   | true     | -             |
+| weekStartsOn | number   | true     | -             |
+| className    | string   | false    | null          |
+| weekDayKey   | string   | false    | nameAbbr      |
 
 ### BpkCalendarGrid
 
 The BpkCalendarGrid component displays a month as a table.
 
-| Property              | PropType             | Required | Default Value    |
-| --------------------- | -------------------- | -------- | ---------------- |
-| DateComponent         | elementType          | true     | -                |
-| daysOfWeek            | array(object)        | true     | -                |
-| formatDateFull        | func                 | true     | -                |
-| formatMonth           | func                 | true     | -                |
-| month                 | Date                 | true     | -                |
-| weekStartsOn          | number               | true     | -                |
-| selectionConfiguration| object               | false    | { type: CALENDAR_SELECTION_TYPE.single, date: null }  |
-| focusedDate           | Date                 | false    | null             |
-| isKeyboardFocusable   | bool                 | false    | true             |
-| markOutsideDays       | bool                 | false    | true             |
-| markToday             | bool                 | false    | true             |
-| maxDate               | Date                 | false    | new Date() + 1 year |
-| minDate               | Date                 | false    | new Date()       |
-| onDateClick           | func                 | false    | null             |
-| onDateKeyDown         | func                 | false    | null             |
-| preventKeyboardFocus  | bool                 | false    | false            |
+| Property               | PropType    | Required | Default Value                                        |
+| ---------------------- | ----------- | -------- | ---------------------------------------------------- |
+| DateComponent          | elementType | true     | -                                                    |
+| formatDateFull         | func        | true     | -                                                    |
+| month                  | Date        | true     | -                                                    |
+| weekStartsOn           | number      | true     | -                                                    |
+| selectionConfiguration | object      | false    | { type: CALENDAR_SELECTION_TYPE.single, date: null } |
+| focusedDate            | Date        | false    | null                                                 |
+| isKeyboardFocusable    | bool        | false    | true                                                 |
+| markOutsideDays        | bool        | false    | true                                                 |
+| markToday              | bool        | false    | true                                                 |
+| maxDate                | Date        | false    | new Date() + 1 year                                  |
+| minDate                | Date        | false    | new Date()                                           |
+| onDateClick            | func        | false    | null                                                 |
+| onDateKeyDown          | func        | false    | null                                                 |
+| preventKeyboardFocus   | bool        | false    | false                                                |
 
 ### BpkCalendarDate
 
 The BpkCalendarDate component is used to render the content of a cell
 (a single day) inside the calendar grid.
 
-| Property              | PropType             | Required | Default Value    |
-| --------------------- | -------------------- | -------- | ---------------- |
-| date                  | Date                 | true     | -                |
-| isBlocked             | bool                 | false    | false            |
-| isFocused             | bool                 | false    | false            |
-| isKeyboardFocusable   | bool                 | false    | true             |
-| isOutside             | bool                 | false    | false            |
-| isSelected            | bool                 | false    | false            |
-| isToday               | bool                 | false    | false            |
-| onClick               | func                 | false    | null             |
-| onDateKeyDown         | func                 | false    | null             |
-| preventKeyboardFocus  | bool                 | false    | true             |
-| selectionType         | oneOf(SELECTION_TYPES.single, SELECTION_TYPES.start, SELECTION_TYPES.middle, SELECTION_TYPES.end)      | false    | SELECTION_TYPES.single             |
-| style                 | object               | false    | null             |
+| Property             | PropType                                                                                          | Required | Default Value          |
+| -------------------- | ------------------------------------------------------------------------------------------------- | -------- | ---------------------- |
+| date                 | Date                                                                                              | true     | -                      |
+| isBlocked            | bool                                                                                              | false    | false                  |
+| isFocused            | bool                                                                                              | false    | false                  |
+| isKeyboardFocusable  | bool                                                                                              | false    | true                   |
+| isOutside            | bool                                                                                              | false    | false                  |
+| isSelected           | bool                                                                                              | false    | false                  |
+| isToday              | bool                                                                                              | false    | false                  |
+| onClick              | func                                                                                              | false    | null                   |
+| onDateKeyDown        | func                                                                                              | false    | null                   |
+| preventKeyboardFocus | bool                                                                                              | false    | true                   |
+| selectionType        | oneOf(SELECTION_TYPES.single, SELECTION_TYPES.start, SELECTION_TYPES.middle, SELECTION_TYPES.end) | false    | SELECTION_TYPES.single |
+| style                | object                                                                                            | false    | null                   |
 
 #### `selectionType` prop
 
@@ -341,7 +330,7 @@ A function to format a full, human-readable date, for example: "Monday, 8th Janu
 ```js
 import format from 'date-fns/format';
 
-const formatDateFull = date => format(date, 'EEEE, do MMMM yyyy');
+const formatDateFull = (date) => format(date, 'EEEE, do MMMM yyyy');
 ```
 
 #### formatMonth
@@ -353,7 +342,7 @@ If you just need to quickly prototype, use the following from [`date-fns`](https
 ```js
 import format from 'date-fns/format';
 
-const formatMonth = date => format(date, 'MMMM yyyy');
+const formatMonth = (date) => format(date, 'MMMM yyyy');
 ```
 
 #### weekStartsOn
@@ -381,14 +370,13 @@ These are useful if your custom implementation of one of these components requir
 
 ## Theme Props
 
-* `calendarDateTextColor`
-* `calendarDateTextHoverColor`
-* `calendarDateTextActiveColor`
-* `calendarDateTextFocusColor`
-* `calendarDateTextSelectedColor`
-* `calendarDateSelectedBackgroundColor`
-* `calendarDateFocusedBorderColor`
-* `calendarNudgerIconColor`
-* `calendarNudgerIconHoverColor`
-* `calendarNudgerIconActiveColor`
-
+- `calendarDateTextColor`
+- `calendarDateTextHoverColor`
+- `calendarDateTextActiveColor`
+- `calendarDateTextFocusColor`
+- `calendarDateTextSelectedColor`
+- `calendarDateSelectedBackgroundColor`
+- `calendarDateFocusedBorderColor`
+- `calendarNudgerIconColor`
+- `calendarNudgerIconHoverColor`
+- `calendarNudgerIconActiveColor`

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -21,14 +21,12 @@ import { Component } from 'react';
 
 import { cssModules, isDeviceIos } from '../../bpk-react-utils';
 
-import BpkCalendarGridHeader from './BpkCalendarGridHeader';
 import Week from './Week';
 import {
   addMonths,
   formatIsoDate,
   getCalendarMonthWeeks,
   isSameMonth,
-  orderDaysOfWeek,
 } from './date-utils';
 import CustomPropTypes, { CALENDAR_SELECTION_TYPE } from './custom-proptypes';
 import STYLES from './BpkCalendarGrid.module.scss';
@@ -58,24 +56,18 @@ class BpkCalendarGrid extends Component {
         props.month,
         props.weekStartsOn,
       ),
-      daysOfWeek: orderDaysOfWeek(props.daysOfWeek, props.weekStartsOn),
     };
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     // We cache expensive calculations (and identities) in state
     if (
-      nextProps.daysOfWeek !== this.props.daysOfWeek ||
       !isSameMonth(nextProps.month, this.props.month) ||
       nextProps.weekStartsOn !== this.props.weekStartsOn
     ) {
       this.setState({
         calendarMonthWeeks: getCalendarMonthWeeks(
           nextProps.month,
-          nextProps.weekStartsOn,
-        ),
-        daysOfWeek: orderDaysOfWeek(
-          nextProps.daysOfWeek,
           nextProps.weekStartsOn,
         ),
       });
@@ -91,7 +83,6 @@ class BpkCalendarGrid extends Component {
       dateProps,
       focusedDate,
       formatDateFull,
-      formatMonth,
       ignoreOutsideDate,
       isKeyboardFocusable,
       markOutsideDays,
@@ -106,7 +97,7 @@ class BpkCalendarGrid extends Component {
       weekStartsOn,
     } = this.props;
 
-    const { calendarMonthWeeks, daysOfWeek } = this.state;
+    const { calendarMonthWeeks } = this.state;
 
     const classNames = getClassName('bpk-calendar-grid', className);
 
@@ -146,9 +137,7 @@ class BpkCalendarGrid extends Component {
 export const propTypes = {
   // Required
   DateComponent: PropTypes.elementType.isRequired,
-  daysOfWeek: CustomPropTypes.DaysOfWeek.isRequired,
   formatDateFull: PropTypes.func.isRequired,
-  formatMonth: PropTypes.func.isRequired,
   month: PropTypes.instanceOf(Date).isRequired,
   weekStartsOn: PropTypes.number.isRequired,
   // Optional

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.js
@@ -112,14 +112,6 @@ class BpkCalendarGrid extends Component {
 
     return (
       <div className={classNames} aria-hidden={!isKeyboardFocusable}>
-        <caption className={getClassName('bpk-calendar-grid__caption')} hidden>
-          {formatMonth(month)}
-        </caption>
-        <BpkCalendarGridHeader
-          isTableHead
-          daysOfWeek={daysOfWeek}
-          weekStartsOn={weekStartsOn}
-        />
         <div>
           {calendarMonthWeeks.map((dates) => (
             <Week

--- a/packages/bpk-component-calendar/src/BpkCalendarGridHeader.js
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridHeader.js
@@ -55,35 +55,28 @@ WeekDay.defaultProps = {
 
 class BpkCalendarGridHeader extends PureComponent {
   render() {
-    const { className, isTableHead, weekDayKey, weekStartsOn } = this.props;
-
-    const Header = isTableHead ? 'thead' : 'header';
-    const List = isTableHead ? 'tr' : 'ol';
-    const Item = isTableHead ? 'th' : 'li';
+    const { className, weekDayKey, weekStartsOn } = this.props;
 
     const daysOfWeek = orderDaysOfWeek(this.props.daysOfWeek, weekStartsOn);
 
     const classNames = [getClassName('bpk-calendar-header')];
-    if (isTableHead) {
-      classNames.push(getClassName('bpk-calendar-header--table-head'));
-    }
     if (className) {
       classNames.push(className);
     }
 
     return (
-      <Header className={classNames.join(' ')} aria-hidden>
-        <List className={getClassName('bpk-calendar-header__week')}>
+      <header className={classNames.join(' ')} aria-hidden>
+        <ol className={getClassName('bpk-calendar-header__week')}>
           {daysOfWeek.map((weekDay) => (
             <WeekDay
-              Element={Item}
+              Element="li"
               key={weekDay.index}
               weekDay={weekDay}
               weekDayKey={weekDayKey}
             />
           ))}
-        </List>
-      </Header>
+        </ol>
+      </header>
     );
   }
 }
@@ -91,13 +84,11 @@ class BpkCalendarGridHeader extends PureComponent {
 BpkCalendarGridHeader.propTypes = {
   daysOfWeek: CustomPropTypes.DaysOfWeek.isRequired,
   weekStartsOn: PropTypes.number.isRequired,
-  isTableHead: PropTypes.bool,
   className: PropTypes.string,
   weekDayKey: CustomPropTypes.WeekDayKey,
 };
 
 BpkCalendarGridHeader.defaultProps = {
-  isTableHead: false,
   className: null,
   weekDayKey: 'nameAbbr',
 };

--- a/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarContainer-test.js.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarContainer-test.js.snap
@@ -178,28 +178,6 @@ exports[`BpkCalendarContainer should focus the correct date when \`initiallyFocu
           aria-hidden="false"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
         >
-          February 2010
-          <span>
-            Mon
-          </span>
-          <span>
-            Tue
-          </span>
-          <span>
-            Wed
-          </span>
-          <span>
-            Thu
-          </span>
-          <span>
-            Fri
-          </span>
-          <span>
-            Sat
-          </span>
-          <span>
-            Sun
-          </span>
           <div>
             <div
               class="bpk-calendar-grid__week"
@@ -1043,28 +1021,6 @@ exports[`BpkCalendarContainer should focus the correct date when \`initiallyFocu
           aria-hidden="true"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
         >
-          March 2010
-          <span>
-            Mon
-          </span>
-          <span>
-            Tue
-          </span>
-          <span>
-            Wed
-          </span>
-          <span>
-            Thu
-          </span>
-          <span>
-            Fri
-          </span>
-          <span>
-            Sat
-          </span>
-          <span>
-            Sun
-          </span>
           <div>
             <div
               class="bpk-calendar-grid__week"
@@ -2101,28 +2057,6 @@ exports[`BpkCalendarContainer should render correctly 1`] = `
           aria-hidden="false"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
         >
-          February 2010
-          <span>
-            Mon
-          </span>
-          <span>
-            Tue
-          </span>
-          <span>
-            Wed
-          </span>
-          <span>
-            Thu
-          </span>
-          <span>
-            Fri
-          </span>
-          <span>
-            Sat
-          </span>
-          <span>
-            Sun
-          </span>
           <div>
             <div
               class="bpk-calendar-grid__week"
@@ -2966,28 +2900,6 @@ exports[`BpkCalendarContainer should render correctly 1`] = `
           aria-hidden="true"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
         >
-          March 2010
-          <span>
-            Mon
-          </span>
-          <span>
-            Tue
-          </span>
-          <span>
-            Wed
-          </span>
-          <span>
-            Thu
-          </span>
-          <span>
-            Fri
-          </span>
-          <span>
-            Sat
-          </span>
-          <span>
-            Sun
-          </span>
           <div>
             <div
               class="bpk-calendar-grid__week"
@@ -4024,28 +3936,6 @@ exports[`BpkCalendarContainer should render correctly in range mode 1`] = `
           aria-hidden="false"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
         >
-          February 2010
-          <span>
-            Mon
-          </span>
-          <span>
-            Tue
-          </span>
-          <span>
-            Wed
-          </span>
-          <span>
-            Thu
-          </span>
-          <span>
-            Fri
-          </span>
-          <span>
-            Sat
-          </span>
-          <span>
-            Sun
-          </span>
           <div>
             <div
               class="bpk-calendar-grid__week"
@@ -4889,28 +4779,6 @@ exports[`BpkCalendarContainer should render correctly in range mode 1`] = `
           aria-hidden="true"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
         >
-          March 2010
-          <span>
-            Mon
-          </span>
-          <span>
-            Tue
-          </span>
-          <span>
-            Wed
-          </span>
-          <span>
-            Thu
-          </span>
-          <span>
-            Fri
-          </span>
-          <span>
-            Sat
-          </span>
-          <span>
-            Sun
-          </span>
           <div>
             <div
               class="bpk-calendar-grid__week"

--- a/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarGrid-test.js.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarGrid-test.js.snap
@@ -6,28 +6,6 @@ exports[`BpkCalendarGrid should render correctly with "weekDayKey" attribute set
     aria-hidden="false"
     class="bpk-calendar-grid"
   >
-    October 2016
-    <span>
-      Sun
-    </span>
-    <span>
-      Mon
-    </span>
-    <span>
-      Tue
-    </span>
-    <span>
-      Wed
-    </span>
-    <span>
-      Thu
-    </span>
-    <span>
-      Fri
-    </span>
-    <span>
-      Sat
-    </span>
     <div>
       <div
         class="bpk-calendar-grid__week"
@@ -862,28 +840,6 @@ exports[`BpkCalendarGrid should render correctly with a "dateModifiers" attribut
     aria-hidden="false"
     class="bpk-calendar-grid"
   >
-    October 2016
-    <span>
-      Mon
-    </span>
-    <span>
-      Tue
-    </span>
-    <span>
-      Wed
-    </span>
-    <span>
-      Thu
-    </span>
-    <span>
-      Fri
-    </span>
-    <span>
-      Sat
-    </span>
-    <span>
-      Sun
-    </span>
     <div>
       <div
         class="bpk-calendar-grid__week"
@@ -1718,28 +1674,6 @@ exports[`BpkCalendarGrid should render correctly with a custom date component 1`
     aria-hidden="false"
     class="bpk-calendar-grid"
   >
-    October 2016
-    <span>
-      Mon
-    </span>
-    <span>
-      Tue
-    </span>
-    <span>
-      Wed
-    </span>
-    <span>
-      Thu
-    </span>
-    <span>
-      Fri
-    </span>
-    <span>
-      Sat
-    </span>
-    <span>
-      Sun
-    </span>
     <div>
       <div
         class="bpk-calendar-grid__week"
@@ -2112,28 +2046,6 @@ exports[`BpkCalendarGrid should render correctly with a different "weekStartsOn"
     aria-hidden="false"
     class="bpk-calendar-grid"
   >
-    October 2016
-    <span>
-      Wed
-    </span>
-    <span>
-      Thu
-    </span>
-    <span>
-      Fri
-    </span>
-    <span>
-      Sat
-    </span>
-    <span>
-      Sun
-    </span>
-    <span>
-      Mon
-    </span>
-    <span>
-      Tue
-    </span>
     <div>
       <div
         class="bpk-calendar-grid__week"

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
@@ -94,28 +94,6 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
                 aria-hidden="false"
                 class="bpk-calendar-grid"
               >
-                February 2010
-                <span>
-                  Mon
-                </span>
-                <span>
-                  Tue
-                </span>
-                <span>
-                  Wed
-                </span>
-                <span>
-                  Thu
-                </span>
-                <span>
-                  Fri
-                </span>
-                <span>
-                  Sat
-                </span>
-                <span>
-                  Sun
-                </span>
                 <div>
                   <div
                     class="bpk-calendar-grid__week"
@@ -697,28 +675,6 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
                 aria-hidden="false"
                 class="bpk-calendar-grid"
               >
-                March 2010
-                <span>
-                  Mon
-                </span>
-                <span>
-                  Tue
-                </span>
-                <span>
-                  Wed
-                </span>
-                <span>
-                  Thu
-                </span>
-                <span>
-                  Fri
-                </span>
-                <span>
-                  Sat
-                </span>
-                <span>
-                  Sun
-                </span>
                 <div>
                   <div
                     class="bpk-calendar-grid__week"
@@ -1450,28 +1406,6 @@ exports[`BpkScrollableCalendar should render ranges correctly 1`] = `
                 aria-hidden="false"
                 class="bpk-calendar-grid"
               >
-                February 2010
-                <span>
-                  Mon
-                </span>
-                <span>
-                  Tue
-                </span>
-                <span>
-                  Wed
-                </span>
-                <span>
-                  Thu
-                </span>
-                <span>
-                  Fri
-                </span>
-                <span>
-                  Sat
-                </span>
-                <span>
-                  Sun
-                </span>
                 <div>
                   <div
                     class="bpk-calendar-grid__week"
@@ -2053,28 +1987,6 @@ exports[`BpkScrollableCalendar should render ranges correctly 1`] = `
                 aria-hidden="false"
                 class="bpk-calendar-grid"
               >
-                March 2010
-                <span>
-                  Mon
-                </span>
-                <span>
-                  Tue
-                </span>
-                <span>
-                  Wed
-                </span>
-                <span>
-                  Thu
-                </span>
-                <span>
-                  Fri
-                </span>
-                <span>
-                  Sat
-                </span>
-                <span>
-                  Sun
-                </span>
                 <div>
                   <div
                     class="bpk-calendar-grid__week"
@@ -2806,28 +2718,6 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
                 aria-hidden="false"
                 class="bpk-calendar-grid"
               >
-                February 2010
-                <span>
-                  Mon
-                </span>
-                <span>
-                  Tue
-                </span>
-                <span>
-                  Wed
-                </span>
-                <span>
-                  Thu
-                </span>
-                <span>
-                  Fri
-                </span>
-                <span>
-                  Sat
-                </span>
-                <span>
-                  Sun
-                </span>
                 <div>
                   <div
                     class="bpk-calendar-grid__week"
@@ -3409,28 +3299,6 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
                 aria-hidden="false"
                 class="bpk-calendar-grid"
               >
-                March 2010
-                <span>
-                  Mon
-                </span>
-                <span>
-                  Tue
-                </span>
-                <span>
-                  Wed
-                </span>
-                <span>
-                  Thu
-                </span>
-                <span>
-                  Fri
-                </span>
-                <span>
-                  Sat
-                </span>
-                <span>
-                  Sun
-                </span>
                 <div>
                   <div
                     class="bpk-calendar-grid__week"
@@ -4162,28 +4030,6 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
                 aria-hidden="false"
                 class="bpk-calendar-grid"
               >
-                February 2010
-                <span>
-                  Mon
-                </span>
-                <span>
-                  Tue
-                </span>
-                <span>
-                  Wed
-                </span>
-                <span>
-                  Thu
-                </span>
-                <span>
-                  Fri
-                </span>
-                <span>
-                  Sat
-                </span>
-                <span>
-                  Sun
-                </span>
                 <div>
                   <div
                     class="bpk-calendar-grid__week"
@@ -4765,28 +4611,6 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
                 aria-hidden="false"
                 class="bpk-calendar-grid"
               >
-                March 2010
-                <span>
-                  Mon
-                </span>
-                <span>
-                  Tue
-                </span>
-                <span>
-                  Wed
-                </span>
-                <span>
-                  Thu
-                </span>
-                <span>
-                  Fri
-                </span>
-                <span>
-                  Sat
-                </span>
-                <span>
-                  Sun
-                </span>
                 <div>
                   <div
                     class="bpk-calendar-grid__week"

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGrid-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGrid-test.js.snap
@@ -14,28 +14,6 @@ exports[`BpkCalendarScrollGrid should render correctly with a "dateModifiers" at
       aria-hidden="false"
       class="bpk-calendar-grid"
     >
-      October 2016
-      <span>
-        Mon
-      </span>
-      <span>
-        Tue
-      </span>
-      <span>
-        Wed
-      </span>
-      <span>
-        Thu
-      </span>
-      <span>
-        Fri
-      </span>
-      <span>
-        Sat
-      </span>
-      <span>
-        Sun
-      </span>
       <div>
         <div
           class="bpk-calendar-grid__week"
@@ -714,28 +692,6 @@ exports[`BpkCalendarScrollGrid should render correctly with a custom date compon
       aria-hidden="false"
       class="bpk-calendar-grid"
     >
-      October 2016
-      <span>
-        Mon
-      </span>
-      <span>
-        Tue
-      </span>
-      <span>
-        Wed
-      </span>
-      <span>
-        Thu
-      </span>
-      <span>
-        Fri
-      </span>
-      <span>
-        Sat
-      </span>
-      <span>
-        Sun
-      </span>
       <div>
         <div
           class="bpk-calendar-grid__week"
@@ -1117,28 +1073,6 @@ exports[`BpkCalendarScrollGrid should render correctly with a different "weekSta
       aria-hidden="false"
       class="bpk-calendar-grid"
     >
-      October 2016
-      <span>
-        Fri
-      </span>
-      <span>
-        Sat
-      </span>
-      <span>
-        Sun
-      </span>
-      <span>
-        Mon
-      </span>
-      <span>
-        Tue
-      </span>
-      <span>
-        Wed
-      </span>
-      <span>
-        Thu
-      </span>
       <div>
         <div
           class="bpk-calendar-grid__week"
@@ -1785,28 +1719,6 @@ exports[`BpkCalendarScrollGrid should render correctly with no optional props se
       aria-hidden="false"
       class="bpk-calendar-grid"
     >
-      October 2016
-      <span>
-        Mon
-      </span>
-      <span>
-        Tue
-      </span>
-      <span>
-        Wed
-      </span>
-      <span>
-        Thu
-      </span>
-      <span>
-        Fri
-      </span>
-      <span>
-        Sat
-      </span>
-      <span>
-        Sun
-      </span>
       <div>
         <div
           class="bpk-calendar-grid__week"

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
@@ -26,28 +26,6 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
               aria-hidden="false"
               class="bpk-calendar-grid"
             >
-              February 2010
-              <span>
-                Mon
-              </span>
-              <span>
-                Tue
-              </span>
-              <span>
-                Wed
-              </span>
-              <span>
-                Thu
-              </span>
-              <span>
-                Fri
-              </span>
-              <span>
-                Sat
-              </span>
-              <span>
-                Sun
-              </span>
               <div>
                 <div
                   class="bpk-calendar-grid__week"
@@ -629,28 +607,6 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
               aria-hidden="false"
               class="bpk-calendar-grid"
             >
-              March 2010
-              <span>
-                Mon
-              </span>
-              <span>
-                Tue
-              </span>
-              <span>
-                Wed
-              </span>
-              <span>
-                Thu
-              </span>
-              <span>
-                Fri
-              </span>
-              <span>
-                Sat
-              </span>
-              <span>
-                Sun
-              </span>
               <div>
                 <div
                   class="bpk-calendar-grid__week"
@@ -1313,28 +1269,6 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
               aria-hidden="false"
               class="bpk-calendar-grid"
             >
-              February 2010
-              <span>
-                Mon
-              </span>
-              <span>
-                Tue
-              </span>
-              <span>
-                Wed
-              </span>
-              <span>
-                Thu
-              </span>
-              <span>
-                Fri
-              </span>
-              <span>
-                Sat
-              </span>
-              <span>
-                Sun
-              </span>
               <div>
                 <div
                   class="bpk-calendar-grid__week"
@@ -1595,28 +1529,6 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
               aria-hidden="false"
               class="bpk-calendar-grid"
             >
-              March 2010
-              <span>
-                Mon
-              </span>
-              <span>
-                Tue
-              </span>
-              <span>
-                Wed
-              </span>
-              <span>
-                Thu
-              </span>
-              <span>
-                Fri
-              </span>
-              <span>
-                Sat
-              </span>
-              <span>
-                Sun
-              </span>
               <div>
                 <div
                   class="bpk-calendar-grid__week"
@@ -1954,28 +1866,6 @@ exports[`BpkCalendarScrollGridList should render correctly with a different "wee
               aria-hidden="false"
               class="bpk-calendar-grid"
             >
-              February 2010
-              <span>
-                Wed
-              </span>
-              <span>
-                Thu
-              </span>
-              <span>
-                Fri
-              </span>
-              <span>
-                Sat
-              </span>
-              <span>
-                Sun
-              </span>
-              <span>
-                Mon
-              </span>
-              <span>
-                Tue
-              </span>
               <div>
                 <div
                   class="bpk-calendar-grid__week"
@@ -2589,28 +2479,6 @@ exports[`BpkCalendarScrollGridList should render correctly with a different "wee
               aria-hidden="false"
               class="bpk-calendar-grid"
             >
-              March 2010
-              <span>
-                Wed
-              </span>
-              <span>
-                Thu
-              </span>
-              <span>
-                Fri
-              </span>
-              <span>
-                Sat
-              </span>
-              <span>
-                Sun
-              </span>
-              <span>
-                Mon
-              </span>
-              <span>
-                Tue
-              </span>
               <div>
                 <div
                   class="bpk-calendar-grid__week"
@@ -3305,28 +3173,6 @@ exports[`BpkCalendarScrollGridList should render correctly with no optional prop
               aria-hidden="false"
               class="bpk-calendar-grid"
             >
-              February 2010
-              <span>
-                Sun
-              </span>
-              <span>
-                Mon
-              </span>
-              <span>
-                Tue
-              </span>
-              <span>
-                Wed
-              </span>
-              <span>
-                Thu
-              </span>
-              <span>
-                Fri
-              </span>
-              <span>
-                Sat
-              </span>
               <div>
                 <div
                   class="bpk-calendar-grid__week"
@@ -3940,28 +3786,6 @@ exports[`BpkCalendarScrollGridList should render correctly with no optional prop
               aria-hidden="false"
               class="bpk-calendar-grid"
             >
-              March 2010
-              <span>
-                Sun
-              </span>
-              <span>
-                Mon
-              </span>
-              <span>
-                Tue
-              </span>
-              <span>
-                Wed
-              </span>
-              <span>
-                Thu
-              </span>
-              <span>
-                Fri
-              </span>
-              <span>
-                Sat
-              </span>
               <div>
                 <div
                   class="bpk-calendar-grid__week"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

While testing the calendar on Percy, we identified legacy components for displaying weekdays and the current month that are causing trouble. The components do not display on the screen and are hidden from screen readers under normal circumstances. However, they contain invalid HTML which confuses Percy, leading to irrational screenshots.

See [here](https://percy.io/4ea9fae5/flights-search-controls/builds/25407558/changed/1416658585?browser=chrome&browser_ids=34&subcategories=unreviewed%2Cchanges_requested&viewLayout=overlay&viewMode=new&width=1280&widths=359%2C1280) for the issue that this PR is going to fix.

We decided to remove these components completely since they do not seem to serve any purpose and they do more harm than good.

I tested the accessibility of the calendar and the behaviour hasn't changed from the original.

https://user-images.githubusercontent.com/65911077/221234561-a3033b34-e52c-44a7-a56b-8c69a545be2e.mov

Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [x] Storybook examples created/updated
