### PR TITLE
[NO-JIRA] Fix Bug on dialog with open attribute for BpkModalV2

### DIFF
--- a/packages/bpk-component-modal/src/BpkModalV2/BpkModal.tsx
+++ b/packages/bpk-component-modal/src/BpkModalV2/BpkModal.tsx
@@ -134,6 +134,8 @@ export const BpkModalV2 = (props: Props) => {
     };
 
     if (isOpen) {
+      // There is a bug on older version of browser using chromium (chrome >114) where the dialog got an open attribute even before it is opened.
+      // Therefore, when trying to open it, it crashes and log an error mentioning the dialog has already an open attribute.
       ref.current?.removeAttribute('open');
       ref.current?.showModal?.();
 

--- a/packages/bpk-component-modal/src/BpkModalV2/BpkModal.tsx
+++ b/packages/bpk-component-modal/src/BpkModalV2/BpkModal.tsx
@@ -134,7 +134,7 @@ export const BpkModalV2 = (props: Props) => {
     };
 
     if (isOpen) {
-      // There is a bug on older version of browser using chromium (chrome >114) where the dialog got an open attribute even before it is opened.
+      // There is a bug on older versions of browser using chromium (chrome, firefox, edge >114) where the dialog got an open attribute even before it is opened.
       // Therefore, when trying to open it, it crashes and log an error mentioning the dialog has already an open attribute.
       ref.current?.removeAttribute('open');
       ref.current?.showModal?.();

--- a/packages/bpk-component-modal/src/BpkModalV2/BpkModal.tsx
+++ b/packages/bpk-component-modal/src/BpkModalV2/BpkModal.tsx
@@ -134,6 +134,7 @@ export const BpkModalV2 = (props: Props) => {
     };
 
     if (isOpen) {
+      ref.current?.removeAttribute('open');
       ref.current?.showModal?.();
 
       if (dialogWithPolyfill) {


### PR DESCRIPTION
We noticed during some testing of the new BpkModalV2 in Acorn a bug when opening the modal:
- The modal opens and the page crashes;
- An error was logged mentioning the DialogHTML element had already an open attribute.

This seems to be a bug. It has been reported by other developers in this thread for example: https://github.com/facebook/react/issues/24399.

In summary, an open attribute is added to a dialog element when used in react (despite the fact the dialog element adds an open attribute when it opens). Therefore, this causes the modal to crash.

This PR introduces a change to remove any attribute 'open' on the dialog before opening it. This fixes the bug and the modal opens as it should.

Bug occurs in Chrome 103-114, Firefox 103-114.

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here