### PR TITLE
[LOOM-614]: add onDark prop, modify divider logic & behaviour

### DIFF
--- a/examples/bpk-component-accordion/examples.js
+++ b/examples/bpk-component-accordion/examples.js
@@ -23,9 +23,11 @@ import {
   colorPanjin,
   iconSizeSm,
   lineHeightBase,
+  surfaceContrastDay,
 } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 import BpkCheckbox from '../../packages/bpk-component-checkbox';
+import BpkText from '../../packages/bpk-component-text';
 import { withAlignment } from '../../packages/bpk-component-icon';
 import StopsIcon from '../../packages/bpk-component-icon/sm/stops';
 import TimeIcon from '../../packages/bpk-component-icon/sm/time';
@@ -153,6 +155,16 @@ const AirportsContent = () => (
       />
     </CheckboxWrapper>
   </form>
+);
+
+const SeoTextContent = () => (
+  <BpkText>
+    Synth umami, whatever tacos vape retro selvage venmo cred kale chips photo
+    booth neutra mlkshk. Cold-pressed banh mi williamsburg deep v master cleanse
+    woke vinyl slow-carb glossier man braid bitters iceland venmo 8-bit
+    vexillologist. Fashion axe air plant shabby chic bushwick man braid. Vice
+    fam typewriter iPhone selfies tattooed.
+  </BpkText>
 );
 
 const SingleItemExample = () => (
@@ -303,6 +315,67 @@ const WithBoldTitlesExample = () => (
   </SingleItemAccordion>
 );
 
+const WithDarkBackgroundExample = () => (
+  <div style={{ backgroundColor: surfaceContrastDay }}>
+    <SingleItemAccordion onDark>
+      <BpkAccordionItem
+        id="stops"
+        title="Stops"
+        initiallyExpanded
+        textStyle="label-1"
+      >
+        <StopsContent />
+      </BpkAccordionItem>
+      <BpkAccordionItem id="airlines" title="Airlines" textStyle="heading-4">
+        <AirlinesContent />
+      </BpkAccordionItem>
+      <BpkAccordionItem id="airports" title="Airports" textStyle="heading-3">
+        <AirportsContent />
+      </BpkAccordionItem>
+    </SingleItemAccordion>
+  </div>
+);
+
+const WithSeoContentOnDarkExample = () => (
+  <div style={{ backgroundColor: surfaceContrastDay }}>
+    <SingleItemAccordion onDark>
+      <BpkAccordionItem
+        id="travel"
+        title="Join 100 million savvy travellers as you compare flights, hotels and cars from hundreds of providers. Here’s how."
+        textStyle="heading-5"
+      >
+        <SeoTextContent />
+      </BpkAccordionItem>
+      <BpkAccordionItem
+        id="travel-2"
+        title="Our international sites"
+        textStyle="heading-3"
+      >
+        <SeoTextContent />
+      </BpkAccordionItem>
+    </SingleItemAccordion>
+  </div>
+);
+
+const WithSeoContentExample = () => (
+  <SingleItemAccordion>
+    <BpkAccordionItem
+      id="travel"
+      title="Join 100 million savvy travellers as you compare flights, hotels and cars from hundreds of providers. Here’s how."
+      textStyle="heading-5"
+    >
+      <SeoTextContent />
+    </BpkAccordionItem>
+    <BpkAccordionItem
+      id="travel-2"
+      title="Our international sites"
+      textStyle="heading-3"
+    >
+      <SeoTextContent />
+    </BpkAccordionItem>
+  </SingleItemAccordion>
+);
+
 export {
   SingleItemExample,
   SingleItemExampleInitiallyExpandedExample,
@@ -312,4 +385,7 @@ export {
   CustomTitleTextStyleExample,
   WithIconsExample,
   WithBoldTitlesExample,
+  WithDarkBackgroundExample,
+  WithSeoContentExample,
+  WithSeoContentOnDarkExample,
 };

--- a/examples/bpk-component-accordion/stories.js
+++ b/examples/bpk-component-accordion/stories.js
@@ -27,6 +27,9 @@ import {
   CustomTitleTextStyleExample,
   WithIconsExample,
   WithBoldTitlesExample,
+  WithDarkBackgroundExample,
+  WithSeoContentExample,
+  WithSeoContentOnDarkExample,
 } from './examples';
 
 export default {
@@ -50,5 +53,9 @@ export const CustomTitleTextStyle = CustomTitleTextStyleExample;
 export const WithIcons = WithIconsExample;
 
 export const WithBoldTitles = WithBoldTitlesExample;
+
+export const WithDarkBackground = WithDarkBackgroundExample;
+export const WithContent = WithSeoContentExample;
+export const WithSeoContentOnDark = WithSeoContentOnDarkExample;
 
 export const VisualTest = SingleItemExample;

--- a/packages/bpk-component-accordion/README.md
+++ b/packages/bpk-component-accordion/README.md
@@ -84,6 +84,7 @@ const AlignedStopsIcon = withAlignment(StopsIcon, lineHeightBase, iconSizeSm);
 | --------- | -------- | -------- | ------------- |
 | children  | node     | true     | -             |
 | className | string   | false    | null          |
+| onDark    | bool     | false    | false         |
 
 ### BpkAccordionItem
 

--- a/packages/bpk-component-accordion/src/BpkAccordion.js
+++ b/packages/bpk-component-accordion/src/BpkAccordion.js
@@ -36,7 +36,7 @@ const BpkAccordion = (props: Props) => {
 
   const classNames = getClassName(
     'bpk-accordion',
-    props.onDark ? 'bpk-accordion--day' : undefined,
+    props.onDark && 'bpk-accordion--on-dark',
     className,
   );
 

--- a/packages/bpk-component-accordion/src/BpkAccordion.js
+++ b/packages/bpk-component-accordion/src/BpkAccordion.js
@@ -19,7 +19,7 @@
 /* @flow strict */
 
 import PropTypes from 'prop-types';
-import type { Node } from 'react';
+import { createContext, Node } from 'react';
 
 import { cssModules } from '../../bpk-react-utils';
 
@@ -29,26 +29,36 @@ const getClassName = cssModules(STYLES);
 
 type Props = { children: Node, className: ?string };
 
+export const BpkAccordionContext = createContext({ onDark: false });
+
 const BpkAccordion = (props: Props) => {
   const { children, className, ...rest } = props;
 
-  const classNames = getClassName('bpk-accordion', className);
+  const classNames = getClassName(
+    'bpk-accordion',
+    props.onDark ? 'bpk-accordion--day' : undefined,
+    className,
+  );
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
-    <dl className={classNames} {...rest}>
-      {children}
-    </dl>
+    <BpkAccordionContext.Provider value={{ onDark: props.onDark }}>
+      {/* // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md */}
+      <dl className={classNames} {...rest}>
+        {children}
+      </dl>
+    </BpkAccordionContext.Provider>
   );
 };
 
 BpkAccordion.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  onDark: PropTypes.bool,
 };
 
 BpkAccordion.defaultProps = {
   className: null,
+  onDark: false,
 };
 
 export default BpkAccordion;

--- a/packages/bpk-component-accordion/src/BpkAccordion.module.scss
+++ b/packages/bpk-component-accordion/src/BpkAccordion.module.scss
@@ -21,7 +21,7 @@
 .bpk-accordion {
   margin: 0;
 
-  &--day {
+  &--on-dark {
     color: $bpk-text-on-dark-day;
   }
 }

--- a/packages/bpk-component-accordion/src/BpkAccordion.module.scss
+++ b/packages/bpk-component-accordion/src/BpkAccordion.module.scss
@@ -20,4 +20,8 @@
 
 .bpk-accordion {
   margin: 0;
+
+  &--day {
+    color: $bpk-text-on-dark-day;
+  }
 }

--- a/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem-test.js
@@ -22,6 +22,7 @@ import { render } from '@testing-library/react';
 
 import StopsIcon from '../../bpk-component-icon/sm/stops';
 
+import { BpkAccordionContext } from './BpkAccordion';
 import BpkAccordionItem from './BpkAccordionItem';
 
 describe('BpkAccordionItem', () => {
@@ -104,6 +105,18 @@ describe('BpkAccordionItem', () => {
       >
         My accordion content
       </BpkAccordionItem>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with onDark set', () => {
+    const { asFragment } = render(
+      <BpkAccordionContext.Provider value={{ onDark: true }}>
+        <BpkAccordionItem id="my-accordion" title="My accordion item">
+          My accordion content
+        </BpkAccordionItem>
+        ,
+      </BpkAccordionContext.Provider>,
     );
     expect(asFragment()).toMatchSnapshot();
   });

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -19,8 +19,7 @@
 /* @flow strict */
 
 import PropTypes from 'prop-types';
-import type { Node, Element } from 'react';
-import { cloneElement } from 'react';
+import { Node, Element, useContext, cloneElement } from 'react';
 
 import AnimateHeight from '../../bpk-animate-height';
 import { withButtonAlignment } from '../../bpk-component-icon';
@@ -28,6 +27,7 @@ import ChevronDownIcon from '../../bpk-component-icon/sm/chevron-down';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
 
+import { BpkAccordionContext } from './BpkAccordion';
 import STYLES from './BpkAccordionItem.module.scss';
 
 const getClassName = cssModules(STYLES);
@@ -46,7 +46,11 @@ type Props = {
 };
 
 const BpkAccordionItem = (props: Props) => {
+  const { onDark } = useContext(BpkAccordionContext);
   const iconClassNames = [getClassName('bpk-accordion__item-expand-icon')];
+  const titleTextClassNames = [getClassName('bpk-accordion__title-text')];
+  const titleClassNames = [getClassName('bpk-accordion__title')];
+  const contentClassNames = [getClassName('bpk-accordion__content-container')];
   const {
     children,
     expanded,
@@ -65,10 +69,31 @@ const BpkAccordionItem = (props: Props) => {
   // $FlowFixMe[prop-missing] - see above
   delete rest.initiallyExpanded;
 
-  if (expanded) {
+  if (expanded && !onDark) {
     iconClassNames.push(
       getClassName('bpk-accordion__item-expand-icon--flipped'),
     );
+    contentClassNames.push(
+      getClassName('bpk-accordion__content-container--expanded'),
+    );
+  }
+
+  if (expanded && onDark) {
+    iconClassNames.push(getClassName('bpk-accordion__item-expand-icon--day'));
+    contentClassNames.push(
+      getClassName('bpk-accordion__content-container--expanded-day'),
+    );
+    titleTextClassNames.push(getClassName('bpk-accordion__title-text--day'));
+  }
+
+  if (!expanded && onDark) {
+    iconClassNames.push(getClassName('bpk-accordion__item-expand-icon--day'));
+    titleClassNames.push(getClassName('bpk-accordion__title--expanded-day'));
+    titleTextClassNames.push(getClassName('bpk-accordion__title-text--day'));
+  }
+
+  if (!expanded && !onDark) {
+    titleClassNames.push(getClassName('bpk-accordion__title--expanded'));
   }
 
   const contentId = `${id}_content`;
@@ -81,7 +106,7 @@ const BpkAccordionItem = (props: Props) => {
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
     <div id={id} {...rest}>
-      <dt className={getClassName('bpk-accordion__title')}>
+      <dt className={titleClassNames.join(' ')}>
         <button
           type="button"
           aria-expanded={expanded}
@@ -93,7 +118,7 @@ const BpkAccordionItem = (props: Props) => {
             <BpkText
               textStyle={textStyle}
               tagName={tagName}
-              className={getClassName('bpk-accordion__title-text')}
+              className={titleTextClassNames.join(' ')}
             >
               {clonedIcon}
               {title}
@@ -104,10 +129,7 @@ const BpkAccordionItem = (props: Props) => {
           </span>
         </button>
       </dt>
-      <dd
-        id={contentId}
-        className={getClassName('bpk-accordion__content-container')}
-      >
+      <dd id={contentId} className={contentClassNames.join(' ')}>
         <AnimateHeight duration={200} height={expanded ? 'auto' : 0}>
           {children}
         </AnimateHeight>

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -79,6 +79,9 @@ const BpkAccordionItem = (props: Props) => {
   }
 
   if (expanded && onDark) {
+    iconClassNames.push(
+      getClassName('bpk-accordion__item-expand-icon--flipped'),
+    );
     iconClassNames.push(getClassName('bpk-accordion__item-expand-icon--day'));
     contentClassNames.push(
       getClassName('bpk-accordion__content-container--expanded-day'),

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -82,21 +82,31 @@ const BpkAccordionItem = (props: Props) => {
     iconClassNames.push(
       getClassName('bpk-accordion__item-expand-icon--flipped'),
     );
-    iconClassNames.push(getClassName('bpk-accordion__item-expand-icon--day'));
-    contentClassNames.push(
-      getClassName('bpk-accordion__content-container--expanded-day'),
+    iconClassNames.push(
+      getClassName('bpk-accordion__item-expand-icon--on-dark'),
     );
-    titleTextClassNames.push(getClassName('bpk-accordion__title-text--day'));
+    contentClassNames.push(
+      getClassName('bpk-accordion__content-container--expanded-on-dark'),
+    );
+    titleTextClassNames.push(
+      getClassName('bpk-accordion__title-text--on-dark'),
+    );
   }
 
   if (!expanded && onDark) {
-    iconClassNames.push(getClassName('bpk-accordion__item-expand-icon--day'));
-    titleClassNames.push(getClassName('bpk-accordion__title--expanded-day'));
-    titleTextClassNames.push(getClassName('bpk-accordion__title-text--day'));
+    iconClassNames.push(
+      getClassName('bpk-accordion__item-expand-icon--on-dark'),
+    );
+    titleClassNames.push(
+      getClassName('bpk-accordion__title--collapsed-on-dark'),
+    );
+    titleTextClassNames.push(
+      getClassName('bpk-accordion__title-text--on-dark'),
+    );
   }
 
   if (!expanded && !onDark) {
-    titleClassNames.push(getClassName('bpk-accordion__title--expanded'));
+    titleClassNames.push(getClassName('bpk-accordion__title--collapsed'));
   }
 
   const contentId = `${id}_content`;

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
@@ -24,11 +24,11 @@ $bpk-spacing-v2: true;
   &__title {
     height: auto;
 
-    &--expanded {
+    &--collapsed {
       @include bpk-border-bottom-sm($bpk-line-day);
 
-      &-day {
-        @include bpk-border-bottom-sm($bpk-line-on-dark-night);
+      &-on-dark {
+        @include bpk-border-bottom-sm($bpk-line-night);
       }
     }
   }
@@ -59,7 +59,7 @@ $bpk-spacing-v2: true;
     display: inline-block;
     flex-grow: 1;
 
-    &--day {
+    &--on-dark {
       color: $bpk-canvas-day;
     }
   }
@@ -79,7 +79,7 @@ $bpk-spacing-v2: true;
       transform: scaleY(-1);
     }
 
-    &--day {
+    &--on-dark {
       fill: $bpk-canvas-day;
     }
   }
@@ -91,11 +91,11 @@ $bpk-spacing-v2: true;
       padding-bottom: bpk-spacing-base();
 
       @include bpk-border-bottom-sm($bpk-line-day);
+      
+      &-on-dark {
+        padding-bottom: bpk-spacing-base();
 
-      &-day {
-      padding-bottom: bpk-spacing-base();
-
-        @include bpk-border-bottom-sm($bpk-line-on-dark-night);
+        @include bpk-border-bottom-sm($bpk-line-night);
       }
     }
   }

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
@@ -88,12 +88,12 @@ $bpk-spacing-v2: true;
     margin: 0;
 
     &--expanded {
-      padding-bottom: $bpk-spacing-base-v-2;
+      padding-bottom: bpk-spacing-base();
 
       @include bpk-border-bottom-sm($bpk-line-day);
 
       &-day {
-        padding-bottom: $bpk-spacing-base-v-2;
+      padding-bottom: bpk-spacing-base();
 
         @include bpk-border-bottom-sm($bpk-line-on-dark-night);
       }

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
@@ -24,7 +24,13 @@ $bpk-spacing-v2: true;
   &__title {
     height: auto;
 
-    @include bpk-border-bottom-sm($bpk-line-day);
+    &--expanded {
+      @include bpk-border-bottom-sm($bpk-line-day);
+
+      &-day {
+        @include bpk-border-bottom-sm($bpk-line-on-dark-night);
+      }
+    }
   }
 
   &__toggle-button {
@@ -45,13 +51,17 @@ $bpk-spacing-v2: true;
   &__flex-container {
     display: inline-flex;
     width: 100%;
-    margin: (bpk-spacing-md()) 0;
+    margin: (bpk-spacing-base()) 0;
     flex-direction: row;
   }
 
   &__title-text {
     display: inline-block;
     flex-grow: 1;
+
+    &--day {
+      color: $bpk-canvas-day;
+    }
   }
 
   &__icon-wrapper {
@@ -68,9 +78,25 @@ $bpk-spacing-v2: true;
     &--flipped {
       transform: scaleY(-1);
     }
+
+    &--day {
+      fill: $bpk-canvas-day;
+    }
   }
 
   &__content-container {
     margin: 0;
+
+    &--expanded {
+      padding-bottom: $bpk-spacing-base-v-2;
+
+      @include bpk-border-bottom-sm($bpk-line-day);
+
+      &-day {
+        padding-bottom: $bpk-spacing-base-v-2;
+
+        @include bpk-border-bottom-sm($bpk-line-on-dark-night);
+      }
+    }
   }
 }

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -6,7 +6,7 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title"
+      class="bpk-accordion__title bpk-accordion__title--expanded"
     >
       <button
         aria-controls="my-accordion_content"
@@ -69,7 +69,7 @@ exports[`BpkAccordionItem should render correctly 1`] = `
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title"
+      class="bpk-accordion__title bpk-accordion__title--expanded"
     >
       <button
         aria-controls="my-accordion_content"
@@ -133,7 +133,7 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title"
+      class="bpk-accordion__title bpk-accordion__title--expanded"
     >
       <button
         aria-controls="my-accordion_content"
@@ -236,7 +236,7 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
       </button>
     </dt>
     <dd
-      class="bpk-accordion__content-container"
+      class="bpk-accordion__content-container bpk-accordion__content-container--expanded"
       id="my-accordion_content"
     >
       <div
@@ -257,7 +257,7 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title"
+      class="bpk-accordion__title bpk-accordion__title--expanded"
     >
       <button
         aria-controls="my-accordion_content"
@@ -320,7 +320,7 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title"
+      class="bpk-accordion__title bpk-accordion__title--expanded"
     >
       <button
         aria-controls="my-accordion_content"
@@ -383,7 +383,7 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title"
+      class="bpk-accordion__title bpk-accordion__title--expanded"
     >
       <button
         aria-controls="my-accordion_content"
@@ -449,5 +449,69 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
       </div>
     </dd>
   </div>
+</DocumentFragment>
+`;
+
+exports[`BpkAccordionItem should render correctly with onDark set 1`] = `
+<DocumentFragment>
+  <div
+    id="my-accordion"
+  >
+    <dt
+      class="bpk-accordion__title bpk-accordion__title--expanded-day"
+    >
+      <button
+        aria-controls="my-accordion_content"
+        aria-expanded="false"
+        class="bpk-accordion__toggle-button"
+        type="button"
+      >
+        <span
+          class="bpk-accordion__flex-container"
+        >
+          <span
+            class="bpk-text bpk-text--body-default bpk-accordion__title-text bpk-accordion__title-text--day"
+          >
+            My accordion item
+          </span>
+          <span
+            class="bpk-accordion__icon-wrapper"
+          >
+            <span
+              style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
+            >
+              <svg
+                class="bpk-accordion__item-expand-icon bpk-accordion__item-expand-icon--day"
+                height="16"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M19.113 8.095a1.496 1.496 0 010 2.008l-6.397 5.948a1 1 0 01-1.358.003l-6.532-6.01a1.427 1.427 0 01.138-1.949 1.572 1.572 0 011.997-.103l5.078 4.638 4.97-4.535a1.72 1.72 0 012.104 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </span>
+      </button>
+    </dt>
+    <dd
+      class="bpk-accordion__content-container"
+      id="my-accordion_content"
+    >
+      <div
+        style="height: 0px; overflow: hidden; transition: height 200ms ease;"
+      >
+        <div
+          style="display: none;"
+        >
+          My accordion content
+        </div>
+      </div>
+    </dd>
+  </div>
+  ,
 </DocumentFragment>
 `;

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -6,7 +6,7 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title bpk-accordion__title--expanded"
+      class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
         aria-controls="my-accordion_content"
@@ -69,7 +69,7 @@ exports[`BpkAccordionItem should render correctly 1`] = `
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title bpk-accordion__title--expanded"
+      class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
         aria-controls="my-accordion_content"
@@ -133,7 +133,7 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title bpk-accordion__title--expanded"
+      class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
         aria-controls="my-accordion_content"
@@ -257,7 +257,7 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title bpk-accordion__title--expanded"
+      class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
         aria-controls="my-accordion_content"
@@ -320,7 +320,7 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title bpk-accordion__title--expanded"
+      class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
         aria-controls="my-accordion_content"
@@ -383,7 +383,7 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title bpk-accordion__title--expanded"
+      class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
         aria-controls="my-accordion_content"
@@ -458,7 +458,7 @@ exports[`BpkAccordionItem should render correctly with onDark set 1`] = `
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title bpk-accordion__title--expanded-day"
+      class="bpk-accordion__title bpk-accordion__title--collapsed-on-dark"
     >
       <button
         aria-controls="my-accordion_content"
@@ -470,7 +470,7 @@ exports[`BpkAccordionItem should render correctly with onDark set 1`] = `
           class="bpk-accordion__flex-container"
         >
           <span
-            class="bpk-text bpk-text--body-default bpk-accordion__title-text bpk-accordion__title-text--day"
+            class="bpk-text bpk-text--body-default bpk-accordion__title-text bpk-accordion__title-text--on-dark"
           >
             My accordion item
           </span>
@@ -481,7 +481,7 @@ exports[`BpkAccordionItem should render correctly with onDark set 1`] = `
               style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
             >
               <svg
-                class="bpk-accordion__item-expand-icon bpk-accordion__item-expand-icon--day"
+                class="bpk-accordion__item-expand-icon bpk-accordion__item-expand-icon--on-dark"
                 height="16"
                 style="width: 1rem; height: 1rem;"
                 viewBox="0 0 24 24"

--- a/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
@@ -6,7 +6,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title"
+      class="bpk-accordion__title bpk-accordion__title--expanded"
     >
       <button
         aria-controls="my-accordion_content"
@@ -69,7 +69,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title"
+      class="bpk-accordion__title bpk-accordion__title--expanded"
     >
       <button
         aria-controls="my-accordion_content"
@@ -172,7 +172,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
       </button>
     </dt>
     <dd
-      class="bpk-accordion__content-container"
+      class="bpk-accordion__content-container bpk-accordion__content-container--expanded"
       id="my-accordion_content"
     >
       <div

--- a/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
@@ -6,7 +6,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title bpk-accordion__title--expanded"
+      class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
         aria-controls="my-accordion_content"
@@ -69,7 +69,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
     id="my-accordion"
   >
     <dt
-      class="bpk-accordion__title bpk-accordion__title--expanded"
+      class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
         aria-controls="my-accordion_content"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Change description: 
Hi folks 👋 

This is a change to the design of the accordion component to align with the design. I'll be including a screenshot of what has changed below. Namely: 

- Functionality to support the accordion on a dark background
- Divider behaviour change. The divider line between title & content has changed. There will no longer be a divider placed between title and content. This change will make more sense visually 👇  

![Screenshot 2023-03-17 at 16 47 02](https://user-images.githubusercontent.com/89925955/225967430-520c5918-c206-4bdd-b5ae-ec847d8a577f.png)
![Screenshot 2023-03-17 at 16 47 10](https://user-images.githubusercontent.com/89925955/225967436-e86e4a28-fc72-40b2-8c74-57913a1deedd.png)
![Screenshot 2023-03-17 at 16 47 16](https://user-images.githubusercontent.com/89925955/225967437-812f8b50-e8ce-4fda-9dc1-1c1a9a8c8a72.png)



Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Storybook examples created/updated
