### PR TITLE
Checkout code for supernova install and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: Publishing
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
       - uses: actions/setup-node@v3
         with:
           node-version: '16.13.0'


### PR DESCRIPTION
Fridays.....

When I made the adjustment to install the dependencies, I forgot this needs the code checked out so it has a lockfile to install so the project is available.

I naively thought that this would be available from other steps so would be fine but it's not :(  