### PR TITLE
[NO JIRA] Update import path BpkButtonV2 in migrating docs

### DIFF
--- a/packages/bpk-component-button/docs/migrating-from-v1-to-v2.md
+++ b/packages/bpk-component-button/docs/migrating-from-v1-to-v2.md
@@ -8,7 +8,7 @@ Version 2 of `bpk-component-button` removes the individual boolean properties to
 
 When selecting the type of button to use the type is now defined through the `type` property and selecting the type from `BUTTON_TYPES` object to specify the available buttons.
 
-Object contains the following:  `primary`, `primaryOnDark`, `primaryOnLight`, `secondary`, `secondaryOnDark`, `destructive`, `featured`, `link`, `linkOnDark`
+Object contains the following: `primary`, `primaryOnDark`, `primaryOnLight`, `secondary`, `secondaryOnDark`, `destructive`, `featured`, `link`, `linkOnDark`
 
 ### Original:
 
@@ -42,7 +42,7 @@ class Toggle extends React.Component {
 
 When wishing to render a large button the `large` property has been removed to be replaced with `size` and passing in a `SIZE_TYPES` to set the desired large size
 
-Object contains the following:  `small` (component default value) and `large`
+Object contains the following: `small` (component default value) and `large`
 
 ### Original:
 
@@ -61,7 +61,7 @@ class SearchButton extends React.Component {
 ### Replacement:
 
 ```
-import BpkButtonV2, { SIZE_TYPES } from 'bpk-component-button';
+import { BpkButtonV2, SIZE_TYPES } from 'bpk-component-button';
 
 class Toggle extends React.Component {
   render() {

--- a/packages/bpk-component-button/index.js
+++ b/packages/bpk-component-button/index.js
@@ -30,6 +30,8 @@ import BpkButtonLink from './src/BpkButtonLink';
 import BpkButtonLinkOnDark from './src/BpkButtonLinkOnDark';
 import BpkButtonFeatured from './src/BpkButtonFeatured';
 
+export { BUTTON_TYPES, SIZE_TYPES } from './src/BpkButtonV2/common-types';
+
 export {
   buttonThemeAttributes,
   primaryThemeAttributes,


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
It seems the import path for `BpkButtonV2` not correct, therefore update import path `BpkButtonV2` in migrating docs.

### Change discription
- Update import path for `BpkButtonV2` in migrating docs
- export `BUTTON_TYPES` and `SIZE_TYPES` in `packages/bpk-component-button/index.js`


Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
