### PR TITLE
[No Jira] Fix a11y issue for BpkSelectableChip

### DIFF
--- a/packages/bpk-component-chip/README.md
+++ b/packages/bpk-component-chip/README.md
@@ -9,62 +9,74 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 ## Usage
 
 ```tsx
-import BpkSelectableChip, { BpkDismissibleChip, BpkDropdownChip, CHIP_TYPES } from '@skyscanner/backpack-web/bpk-component-chip';
+import BpkSelectableChip, {
+  BpkDismissibleChip,
+  BpkDropdownChip,
+  CHIP_TYPES,
+} from '@skyscanner/backpack-web/bpk-component-chip';
 import BeachIconSm from '@skyscanner/backpack-web/bpk-component-icon/sm/beach';
 
 export default () => (
-
-  <div style={{ display: 'flex' }}> // IMPORTANT: Flex styles make sure chips align with each other
-    // Standard selectable chip.
+  <div style={{ display: 'flex' }}>
+    {' '}
+    // IMPORTANT: Flex styles make sure chips align with each other // Standard selectable
+    chip.
     <BpkSelectableChip
       accessibilityLabel="Press to toggle chip"
       selected={false}
-      onClick={() => { /* Use state to set 'selected={true}' */ }}
+      onClick={() => {
+        /* Use state to set 'selected={true}' */
+      }}
     >
       Toggle me
     </BpkSelectableChip>
-
     // Selectable chip with an icon.
     <BpkSelectableChip
       accessibilityLabel="Press to toggle chip"
       selected={false}
-      onClick={() => { /* Use state to set 'selected={true}' */ }}
+      onClick={() => {
+        /* Use state to set 'selected={true}' */
+      }}
       leadingAccessoryView={<BeachIconSm />}
     >
       Toggle me
     </BpkSelectableChip>
-
     // Standard dropdown chip.
     <BpkDropdownChip
       accessibilityLabel="Press to toggle chip"
       selected={false}
-      onClick={() => { /* Use state to set 'selected={true}' */ }}
+      onClick={() => {
+        /* Use state to set 'selected={true}' */
+      }}
     >
       Toggle me
     </BpkDropdownChip>
-
     // Dropdown chip with an icon.
     <BpkDropdownChip
       accessibilityLabel="Press to toggle chip"
       selected={false}
-      onClick={() => { /* Use state to set 'selected={true}' */ }}
+      onClick={() => {
+        /* Use state to set 'selected={true}' */
+      }}
       leadingAccessoryView={<BeachIconSm />}
     >
       Toggle me
     </BpkDropdownChip>
-
     // Standard dismissible chip.
     <BpkDismissibleChip
       accessibilityLabel="Press to dismiss chip"
-      onClick={() => { /* Use state to handle removing this chip. */ }}
+      onClick={() => {
+        /* Use state to handle removing this chip. */
+      }}
     >
       Dismiss me
     </BpkDismissibleChip>
-
     // Dismissible chip with an icon.
-      <BpkDismissibleChip
+    <BpkDismissibleChip
       accessibilityLabel="Press to dismiss chip"
-      onClick={() => { /* Use state to handle removing this chip. */ }}
+      onClick={() => {
+        /* Use state to handle removing this chip. */
+      }}
       leadingAccessoryView={<BeachIconSm />}
     >
       Dismiss me
@@ -77,42 +89,43 @@ export default () => (
 
 ### BpkSelectableChip
 
-| Property              | PropType                                                              | Required | Default Value |
-| --------------------- | --------------------------------------------------------------------- | -------- | ------------- |
-| accessibilityLabel    | string                                                                | true     | -             |
-| children              | node                                                                  | true     | -             |
-| onClick               | func                                                                  | true     | -             |
-| className             | string                                                                | false    | null          |
-| disabled              | bool                                                                  | false    | false         |
-| leadingAccessoryView  | node                                                                  | false    | null          |
-| selected              | bool                                                                  | false    | false         |
-| trailingAccessoryView | node                                                                  | false    | null          |
-| type                  | oneOf(`CHIP_TYPES.onDark`, `CHIP_TYPES.default`, `CHIP_TYPES.onImage`) |
+| Property              | PropType                                                               | Required | Default Value |
+| --------------------- | ---------------------------------------------------------------------- | -------- | ------------- |
+| accessibilityLabel    | string                                                                 | true     | -             |
+| children              | node                                                                   | true     | -             |
+| onClick               | func                                                                   | true     | -             |
+| className             | string                                                                 | false    | null          |
+| disabled              | bool                                                                   | false    | false         |
+| leadingAccessoryView  | node                                                                   | false    | null          |
+| selected              | bool                                                                   | false    | false         |
+| trailingAccessoryView | node                                                                   | false    | null          |
+| type                  | oneOf(`CHIP_TYPES.onDark`, `CHIP_TYPES.default`, `CHIP_TYPES.onImage`) |          |               |
+| role                  | string                                                                 | false    | checkbox      |
 
 ### BpkDropdownChip
 
-| Property              | PropType                                                              | Required | Default Value |
-| --------------------- | --------------------------------------------------------------------- | -------- | ------------- |
-| accessibilityLabel    | string                                                                | true     | -             |
-| children              | node                                                                  | true     | -             |
-| onClick               | func                                                                  | true     | -             |
-| className             | string                                                                | false    | null          |
-| disabled              | bool                                                                  | false    | false         |
-| leadingAccessoryView  | node                                                                  | false    | null          |
-| selected              | bool                                                                  | false    | false         |
-| type                  | oneOf(`CHIP_TYPES.onDark`, `CHIP_TYPES.default`, `CHIP_TYPES.onImage`) |
+| Property             | PropType                                                               | Required | Default Value |
+| -------------------- | ---------------------------------------------------------------------- | -------- | ------------- |
+| accessibilityLabel   | string                                                                 | true     | -             |
+| children             | node                                                                   | true     | -             |
+| onClick              | func                                                                   | true     | -             |
+| className            | string                                                                 | false    | null          |
+| disabled             | bool                                                                   | false    | false         |
+| leadingAccessoryView | node                                                                   | false    | null          |
+| selected             | bool                                                                   | false    | false         |
+| type                 | oneOf(`CHIP_TYPES.onDark`, `CHIP_TYPES.default`, `CHIP_TYPES.onImage`) |
 
 ### BpkDismissibleChip
 
 Dismissible chips are selectable chips that have been preconfigured to have a 'close' icon trailing accessory view and cannot be selected, so they have the same props as `BpkSelectableChip`, minus `trailingAccessoryView` and `selected`.
 
-| Property             | PropType                                                              | Required | Default Value |
-| -------------------- | --------------------------------------------------------------------- | -------- | ------------- |
-| accessibilityLabel   | string                                                                | true     | -             |
-| children             | node                                                                  | true     | -             |
-| onClick              | func                                                                  | true     | -             |
-| className            | string                                                                | false    | null          |
-| leadingAccessoryView | node                                                                  | false    | null          |
+| Property             | PropType                                                               | Required | Default Value |
+| -------------------- | ---------------------------------------------------------------------- | -------- | ------------- |
+| accessibilityLabel   | string                                                                 | true     | -             |
+| children             | node                                                                   | true     | -             |
+| onClick              | func                                                                   | true     | -             |
+| className            | string                                                                 | false    | null          |
+| leadingAccessoryView | node                                                                   | false    | null          |
 | type                 | oneOf(`CHIP_TYPES.onDark`, `CHIP_TYPES.default`, `CHIP_TYPES.onImage`) |
 
 ## Theme Props

--- a/packages/bpk-component-chip/src/BpkSelectableChip.tsx
+++ b/packages/bpk-component-chip/src/BpkSelectableChip.tsx
@@ -55,7 +55,7 @@ const BpkSelectableChip = ({
 
   return (
     <button
-      aria-checked={role === 'button' ? undefined : selected}
+      aria-checked={role === 'button' || role === 'tab' ? undefined : selected}
       className={classNames}
       disabled={disabled}
       role={role}

--- a/packages/bpk-component-chip/src/accessibility-test.tsx
+++ b/packages/bpk-component-chip/src/accessibility-test.tsx
@@ -47,13 +47,15 @@ describe('BpkSelectableChip accessibility tests', () => {
 
   it('should not have programmatically-detectable accessibility issues when role=tab', async () => {
     const { container } = render(
-      <BpkSelectableChip
-        onClick={() => null}
-        accessibilityLabel="Tab"
-        role="tab"
-      >
-        Toggle me
-      </BpkSelectableChip>,
+      <div role="tablist">
+        <BpkSelectableChip
+          onClick={() => null}
+          accessibilityLabel="Tab"
+          role="tab"
+        >
+          Toggle me
+        </BpkSelectableChip>
+      </div>,
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/packages/bpk-component-chip/src/accessibility-test.tsx
+++ b/packages/bpk-component-chip/src/accessibility-test.tsx
@@ -45,3 +45,19 @@ describe('BpkSelectableChip accessibility tests', () => {
     expect(results).toHaveNoViolations();
   });
 });
+
+describe('BpkSelectableChip accessibility tests', () => {
+  it('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(
+      <BpkSelectableChip
+        onClick={() => null}
+        accessibilityLabel="Tab"
+        role="tab"
+      >
+        Toggle me
+      </BpkSelectableChip>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/bpk-component-chip/src/accessibility-test.tsx
+++ b/packages/bpk-component-chip/src/accessibility-test.tsx
@@ -44,10 +44,8 @@ describe('BpkSelectableChip accessibility tests', () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
-});
 
-describe('BpkSelectableChip accessibility tests', () => {
-  it('should not have programmatically-detectable accessibility issues', async () => {
+  it('should not have programmatically-detectable accessibility issues when role=tab', async () => {
     const { container } = render(
       <BpkSelectableChip
         onClick={() => null}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
**Context**
This PR fixes the accessibility issue when BpkSelectableChip is used as a tab. For role='tab' the aria-checked attibute is not allowed.
https://dequeuniversity.com/rules/axe/4.5/aria-allowed-attr?application=axeAPI

More details here - https://skyscanner.slack.com/archives/C01T6U38DK3/p1693906192845719

Remember to include the following changes:

- [x] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here