### PR TITLE
Fix BpkPrice className warning

### DIFF
--- a/packages/bpk-component-price/src/BpkPrice.js
+++ b/packages/bpk-component-price/src/BpkPrice.js
@@ -97,7 +97,7 @@ const BpkPrice = (props: Props) => {
         )}
       </div>
       <div
-        className={isAlignRight && getClassName('bpk-price__column-container')}
+        className={getClassName(isAlignRight && 'bpk-price__column-container')}
       >
         <BpkText
           textStyle={isSmall ? TEXT_STYLES.heading4 : TEXT_STYLES.xxl}

--- a/packages/bpk-component-price/src/__snapshots__/BpkPrice-test.js.snap
+++ b/packages/bpk-component-price/src/__snapshots__/BpkPrice-test.js.snap
@@ -8,7 +8,9 @@ exports[`large left view should render correctly 1`] = `
     <div
       class=""
     />
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--xxl bpk-price__price bpk-price__spacing"
       >
@@ -27,7 +29,9 @@ exports[`large left view should support custom class names 1`] = `
     <div
       class=""
     />
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--xxl bpk-price__price bpk-price__spacing"
       >
@@ -52,7 +56,9 @@ exports[`large left view should support leading text attribute 1`] = `
         from
       </span>
     </div>
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--xxl bpk-price__price bpk-price__spacing"
       >
@@ -77,7 +83,9 @@ exports[`large left view should support previous price attribute 1`] = `
         £2,000
       </span>
     </div>
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--xxl bpk-price__price bpk-price__spacing"
       >
@@ -117,7 +125,9 @@ exports[`large left view should support previous price with leading text attribu
         from
       </span>
     </div>
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--xxl bpk-price__price bpk-price__spacing"
       >
@@ -141,7 +151,9 @@ exports[`large left view should support trailing text attribute 1`] = `
     <div
       class=""
     />
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--xxl bpk-price__price bpk-price__spacing"
       >
@@ -165,7 +177,9 @@ exports[`small left view should render correctly 1`] = `
     <div
       class=""
     />
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--heading-4 bpk-price__price bpk-price__spacing"
       >
@@ -184,7 +198,9 @@ exports[`small left view should support custom class names 1`] = `
     <div
       class=""
     />
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--heading-4 bpk-price__price bpk-price__spacing"
       >
@@ -209,7 +225,9 @@ exports[`small left view should support leading text attribute 1`] = `
         from
       </span>
     </div>
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--heading-4 bpk-price__price bpk-price__spacing"
       >
@@ -234,7 +252,9 @@ exports[`small left view should support previous price attribute 1`] = `
         £2,000
       </span>
     </div>
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--heading-4 bpk-price__price bpk-price__spacing"
       >
@@ -274,7 +294,9 @@ exports[`small left view should support previous price with leading text attribu
         from
       </span>
     </div>
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--heading-4 bpk-price__price bpk-price__spacing"
       >
@@ -298,7 +320,9 @@ exports[`small left view should support trailing text attribute 1`] = `
     <div
       class=""
     />
-    <div>
+    <div
+      class=""
+    >
       <span
         class="bpk-text bpk-text--heading-4 bpk-price__price bpk-price__spacing"
       >


### PR DESCRIPTION
When isAlignRight is false, the classname is false, and thus react throws a warning. Verified this fixes it in storybook locally

![image](https://github.com/Skyscanner/backpack/assets/1532576/98af16cd-3817-4606-998c-5a3113efe9f5)


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
