### PR TITLE
Fix BpkDialog type

### DIFF
--- a/packages/bpk-component-dialog/src/common-types.ts
+++ b/packages/bpk-component-dialog/src/common-types.ts
@@ -28,8 +28,8 @@ export type DialogInnerProps = {
   ariaLabel: string;
   id: string;
   children: ReactNode;
-  dialogRef: (ref: HTMLElement) => void;
-  getApplicationElement: () => HTMLElement;
+  dialogRef?: (ref: HTMLElement) => void;
+  getApplicationElement: () => HTMLElement | null;
   className?: string;
   contentClassName?: string;
   flare?: boolean;


### PR DESCRIPTION
### getApplicationElement

`getApplicationElement` is designed per the README to be used with `getElementById`.

`getElementById` returns null if the element can't be found

![image](https://github.com/Skyscanner/backpack/assets/1532576/c57b63c1-1258-41c7-9d2f-15baa5db7795)


### dialogRef

`dialogRef` is an internal prop that isn't part of the public API, but is listed as required.

![image](https://github.com/Skyscanner/backpack/assets/1532576/73b5e297-46ea-4696-b5d0-c4687f36e99f)

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
