### PR TITLE
[NOJIRA] Export TS types for Section Header Component

### DIFF
--- a/packages/bpk-component-section-header/index.d.ts
+++ b/packages/bpk-component-section-header/index.d.ts
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-import BpkSectionHeader, { type Props } from './src/BpkSectionHeader';
+import BpkSectionHeader, { SECTION_TYPES } from './src/BpkSectionHeader';
 
 export default BpkSectionHeader;
-export type BpkSectionHeaderProps = Props;

--- a/packages/bpk-component-section-header/index.d.ts
+++ b/packages/bpk-component-section-header/index.d.ts
@@ -19,3 +19,4 @@
 import BpkSectionHeader, { SECTION_TYPES } from './src/BpkSectionHeader';
 
 export default BpkSectionHeader;
+export { SECTION_TYPES };

--- a/packages/bpk-component-section-header/index.d.ts
+++ b/packages/bpk-component-section-header/index.d.ts
@@ -1,0 +1,22 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BpkSectionHeader, { type Props } from './src/BpkSectionHeader';
+
+export default BpkSectionHeader;
+export type BpkSectionHeaderProps = Props;

--- a/packages/bpk-component-section-header/src/BpkSectionHeader.tsx
+++ b/packages/bpk-component-section-header/src/BpkSectionHeader.tsx
@@ -32,7 +32,7 @@ export const SECTION_TYPES = {
 
 export type SectionType = (typeof SECTION_TYPES)[keyof typeof SECTION_TYPES];
 
-export type Props = {
+type Props = {
   title: string;
   description?: string;
   button?: ReactNode;

--- a/packages/bpk-component-section-header/src/BpkSectionHeader.tsx
+++ b/packages/bpk-component-section-header/src/BpkSectionHeader.tsx
@@ -32,7 +32,7 @@ export const SECTION_TYPES = {
 
 export type SectionType = (typeof SECTION_TYPES)[keyof typeof SECTION_TYPES];
 
-type Props = {
+export type Props = {
   title: string;
   description?: string;
   button?: ReactNode;


### PR DESCRIPTION
Description:
Backpack Section Header was not exporting typings

Changes made: 
- Export the types for the `BackpackSectionHeader` component

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here