### PR TITLE
Fix bpkButton ts imports

### DIFF
--- a/packages/bpk-component-button/src/BpkButtonBase.js
+++ b/packages/bpk-component-button/src/BpkButtonBase.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { Props, propTypes, defaultProps } from './common-types';
+import { type Props, propTypes, defaultProps } from './common-types';
 import COMMON_STYLES from './BpkButtonBase.module.scss';
 
 // This was originally depended upon from the bpk-react-utils package, however

--- a/packages/bpk-component-button/src/BpkButtonDestructive.js
+++ b/packages/bpk-component-button/src/BpkButtonDestructive.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { Props, defaultProps, propTypes } from './common-types';
+import { type Props, defaultProps, propTypes } from './common-types';
 import BpkButtonBase, { cssModules } from './BpkButtonBase';
 import STYLES from './BpkButtonDestructive.module.scss';
 

--- a/packages/bpk-component-button/src/BpkButtonFeatured.js
+++ b/packages/bpk-component-button/src/BpkButtonFeatured.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { Props, defaultProps, propTypes } from './common-types';
+import { type Props, defaultProps, propTypes } from './common-types';
 import BpkButtonBase, { cssModules } from './BpkButtonBase';
 import STYLES from './BpkButtonFeatured.module.scss';
 

--- a/packages/bpk-component-button/src/BpkButtonLink.js
+++ b/packages/bpk-component-button/src/BpkButtonLink.js
@@ -18,7 +18,11 @@
 
 /* @flow strict */
 
-import { Props as CommonProps, defaultProps, propTypes } from './common-types';
+import {
+  type Props as CommonProps,
+  defaultProps,
+  propTypes,
+} from './common-types';
 import BpkButtonBase, { cssModules } from './BpkButtonBase';
 import STYLES from './BpkButtonLink.module.scss';
 

--- a/packages/bpk-component-button/src/BpkButtonLinkOnDark.js
+++ b/packages/bpk-component-button/src/BpkButtonLinkOnDark.js
@@ -18,7 +18,11 @@
 
 /* @flow strict */
 
-import { Props as CommonProps, defaultProps, propTypes } from './common-types';
+import {
+  type Props as CommonProps,
+  defaultProps,
+  propTypes,
+} from './common-types';
 import BpkButtonBase, { cssModules } from './BpkButtonBase';
 import STYLES from './BpkButtonLinkOnDark.module.scss';
 

--- a/packages/bpk-component-button/src/BpkButtonPrimary.js
+++ b/packages/bpk-component-button/src/BpkButtonPrimary.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { Props, defaultProps, propTypes } from './common-types';
+import { type Props, defaultProps, propTypes } from './common-types';
 import BpkButtonBase from './BpkButtonBase';
 
 // TODO: BpkButtonBase has the primary button style as it wasn't removed to

--- a/packages/bpk-component-button/src/BpkButtonPrimaryOnDark.js
+++ b/packages/bpk-component-button/src/BpkButtonPrimaryOnDark.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { Props, defaultProps, propTypes } from './common-types';
+import { type Props, defaultProps, propTypes } from './common-types';
 import BpkButtonBase, { cssModules } from './BpkButtonBase';
 import STYLES from './BpkButtonPrimaryOnDark.module.scss';
 

--- a/packages/bpk-component-button/src/BpkButtonPrimaryOnLight.js
+++ b/packages/bpk-component-button/src/BpkButtonPrimaryOnLight.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { Props, defaultProps, propTypes } from './common-types';
+import { type Props, defaultProps, propTypes } from './common-types';
 import BpkButtonBase, { cssModules } from './BpkButtonBase';
 import STYLES from './BpkButtonPrimaryOnLight.module.scss';
 

--- a/packages/bpk-component-button/src/BpkButtonSecondary.js
+++ b/packages/bpk-component-button/src/BpkButtonSecondary.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { Props, defaultProps, propTypes } from './common-types';
+import { type Props, defaultProps, propTypes } from './common-types';
 import BpkButtonBase, { cssModules } from './BpkButtonBase';
 import STYLES from './BpkButtonSecondary.module.scss';
 

--- a/packages/bpk-component-button/src/BpkButtonSecondaryOnDark.js
+++ b/packages/bpk-component-button/src/BpkButtonSecondaryOnDark.js
@@ -18,7 +18,7 @@
 
 /* @flow strict */
 
-import { Props, defaultProps, propTypes } from './common-types';
+import { type Props, defaultProps, propTypes } from './common-types';
 import BpkButtonBase, { cssModules } from './BpkButtonBase';
 import STYLES from './BpkButtonSecondaryOnDark.module.scss';
 


### PR DESCRIPTION
Importing ts types should be done with the type keyword. When the code is transpiled, these imports are stripped out.

If we don't add the keyword, the import of Props sticks around, and if consumers evaluate the code at all, it will fail as the module has no export named Props as it's already been stripped out.

Spotted in Remix as part of the CSS bundling. (_no idea why_)

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here