### PR TITLE
Change imports for breakpoints into bpk-component-breakpoint

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import TOKENS from '@skyscanner/bpk-foundations-web/tokens/base.common';
+import { spacingBase } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 import { addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 
@@ -34,7 +34,7 @@ const EnhancedThemeProvider = updateOnThemeChange(BpkThemeProvider);
 
 addDecorator(withA11y);
 addDecorator((story) => (
-  <div style={{ padding: TOKENS.spacingBase }}>
+  <div style={{ padding: spacingBase }}>
     <EnhancedThemeProvider themeAttributes={themeableAttributes}>
       {story()}
     </EnhancedThemeProvider>

--- a/packages/bpk-component-breakpoint/src/BpkBreakpoint.tsx
+++ b/packages/bpk-component-breakpoint/src/BpkBreakpoint.tsx
@@ -19,19 +19,19 @@
 import type { ReactNode } from 'react';
 import MediaQuery from 'react-responsive';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import TOKENS from '@skyscanner/bpk-foundations-web/tokens/base.common';
+import { breakpoints } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 const BREAKPOINTS = {
-  SMALL_MOBILE: TOKENS.breakpointQuerySmallMobile,
-  MOBILE: TOKENS.breakpointQueryMobile,
-  SMALL_TABLET: TOKENS.breakpointQuerySmallTablet,
-  SMALL_TABLET_ONLY: TOKENS.breakpointQuerySmallTabletOnly,
-  TABLET: TOKENS.breakpointQueryTablet,
-  TABLET_ONLY: TOKENS.breakpointQueryTabletOnly,
-  ABOVE_MOBILE: TOKENS.breakpointQueryAboveMobile,
-  ABOVE_TABLET: TOKENS.breakpointQueryAboveTablet,
-  ABOVE_DESKTOP: TOKENS.breakpointQueryAboveDesktop,
-  DESKTOP_ONLY: TOKENS.breakpointQueryDesktopOnly,
+  SMALL_MOBILE: breakpoints.breakpointQuerySmallMobile,
+  MOBILE: breakpoints.breakpointQueryMobile,
+  SMALL_TABLET: breakpoints.breakpointQuerySmallTablet,
+  SMALL_TABLET_ONLY: breakpoints.breakpointQuerySmallTabletOnly,
+  TABLET: breakpoints.breakpointQueryTablet,
+  TABLET_ONLY: breakpoints.breakpointQueryTabletOnly,
+  ABOVE_MOBILE: breakpoints.breakpointQueryAboveMobile,
+  ABOVE_TABLET: breakpoints.breakpointQueryAboveTablet,
+  ABOVE_DESKTOP: breakpoints.breakpointQueryAboveDesktop,
+  DESKTOP_ONLY: breakpoints.breakpointQueryDesktopOnly,
 } as const;
 
 type Props = {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

During investigations into transpiled bundlesizes it was found that the `BpkBreakpoint` component when importing tokens for use in the component was importing a full suite of Backpack tokens into the component to only then use a subset of breakpoints.

With this change we switch to importing from the `base.es6` tokens file and only import the breakpoint object into the component, so that when we ship this it means it should be lighter and only importing the tokens it requires instead of the whole suite.

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here