### PR TITLE
[NO JIRA]: Correct types for datepicker and dialog

### DIFF
--- a/packages/bpk-component-datepicker/src/BpkDatepicker.d.ts
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.d.ts
@@ -17,6 +17,7 @@
  */
 
 import { Component } from 'react';
+import type { ReactElement } from 'react';
 import type { DaysOfWeek, ReactComponent, SelectionConfiguration } from '../../bpk-component-calendar';
 type Props = {
     changeMonthLabel: string;
@@ -32,7 +33,7 @@ type Props = {
     previousMonthLabel: string;
     weekStartsOn: number;
     calendarComponent: ReactComponent;
-    inputComponent: ReactComponent;
+    inputComponent: ReactElement | null;
     dateModifiers?: {};
     fixedWidth?: boolean;
     inputProps?: {};
@@ -60,75 +61,113 @@ declare class BpkDatepicker extends Component<Props, State> {
     inputRef: React.RefObject<HTMLInputElement>;
     static defaultProps: {
         calendarComponent: {
-            new (props: {
-                className?: string | null | undefined;
-                id: string;
+            new (props: Omit<{
                 changeMonthLabel?: string | null | undefined;
+                daysOfWeek: DaysOfWeek;
+                formatDateFull: (date: Date) => string | Date;
                 formatMonth: (date: Date) => string | Date;
+                id: string;
                 maxDate: Date;
                 minDate: Date;
+                month: Date;
                 nextMonthLabel?: string | null | undefined;
-                onMonthChange?: (((event: UIEvent, { month, source }: {
-                    month: Date;
-                    source: string;
-                }) => void) & ((event: UIEvent, { month, source }: {
-                    month: Date;
-                    source: string;
-                }) => void)) | null | undefined;
                 previousMonthLabel?: string | null | undefined;
-                preventKeyboardFocus?: boolean | undefined;
+                weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                className?: string | null | undefined;
                 dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                formatDateFull: (date: Date) => string | Date;
+                fixedWidth?: boolean | undefined;
+                focusedDate?: Date | null | undefined;
+                markOutsideDays?: boolean | undefined;
+                markToday?: boolean | undefined;
+                onMonthChange?: ((event: UIEvent, { month, source }: {
+                    month: Date;
+                    source: string;
+                }) => void) | null | undefined;
+                onDateClick?: ((date: Date) => void) | null | undefined;
+                onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                preventKeyboardFocus?: boolean | undefined;
+                selectionConfiguration?: SelectionConfiguration | undefined;
+                gridClassName?: string | null | undefined;
+                weekDayKey?: string | undefined;
+                navProps?: {} | null | undefined;
+                headerProps?: {} | null | undefined;
+                gridProps?: {} | null | undefined;
+                dateProps?: {} | null | undefined;
+            } & {
+                fixedWidth?: boolean | undefined;
+                maxDate?: Date | undefined;
+                minDate?: Date | undefined;
+                onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                onMonthChange?: ((event: UIEvent, { month, source }: {
+                    month: Date;
+                    source: string;
+                }) => void) | null | undefined;
+                selectionConfiguration?: SelectionConfiguration | undefined;
+                initiallyFocusedDate?: Date | null | undefined;
                 markToday?: boolean | undefined;
                 markOutsideDays?: boolean | undefined;
-                weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                dateProps?: {} | null | undefined;
-                focusedDate?: Date | null | undefined;
-                selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                weekDayKey?: string | undefined;
-                daysOfWeek: DaysOfWeek;
-                fixedWidth: boolean;
-                gridClassName?: string | null | undefined;
-                gridProps?: {} | null | undefined;
-                headerProps?: {} | null | undefined;
-                navProps?: {} | null | undefined;
-                onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                initiallyFocusedDate: Date | null;
+            }, keyof {
+                onDateClick: ((date: Date) => void) | null;
+                onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                month: Date;
+                minDate: Date;
+                maxDate: Date;
+            }> & {
+                [rest: string]: any;
             }): {
-                UNSAFE_componentWillReceiveProps(nextProps: {
-                    className?: string | null | undefined;
-                    id: string;
+                UNSAFE_componentWillReceiveProps(nextProps: Omit<{
                     changeMonthLabel?: string | null | undefined;
+                    daysOfWeek: DaysOfWeek;
+                    formatDateFull: (date: Date) => string | Date;
                     formatMonth: (date: Date) => string | Date;
+                    id: string;
                     maxDate: Date;
                     minDate: Date;
+                    month: Date;
                     nextMonthLabel?: string | null | undefined;
-                    onMonthChange?: (((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void) & ((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void)) | null | undefined;
                     previousMonthLabel?: string | null | undefined;
-                    preventKeyboardFocus?: boolean | undefined;
+                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                    className?: string | null | undefined;
                     dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                    formatDateFull: (date: Date) => string | Date;
+                    fixedWidth?: boolean | undefined;
+                    focusedDate?: Date | null | undefined;
+                    markOutsideDays?: boolean | undefined;
+                    markToday?: boolean | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    onDateClick?: ((date: Date) => void) | null | undefined;
+                    onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                    preventKeyboardFocus?: boolean | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    gridClassName?: string | null | undefined;
+                    weekDayKey?: string | undefined;
+                    navProps?: {} | null | undefined;
+                    headerProps?: {} | null | undefined;
+                    gridProps?: {} | null | undefined;
+                    dateProps?: {} | null | undefined;
+                } & {
+                    fixedWidth?: boolean | undefined;
+                    maxDate?: Date | undefined;
+                    minDate?: Date | undefined;
+                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    initiallyFocusedDate?: Date | null | undefined;
                     markToday?: boolean | undefined;
                     markOutsideDays?: boolean | undefined;
-                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                    dateProps?: {} | null | undefined;
-                    focusedDate?: Date | null | undefined;
-                    selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                    weekDayKey?: string | undefined;
-                    daysOfWeek: DaysOfWeek;
-                    fixedWidth: boolean;
-                    gridClassName?: string | null | undefined;
-                    gridProps?: {} | null | undefined;
-                    headerProps?: {} | null | undefined;
-                    navProps?: {} | null | undefined;
-                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                    initiallyFocusedDate: Date | null;
+                }, keyof {
+                    onDateClick: ((date: Date) => void) | null;
+                    onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                    month: Date;
+                    minDate: Date;
+                    maxDate: Date;
+                }> & {
+                    [rest: string]: any;
                 }): void;
                 handleDateFocus: (event: UIEvent, { date, source }: {
                     date: Date;
@@ -140,7 +179,7 @@ declare class BpkDatepicker extends Component<Props, State> {
                     source: string;
                 }) => void;
                 handleDateKeyDown: (event: KeyboardEvent) => void;
-                render(): JSX.Element;
+                render(): globalThis.JSX.Element;
                 context: any;
                 setState<K extends keyof {
                     preventKeyboardFocus: boolean;
@@ -151,40 +190,59 @@ declare class BpkDatepicker extends Component<Props, State> {
                 } | ((prevState: Readonly<{
                     preventKeyboardFocus: boolean;
                     focusedDate: Date;
-                }>, props: Readonly<{
-                    className?: string | null | undefined;
-                    id: string;
+                }>, props: Readonly<Omit<{
                     changeMonthLabel?: string | null | undefined;
+                    daysOfWeek: DaysOfWeek;
+                    formatDateFull: (date: Date) => string | Date;
                     formatMonth: (date: Date) => string | Date;
+                    id: string;
                     maxDate: Date;
                     minDate: Date;
+                    month: Date;
                     nextMonthLabel?: string | null | undefined;
-                    onMonthChange?: (((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void) & ((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void)) | null | undefined;
                     previousMonthLabel?: string | null | undefined;
-                    preventKeyboardFocus?: boolean | undefined;
+                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                    className?: string | null | undefined;
                     dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                    formatDateFull: (date: Date) => string | Date;
+                    fixedWidth?: boolean | undefined;
+                    focusedDate?: Date | null | undefined;
+                    markOutsideDays?: boolean | undefined;
+                    markToday?: boolean | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    onDateClick?: ((date: Date) => void) | null | undefined;
+                    onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                    preventKeyboardFocus?: boolean | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    gridClassName?: string | null | undefined;
+                    weekDayKey?: string | undefined;
+                    navProps?: {} | null | undefined;
+                    headerProps?: {} | null | undefined;
+                    gridProps?: {} | null | undefined;
+                    dateProps?: {} | null | undefined;
+                } & {
+                    fixedWidth?: boolean | undefined;
+                    maxDate?: Date | undefined;
+                    minDate?: Date | undefined;
+                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    initiallyFocusedDate?: Date | null | undefined;
                     markToday?: boolean | undefined;
                     markOutsideDays?: boolean | undefined;
-                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                    dateProps?: {} | null | undefined;
-                    focusedDate?: Date | null | undefined;
-                    selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                    weekDayKey?: string | undefined;
-                    daysOfWeek: DaysOfWeek;
-                    fixedWidth: boolean;
-                    gridClassName?: string | null | undefined;
-                    gridProps?: {} | null | undefined;
-                    headerProps?: {} | null | undefined;
-                    navProps?: {} | null | undefined;
-                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                    initiallyFocusedDate: Date | null;
+                }, keyof {
+                    onDateClick: ((date: Date) => void) | null;
+                    onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                    month: Date;
+                    minDate: Date;
+                    maxDate: Date;
+                }> & {
+                    [rest: string]: any;
                 }>) => {
                     preventKeyboardFocus: boolean;
                     focusedDate: Date;
@@ -196,40 +254,59 @@ declare class BpkDatepicker extends Component<Props, State> {
                     focusedDate: Date;
                 }, K> | null, callback?: (() => void) | undefined): void;
                 forceUpdate(callback?: (() => void) | undefined): void;
-                readonly props: Readonly<{
-                    className?: string | null | undefined;
-                    id: string;
+                readonly props: Readonly<Omit<{
                     changeMonthLabel?: string | null | undefined;
+                    daysOfWeek: DaysOfWeek;
+                    formatDateFull: (date: Date) => string | Date;
                     formatMonth: (date: Date) => string | Date;
+                    id: string;
                     maxDate: Date;
                     minDate: Date;
+                    month: Date;
                     nextMonthLabel?: string | null | undefined;
-                    onMonthChange?: (((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void) & ((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void)) | null | undefined;
                     previousMonthLabel?: string | null | undefined;
-                    preventKeyboardFocus?: boolean | undefined;
+                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                    className?: string | null | undefined;
                     dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                    formatDateFull: (date: Date) => string | Date;
+                    fixedWidth?: boolean | undefined;
+                    focusedDate?: Date | null | undefined;
+                    markOutsideDays?: boolean | undefined;
+                    markToday?: boolean | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    onDateClick?: ((date: Date) => void) | null | undefined;
+                    onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                    preventKeyboardFocus?: boolean | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    gridClassName?: string | null | undefined;
+                    weekDayKey?: string | undefined;
+                    navProps?: {} | null | undefined;
+                    headerProps?: {} | null | undefined;
+                    gridProps?: {} | null | undefined;
+                    dateProps?: {} | null | undefined;
+                } & {
+                    fixedWidth?: boolean | undefined;
+                    maxDate?: Date | undefined;
+                    minDate?: Date | undefined;
+                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    initiallyFocusedDate?: Date | null | undefined;
                     markToday?: boolean | undefined;
                     markOutsideDays?: boolean | undefined;
-                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                    dateProps?: {} | null | undefined;
-                    focusedDate?: Date | null | undefined;
-                    selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                    weekDayKey?: string | undefined;
-                    daysOfWeek: DaysOfWeek;
-                    fixedWidth: boolean;
-                    gridClassName?: string | null | undefined;
-                    gridProps?: {} | null | undefined;
-                    headerProps?: {} | null | undefined;
-                    navProps?: {} | null | undefined;
-                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                    initiallyFocusedDate: Date | null;
+                }, keyof {
+                    onDateClick: ((date: Date) => void) | null;
+                    onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                    month: Date;
+                    minDate: Date;
+                    maxDate: Date;
+                }> & {
+                    [rest: string]: any;
                 }> & Readonly<{
                     children?: import("react").ReactNode;
                 }>;
@@ -241,231 +318,345 @@ declare class BpkDatepicker extends Component<Props, State> {
                     [key: string]: import("react").ReactInstance;
                 };
                 componentDidMount?(): void;
-                shouldComponentUpdate?(nextProps: Readonly<{
-                    className?: string | null | undefined;
-                    id: string;
+                shouldComponentUpdate?(nextProps: Readonly<Omit<{
                     changeMonthLabel?: string | null | undefined;
+                    daysOfWeek: DaysOfWeek;
+                    formatDateFull: (date: Date) => string | Date;
                     formatMonth: (date: Date) => string | Date;
+                    id: string;
                     maxDate: Date;
                     minDate: Date;
+                    month: Date;
                     nextMonthLabel?: string | null | undefined;
-                    onMonthChange?: (((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void) & ((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void)) | null | undefined;
                     previousMonthLabel?: string | null | undefined;
-                    preventKeyboardFocus?: boolean | undefined;
+                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                    className?: string | null | undefined;
                     dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                    formatDateFull: (date: Date) => string | Date;
+                    fixedWidth?: boolean | undefined;
+                    focusedDate?: Date | null | undefined;
+                    markOutsideDays?: boolean | undefined;
+                    markToday?: boolean | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    onDateClick?: ((date: Date) => void) | null | undefined;
+                    onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                    preventKeyboardFocus?: boolean | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    gridClassName?: string | null | undefined;
+                    weekDayKey?: string | undefined;
+                    navProps?: {} | null | undefined;
+                    headerProps?: {} | null | undefined;
+                    gridProps?: {} | null | undefined;
+                    dateProps?: {} | null | undefined;
+                } & {
+                    fixedWidth?: boolean | undefined;
+                    maxDate?: Date | undefined;
+                    minDate?: Date | undefined;
+                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    initiallyFocusedDate?: Date | null | undefined;
                     markToday?: boolean | undefined;
                     markOutsideDays?: boolean | undefined;
-                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                    dateProps?: {} | null | undefined;
-                    focusedDate?: Date | null | undefined;
-                    selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                    weekDayKey?: string | undefined;
-                    daysOfWeek: DaysOfWeek;
-                    fixedWidth: boolean;
-                    gridClassName?: string | null | undefined;
-                    gridProps?: {} | null | undefined;
-                    headerProps?: {} | null | undefined;
-                    navProps?: {} | null | undefined;
-                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                    initiallyFocusedDate: Date | null;
+                }, keyof {
+                    onDateClick: ((date: Date) => void) | null;
+                    onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                    month: Date;
+                    minDate: Date;
+                    maxDate: Date;
+                }> & {
+                    [rest: string]: any;
                 }>, nextState: Readonly<{
                     preventKeyboardFocus: boolean;
                     focusedDate: Date;
                 }>, nextContext: any): boolean;
                 componentWillUnmount?(): void;
                 componentDidCatch?(error: Error, errorInfo: import("react").ErrorInfo): void;
-                getSnapshotBeforeUpdate?(prevProps: Readonly<{
-                    className?: string | null | undefined;
-                    id: string;
+                getSnapshotBeforeUpdate?(prevProps: Readonly<Omit<{
                     changeMonthLabel?: string | null | undefined;
+                    daysOfWeek: DaysOfWeek;
+                    formatDateFull: (date: Date) => string | Date;
                     formatMonth: (date: Date) => string | Date;
+                    id: string;
                     maxDate: Date;
                     minDate: Date;
+                    month: Date;
                     nextMonthLabel?: string | null | undefined;
-                    onMonthChange?: (((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void) & ((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void)) | null | undefined;
                     previousMonthLabel?: string | null | undefined;
-                    preventKeyboardFocus?: boolean | undefined;
+                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                    className?: string | null | undefined;
                     dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                    formatDateFull: (date: Date) => string | Date;
+                    fixedWidth?: boolean | undefined;
+                    focusedDate?: Date | null | undefined;
+                    markOutsideDays?: boolean | undefined;
+                    markToday?: boolean | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    onDateClick?: ((date: Date) => void) | null | undefined;
+                    onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                    preventKeyboardFocus?: boolean | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    gridClassName?: string | null | undefined;
+                    weekDayKey?: string | undefined;
+                    navProps?: {} | null | undefined;
+                    headerProps?: {} | null | undefined;
+                    gridProps?: {} | null | undefined;
+                    dateProps?: {} | null | undefined;
+                } & {
+                    fixedWidth?: boolean | undefined;
+                    maxDate?: Date | undefined;
+                    minDate?: Date | undefined;
+                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    initiallyFocusedDate?: Date | null | undefined;
                     markToday?: boolean | undefined;
                     markOutsideDays?: boolean | undefined;
-                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                    dateProps?: {} | null | undefined;
-                    focusedDate?: Date | null | undefined;
-                    selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                    weekDayKey?: string | undefined;
-                    daysOfWeek: DaysOfWeek;
-                    fixedWidth: boolean;
-                    gridClassName?: string | null | undefined;
-                    gridProps?: {} | null | undefined;
-                    headerProps?: {} | null | undefined;
-                    navProps?: {} | null | undefined;
-                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                    initiallyFocusedDate: Date | null;
+                }, keyof {
+                    onDateClick: ((date: Date) => void) | null;
+                    onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                    month: Date;
+                    minDate: Date;
+                    maxDate: Date;
+                }> & {
+                    [rest: string]: any;
                 }>, prevState: Readonly<{
                     preventKeyboardFocus: boolean;
                     focusedDate: Date;
                 }>): any;
-                componentDidUpdate?(prevProps: Readonly<{
-                    className?: string | null | undefined;
-                    id: string;
+                componentDidUpdate?(prevProps: Readonly<Omit<{
                     changeMonthLabel?: string | null | undefined;
+                    daysOfWeek: DaysOfWeek;
+                    formatDateFull: (date: Date) => string | Date;
                     formatMonth: (date: Date) => string | Date;
+                    id: string;
                     maxDate: Date;
                     minDate: Date;
+                    month: Date;
                     nextMonthLabel?: string | null | undefined;
-                    onMonthChange?: (((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void) & ((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void)) | null | undefined;
                     previousMonthLabel?: string | null | undefined;
-                    preventKeyboardFocus?: boolean | undefined;
+                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                    className?: string | null | undefined;
                     dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                    formatDateFull: (date: Date) => string | Date;
+                    fixedWidth?: boolean | undefined;
+                    focusedDate?: Date | null | undefined;
+                    markOutsideDays?: boolean | undefined;
+                    markToday?: boolean | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    onDateClick?: ((date: Date) => void) | null | undefined;
+                    onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                    preventKeyboardFocus?: boolean | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    gridClassName?: string | null | undefined;
+                    weekDayKey?: string | undefined;
+                    navProps?: {} | null | undefined;
+                    headerProps?: {} | null | undefined;
+                    gridProps?: {} | null | undefined;
+                    dateProps?: {} | null | undefined;
+                } & {
+                    fixedWidth?: boolean | undefined;
+                    maxDate?: Date | undefined;
+                    minDate?: Date | undefined;
+                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    initiallyFocusedDate?: Date | null | undefined;
                     markToday?: boolean | undefined;
                     markOutsideDays?: boolean | undefined;
-                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                    dateProps?: {} | null | undefined;
-                    focusedDate?: Date | null | undefined;
-                    selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                    weekDayKey?: string | undefined;
-                    daysOfWeek: DaysOfWeek;
-                    fixedWidth: boolean;
-                    gridClassName?: string | null | undefined;
-                    gridProps?: {} | null | undefined;
-                    headerProps?: {} | null | undefined;
-                    navProps?: {} | null | undefined;
-                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                    initiallyFocusedDate: Date | null;
+                }, keyof {
+                    onDateClick: ((date: Date) => void) | null;
+                    onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                    month: Date;
+                    minDate: Date;
+                    maxDate: Date;
+                }> & {
+                    [rest: string]: any;
                 }>, prevState: Readonly<{
                     preventKeyboardFocus: boolean;
                     focusedDate: Date;
                 }>, snapshot?: any): void;
                 componentWillMount?(): void;
                 UNSAFE_componentWillMount?(): void;
-                componentWillReceiveProps?(nextProps: Readonly<{
-                    className?: string | null | undefined;
-                    id: string;
+                componentWillReceiveProps?(nextProps: Readonly<Omit<{
                     changeMonthLabel?: string | null | undefined;
+                    daysOfWeek: DaysOfWeek;
+                    formatDateFull: (date: Date) => string | Date;
                     formatMonth: (date: Date) => string | Date;
+                    id: string;
                     maxDate: Date;
                     minDate: Date;
+                    month: Date;
                     nextMonthLabel?: string | null | undefined;
-                    onMonthChange?: (((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void) & ((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void)) | null | undefined;
                     previousMonthLabel?: string | null | undefined;
-                    preventKeyboardFocus?: boolean | undefined;
+                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                    className?: string | null | undefined;
                     dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                    formatDateFull: (date: Date) => string | Date;
+                    fixedWidth?: boolean | undefined;
+                    focusedDate?: Date | null | undefined;
+                    markOutsideDays?: boolean | undefined;
+                    markToday?: boolean | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    onDateClick?: ((date: Date) => void) | null | undefined;
+                    onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                    preventKeyboardFocus?: boolean | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    gridClassName?: string | null | undefined;
+                    weekDayKey?: string | undefined;
+                    navProps?: {} | null | undefined;
+                    headerProps?: {} | null | undefined;
+                    gridProps?: {} | null | undefined;
+                    dateProps?: {} | null | undefined;
+                } & {
+                    fixedWidth?: boolean | undefined;
+                    maxDate?: Date | undefined;
+                    minDate?: Date | undefined;
+                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    initiallyFocusedDate?: Date | null | undefined;
                     markToday?: boolean | undefined;
                     markOutsideDays?: boolean | undefined;
-                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                    dateProps?: {} | null | undefined;
-                    focusedDate?: Date | null | undefined;
-                    selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                    weekDayKey?: string | undefined;
-                    daysOfWeek: DaysOfWeek;
-                    fixedWidth: boolean;
-                    gridClassName?: string | null | undefined;
-                    gridProps?: {} | null | undefined;
-                    headerProps?: {} | null | undefined;
-                    navProps?: {} | null | undefined;
-                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                    initiallyFocusedDate: Date | null;
+                }, keyof {
+                    onDateClick: ((date: Date) => void) | null;
+                    onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                    month: Date;
+                    minDate: Date;
+                    maxDate: Date;
+                }> & {
+                    [rest: string]: any;
                 }>, nextContext: any): void;
-                componentWillUpdate?(nextProps: Readonly<{
-                    className?: string | null | undefined;
-                    id: string;
+                componentWillUpdate?(nextProps: Readonly<Omit<{
                     changeMonthLabel?: string | null | undefined;
+                    daysOfWeek: DaysOfWeek;
+                    formatDateFull: (date: Date) => string | Date;
                     formatMonth: (date: Date) => string | Date;
+                    id: string;
                     maxDate: Date;
                     minDate: Date;
+                    month: Date;
                     nextMonthLabel?: string | null | undefined;
-                    onMonthChange?: (((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void) & ((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void)) | null | undefined;
                     previousMonthLabel?: string | null | undefined;
-                    preventKeyboardFocus?: boolean | undefined;
+                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                    className?: string | null | undefined;
                     dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                    formatDateFull: (date: Date) => string | Date;
+                    fixedWidth?: boolean | undefined;
+                    focusedDate?: Date | null | undefined;
+                    markOutsideDays?: boolean | undefined;
+                    markToday?: boolean | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    onDateClick?: ((date: Date) => void) | null | undefined;
+                    onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                    preventKeyboardFocus?: boolean | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    gridClassName?: string | null | undefined;
+                    weekDayKey?: string | undefined;
+                    navProps?: {} | null | undefined;
+                    headerProps?: {} | null | undefined;
+                    gridProps?: {} | null | undefined;
+                    dateProps?: {} | null | undefined;
+                } & {
+                    fixedWidth?: boolean | undefined;
+                    maxDate?: Date | undefined;
+                    minDate?: Date | undefined;
+                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    initiallyFocusedDate?: Date | null | undefined;
                     markToday?: boolean | undefined;
                     markOutsideDays?: boolean | undefined;
-                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                    dateProps?: {} | null | undefined;
-                    focusedDate?: Date | null | undefined;
-                    selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                    weekDayKey?: string | undefined;
-                    daysOfWeek: DaysOfWeek;
-                    fixedWidth: boolean;
-                    gridClassName?: string | null | undefined;
-                    gridProps?: {} | null | undefined;
-                    headerProps?: {} | null | undefined;
-                    navProps?: {} | null | undefined;
-                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                    initiallyFocusedDate: Date | null;
+                }, keyof {
+                    onDateClick: ((date: Date) => void) | null;
+                    onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                    month: Date;
+                    minDate: Date;
+                    maxDate: Date;
+                }> & {
+                    [rest: string]: any;
                 }>, nextState: Readonly<{
                     preventKeyboardFocus: boolean;
                     focusedDate: Date;
                 }>, nextContext: any): void;
-                UNSAFE_componentWillUpdate?(nextProps: Readonly<{
-                    className?: string | null | undefined;
-                    id: string;
+                UNSAFE_componentWillUpdate?(nextProps: Readonly<Omit<{
                     changeMonthLabel?: string | null | undefined;
+                    daysOfWeek: DaysOfWeek;
+                    formatDateFull: (date: Date) => string | Date;
                     formatMonth: (date: Date) => string | Date;
+                    id: string;
                     maxDate: Date;
                     minDate: Date;
+                    month: Date;
                     nextMonthLabel?: string | null | undefined;
-                    onMonthChange?: (((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void) & ((event: UIEvent, { month, source }: {
-                        month: Date;
-                        source: string;
-                    }) => void)) | null | undefined;
                     previousMonthLabel?: string | null | undefined;
-                    preventKeyboardFocus?: boolean | undefined;
+                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+                    className?: string | null | undefined;
                     dateModifiers?: import("../../bpk-component-calendar/src/custom-proptypes").DateModifiers | undefined;
-                    formatDateFull: (date: Date) => string | Date;
+                    fixedWidth?: boolean | undefined;
+                    focusedDate?: Date | null | undefined;
+                    markOutsideDays?: boolean | undefined;
+                    markToday?: boolean | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    onDateClick?: ((date: Date) => void) | null | undefined;
+                    onDateKeyDown?: ((event: KeyboardEvent) => void) | null | undefined;
+                    preventKeyboardFocus?: boolean | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    gridClassName?: string | null | undefined;
+                    weekDayKey?: string | undefined;
+                    navProps?: {} | null | undefined;
+                    headerProps?: {} | null | undefined;
+                    gridProps?: {} | null | undefined;
+                    dateProps?: {} | null | undefined;
+                } & {
+                    fixedWidth?: boolean | undefined;
+                    maxDate?: Date | undefined;
+                    minDate?: Date | undefined;
+                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
+                    onMonthChange?: ((event: UIEvent, { month, source }: {
+                        month: Date;
+                        source: string;
+                    }) => void) | null | undefined;
+                    selectionConfiguration?: SelectionConfiguration | undefined;
+                    initiallyFocusedDate?: Date | null | undefined;
                     markToday?: boolean | undefined;
                     markOutsideDays?: boolean | undefined;
-                    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-                    dateProps?: {} | null | undefined;
-                    focusedDate?: Date | null | undefined;
-                    selectionConfiguration: import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationSingle | import("../../bpk-component-calendar/src/custom-proptypes").SelectionConfigurationRange;
-                    weekDayKey?: string | undefined;
-                    daysOfWeek: DaysOfWeek;
-                    fixedWidth: boolean;
-                    gridClassName?: string | null | undefined;
-                    gridProps?: {} | null | undefined;
-                    headerProps?: {} | null | undefined;
-                    navProps?: {} | null | undefined;
-                    onDateSelect?: ((date: Date, newDate?: Date | undefined) => void) | null | undefined;
-                    initiallyFocusedDate: Date | null;
+                }, keyof {
+                    onDateClick: ((date: Date) => void) | null;
+                    onDateKeyDown: ((event: KeyboardEvent) => void) | null;
+                    month: Date;
+                    minDate: Date;
+                    maxDate: Date;
+                }> & {
+                    [rest: string]: any;
                 }>, nextState: Readonly<{
                     preventKeyboardFocus: boolean;
                     focusedDate: Date;
@@ -528,6 +719,6 @@ declare class BpkDatepicker extends Component<Props, State> {
      */
     getValue: (selectionConfiguration: SelectionConfiguration, formatDate: (date: Date) => string) => string;
     handleDateSelect: (startDate: Date, endDate?: Date | null) => void;
-    render(): JSX.Element;
+    render(): globalThis.JSX.Element;
 }
 export default BpkDatepicker;

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.d.ts
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.d.ts
@@ -179,7 +179,7 @@ declare class BpkDatepicker extends Component<Props, State> {
                     source: string;
                 }) => void;
                 handleDateKeyDown: (event: KeyboardEvent) => void;
-                render(): globalThis.JSX.Element;
+                render(): JSX.Element;
                 context: any;
                 setState<K extends keyof {
                     preventKeyboardFocus: boolean;
@@ -719,6 +719,6 @@ declare class BpkDatepicker extends Component<Props, State> {
      */
     getValue: (selectionConfiguration: SelectionConfiguration, formatDate: (date: Date) => string) => string;
     handleDateSelect: (startDate: Date, endDate?: Date | null) => void;
-    render(): globalThis.JSX.Element;
+    render(): JSX.Element;
 }
 export default BpkDatepicker;

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.tsx
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.tsx
@@ -17,6 +17,7 @@
  */
 
 import { createRef, Component } from 'react';
+import type {JSX, ReactElement} from 'react';
 
 import BpkInput, { withOpenEvents } from '../../bpk-component-input';
 import BpkModal from '../../bpk-component-modal';
@@ -71,7 +72,7 @@ type Props = {
   weekStartsOn: number;
   // Optional
   calendarComponent: ReactComponent;
-  inputComponent: ReactComponent;
+  inputComponent: ReactElement | null;
   dateModifiers?: {};
   fixedWidth?: boolean;
   inputProps?: {};

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.tsx
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.tsx
@@ -17,7 +17,7 @@
  */
 
 import { createRef, Component } from 'react';
-import type {JSX, ReactElement} from 'react';
+import type { ReactElement} from 'react';
 
 import BpkInput, { withOpenEvents } from '../../bpk-component-input';
 import BpkModal from '../../bpk-component-modal';

--- a/packages/bpk-component-dialog/README.md
+++ b/packages/bpk-component-dialog/README.md
@@ -85,7 +85,7 @@ class App extends Component {
 
 #### onClose
 
-This is required unless `dismissible` is false.
+This property is only required when `dismissible` is true.
 
 #### flareClassName
 

--- a/packages/bpk-component-dialog/src/BpkDialog.tsx
+++ b/packages/bpk-component-dialog/src/BpkDialog.tsx
@@ -34,7 +34,7 @@ const BpkDialog = ({
   headerIcon = null,
   headerIconType = HEADER_ICON_TYPES.primary,
   isOpen,
-  onClose = () => {},
+  onClose,
   renderTarget = () => null,
   ...rest
 }: Props) => {
@@ -43,6 +43,11 @@ const BpkDialog = ({
     `bpk-dialog__icon--${headerIconType}`,
   );
   const closeButtonClassNames = getClassName('bpk-dialog__close-button');
+
+  if(!onClose && dismissible === true) {
+    // eslint-disable-next-line no-console
+    console.warn('BpkDialog: dismissible is true but no onClose prop was provided. Dialog will not be dismissible.');
+  }
 
   return (
     <Portal

--- a/packages/bpk-component-dialog/src/common-types.d.ts
+++ b/packages/bpk-component-dialog/src/common-types.d.ts
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2022 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { ReactNode } from 'react';
 export declare const HEADER_ICON_TYPES: {
     readonly primary: "primary";
@@ -19,7 +37,7 @@ export type Props = Omit<DialogInnerProps, 'dialogRef'> & {
     dialogRef?: (ref: HTMLElement | null | undefined) => void;
     isOpen: boolean;
     renderTarget?: () => HTMLElement | null;
-    onClose: (event?: TouchEvent | MouseEvent | KeyboardEvent) => void | null;
+    onClose?: (event?: TouchEvent | MouseEvent | KeyboardEvent) => void | null;
     closeLabel?: string;
     dismissible?: boolean;
     headerIcon?: ReactNode;

--- a/packages/bpk-component-dialog/src/common-types.ts
+++ b/packages/bpk-component-dialog/src/common-types.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode, SyntheticEvent } from 'react';
+import type { ReactNode } from 'react';
 
 export const HEADER_ICON_TYPES = {
   primary: 'primary',
@@ -40,7 +40,7 @@ export type Props = Omit<DialogInnerProps, 'dialogRef'> & {
   dialogRef?: (ref: HTMLElement | null | undefined) => void;
   isOpen: boolean;
   renderTarget?: () => HTMLElement | null;
-  onClose: (event?: TouchEvent | MouseEvent | KeyboardEvent) => void | null;
+  onClose?: (event?: TouchEvent | MouseEvent | KeyboardEvent) => void | null;
   closeLabel?: string;
   dismissible?: boolean;
   headerIcon?: ReactNode;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR corrects some types that we had some issues with when we moved to TS.
- Corrects Datepicker input type to accept a ReactElement vs a shared prop across multiple components
- Improves readability of README for dialog to be clearer on the `onClose` prop
- Adds a runtime type check to ensure that the correct types and combinations are passed
- Makes the Dialog `onClose` prop optional for when dismissible is true

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here