### PR TITLE
[No-Jira] BpkSelectableChip: Fix accessibility issue for role=tab

### DIFF
--- a/packages/bpk-component-chip/src/BpkSelectableChip.tsx
+++ b/packages/bpk-component-chip/src/BpkSelectableChip.tsx
@@ -55,7 +55,7 @@ const BpkSelectableChip = ({
 
   return (
     <button
-      aria-checked={role === 'button' ? undefined : selected}
+      aria-checked={role === 'button' || role === 'tab' ? undefined : selected}
       className={classNames}
       disabled={disabled}
       role={role}

--- a/packages/bpk-component-chip/src/accessibility-test.tsx
+++ b/packages/bpk-component-chip/src/accessibility-test.tsx
@@ -45,3 +45,19 @@ describe('BpkSelectableChip accessibility tests', () => {
     expect(results).toHaveNoViolations();
   });
 });
+
+describe('BpkSelectableChip accessibility tests', () => {
+  it('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(
+      <BpkSelectableChip
+        onClick={() => null}
+        accessibilityLabel="Toggle"
+        role="tab"
+      >
+        Toggle me
+      </BpkSelectableChip>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR fixes the accessibility issue when BpkSelectableChip is used as a tab. For role='tab' the `aria-checked` attibute is not allowed.
https://dequeuniversity.com/rules/axe/4.5/aria-allowed-attr?application=axeAPI

More details here - https://skyscanner.slack.com/archives/C01T6U38DK3/p1693906192845719

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here



🏷️ minor