### PR TITLE
SEARCHEXP-873: Do not set height to 0 on re-size

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,3 +16,6 @@
 
 - `BpkThemeToggle`:
     - Fix theme toggle component to use correct tokens
+
+- `BpkScrollableCalendarGridList`:
+  - Fix issue where calendar grid list was disappearing

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
@@ -16,6 +16,9 @@
  * limitations under the License.
  */
 
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { startOfDay, startOfMonth } from 'date-fns';
 import { VariableSizeList as List } from 'react-window';
 
 import { cssModules } from '../../bpk-react-utils';
@@ -27,10 +30,6 @@ import {
 import STYLES from './BpkScrollableCalendarGridList.module.scss';
 import BpkScrollableCalendarGrid from './BpkScrollableCalendarGrid';
 import { getMonthsArray, getMonthItemHeights } from './utils';
-
-import { startOfDay, startOfMonth } from 'date-fns';
-import { Component } from 'react';
-import PropTypes from 'prop-types';
 
 const getClassName = cssModules(STYLES);
 

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.js
@@ -16,9 +16,6 @@
  * limitations under the License.
  */
 
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { startOfDay, startOfMonth } from 'date-fns';
 import { VariableSizeList as List } from 'react-window';
 
 import { cssModules } from '../../bpk-react-utils';
@@ -30,6 +27,10 @@ import {
 import STYLES from './BpkScrollableCalendarGridList.module.scss';
 import BpkScrollableCalendarGrid from './BpkScrollableCalendarGrid';
 import { getMonthsArray, getMonthItemHeights } from './utils';
+
+import { startOfDay, startOfMonth } from 'date-fns';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 
 const getClassName = cssModules(STYLES);
 
@@ -99,8 +100,10 @@ class BpkScrollableCalendarGridList extends Component {
   setComponentHeight = () => {
     const outerNode = this.outerDiv;
     if (outerNode) {
-      const newHeight = outerNode.clientHeight;
-      this.setState({ outerHeight: newHeight });
+      if (outerNode.clientHeight > 0) {
+        const newHeight = outerNode.clientHeight;
+        this.setState({ outerHeight: newHeight });
+      }
     } else {
       this.setState({ outerHeight: ESTIMATED_MONTH_ITEM_HEIGHT });
     }

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.js.snap
@@ -74,7 +74,7 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
       class="bpk-scrollable-calendar-grid-list"
     >
       <div
-        style="position: relative; height: 0px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+        style="position: relative; height: 350px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
       >
         <div
           style="height: 4506px; width: 100%;"
@@ -1305,6 +1305,636 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
               </div>
             </div>
           </div>
+          <div
+            style="position: absolute; left: 0px; top: 656px; height: 350px; width: 100%;"
+          >
+            <div
+              class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"
+            >
+              <h1
+                class="bpk-text bpk-text--heading-4 bpk-scrollable-calendar-grid__title"
+              >
+                April 2010
+              </h1>
+              <div
+                aria-hidden="false"
+                class="bpk-calendar-grid"
+              >
+                <div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 1st April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          1
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 2nd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          2
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 3rd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          3
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 4th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          4
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 5th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          5
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 6th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          6
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 7th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          7
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 8th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          8
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 9th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          9
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 10th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          10
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 11th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          11
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 12th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          12
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 13th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          13
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 14th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          14
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 15th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          15
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 16th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          16
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 17th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          17
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 18th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          18
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 19th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          19
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 20th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          20
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 21st April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          21
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 22nd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          22
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 23rd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          23
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 24th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          24
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 25th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          25
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 26th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          26
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 27th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          27
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 28th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          28
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 29th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          29
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 30th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          30
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -1386,7 +2016,7 @@ exports[`BpkScrollableCalendar should render ranges correctly 1`] = `
       class="bpk-scrollable-calendar-grid-list"
     >
       <div
-        style="position: relative; height: 0px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+        style="position: relative; height: 350px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
       >
         <div
           style="height: 4506px; width: 100%;"
@@ -2617,6 +3247,636 @@ exports[`BpkScrollableCalendar should render ranges correctly 1`] = `
               </div>
             </div>
           </div>
+          <div
+            style="position: absolute; left: 0px; top: 656px; height: 350px; width: 100%;"
+          >
+            <div
+              class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"
+            >
+              <h1
+                class="bpk-text bpk-text--heading-4 bpk-scrollable-calendar-grid__title"
+              >
+                April 2010
+              </h1>
+              <div
+                aria-hidden="false"
+                class="bpk-calendar-grid"
+              >
+                <div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 1st April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          1
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 2nd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          2
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 3rd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          3
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 4th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          4
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 5th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          5
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 6th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          6
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 7th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          7
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 8th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          8
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 9th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          9
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 10th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          10
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 11th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          11
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 12th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          12
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 13th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          13
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 14th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          14
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 15th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          15
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 16th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          16
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 17th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          17
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 18th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          18
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 19th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          19
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 20th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          20
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 21st April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          21
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 22nd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          22
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 23rd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          23
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 24th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          24
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 25th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          25
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 26th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          26
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 27th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          27
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 28th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          28
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 29th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          29
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 30th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          30
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -2698,7 +3958,7 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
       class="bpk-scrollable-calendar-grid-list"
     >
       <div
-        style="position: relative; height: 0px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+        style="position: relative; height: 350px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
       >
         <div
           style="height: 4506px; width: 100%;"
@@ -3916,6 +5176,636 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
                       aria-hidden="true"
                       class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
                     />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style="position: absolute; left: 0px; top: 656px; height: 350px; width: 100%;"
+          >
+            <div
+              class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"
+            >
+              <h1
+                class="bpk-text bpk-text--heading-4 bpk-scrollable-calendar-grid__title"
+              >
+                April 2010
+              </h1>
+              <div
+                aria-hidden="false"
+                class="bpk-calendar-grid"
+              >
+                <div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 1st April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          1
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 2nd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          2
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 3rd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          3
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 4th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          4
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 5th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          5
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 6th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          6
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 7th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          7
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 8th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          8
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 9th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          9
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 10th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          10
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 11th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          11
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 12th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          12
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 13th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          13
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 14th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          14
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 15th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          15
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 16th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          16
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 17th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          17
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 18th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          18
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 19th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          19
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 20th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          20
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 21st April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          21
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 22nd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          22
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 23rd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          23
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 24th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          24
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 25th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          25
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 26th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          26
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 27th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          27
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 28th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          28
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 29th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          29
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 30th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          30
+                        </span>
+                      </button>
+                    </div>
                     <div
                       aria-hidden="true"
                       class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
@@ -4010,7 +5900,7 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
       class="bpk-scrollable-calendar-grid-list"
     >
       <div
-        style="position: relative; height: 0px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+        style="position: relative; height: 350px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
       >
         <div
           style="height: 4506px; width: 100%;"
@@ -5228,6 +7118,636 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
                       aria-hidden="true"
                       class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
                     />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style="position: absolute; left: 0px; top: 656px; height: 350px; width: 100%;"
+          >
+            <div
+              class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"
+            >
+              <h1
+                class="bpk-text bpk-text--heading-4 bpk-scrollable-calendar-grid__title"
+              >
+                April 2010
+              </h1>
+              <div
+                aria-hidden="false"
+                class="bpk-calendar-grid"
+              >
+                <div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 1st April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          1
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 2nd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          2
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 3rd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          3
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 4th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          4
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 5th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          5
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 6th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          6
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 7th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          7
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 8th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          8
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 9th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          9
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 10th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          10
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 11th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          11
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 12th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          12
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 13th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          13
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 14th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          14
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 15th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          15
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 16th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          16
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 17th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          17
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 18th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          18
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 19th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          19
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 20th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          20
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 21st April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          21
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 22nd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          22
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 23rd April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          23
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 24th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          24
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 25th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          25
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 26th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          26
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 27th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          27
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 28th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          28
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 29th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          29
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 30th April 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          30
+                        </span>
+                      </button>
+                    </div>
                     <div
                       aria-hidden="true"
                       class="bpk-calendar-grid__date bpk-calendar-grid__date--none"

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.js.snap
@@ -6,7 +6,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
     class="bpk-scrollable-calendar-grid-list"
   >
     <div
-      style="position: relative; height: 0px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+      style="position: relative; height: 350px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
     >
       <div
         style="height: 4506px; width: 100%;"
@@ -1237,6 +1237,636 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
             </div>
           </div>
         </div>
+        <div
+          style="position: absolute; left: 0px; top: 656px; height: 350px; width: 100%;"
+        >
+          <div
+            class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"
+          >
+            <h1
+              class="bpk-text bpk-text--heading-4 bpk-scrollable-calendar-grid__title"
+            >
+              April 2010
+            </h1>
+            <div
+              aria-hidden="false"
+              class="bpk-calendar-grid"
+            >
+              <div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  />
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Thursday, 1st April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        1
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Friday, 2nd April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        2
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Saturday, 3rd April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        3
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Sunday, 4th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        4
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Monday, 5th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        5
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Tuesday, 6th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        6
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Wednesday, 7th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        7
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Thursday, 8th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        8
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Friday, 9th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        9
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Saturday, 10th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        10
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Sunday, 11th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        11
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Monday, 12th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        12
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Tuesday, 13th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        13
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Wednesday, 14th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        14
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Thursday, 15th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        15
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Friday, 16th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        16
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Saturday, 17th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        17
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Sunday, 18th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        18
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Monday, 19th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        19
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Tuesday, 20th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        20
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Wednesday, 21st April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        21
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Thursday, 22nd April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        22
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Friday, 23rd April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        23
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Saturday, 24th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        24
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Sunday, 25th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        25
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Monday, 26th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        26
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Tuesday, 27th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        27
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Wednesday, 28th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        28
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Thursday, 29th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        29
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <button
+                      aria-hidden="false"
+                      aria-label="Friday, 30th April 2010"
+                      aria-pressed="false"
+                      class="bpk-calendar-date bpk-calendar-date--modifier-someClass"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        30
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -1249,7 +1879,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
     class="bpk-scrollable-calendar-grid-list"
   >
     <div
-      style="position: relative; height: 0px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+      style="position: relative; height: 350px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
     >
       <div
         style="height: 4506px; width: 100%;"
@@ -1834,6 +2464,326 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
             </div>
           </div>
         </div>
+        <div
+          style="position: absolute; left: 0px; top: 656px; height: 350px; width: 100%;"
+        >
+          <div
+            class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"
+          >
+            <h1
+              class="bpk-text bpk-text--heading-4 bpk-scrollable-calendar-grid__title"
+            >
+              April 2010
+            </h1>
+            <div
+              aria-hidden="false"
+              class="bpk-calendar-grid"
+            >
+              <div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="bpk-calendar-grid__week"
+                >
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="false"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(209, 67, 91); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                  >
+                    <div
+                      style="background-color: rgb(0, 215, 117); width: 50%; height: 50%; border-radius: 5rem; margin: 25%;"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -1846,7 +2796,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a different "wee
     class="bpk-scrollable-calendar-grid-list"
   >
     <div
-      style="position: relative; height: 0px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+      style="position: relative; height: 350px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
     >
       <div
         style="height: 4594px; width: 100%;"
@@ -3153,7 +4103,7 @@ exports[`BpkCalendarScrollGridList should render correctly with no optional prop
     class="bpk-scrollable-calendar-grid-list"
   >
     <div
-      style="position: relative; height: 0px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+      style="position: relative; height: 350px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
     >
       <div
         style="height: 4550px; width: 100%;"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

There is a bug with the BpkScrollableCalendarGridList where if you hide it (ie. `display: none`) and a re-size event is fired, the `setComponentHeight()` fn will be called and the BpkScrollableCalendarGridList will copy the `outerDiv` height of 0. If another re-size event does not occur, when the calendar is no longer hidden (ie. NOT `display: none`) then the calendar will still have a height of 0, making it invisible. 

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
