### PR TITLE
[LOOM-796]: Fix scroll behaviour for _non_ iOS devices

### DIFF
--- a/packages/bpk-scrim-utils/src/withScrim-test.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim-test.tsx
@@ -52,6 +52,9 @@ jest.mock('./scroll-utils', () => ({
   unfixBody: jest.fn(),
 }));
 
+beforeEach(() => {
+  jest.resetAllMocks();
+});
 describe('BpkScrim', () => {
   describe('render', () => {
     let TestComponent: ComponentType<any> | string;

--- a/packages/bpk-scrim-utils/src/withScrim-test.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim-test.tsx
@@ -156,6 +156,8 @@ describe('BpkScrim', () => {
       );
       expect(lockScroll).toHaveBeenCalled();
       expect(focusStore.storeFocus).toHaveBeenCalled();
+      expect(storeScroll).not.toHaveBeenCalled();
+      expect(fixBody).not.toHaveBeenCalled();
       expect(mockSetAttribute).toHaveBeenCalledWith('aria-hidden', 'true');
     });
   });
@@ -210,6 +212,8 @@ describe('BpkScrim', () => {
       unmount();
 
       expect(unlockScroll).toHaveBeenCalled();
+      expect(restoreScroll).not.toHaveBeenCalled();
+      expect(unfixBody).not.toHaveBeenCalled();
       expect(focusStore.storeFocus).toHaveBeenCalled();
       expect(focusScope.unscopeFocus).toHaveBeenCalled();
       expect(mockRemoveAttribute).toHaveBeenCalledWith('aria-hidden');

--- a/packages/bpk-scrim-utils/src/withScrim.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim.tsx
@@ -90,9 +90,9 @@ const withScrim = <P extends object>(
        */
       if (isIphone || isIpad) {
         storeScroll();
-        lockScroll();
         fixBody();
       }
+      lockScroll();
 
       if (applicationElement) {
         applicationElement.setAttribute('aria-hidden', 'true');
@@ -109,9 +109,10 @@ const withScrim = <P extends object>(
 
       if (isIphone || isIpad) {
         setTimeout(restoreScroll, 0);
-        unlockScroll();
         unfixBody();
       }
+
+      unlockScroll();
 
       if (applicationElement) {
         applicationElement.removeAttribute('aria-hidden');

--- a/packages/bpk-scrim-utils/src/withScrim.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim.tsx
@@ -92,6 +92,13 @@ const withScrim = <P extends object>(
         storeScroll();
         fixBody();
       }
+      /**
+       * lockScroll and the associated unlockScroll is how we control the scroll behaviour of the application when the scrim is active.
+       * The desired behaviour is to prevent the user from scrolling content behind the scrim. The above iOS fixes are in place because lockScroll alone does not solve due to iOS specific issues.
+       *
+       * The lockScroll function is still called for iOS devices as it solves some scrolling issues. Without this applied for example, iPads have the ability to scroll the content behind the scrim once.
+       */
+
       lockScroll();
 
       if (applicationElement) {
@@ -111,7 +118,6 @@ const withScrim = <P extends object>(
         setTimeout(restoreScroll, 0);
         unfixBody();
       }
-
       unlockScroll();
 
       if (applicationElement) {

--- a/packages/bpk-scrim-utils/src/withScrim.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim.tsx
@@ -95,8 +95,6 @@ const withScrim = <P extends object>(
       /**
        * lockScroll and the associated unlockScroll is how we control the scroll behaviour of the application when the scrim is active.
        * The desired behaviour is to prevent the user from scrolling content behind the scrim. The above iOS fixes are in place because lockScroll alone does not solve due to iOS specific issues.
-       *
-       * The lockScroll function is still called for iOS devices as it solves some scrolling issues. Without this applied for example, iPads have the ability to scroll the content behind the scrim once.
        */
 
       lockScroll();


### PR DESCRIPTION
Related to [this change](https://github.com/Skyscanner/backpack/pull/2892). The linked change is bugged in that it removes the `lockScroll` functionality from non iOS devices/browsers. This is an error and this PR fixes this. 

1. Why wasn't this regression caught in tests? 

The tests unfortunetly didn't catch this regression as the mocks used within the unit tests were not being reset correctly. This resulted in a test that was providing false expectations. This has also been addressed within this PR. 

2. Why wasn't this caught in the manual testing done previously in the above PR?

Again unfortunetly only iPhone devices/simulators were tested, the bug only appears on _non_ iOS devices as it was believed that this is the only area of code that was being impacted. 😮‍💨 This changes has been tested against iPHone, iPad and chrome to ensure that all cases are covered, which you will find below.


https://github.com/Skyscanner/backpack/assets/89925955/28b89f09-b6c0-44ca-9c00-b8cf2cc0cd47


https://github.com/Skyscanner/backpack/assets/89925955/030e869f-b0d4-4453-b091-23e5396ef84d


## iPad util bug discovery

This bug has been detailed and recorded within: https://skyscanner.atlassian.net/browse/KOA-6198

We have identified an issue with the `isIpad` helper function. This utility does not correctly identify `iPads` from iOS version 13 and above. This means that without a bug fix to this function the iPad specfic fixes will continue to not be applied to modern versions of iPads. 

What is the impact of the iPad util bug? 

This means that iPads on iOS >=13 will be able to scroll on content behind all scrims on Skyscanner, the modal must not be "open by default" (see examples below to understand what I mean). That sounds bad, untill you realise that there are _very_ few instances of a non-dismissable modal that is not open by default. In fact, when researching this I couldn't find an example. 

In addition to the impact to `withScrim` users any other components that rely on this behaviour will not function correctly.

https://github.com/Skyscanner/backpack/assets/89925955/14f3adb2-0dab-4d6a-8eda-9136d294b0c2

In the above demo notice how the scroll bug is not present when the modal is initially open, however, when I close and re-open the bug appears. 

Some famous modals: 

- Cookie banner -> shown by default & so not impacted
- Culture selector -> dismissable & so not impacted
- Login -> dismissable & so not impacted

Regardless, we believe that this should be rectified by Koala but the prio is low. 


- [x] Tests
