### PR TITLE
[KOA-6290][BpkSlider]: Bump react-slider to solve snap back issue

### DIFF
--- a/packages/bpk-component-slider/src/BpkSlider-test.tsx
+++ b/packages/bpk-component-slider/src/BpkSlider-test.tsx
@@ -20,6 +20,15 @@ import { render } from '@testing-library/react';
 
 import BpkSlider from './BpkSlider';
 
+// Mock the ResizeObserver which 'react-slider' uses to handle slider resize programatically 
+window.ResizeObserver =
+  window.ResizeObserver ||
+  jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+  }));
+
 describe('BpkSlider', () => {
   it('should render correctly', () => {
     const { asFragment } = render(<BpkSlider min={0} max={100} value={25} />);
@@ -28,25 +37,29 @@ describe('BpkSlider', () => {
 
   it('should render correctly with a "className" attribute', () => {
     const { asFragment } = render(
-      <BpkSlider min={0} max={100} value={25} className="my-slider" />);
+      <BpkSlider min={0} max={100} value={25} className="my-slider" />,
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('should render correctly with a "step" attribute', () => {
     const { asFragment } = render(
-      <BpkSlider min={0} max={100} value={2} step={10} />);
+      <BpkSlider min={0} max={100} value={2} step={10} />,
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('should render correctly with a range of values', () => {
     const { asFragment } = render(
-      <BpkSlider min={0} max={100} value={[10, 90]} />);
+      <BpkSlider min={0} max={100} value={[10, 90]} />,
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('should render correctly with a minimum distance between controls', () => {
     const { asFragment } = render(
-      <BpkSlider min={0} max={100} value={[10, 90]} minDistance={20} />);
+      <BpkSlider min={0} max={100} value={[10, 90]} minDistance={20} />,
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/packages/bpk-component-slider/src/__snapshots__/BpkSlider-test.tsx.snap
+++ b/packages/bpk-component-slider/src/__snapshots__/BpkSlider-test.tsx.snap
@@ -15,6 +15,7 @@ exports[`BpkSlider should render correctly 1`] = `
       style="position: absolute; left: 0px; right: 0px;"
     />
     <div
+      aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
       aria-valuemin="0"
@@ -43,6 +44,7 @@ exports[`BpkSlider should render correctly with a "className" attribute 1`] = `
       style="position: absolute; left: 0px; right: 0px;"
     />
     <div
+      aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
       aria-valuemin="0"
@@ -71,6 +73,7 @@ exports[`BpkSlider should render correctly with a "step" attribute 1`] = `
       style="position: absolute; left: 0px; right: 0px;"
     />
     <div
+      aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
       aria-valuemin="0"
@@ -103,6 +106,7 @@ exports[`BpkSlider should render correctly with a minimum distance between contr
       style="position: absolute; left: 0px; right: 0px;"
     />
     <div
+      aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
       aria-valuemin="0"
@@ -113,6 +117,7 @@ exports[`BpkSlider should render correctly with a minimum distance between contr
       tabindex="0"
     />
     <div
+      aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
       aria-valuemin="0"
@@ -145,6 +150,7 @@ exports[`BpkSlider should render correctly with a range of values 1`] = `
       style="position: absolute; left: 0px; right: 0px;"
     />
     <div
+      aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
       aria-valuemin="0"
@@ -155,6 +161,7 @@ exports[`BpkSlider should render correctly with a range of values 1`] = `
       tabindex="0"
     />
     <div
+      aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
       aria-valuemin="0"

--- a/packages/bpk-component-slider/src/accessibility-test.tsx
+++ b/packages/bpk-component-slider/src/accessibility-test.tsx
@@ -21,6 +21,14 @@ import { axe } from 'jest-axe';
 
 import BpkSlider from './BpkSlider';
 
+window.ResizeObserver =
+  window.ResizeObserver ||
+  jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+  }));
+
 describe('BpkSlider accessibility tests', () => {
   /*
   Currently this test fails because the third-party library

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -27,7 +27,7 @@
         "prop-types": "^15.7.2",
         "react-autosuggest": "^9.4.3",
         "react-responsive": "^9.0.2",
-        "react-slider": "^1.3.1",
+        "react-slider": "^2.0.6",
         "react-table": "^7.8.0",
         "react-transition-group": "^2.5.3",
         "react-virtualized-auto-sizer": "^1.0.20",
@@ -2119,11 +2119,13 @@
       }
     },
     "node_modules/react-slider": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/react-slider/-/react-slider-1.3.2.tgz",
-      "integrity": "sha512-F8iqi+HtdSWnn1M0CCFgojz0o+SE1nSa6Uo1MFoasTuBHTfFQ8NaIr/coAkmCIqmWwpkv9e3I9oGZfhKQAlBfw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/react-slider/-/react-slider-2.0.6.tgz",
+      "integrity": "sha512-gJxG1HwmuMTJ+oWIRCmVWvgwotNCbByTwRkFZC6U4MBsHqJBmxwbYRJUmxy4Tke1ef8r9jfXjgkmY/uHOCEvbA==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
       "peerDependencies": {
-        "prop-types": "^15.6",
         "react": "^16 || ^17 || ^18"
       }
     },

--- a/packages/package.json
+++ b/packages/package.json
@@ -40,7 +40,7 @@
     "prop-types": "^15.7.2",
     "react-autosuggest": "^9.4.3",
     "react-responsive": "^9.0.2",
-    "react-slider": "^1.3.1",
+    "react-slider": "^2.0.6",
     "react-table": "^7.8.0",
     "react-transition-group": "^2.5.3",
     "react-virtualized-auto-sizer": "^1.0.20",


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR bumps the `react-slider` dependency to the latest version that solves an issue whereby when moving the slider by small increments it would snap back to the previous value rather than the new value.

The same issue that was reported to Backpack was raised with [`react-slider`](https://github.com/zillow/react-slider/issues/279) and published in `2.0.5`, so bumping to the latest and it all works as expected

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here