### PR TITLE
[KOA-6198]: Fix iPad detection utility for newer generation devices

### DIFF
--- a/packages/bpk-react-utils/src/deviceDetection-test.ts
+++ b/packages/bpk-react-utils/src/deviceDetection-test.ts
@@ -18,9 +18,16 @@
 
 import { isDeviceIphone, isDeviceIpad, isDeviceIos } from './deviceDetection';
 
+let windowSpy: jest.SpyInstance;
+
 describe('isIphone tests', () => {
   beforeEach(() => {
     jest.resetModules();
+    windowSpy = jest.spyOn(window, 'window', 'get');
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
   });
 
   it('should return a boolean', () => {
@@ -32,8 +39,11 @@ describe('isIphone tests', () => {
   });
 
   it('should return true if an iPhone', () => {
-    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
-    platform.mockReturnValue('iPhone');
+    windowSpy.mockImplementation(() => ({
+      navigator: {
+        userAgent: 'iPhone'
+      }
+  }));
 
     expect(isDeviceIphone()).toBe(true);
   });
@@ -42,6 +52,11 @@ describe('isIphone tests', () => {
 describe('isIpad tests', () => {
   beforeEach(() => {
     jest.resetModules();
+    windowSpy = jest.spyOn(window, 'window', 'get');
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
   });
 
   it('should return a boolean', () => {
@@ -53,9 +68,22 @@ describe('isIpad tests', () => {
   });
 
   it('should return true if an iPad', () => {
-    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
-    platform.mockReturnValue('iPad');
+    windowSpy.mockImplementation(() => ({
+      navigator: {
+        userAgent: 'iPad'
+      }
+  }));
 
+    expect(isDeviceIpad()).toBe(true);
+  });
+
+  it('should return true if an iPad Pro', () => {
+    windowSpy.mockImplementation(() => ({
+      navigator: {
+        maxTouchPoints: 3,
+        userAgent: 'Macintosh'
+      }
+    }));
     expect(isDeviceIpad()).toBe(true);
   });
 });
@@ -63,6 +91,11 @@ describe('isIpad tests', () => {
 describe('isIos tests', () => {
   beforeEach(() => {
     jest.resetModules();
+    windowSpy = jest.spyOn(window, 'window', 'get');
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
   });
 
   it('should return a boolean', () => {
@@ -70,22 +103,42 @@ describe('isIos tests', () => {
   });
 
   it('should return false by default', () => {
-    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
-    platform.mockReturnValue('Mac');
+    windowSpy.mockImplementation(() => ({
+      navigator: {
+        userAgent: 'Mac'
+      }
+  }));
 
     expect(isDeviceIos()).toBe(false);
   });
 
   it('should return true if an iPhone', () => {
-    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
-    platform.mockReturnValue('iPhone');
+    windowSpy.mockImplementation(() => ({
+      navigator: {
+        userAgent: 'iPhone'
+      }
+  }));
 
     expect(isDeviceIos()).toBe(true);
   });
 
   it('should return true if an iPad', () => {
-    const platform = jest.spyOn(window.navigator, 'userAgent', 'get');
-    platform.mockReturnValue('iPad');
+    windowSpy.mockImplementation(() => ({
+      navigator: {
+        userAgent: 'iPad'
+      }
+  }));
+
+    expect(isDeviceIos()).toBe(true);
+  });
+
+  it('should return true if an iPad Pro', () => {
+    windowSpy.mockImplementation(() => ({
+      navigator: {
+        userAgent: 'Macintosh',
+        maxTouchPoints: 3
+      }
+    }));
 
     expect(isDeviceIos()).toBe(true);
   });

--- a/packages/bpk-react-utils/src/deviceDetection.ts
+++ b/packages/bpk-react-utils/src/deviceDetection.ts
@@ -16,14 +16,28 @@
  * limitations under the License.
  */
 
+/*
+  Checks if the current device is an iPhone as reported by the user agent.
+*/
 const isDeviceIphone = () =>
   /iPhone/i.test(
     typeof window !== 'undefined' ? window.navigator.userAgent : '',
   );
 
+/*
+  Checks if the current device is an iPad as reported by the user agent for older generation iPads
+  or by checking the number of touch points for newer generation iPads as in newer devices the user agent
+  reports as a Macintosh.
+*/
 const isDeviceIpad = () =>
-  /iPad/i.test(typeof window !== 'undefined' ? window.navigator.userAgent : '');
+  /iPad/i.test(typeof window !== 'undefined' ? window.navigator.userAgent : '') ||
+  window.navigator.maxTouchPoints &&
+  window.navigator.maxTouchPoints > 2 &&
+    /Macintosh/.test(window.navigator.userAgent);
 
+/*
+  Checks if the current device is an iOS device.  
+*/
 const isDeviceIos = () => isDeviceIphone() || isDeviceIpad();
 
 export { isDeviceIphone, isDeviceIpad, isDeviceIos };

--- a/packages/bpk-react-utils/src/deviceDetection.ts
+++ b/packages/bpk-react-utils/src/deviceDetection.ts
@@ -30,10 +30,7 @@ const isDeviceIphone = () =>
   reports as a Macintosh.
 */
 const isDeviceIpad = () =>
-  /iPad/i.test(typeof window !== 'undefined' ? window.navigator.userAgent : '') ||
-  window.navigator.maxTouchPoints &&
-  window.navigator.maxTouchPoints > 2 &&
-    /Macintosh/.test(window.navigator.userAgent);
+  /iPad/i.test(typeof window !== 'undefined' ? window.navigator.userAgent : '') || /Macintosh/.test(typeof window !== 'undefined' ? window.navigator.userAgent : '') && (window.navigator.maxTouchPoints > 2);
 
 /*
   Checks if the current device is an iOS device.  


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

The purpose of this PR is to fix an issue that was found whereby on newer generation of iPad Devices, due to their hardware and architecture they now report their device from the browser as a Macintosh/MacOS device instead of an iPad in their userAgent.

Below is a capture of an iPad Pro 10th Generation and what the browser is reporting as the user agent

![Image displaying browser user agent reporting](https://github.com/Skyscanner/backpack/assets/8831547/f7a690f9-6980-4b38-9f44-350363bb340e)


To solve this from others encountering the issue in the community, the way in which it looks to solve this is by checking if the device has a number of touch points to indicate it is a touch device (more than 2 because iPad gestures support up to five touches at once) and in order to ensure we still only target iPads and not cross capture iPhones or other tablets and phones, we check for Macintosh being reported in the UA string

Below are showing screenshots to verify reporting is working as expected and not causing any side effects

| Device | Screenshot |
| - | - |
| iPad 10th Gen | ![Screenshot 2023-09-07 at 18 10 38](https://github.com/Skyscanner/backpack/assets/8831547/cc42cf21-ed05-45b6-adb8-6aca3ed58d05) |
| iPhone 14 | ![Screenshot 2023-09-07 at 18 10 42](https://github.com/Skyscanner/backpack/assets/8831547/b98b2cee-f248-48db-9b49-5bd2ce890c98) |
| Safari MacOS | ![Screenshot 2023-09-07 at 18 10 59](https://github.com/Skyscanner/backpack/assets/8831547/4f29a44d-8616-47e0-9940-f1a238276cab)|
| Firefox MacOS | ![Screenshot 2023-09-07 at 18 11 28](https://github.com/Skyscanner/backpack/assets/8831547/17eaf3c3-9e26-417d-92a2-739613e6b494) |
| Firefox Android | ![Screenshot_20230907-182456](https://github.com/Skyscanner/backpack/assets/8831547/054ed36b-8351-4fb6-99e1-9af2ded46459) |


Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here