### PR TITLE
[KOA-5932][Phase 2]: Introduce build caching for visual tests and storybook deploy

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -9,6 +9,7 @@ defaults:
 
 env: 
   CACHE_NAME: node-modules-cache
+  BUILD_CACHE_NAME: build-cache
 
 jobs:
   Build:
@@ -69,8 +70,15 @@ jobs:
             packages/node_modules/
           key: ${{ env.CACHE_NAME }}-${{ hashFiles('**/package-lock.json') }}
 
-      - name: Build Storybook
-        run: npm run build && npm run storybook:dist
+      - name: Restore Cache
+        uses: actions/cache/restore@v3.2.6
+        id: storybook-dist-cache
+        with:
+          path: dist-storybook/
+          key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/**') }}
+
+      - name: Build Backpack
+        run: npm run build
 
       - name: Run visual tests
         id: visualTests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ defaults:
 
 env: 
   CACHE_NAME: node-modules-cache
+  BUILD_CACHE_NAME: build-cache
 
 jobs:
   Create-NPM-Cache:
@@ -38,16 +39,8 @@ jobs:
       - name: Install dependencies
         if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: npm ci
-
-  Build:
-    name: Build
-    needs: [Create-NPM-Cache]
-    permissions:
-      statuses: write
-      pull-requests: write
-    uses: ./.github/workflows/_build.yml
-
-  StorybookDeploy:
+  
+  Create-Build-Cache:
     runs-on: ubuntu-latest
     needs: [Create-NPM-Cache]
     steps:
@@ -57,8 +50,8 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
-      
-      - name: Restore Cache
+
+      - name: Restore NPM Cache
         uses: actions/cache/restore@v3.2.6
         id: npm-cache
         with:
@@ -66,11 +59,54 @@ jobs:
             node_modules/
             packages/node_modules/
           key: ${{ env.CACHE_NAME }}-${{ hashFiles('**/package-lock.json') }}
+      
+      - name: Upload dist-storybook to Cache
+        uses: actions/cache@v3.2.6
+        id: storybook-dist-cache
+        with:
+          path: |
+            dist-storybook/
+          key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/**') }}
 
-      - name: Build Backpack for Storybook
+      - name: Create build cache
+        if: ${{ steps.storybook-dist-cache.outputs.cache-hit != 'true' }}
         run: |
           npm run build
           npm run storybook:dist
+
+  Build:
+    permissions:
+      statuses: write
+      pull-requests: write
+    needs: [Create-NPM-Cache, Create-Build-Cache]
+    uses: ./.github/workflows/_build.yml
+
+  StorybookDeploy:
+    runs-on: ubuntu-latest
+    needs: [Create-NPM-Cache, Create-Build-Cache]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Restore npm Cache
+        uses: actions/cache/restore@v3.2.6
+        id: npm-cache
+        with:
+          path: |
+            node_modules/
+            packages/node_modules/
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('**/package-lock.json') }}
+      
+      - name: Restore Cache
+        uses: actions/cache/restore@v3.2.6
+        id: storybook-dist-cache
+        with:
+          path: dist-storybook/
+          key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/**') }}
       
       - name: Deploy Storybook for main
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,7 @@ defaults:
 
 env: 
   CACHE_NAME: node-modules-cache
+  BUILD_CACHE_NAME: build-cache
 
 jobs:
   Create-NPM-Cache:
@@ -39,17 +40,51 @@ jobs:
         if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: npm ci
 
+  Create-Build-Cache:
+    runs-on: ubuntu-latest
+    needs: [Create-NPM-Cache]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Restore NPM Cache
+        uses: actions/cache/restore@v3.2.6
+        id: npm-cache
+        with:
+          path: |
+            node_modules/
+            packages/node_modules/
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('**/package-lock.json') }}
+      
+      - name: Upload dist-storybook to Cache
+        uses: actions/cache@v3.2.6
+        id: storybook-dist-cache
+        with:
+          path: |
+            dist-storybook/
+          key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/**') }}
+
+      - name: Create build cache
+        if: ${{ steps.storybook-dist-cache.outputs.cache-hit != 'true' }}
+        run: |
+          npm run build
+          npm run storybook:dist
+
   Build:
     permissions:
       statuses: write
       pull-requests: write
-    needs: [Create-NPM-Cache]
+    needs: [Create-NPM-Cache, Create-Build-Cache]
     uses: ./.github/workflows/_build.yml
 
 
   StorybookDeploy:
     runs-on: ubuntu-latest
-    needs: [Create-NPM-Cache]
+    needs: [Create-NPM-Cache, Create-Build-Cache]
     steps:
     - uses: actions/checkout@v3
 
@@ -58,7 +93,7 @@ jobs:
         node-version-file: ".nvmrc"
         registry-url: 'https://registry.npmjs.org'
 
-    - name: Restore Cache
+    - name: Restore npm Cache
       uses: actions/cache/restore@v3.2.6
       id: npm-cache
       with:
@@ -67,10 +102,12 @@ jobs:
           packages/node_modules/
         key: ${{ env.CACHE_NAME }}-${{ hashFiles('**/package-lock.json') }}
 
-    - name: Build Backpack for Storybook deploy
-      run: |
-        npm run build
-        npm run storybook:dist
+    - name: Restore Cache
+      uses: actions/cache/restore@v3.2.6
+      id: storybook-dist-cache
+      with:
+        path: dist-storybook/
+        key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/**') }}
 
     - name: Prepare to deploy Storybook (pull request build)
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ defaults:
 
 env: 
   CACHE_NAME: node-modules-cache
+  BUILD_CACHE_NAME: build-cache
 
 jobs:
   Create-NPM-Cache:
@@ -35,12 +36,39 @@ jobs:
         if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: npm ci
 
-  Build:
-    name: Build
+  Create-Build-Cache:
+    runs-on: ubuntu-latest
     needs: [Create-NPM-Cache]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Restore NPM Cache
+        uses: actions/cache/restore@v3.2.6
+        id: npm-cache
+        with:
+          path: |
+            node_modules/
+            packages/node_modules/
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('**/package-lock.json') }}
+      
+      - name: Upload dist-storybook to Cache
+        uses: actions/cache@v3.2.6
+        id: storybook-dist-cache
+        with:
+          path: |
+            dist-storybook/
+          key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/**') }}
+
+  Build:
     permissions:
       statuses: write
       pull-requests: write
+    needs: [Create-NPM-Cache, Create-Build-Cache]
     uses: ./.github/workflows/_build.yml
 
   ReleaseWeb:


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Phase 2 in build improvements for our CI. This PR aims to improve the workflow by creating a cache for storybook builds to then be used as part of our visual tests and also our storybook deployments as this same build is shared by both steps.

This can lead to a reduction of about ~10mins of overall CI time down from ~15mins