### PR TITLE
[no-jira]: Add missing dependency for the calendar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-svg-loader": "^3.0.1",
-        "react-virtualized-auto-sizer": "^1.0.20",
         "sass-loader": "^10.4.1",
         "sassdoc": "^2.7.0",
         "storybook": "^7.1.1",
@@ -30259,16 +30258,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
-      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
-      "dev": true,
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-svg-loader": "^3.0.1",
-    "react-virtualized-auto-sizer": "^1.0.20",
     "sass-loader": "^10.4.1",
     "sassdoc": "^2.7.0",
     "storybook": "^7.1.1",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -30,6 +30,7 @@
         "react-slider": "^1.3.1",
         "react-table": "^7.8.0",
         "react-transition-group": "^2.5.3",
+        "react-virtualized-auto-sizer": "^1.0.20",
         "react-window": "^1.8.7"
       },
       "peerDependencies": {
@@ -2167,6 +2168,15 @@
       "peerDependencies": {
         "react": ">=15.0.0",
         "react-dom": ">=15.0.0"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
+      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
       }
     },
     "node_modules/react-window": {

--- a/packages/package.json
+++ b/packages/package.json
@@ -43,6 +43,7 @@
     "react-slider": "^1.3.1",
     "react-table": "^7.8.0",
     "react-transition-group": "^2.5.3",
+    "react-virtualized-auto-sizer": "^1.0.20",
     "react-window": "^1.8.7"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Fixes the location of the `react-virtualized-auto-sizer` dependency that was added in #2976 - it was added in this PR but only at the root so when shipping the single package was not included when required by the Scrollable calendar.

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here