### PR TITLE
[NO JIRA]: Add export of ButtonV2 types

### DIFF
--- a/packages/bpk-component-button/index.d.ts
+++ b/packages/bpk-component-button/index.d.ts
@@ -1,0 +1,24 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BpkButtonV2 from './src/BpkButtonV2/BpkButton';
+export { BUTTON_TYPES, SIZE_TYPES } from './src/BpkButtonV2/common-types';
+
+export {
+  BpkButtonV2,
+};

--- a/packages/bpk-component-button/src/BpkButtonV2/common-types.d.ts
+++ b/packages/bpk-component-button/src/BpkButtonV2/common-types.d.ts
@@ -42,7 +42,7 @@ export type Props = {
   className?: string | null;
   disabled?: boolean;
   iconOnly?: boolean;
-  onClick?: (event: MouseEvent) => void;
+  onClick?: (event: MouseEvent<any>) => void;
   rel?: string | undefined;
   submit?: boolean;
   href?: string | null;

--- a/packages/bpk-component-button/src/BpkButtonV2/common-types.tsx
+++ b/packages/bpk-component-button/src/BpkButtonV2/common-types.tsx
@@ -45,7 +45,7 @@ export type Props = {
   className?: string | null;
   disabled?: boolean;
   iconOnly?: boolean;
-  onClick?: (event: MouseEvent) => void;
+  onClick?: (event: MouseEvent<any>) => void; // TODO: We need to check this and make this more specific
   rel?: string | undefined;
   submit?: boolean;
   href?: string | null;

--- a/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.tsx
+++ b/packages/bpk-component-graphic-promotion/src/BpkGraphicPromo.tsx
@@ -20,8 +20,7 @@ import type { KeyboardEvent, MouseEvent } from 'react';
 
 import { cssModules } from '../../bpk-react-utils';
 import BpkText from '../../bpk-component-text';
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import BpkButton from '../../bpk-component-button';
+import {BpkButtonV2, BUTTON_TYPES} from '../../bpk-component-button';
 
 import STYLES from './BpkGraphicPromo.module.scss';
 
@@ -184,14 +183,14 @@ const BpkGraphicPromo = ({
               {subheading}
             </BpkText>
           )}
-          <BpkButton
-            primaryOnDark
+          <BpkButtonV2
+            type={BUTTON_TYPES.primaryOnDark}
             className={getClassName('bpk-graphic-promo__cta')}
             onClick={onClickWrapper}
             tabIndex={-1} /* button is not focusable for accessibility */
           >
             {buttonText}
-          </BpkButton>
+          </BpkButtonV2>
         </div>
       </div>
     </div>

--- a/packages/bpk-component-nudger/src/BpkConfigurableNudger.tsx
+++ b/packages/bpk-component-nudger/src/BpkConfigurableNudger.tsx
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import { BpkButtonV2, BUTTON_TYPES } from '../../bpk-component-button';
 import { withButtonAlignment } from '../../bpk-component-icon';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.

--- a/packages/bpk-component-nudger/src/common-types.d.ts
+++ b/packages/bpk-component-nudger/src/common-types.d.ts
@@ -17,6 +17,7 @@
  */
 
 import type { ReactNode } from "react";
+import type { BUTTON_TYPES } from "../../bpk-component-button/src/BpkButtonV2/common-types";
 export type CommonProps = {
     id: string;
     min: string | number;
@@ -26,7 +27,7 @@ export type CommonProps = {
     className?: string | null;
     increaseButtonLabel: string;
     decreaseButtonLabel: string;
-    buttonType?: string;
+    buttonType?: keyof typeof BUTTON_TYPES;
     title?: string;
     subtitle?: string;
     icon?: ReactNode;

--- a/packages/bpk-component-nudger/src/common-types.ts
+++ b/packages/bpk-component-nudger/src/common-types.ts
@@ -18,6 +18,8 @@
 
 import type { ReactNode } from "react";
 
+import type { BUTTON_TYPES } from "../../bpk-component-button/src/BpkButtonV2/common-types";
+
 export type CommonProps = {
   id: string;
   min: string | number;
@@ -27,7 +29,7 @@ export type CommonProps = {
   className?: string | null;
   increaseButtonLabel: string;
   decreaseButtonLabel: string;
-  buttonType?: string;
+  buttonType?: keyof typeof BUTTON_TYPES;
   title?: string;
   subtitle?: string;
   icon? : ReactNode;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Allows for the export of the ButtonV2 types to be used in TS projects as these weren't available due to the way the whole component is implemented during the transition between Button V1 and Button V2.

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here