### PR TITLE
Remove onClick wrapper for BpkButton

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Changed:**
+
+`bpk-component-button`: Cleaned up the onClick functionality to remove a wrapper that is no longer necessary

--- a/packages/bpk-component-button/src/BpkButtonBase.js
+++ b/packages/bpk-component-button/src/BpkButtonBase.js
@@ -85,16 +85,6 @@ const BpkButton = (props: Props) => {
     );
   }
 
-  // Due to React bug in Chrome, the onClick event fires even if the button is disabled.
-  // Pull request is being worked on (as of 2016-12-22): https://github.com/facebook/react/pull/8329
-  const onClickWrapper = onClick
-    ? (...args) => {
-        if (!disabled) {
-          onClick(...args);
-        }
-      }
-    : null;
-
   const buttonType = submit ? 'submit' : 'button';
 
   /* eslint-disable react/button-has-type */
@@ -104,7 +94,7 @@ const BpkButton = (props: Props) => {
       type={buttonType}
       disabled={disabled}
       className={classNameFinal}
-      onClick={onClickWrapper}
+      onClick={onClick}
       {...rest}
     >
       {children}


### PR DESCRIPTION
Tested this functionality in Safari, Chrome and FF and the bug doesn't appear.

This issue was raised in 2016 and the issue closed in 2018 due to inactivity.

It's likely this bug was fixed a long time ago so any risk from old browsers still with this bug (if it was a browser bug) is very minimal

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
