### PR TITLE
[NO JIRA]: Add missing build cache creation for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,12 @@ jobs:
           path: |
             dist-storybook/
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/**') }}
+      
+      - name: Create build cache
+        if: ${{ steps.storybook-dist-cache.outputs.cache-hit != 'true' }}
+        run: |
+          npm run build
+          npm run storybook:dist
 
   Build:
     permissions:


### PR DESCRIPTION
When originally creating caching and the process for building the storybook distribution, we relied on for the releases to reuse a previous created storybook build that was created when changes got merged to main.

This meant it relied heavily on a cache being present when releasing and if say that cache was removed it would never create a new one as the step wasn't present as it relied on main.

So this change adds that functionality back that in the instance we manually deleted the main cache or it gets autoremoved by github (which should be very rare), it will now create it and upload it.