### PR TITLE
[KOA-2617]: Update device detection utils to support latest UA string

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+- `bpk-react-utils`
+  - Updated `isDeviceIphone`, `isDeviceIpad` and `isDeviceIOS` to use `window.navigator.userAgent` instead of `window.navigator.platform` to determine the device type. This is because `window.navigator.platform` has implementation between browsers and is not reliable.

--- a/packages/bpk-react-utils/src/deviceDetection-test.js
+++ b/packages/bpk-react-utils/src/deviceDetection-test.js
@@ -35,7 +35,7 @@ describe('isIphone tests', () => {
 
   it('should return true if an iPhone', () => {
     // $FlowIssue[extra-arg] - The extra arg for accessType is valid as per the spec of Jest: https://jestjs.io/docs/jest-object#jestspyonobject-methodname-accesstype
-    const platform = jest.spyOn(window.navigator, 'platform', 'get');
+    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
     platform.mockReturnValue('iPhone');
 
     expect(isDeviceIphone()).toBe(true);
@@ -57,7 +57,7 @@ describe('isIpad tests', () => {
 
   it('should return true if an iPad', () => {
     // $FlowIssue[extra-arg] - The extra arg for accessType is valid as per the spec of Jest: https://jestjs.io/docs/jest-object#jestspyonobject-methodname-accesstype
-    const platform = jest.spyOn(window.navigator, 'platform', 'get');
+    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
     platform.mockReturnValue('iPad');
 
     expect(isDeviceIpad()).toBe(true);
@@ -75,7 +75,7 @@ describe('isIos tests', () => {
 
   it('should return false by default', () => {
     // $FlowIssue[extra-arg] - The extra arg for accessType is valid as per the spec of Jest: https://jestjs.io/docs/jest-object#jestspyonobject-methodname-accesstype
-    const platform = jest.spyOn(window.navigator, 'platform', 'get');
+    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
     platform.mockReturnValue('Mac');
 
     expect(isDeviceIos()).toBe(false);
@@ -83,7 +83,7 @@ describe('isIos tests', () => {
 
   it('should return true if an iPhone', () => {
     // $FlowIssue[extra-arg] - The extra arg for accessType is valid as per the spec of Jest: https://jestjs.io/docs/jest-object#jestspyonobject-methodname-accesstype
-    const platform = jest.spyOn(window.navigator, 'platform', 'get');
+    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
     platform.mockReturnValue('iPhone');
 
     expect(isDeviceIos()).toBe(true);
@@ -91,7 +91,7 @@ describe('isIos tests', () => {
 
   it('should return true if an iPad', () => {
     // $FlowIssue[extra-arg] - The extra arg for accessType is valid as per the spec of Jest: https://jestjs.io/docs/jest-object#jestspyonobject-methodname-accesstype
-    const platform = jest.spyOn(window.navigator, 'platform', 'get');
+    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
     platform.mockReturnValue('iPad');
 
     expect(isDeviceIos()).toBe(true);

--- a/packages/bpk-react-utils/src/deviceDetection.js
+++ b/packages/bpk-react-utils/src/deviceDetection.js
@@ -20,11 +20,11 @@
 
 const isDeviceIphone = () =>
   /iPhone/i.test(
-    typeof window !== 'undefined' ? window.navigator.platform : '',
+    typeof window !== 'undefined' ? window.navigator.userAgent : '',
   );
 
 const isDeviceIpad = () =>
-  /iPad/i.test(typeof window !== 'undefined' ? window.navigator.platform : '');
+  /iPad/i.test(typeof window !== 'undefined' ? window.navigator.userAgent : '');
 
 const isDeviceIos = () => isDeviceIphone() || isDeviceIpad();
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Google has recently deprecated the use of `navigator.platform` for determining a device being used so moving towards the newer favoured `navigator.userAgent`

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
