### PR TITLE
Correct README.md instructions

### DIFF
--- a/packages/bpk-stylesheets/README.md
+++ b/packages/bpk-stylesheets/README.md
@@ -11,13 +11,13 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 Within your Javascript (usually the entrypoint or top-most JS file)
 
 ```js
-import 'bpk-stylesheets';
+import '@skyscanner/backpack-web/bpk-stylesheets';
 ```
 
 By default font rendering is not included if you need to include Skyscanner Relative in your styles, import it using the following:
 
 ```js
-import 'bpk-stylesheets/font';
+import '@skyscanner/backpack-web/bpk-stylesheets/font';
 ```
 
 ## Contributing

--- a/packages/bpk-stylesheets/README.md
+++ b/packages/bpk-stylesheets/README.md
@@ -8,14 +8,16 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 
 ## Usage
 
-```scss
-@import '~@skyscanner/backpack-web/bpk-stylesheets';
+Within your Javascript (usually the entrypoint or top-most JS file)
+
+```js
+import 'bpk-stylesheets';
 ```
 
 By default font rendering is not included if you need to include Skyscanner Relative in your styles, import it using the following:
 
-```scss
-@import '~@skyscanner/backpack-web/bpk-stylesheets/font';
+```js
+import 'bpk-stylesheets/font';
 ```
 
 ## Contributing


### PR DESCRIPTION
This PR corrects the usage instructions for `bpk-stylesheets` as it's main recommended/best use is to import via JS but the docs were confusing and pointing at CSS