### PR TITLE
LOOM-631: Add forwardRef to BpkLink

### DIFF
--- a/packages/bpk-component-link/README.md
+++ b/packages/bpk-component-link/README.md
@@ -39,6 +39,7 @@ If you're using a SPA framework like `react-router-dom` or `Next.js` to navigate
 | blank     | bool     | false    | false         |
 | rel       | string   | false    | null          |
 | alternate | bool     | false    | false         |
+| ref       | any      | false    | null          |
 
 ### BpkButtonLink
 

--- a/packages/bpk-component-link/src/BpkLink-test.js
+++ b/packages/bpk-component-link/src/BpkLink-test.js
@@ -19,13 +19,27 @@
 /* @flow strict */
 
 import { render } from '@testing-library/react';
+import { createRef } from 'react';
 
 import BpkLink, { themeAttributes } from './BpkLink';
 
 describe('BpkLink', () => {
   it('should render correctly with a "href" attribute', () => {
     const { asFragment } = render(<BpkLink href="#">Link</BpkLink>);
+
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render with a ref forwarded', () => {
+    const myRef = createRef();
+
+    render(
+      <BpkLink ref={myRef} href="#">
+        Link
+      </BpkLink>,
+    );
+
+    expect(myRef.current).not.toBeNull();
   });
 
   it('should render correctly with a "className" attribute', () => {

--- a/packages/bpk-component-link/src/BpkLink.js
+++ b/packages/bpk-component-link/src/BpkLink.js
@@ -17,9 +17,9 @@
  */
 
 /* @flow strict */
-
 import PropTypes from 'prop-types';
 import type { Node } from 'react';
+import { forwardRef } from 'react';
 
 import { cssModules } from '../../bpk-react-utils';
 
@@ -40,7 +40,7 @@ type Props = {
   alternate: boolean,
 };
 
-const BpkLink = (props: Props) => {
+const BpkLink = forwardRef((props: Props, ref) => {
   const {
     alternate,
     blank,
@@ -72,12 +72,13 @@ const BpkLink = (props: Props) => {
       onClick={onClick}
       target={target}
       rel={rel}
+      ref={ref}
       {...rest}
     >
       {children}
     </a>
   );
-};
+});
 
 BpkLink.propTypes = {
   children: PropTypes.oneOfType([


### PR DESCRIPTION
Wrapping the component allows us to pass through a ref prop to a `<BpkLink>` component and have the ref attach to the `<a>` tag.

This allows us to expose the DOM node to the parent and is useful - for example, to allow focusing it.

Using `forwardRef` instead of creating a custom prop like `innerRef` as it gives us a predictable API instead of something custom which might change depending on the component.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
