### PR TITLE
[KOA-6230] Datatable uses rem values

### DIFF
--- a/examples/bpk-component-datatable/examples.js
+++ b/examples/bpk-component-datatable/examples.js
@@ -97,96 +97,96 @@ const CellRenderer = ({ cellData, rowData }) => {
 };
 
 const AutowidthExample = () => (
-  <BpkDataTable rows={rows} height={400} onRowClick={onRowClick}>
-    <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+  <BpkDataTable rows={rows} height="25rem" onRowClick={onRowClick}>
+    <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
     <BpkDataTableColumn
       label="Description"
       dataKey="description"
-      width={100}
+      width="6.25rem"
       flexGrow={1}
     />
-    <BpkDataTableColumn label="Location" dataKey="location" width={100} />
+    <BpkDataTableColumn label="Location" dataKey="location" width="6.25rem" />
     <BpkDataTableColumn
       label="Numeric value"
       dataKey="numericValue"
-      width={100}
+      width="6.25rem"
     />
   </BpkDataTable>
 );
 
 const NonHoverRowsExample = () => (
-  <BpkDataTable rows={rows} height={300}>
-    <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+  <BpkDataTable rows={rows} height="18.75rem">
+    <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
     <BpkDataTableColumn
       label="Description"
       dataKey="description"
-      width={100}
+      width="6.25rem"
       flexGrow={1}
     />
-    <BpkDataTableColumn label="Location" dataKey="location" width={100} />
+    <BpkDataTableColumn label="Location" dataKey="location" width="6.25rem" />
   </BpkDataTable>
 );
 
 const FixedWidthExample = () => (
-  <BpkDataTable rows={rows} height={300} width={400} onRowClick={onRowClick}>
-    <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+  <BpkDataTable rows={rows} height="18.75rem" width="25rem" onRowClick={onRowClick}>
+    <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
     <BpkDataTableColumn
       label="Description"
       dataKey="description"
-      width={100}
+      width="6.25rem"
       flexGrow={1}
     />
-    <BpkDataTableColumn label="Location" dataKey="location" width={100} />
+    <BpkDataTableColumn label="Location" dataKey="location" width="6.25rem" />
   </BpkDataTable>
 );
 
 const DisabledSortExample = () => (
-  <BpkDataTable rows={rows} height={300} onRowClick={onRowClick}>
-    <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+  <BpkDataTable rows={rows} height="18.75rem" onRowClick={onRowClick}>
+    <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
     <BpkDataTableColumn
       label="Description (Disabled Sorting)"
       dataKey="description"
-      width={100}
+      width="6.25rem"
       flexGrow={1}
       disableSort
     />
-    <BpkDataTableColumn label="Location" dataKey="location" width={100} />
+    <BpkDataTableColumn label="Location" dataKey="location" width="6.25rem" />
   </BpkDataTable>
 );
 
 const CustomRowAndHeaderHeightsExample = () => (
   <BpkDataTable
     rows={rows}
-    height={300}
-    headerHeight={80}
-    rowHeight={30}
+    height="18.75rem"
+    headerHeight="5rem"
+    rowHeight="1.875rem"
     onRowClick={onRowClick}
   >
-    <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+    <BpkDataTableColumn label="Name" dataKey="name" width={300} />
     <BpkDataTableColumn
       label="Description"
       dataKey="description"
-      width={100}
+      width="6.25rem"
       flexGrow={1}
     />
-    <BpkDataTableColumn label="Location" dataKey="location" width={100} />
+    <BpkDataTableColumn label="Location" dataKey="location" width="6.25rem" />
   </BpkDataTable>
 );
 
 const HeaderRendererExample = () => (
-  <BpkDataTable rows={rows} height={400} onRowClick={onRowClick}>
-    <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+  <BpkDataTable rows={rows} height="25rem" onRowClick={onRowClick}>
+    <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
     <BpkDataTableColumn
       label="Description"
       dataKey="description"
-      width={100}
+      width="6.25rem"
       flexGrow={1}
     />
-    <BpkDataTableColumn label="Location" dataKey="location" width={100} />
+    <BpkDataTableColumn label="Location" dataKey="location" width="6.25rem" />
     <BpkDataTableColumn
       label="Numeric value"
       dataKey="numericValue"
-      width={100}
+      width="6.25rem"
       headerRenderer={LabelComponent}
     />
   </BpkDataTable>
@@ -195,23 +195,23 @@ const HeaderRendererExample = () => (
 const CustomSortingExample = () => (
   <BpkDataTable
     rows={complexRows}
-    height={400}
+    height="25rem"
     onRowClick={onRowClick}
     sort={sortFunc}
     sortBy="seat"
     sortDirection="DESC"
   >
-    <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+    <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
     <BpkDataTableColumn
       label="Description"
       dataKey="description"
-      width={100}
+      width="6.25rem"
       flexGrow={1}
     />
     <BpkDataTableColumn
       label="Seat"
       dataKey="seat"
-      width={100}
+      width="6.25rem"
       cellRenderer={CellRenderer}
     />
   </BpkDataTable>

--- a/examples/bpk-component-datatable/examples.js
+++ b/examples/bpk-component-datatable/examples.js
@@ -162,7 +162,7 @@ const CustomRowAndHeaderHeightsExample = () => (
     rowHeight="1.875rem"
     onRowClick={onRowClick}
   >
-    <BpkDataTableColumn label="Name" dataKey="name" width={300} />
+    <BpkDataTableColumn label="Name" dataKey="name" width="18.75rem" />
     <BpkDataTableColumn
       label="Description"
       dataKey="description"

--- a/packages/bpk-component-datatable/README.md
+++ b/packages/bpk-component-datatable/README.md
@@ -115,9 +115,9 @@ export default () => (
 | children               | arrayOf(BpkDataTableColumn) | true     | -                    |
 | height                 | oneOfType(number, string)   | true     | -                    |
 | width                  | oneOfType(number, string)   | false    | full width of parent |
-| headerHeight           | oneOfType(number, string)   | false    | 60                   |
+| headerHeight           | oneOfType(number, string)   | false    | '3.75rem'            |
 | rowClassName           | string                      | false    | null                 |
-| rowHeight              | oneOfType(number, string)   | false    | 60                   |
+| rowHeight              | oneOfType(number, string)   | false    | '3.75rem'            |
 | rowStyle               | object                      | false    | {}                   |
 | onRowClick             | func                        | false    | null                 |
 | className              | string                      | false    | null                 |
@@ -132,7 +132,8 @@ export default () => (
 | Property               | PropType                    | Required | Default Value        |
 | ---------------------- | --------------------------- | -------- | -------------------- |
 | dataKey                | string                      | true     | -                    |
-| width                  | number                      | true     | -                    |
+| width                  | oneOfType(number, string)   | true     | -                    |
+| minWidth               | oneOfType(number, string)   | false    | undefined            |
 | flexGrow               | number                      | false    | 0                    |
 | label                  | string                      | false    | null                 |
 | headerRenderer         | func                        | false    | null                 |
@@ -146,6 +147,9 @@ export default () => (
 
 ### Prop Details
 
+#### width (BpkDataTable), height, headerHeight, rowHeight, width (BpkDataTableColumn), minWidth
+
+Please provide values for these props in `rem` to ensure data table is scalable.
 
 #### sort, sortBy, sortDirection
 

--- a/packages/bpk-component-datatable/src/BpkDataTable-test.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable-test.js
@@ -30,7 +30,20 @@ const rows = [
 ];
 
 describe('BpkDataTable', () => {
-  it('should render correctly with multiple columns', () => {
+  let warningSpy;
+  let oldWarning = null;
+
+  beforeEach(() => {
+    warningSpy = jest.fn();
+    oldWarning = window.console.warn;
+    window.console.warn = warningSpy;
+  });
+
+  afterEach(() => {
+    window.console.warn = oldWarning;
+  });
+
+  it('should render correctly with px height', () => {
     const { asFragment } = render(
       <BpkDataTable rows={rows} height={200}>
         <BpkDataTableColumn label="Name" dataKey="name" width={100} />
@@ -44,19 +57,36 @@ describe('BpkDataTable', () => {
       </BpkDataTable>,
     );
     expect(asFragment()).toMatchSnapshot();
+    expect(warningSpy.mock.calls.length).toBe(4);
+  });
+
+  it('should render correctly with multiple columns', () => {
+    const { asFragment } = render(
+      <BpkDataTable rows={rows} height="12.5rem">
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
+        <BpkDataTableColumn
+          label="Description"
+          dataKey="description"
+          width="6.25rem"
+          flexGrow={1}
+        />
+        <BpkDataTableColumn label="Bla" dataKey="bla" width="6.25rem" />
+      </BpkDataTable>,
+    );
+    expect(asFragment()).toMatchSnapshot();
   });
 
   it('should render correctly when "onRowClick" is set', () => {
     const { asFragment } = render(
-      <BpkDataTable rows={rows} height={200} onRowClick={() => {}}>
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+      <BpkDataTable rows={rows} height="12.5rem" onRowClick={() => {}}>
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
           flexGrow={1}
         />
-        <BpkDataTableColumn label="Bla" dataKey="bla" width={100} />
+        <BpkDataTableColumn label="Bla" dataKey="bla" width="6.25rem" />
       </BpkDataTable>,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -64,15 +94,15 @@ describe('BpkDataTable', () => {
 
   it('should render correctly with no data; only headers', () => {
     const { asFragment } = render(
-      <BpkDataTable rows={[]} height={200}>
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+      <BpkDataTable rows={[]} height="12.5rem">
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
           flexGrow={1}
         />
-        <BpkDataTableColumn label="Bla" dataKey="bla" width={100} />
+        <BpkDataTableColumn label="Bla" dataKey="bla" width="6.25rem" />
       </BpkDataTable>,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -80,15 +110,15 @@ describe('BpkDataTable', () => {
 
   it('should render correctly with a specified width', () => {
     const { asFragment } = render(
-      <BpkDataTable rows={rows} height={200} width={400}>
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+      <BpkDataTable rows={rows} height="12.5rem" width="25rem">
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
           flexGrow={1}
         />
-        <BpkDataTableColumn label="Bla" dataKey="bla" width={100} />
+        <BpkDataTableColumn label="Bla" dataKey="bla" width="6.25rem" />
       </BpkDataTable>,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -98,17 +128,17 @@ describe('BpkDataTable', () => {
     const { asFragment } = render(
       <BpkDataTable
         rows={rows}
-        height={200}
+        height="12.5rem"
         rowClassName="custom-data-table__row"
       >
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
           flexGrow={1}
         />
-        <BpkDataTableColumn label="Bla" dataKey="bla" width={100} />
+        <BpkDataTableColumn label="Bla" dataKey="bla" width="6.25rem" />
       </BpkDataTable>,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -118,21 +148,21 @@ describe('BpkDataTable', () => {
     const { asFragment } = render(
       <BpkDataTable
         rows={rows}
-        height={200}
+        height="12.5rem"
         rowClassName={({ index }) =>
           index % 2 === 0
             ? 'custom-data-table__row_even'
             : 'custom-data-table__row_odd'
         }
       >
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
           flexGrow={1}
         />
-        <BpkDataTableColumn label="Bla" dataKey="bla" width={100} />
+        <BpkDataTableColumn label="Bla" dataKey="bla" width="6.25rem" />
       </BpkDataTable>,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -142,32 +172,32 @@ describe('BpkDataTable', () => {
     const { asFragment } = render(
       <BpkDataTable
         rows={rows}
-        height={200}
+        height="12.5rem"
         headerClassName="custom-data-table__header"
       >
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
           flexGrow={1}
         />
-        <BpkDataTableColumn label="Bla" dataKey="bla" width={100} />
+        <BpkDataTableColumn label="Bla" dataKey="bla" width="6.25rem" />
       </BpkDataTable>,
     );
     expect(asFragment()).toMatchSnapshot();
   });
   it('should render correctly with a custom className', () => {
     const { asFragment } = render(
-      <BpkDataTable rows={rows} height={200} className="custom-data-table">
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+      <BpkDataTable rows={rows} height="12.5rem" className="custom-data-table">
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
           flexGrow={1}
         />
-        <BpkDataTableColumn label="Bla" dataKey="bla" width={100} />
+        <BpkDataTableColumn label="Bla" dataKey="bla" width="6.25rem" />
       </BpkDataTable>,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -175,12 +205,12 @@ describe('BpkDataTable', () => {
 
   it('should sort rows if header is clicked', async () => {
     render(
-      <BpkDataTable rows={rows} height={200} width={400}>
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+      <BpkDataTable rows={rows} height="12.5rem" width="25rem">
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
         />
       </BpkDataTable>,
     );
@@ -210,12 +240,12 @@ describe('BpkDataTable', () => {
     render(
       <BpkDataTable
         rows={abcRows}
-        height={200}
-        width={400}
+        height="12.5rem"
+        width="25rem"
         defaultColumnSortIndex={1}
       >
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
-        <BpkDataTableColumn label="Letter" dataKey="letter" width={100} />
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
+        <BpkDataTableColumn label="Letter" dataKey="letter" width="6.25rem" />
       </BpkDataTable>,
     );
 
@@ -245,12 +275,12 @@ describe('BpkDataTable', () => {
     render(
       <BpkDataTable
         rows={abcRows}
-        height={200}
-        width={400}
+        height="12.5rem"
+        width="25rem"
         defaultColumnSortIndex={1}
       >
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
-        <BpkDataTableColumn label="Letter" dataKey="letter" width={100} />
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
+        <BpkDataTableColumn label="Letter" dataKey="letter" width="6.25rem" />
       </BpkDataTable>,
     );
 
@@ -272,17 +302,17 @@ describe('BpkDataTable', () => {
 
   it('should not sort rows if header with disableSort is clicked', async () => {
     render(
-      <BpkDataTable rows={rows} height={200} width={400}>
+      <BpkDataTable rows={rows} height="12.5rem" width="25rem">
         <BpkDataTableColumn
           label="Name"
           dataKey="name"
-          width={100}
+          width="6.25rem"
           disableSort
         />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
         />
       </BpkDataTable>,
     );
@@ -334,8 +364,8 @@ describe('BpkDataTable', () => {
     const getBpkDataTable = (rowsData, sortBy, sortDirection) => (
       <BpkDataTable
         rows={rowsData}
-        height={200}
-        width={400}
+        height="12.5rem"
+        width="25rem"
         sort={sortFunction}
         sortBy={sortBy}
         sortDirection={sortDirection}
@@ -343,18 +373,18 @@ describe('BpkDataTable', () => {
         <BpkDataTableColumn
           label="Name"
           dataKey="name"
-          width={100}
+          width="6.25rem"
           disableSort
         />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
         />
         <BpkDataTableColumn
           label="Seat"
           dataKey="seat"
-          width={100}
+          width="6.25rem"
           flexGrow={1}
           cellRenderer={({ cellData }) => (
             <Fragment>
@@ -393,15 +423,15 @@ describe('BpkDataTable', () => {
     render(
       <BpkDataTable
         rows={rows}
-        height={200}
-        width={400}
+        height="12.5rem"
+        width="25rem"
         onRowClick={onRowClick}
       >
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
         />
       </BpkDataTable>,
     );
@@ -425,12 +455,12 @@ describe('BpkDataTable', () => {
     render(
       <BpkDataTable
         rows={abcRows}
-        height={200}
-        width={400}
+        height="12.5rem"
+        width="25rem"
         onRowClick={onRowClick}
       >
-        <BpkDataTableColumn label="Letter" dataKey="letter" width={100} />
-        <BpkDataTableColumn label="Number" dataKey="number" width={100} />
+        <BpkDataTableColumn label="Letter" dataKey="letter" width="6.25rem" />
+        <BpkDataTableColumn label="Number" dataKey="number" width="6.25rem" />
       </BpkDataTable>,
     );
 
@@ -444,12 +474,12 @@ describe('BpkDataTable', () => {
 
   it('should re-render when rows prop is updated', () => {
     const { rerender } = render(
-      <BpkDataTable rows={rows} height={200} width={400}>
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+      <BpkDataTable rows={rows} height="12.5rem" width="25rem">
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
         />
       </BpkDataTable>,
     );
@@ -458,12 +488,12 @@ describe('BpkDataTable', () => {
     ).toHaveLength(2);
 
     rerender(
-      <BpkDataTable rows={[]} height={200} width={400}>
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+      <BpkDataTable rows={[]} height="12.5rem" width="25rem">
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
         />
       </BpkDataTable>,
     );
@@ -472,12 +502,12 @@ describe('BpkDataTable', () => {
     ).toHaveLength(0);
 
     rerender(
-      <BpkDataTable rows={[rows[0]]} height={200} width={400}>
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+      <BpkDataTable rows={[rows[0]]} height="12.5rem" width="25rem">
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
         />
       </BpkDataTable>,
     );
@@ -495,15 +525,15 @@ describe('BpkDataTable', () => {
     render(
       <BpkDataTable
         rows={abcRows}
-        height={200}
-        width={400}
+        height="12.5rem"
+        width="25rem"
         defaultColumnSortIndex={1}
       >
-        <BpkDataTableColumn label="Letter" dataKey="letter" width={100} />
+        <BpkDataTableColumn label="Letter" dataKey="letter" width="6.25rem" />
         <BpkDataTableColumn
           label="Number"
           dataKey="number"
-          width={100}
+          width="6.25rem"
           defaultSortDirection={SORT_DIRECTION_TYPES.DESC}
         />
       </BpkDataTable>,

--- a/packages/bpk-component-datatable/src/BpkDataTable.js
+++ b/packages/bpk-component-datatable/src/BpkDataTable.js
@@ -28,7 +28,7 @@ import STYLES from './BpkDataTable.module.scss';
 import type { Props } from './common-types';
 import { SORT_DIRECTION_TYPES } from './sort-types';
 import BpkDataTableHeader from './BpkDataTableHeader';
-import { getColumns } from './utils';
+import { pxToRem, getColumns } from './utils';
 
 const getClassName = cssModules(STYLES);
 
@@ -139,7 +139,7 @@ const BpkDataTable = (props: Props) => {
   return (
     <div
       {...getTableProps({
-        style: { width, height },
+        style: { width: pxToRem(width), height: pxToRem(height) },
         className: classNames,
       })}
       {...restOfProps}
@@ -148,7 +148,7 @@ const BpkDataTable = (props: Props) => {
         {headerGroups.map((headerGroup) => (
           <div
             {...headerGroup.getHeaderGroupProps({
-              style: { height: headerHeight },
+              style: { height: pxToRem(headerHeight) },
               className: headerClassNames,
             })}
           >
@@ -177,7 +177,7 @@ const BpkDataTable = (props: Props) => {
               {...row.getRowProps({
                 style: {
                   ...rowStyle,
-                  height: rowHeight,
+                  height: pxToRem(rowHeight),
                 },
                 className: getRowClassNames(rowClassName, i),
               })}
@@ -225,8 +225,8 @@ BpkDataTable.propTypes = {
 
 BpkDataTable.defaultProps = {
   width: null,
-  headerHeight: 60,
-  rowHeight: 60,
+  headerHeight: '3.75rem',
+  rowHeight: '3.75rem',
   className: null,
   defaultColumnSortIndex: 0,
   sort: null,

--- a/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
+++ b/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.js.snap
@@ -5,19 +5,19 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
   <div
     class="bpk-data-table"
     role="table"
-    style="height: 200px;"
+    style="height: 12.5rem;"
   >
     <div>
       <div
         class="bpk-data-table__row bpk-data-table__header-row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
       >
         <div
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Name"
@@ -59,7 +59,7 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           <span
             aria-label="Description"
@@ -101,7 +101,7 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Bla"
@@ -147,27 +147,27 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
       <div
         class="bpk-data-table__row bpk-data-table__row--clickable"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Jose
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Software Engineer
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -175,27 +175,27 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
       <div
         class="bpk-data-table__row bpk-data-table__row--clickable"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Rolf
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Some guy
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -210,19 +210,19 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
   <div
     class="bpk-data-table custom-data-table"
     role="table"
-    style="height: 200px;"
+    style="height: 12.5rem;"
   >
     <div>
       <div
         class="bpk-data-table__row bpk-data-table__header-row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
       >
         <div
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Name"
@@ -264,7 +264,7 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           <span
             aria-label="Description"
@@ -306,7 +306,7 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Bla"
@@ -352,27 +352,27 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
       <div
         class="bpk-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Jose
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Software Engineer
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -380,27 +380,27 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
       <div
         class="bpk-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Rolf
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Some guy
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -415,19 +415,19 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
   <div
     class="bpk-data-table"
     role="table"
-    style="height: 200px;"
+    style="height: 12.5rem;"
   >
     <div>
       <div
         class="bpk-data-table__row bpk-data-table__header-row custom-data-table__header"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
       >
         <div
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Name"
@@ -469,7 +469,7 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           <span
             aria-label="Description"
@@ -511,7 +511,7 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Bla"
@@ -557,27 +557,27 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
       <div
         class="bpk-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Jose
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Software Engineer
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -585,27 +585,27 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
       <div
         class="bpk-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Rolf
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Some guy
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -620,19 +620,19 @@ exports[`BpkDataTable should render correctly with a custom rowClassName functio
   <div
     class="bpk-data-table"
     role="table"
-    style="height: 200px;"
+    style="height: 12.5rem;"
   >
     <div>
       <div
         class="bpk-data-table__row bpk-data-table__header-row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
       >
         <div
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Name"
@@ -674,7 +674,7 @@ exports[`BpkDataTable should render correctly with a custom rowClassName functio
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           <span
             aria-label="Description"
@@ -716,7 +716,7 @@ exports[`BpkDataTable should render correctly with a custom rowClassName functio
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Bla"
@@ -762,27 +762,27 @@ exports[`BpkDataTable should render correctly with a custom rowClassName functio
       <div
         class="bpk-data-table__row custom-data-table__row_even"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Jose
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Software Engineer
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -790,27 +790,27 @@ exports[`BpkDataTable should render correctly with a custom rowClassName functio
       <div
         class="bpk-data-table__row custom-data-table__row_odd"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Rolf
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Some guy
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -825,19 +825,19 @@ exports[`BpkDataTable should render correctly with a custom rowClassName string 
   <div
     class="bpk-data-table"
     role="table"
-    style="height: 200px;"
+    style="height: 12.5rem;"
   >
     <div>
       <div
         class="bpk-data-table__row bpk-data-table__header-row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
       >
         <div
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Name"
@@ -879,7 +879,7 @@ exports[`BpkDataTable should render correctly with a custom rowClassName string 
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           <span
             aria-label="Description"
@@ -921,7 +921,7 @@ exports[`BpkDataTable should render correctly with a custom rowClassName string 
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Bla"
@@ -967,27 +967,27 @@ exports[`BpkDataTable should render correctly with a custom rowClassName string 
       <div
         class="bpk-data-table__row custom-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Jose
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Software Engineer
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -995,27 +995,27 @@ exports[`BpkDataTable should render correctly with a custom rowClassName string 
       <div
         class="bpk-data-table__row custom-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Rolf
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Some guy
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -1030,19 +1030,19 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
   <div
     class="bpk-data-table"
     role="table"
-    style="width: 400px; height: 200px;"
+    style="width: 25rem; height: 12.5rem;"
   >
     <div>
       <div
         class="bpk-data-table__row bpk-data-table__header-row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
       >
         <div
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Name"
@@ -1084,7 +1084,7 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           <span
             aria-label="Description"
@@ -1126,7 +1126,7 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Bla"
@@ -1172,27 +1172,27 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
       <div
         class="bpk-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Jose
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Software Engineer
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -1200,27 +1200,27 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
       <div
         class="bpk-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Rolf
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Some guy
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -1235,19 +1235,19 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
   <div
     class="bpk-data-table"
     role="table"
-    style="height: 200px;"
+    style="height: 12.5rem;"
   >
     <div>
       <div
         class="bpk-data-table__row bpk-data-table__header-row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
       >
         <div
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Name"
@@ -1289,7 +1289,7 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           <span
             aria-label="Description"
@@ -1331,7 +1331,7 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Bla"
@@ -1377,27 +1377,27 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
       <div
         class="bpk-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Jose
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Software Engineer
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -1405,27 +1405,27 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
       <div
         class="bpk-data-table__row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
         tabindex="0"
       >
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Rolf
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           Some guy
         </div>
         <div
           class="bpk-data-table__cell"
           role="cell"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           Bla
         </div>
@@ -1440,19 +1440,19 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
   <div
     class="bpk-data-table"
     role="table"
-    style="height: 200px;"
+    style="height: 12.5rem;"
   >
     <div>
       <div
         class="bpk-data-table__row bpk-data-table__header-row"
         role="row"
-        style="height: 60px;"
+        style="height: 3.75rem;"
       >
         <div
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Name"
@@ -1494,7 +1494,7 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width: 6.25rem; flex-grow: 1;"
         >
           <span
             aria-label="Description"
@@ -1536,7 +1536,7 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
           class="bpk-data-table-column__header"
           colspan="1"
           role="columnheader"
-          style="width: 100px; flex-grow: 0;"
+          style="width: 6.25rem; flex-grow: 0;"
         >
           <span
             aria-label="Bla"
@@ -1579,6 +1579,211 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
     <div
       role="rowgroup"
     />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BpkDataTable should render correctly with px height 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-data-table"
+    role="table"
+    style="height: 12.5rem;"
+  >
+    <div>
+      <div
+        class="bpk-data-table__row bpk-data-table__header-row"
+        role="row"
+        style="height: 3.75rem;"
+      >
+        <div
+          class="bpk-data-table-column__header"
+          colspan="1"
+          role="columnheader"
+          style="width: 6.25rem; flex-grow: 0;"
+        >
+          <span
+            aria-label="Name"
+            aria-pressed="true"
+            role="button"
+            tabindex="0"
+          >
+            Name
+          </span>
+          <div
+            aria-hidden="true"
+            class="bpk-data-table-column__sort-icons"
+          >
+            <svg
+              aria-hidden="true"
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="bpk-data-table-column__header"
+          colspan="1"
+          role="columnheader"
+          style="width: 6.25rem; flex-grow: 1;"
+        >
+          <span
+            aria-label="Description"
+            aria-pressed="false"
+            role="button"
+            tabindex="0"
+          >
+            Description
+          </span>
+          <div
+            aria-hidden="true"
+            class="bpk-data-table-column__sort-icons"
+          >
+            <svg
+              aria-hidden="true"
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="bpk-data-table-column__header"
+          colspan="1"
+          role="columnheader"
+          style="width: 6.25rem; flex-grow: 0;"
+        >
+          <span
+            aria-label="Bla"
+            aria-pressed="false"
+            role="button"
+            tabindex="0"
+          >
+            Bla
+          </span>
+          <div
+            aria-hidden="true"
+            class="bpk-data-table-column__sort-icons"
+          >
+            <svg
+              aria-hidden="true"
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      role="rowgroup"
+    >
+      <div
+        class="bpk-data-table__row"
+        role="row"
+        style="height: 3.75rem;"
+        tabindex="0"
+      >
+        <div
+          class="bpk-data-table__cell"
+          role="cell"
+          style="width: 6.25rem; flex-grow: 0;"
+        >
+          Jose
+        </div>
+        <div
+          class="bpk-data-table__cell"
+          role="cell"
+          style="width: 6.25rem; flex-grow: 1;"
+        >
+          Software Engineer
+        </div>
+        <div
+          class="bpk-data-table__cell"
+          role="cell"
+          style="width: 6.25rem; flex-grow: 0;"
+        >
+          Bla
+        </div>
+      </div>
+      <div
+        class="bpk-data-table__row"
+        role="row"
+        style="height: 3.75rem;"
+        tabindex="0"
+      >
+        <div
+          class="bpk-data-table__cell"
+          role="cell"
+          style="width: 6.25rem; flex-grow: 0;"
+        >
+          Rolf
+        </div>
+        <div
+          class="bpk-data-table__cell"
+          role="cell"
+          style="width: 6.25rem; flex-grow: 1;"
+        >
+          Some guy
+        </div>
+        <div
+          class="bpk-data-table__cell"
+          role="cell"
+          style="width: 6.25rem; flex-grow: 0;"
+        >
+          Bla
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-datatable/src/accessibility-test.js
+++ b/packages/bpk-component-datatable/src/accessibility-test.js
@@ -30,15 +30,15 @@ const rows = [
 describe('BpkDataTable accessibility tests', () => {
   it('should not have programmatically-detectable accessibility issues', async () => {
     const { container } = render(
-      <BpkDataTable rows={rows} height={200}>
-        <BpkDataTableColumn label="Name" dataKey="name" width={100} />
+      <BpkDataTable rows={rows} height="12.5rem">
+        <BpkDataTableColumn label="Name" dataKey="name" width="6.25rem" />
         <BpkDataTableColumn
           label="Description"
           dataKey="description"
-          width={100}
+          width="6.25rem"
           flexGrow={1}
         />
-        <BpkDataTableColumn label="Bla" dataKey="bla" width={100} />
+        <BpkDataTableColumn label="Bla" dataKey="bla" width="6.25rem" />
       </BpkDataTable>,
     );
     const results = await axe(container);

--- a/packages/bpk-component-datatable/src/common-types.js
+++ b/packages/bpk-component-datatable/src/common-types.js
@@ -28,17 +28,17 @@ type CommonColumnProps = {
   headerClassName: ?string,
   headerStyle: ?{},
   label: ?string,
-  minWidth: ?number,
-  width: number,
+  minWidth: ?number | string,
+  width: number | string,
 };
 
 export type Props<Row> = {
   rows: Array<Row>,
   children: Node,
-  height: number,
-  width: ?number,
-  headerHeight: number,
-  rowHeight: number,
+  height: number | string,
+  width: ?number | string,
+  headerHeight: number | string,
+  rowHeight: number | string,
   className: ?string,
   defaultColumnSortIndex: number,
   headerClassName: ?string,

--- a/packages/bpk-component-datatable/src/utils.js
+++ b/packages/bpk-component-datatable/src/utils.js
@@ -17,10 +17,11 @@
  */
 /* @flow strict */
 
+const ROOT_FONT_SIZE_PX = 16;
 // TODO: Remove these functions once we want to change the API to match the react-table library API
 // To maintain backwards compatibility with the old API of BpkDataTable which takes columns as children
 // The `react-table` library however expects columns as an array of objects
-// eslint-disable-next-line import/prefer-default-export
+ 
 export const getColumns = (columns) =>
   columns.map((column) => {
     const { cellDataGetter, cellRenderer, headerRenderer } = column.props;
@@ -85,3 +86,13 @@ export const getColumns = (columns) =>
       width,
     };
   });
+
+export const pxToRem = (value: string | number) => {
+  let parsed = value;
+
+  if (typeof value === 'number') {
+    console.warn("Height in px is deprecated. Please pass the equivalent value in rem."); 
+    parsed = `${value / ROOT_FONT_SIZE_PX}rem`;
+  }
+  return parsed;
+}

--- a/packages/bpk-component-datatable/src/utils.js
+++ b/packages/bpk-component-datatable/src/utils.js
@@ -22,7 +22,7 @@ const ROOT_FONT_SIZE_PX = 16;
 export const pxToRem = (value: string | number) => {
   let parsed = value;
 
-  if (typeof value === 'number') {
+  if (typeof value === 'number' || (typeof value === 'string' && value.includes('px'))) {
     console.warn("Height in px is deprecated. Please pass the equivalent value in rem."); 
     parsed = `${value / ROOT_FONT_SIZE_PX}rem`;
   }

--- a/packages/bpk-component-datatable/src/utils.js
+++ b/packages/bpk-component-datatable/src/utils.js
@@ -18,7 +18,17 @@
 /* @flow strict */
 
 const ROOT_FONT_SIZE_PX = 16;
-// TODO: Remove these functions once we want to change the API to match the react-table library API
+
+export const pxToRem = (value: string | number) => {
+  let parsed = value;
+
+  if (typeof value === 'number') {
+    console.warn("Height in px is deprecated. Please pass the equivalent value in rem."); 
+    parsed = `${value / ROOT_FONT_SIZE_PX}rem`;
+  }
+  return parsed;
+}
+// TODO: Remove this function once we want to change the API to match the react-table library API
 // To maintain backwards compatibility with the old API of BpkDataTable which takes columns as children
 // The `react-table` library however expects columns as an array of objects
  
@@ -81,18 +91,8 @@ export const getColumns = (columns) =>
       headerClassName,
       headerStyle,
       label,
-      minWidth,
+      minWidth: pxToRem(minWidth),
       style,
-      width,
+      width: pxToRem(width),
     };
   });
-
-export const pxToRem = (value: string | number) => {
-  let parsed = value;
-
-  if (typeof value === 'number') {
-    console.warn("Height in px is deprecated. Please pass the equivalent value in rem."); 
-    parsed = `${value / ROOT_FONT_SIZE_PX}rem`;
-  }
-  return parsed;
-}


### PR DESCRIPTION
Data table should use values in rem so that it can scale.
- Add warning messages when value in px (i.e. no unit provided) is passed to data table. This will be removed in the future and only rem values will be allowed.
- Convert px value to rem

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here