### PR TITLE
[SHIBA-2119] Added Optional Height Prop for Scrollable Calendar

### DIFF
--- a/examples/bpk-component-scrollable-calendar/examples.js
+++ b/examples/bpk-component-scrollable-calendar/examples.js
@@ -136,6 +136,24 @@ const DefaultExample = () => (
   />
 );
 
+const DefaultExampleWithCustomHeight = () => (
+  <ScrollableCal
+    weekStartsOn={1}
+    daysOfWeek={weekDays}
+    formatMonth={formatMonth}
+    formatDateFull={formatDateFull}
+    DateComponent={BpkScrollableCalendarDate}
+    minDate={new Date(2020, 3, 1)}
+    maxDate={new Date(2020, 6, 1)}
+    selectionConfiguration={{
+      type: CALENDAR_SELECTION_TYPE.single,
+      date: new Date(2020, 3, 15),
+    }}
+    monthHeight={10}
+  />
+);
+
+
 const RangeExample = () => (
   <ScrollableCal
     weekStartsOn={1}
@@ -349,6 +367,7 @@ const PastCalendarExample = () => (
 
 export {
   DefaultExample,
+  DefaultExampleWithCustomHeight,
   RangeExample,
   SplitWeekRangeExample,
   WeekStartsOnSixExample,

--- a/examples/bpk-component-scrollable-calendar/examples.js
+++ b/examples/bpk-component-scrollable-calendar/examples.js
@@ -149,7 +149,7 @@ const DefaultExampleWithCustomHeight = () => (
       type: CALENDAR_SELECTION_TYPE.single,
       date: new Date(2020, 3, 15),
     }}
-    rowHeight={3}
+    customRowHeight={3}
   />
 );
 

--- a/examples/bpk-component-scrollable-calendar/examples.js
+++ b/examples/bpk-component-scrollable-calendar/examples.js
@@ -149,7 +149,7 @@ const DefaultExampleWithCustomHeight = () => (
       type: CALENDAR_SELECTION_TYPE.single,
       date: new Date(2020, 3, 15),
     }}
-    monthHeight={10}
+    rowHeight={3}
   />
 );
 

--- a/examples/bpk-component-scrollable-calendar/stories.js
+++ b/examples/bpk-component-scrollable-calendar/stories.js
@@ -94,11 +94,10 @@ VisualTestWithZoom.args = {
 };
 
 export const VisualTestWithCustomHeight = DefaultExampleWithCustomHeight;
-export const VisualTestWithCustomHeightWithZoom = VisualTest.bind({});
-VisualTestWithZoom.args = {
+export const VisualTestWithCustomHeightWithZoom = VisualTestWithCustomHeight.bind({});
+VisualTestWithCustomHeightWithZoom.args = {
   zoomEnabled: true
 };
-
 
 export const VisualTestRange = RangeExample;
 export const VisualTestRangeWithZoom = VisualTestRange.bind({});

--- a/examples/bpk-component-scrollable-calendar/stories.js
+++ b/examples/bpk-component-scrollable-calendar/stories.js
@@ -39,6 +39,7 @@ import {
   PastCalendarExample,
   RangeExample,
   SplitWeekRangeExample,
+  DefaultExampleWithCustomHeight,
 } from './examples';
 
 export default {
@@ -91,6 +92,13 @@ export const VisualTestWithZoom = VisualTest.bind({});
 VisualTestWithZoom.args = {
   zoomEnabled: true
 };
+
+export const VisualTestWithCustomHeight = DefaultExampleWithCustomHeight;
+export const VisualTestWithCustomHeightWithZoom = VisualTest.bind({});
+VisualTestWithZoom.args = {
+  zoomEnabled: true
+};
+
 
 export const VisualTestRange = RangeExample;
 export const VisualTestRangeWithZoom = VisualTestRange.bind({});

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.d.ts
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.d.ts
@@ -41,7 +41,7 @@ export type Props = {
     initiallyFocusedDate?: Date | null;
     markToday?: boolean;
     markOutsideDays?: boolean;
-    rowHeight?: number;
+    customRowHeight?: number;
 };
 type InjectedProps = {
     onDateClick: ((date: Date) => void) | null;
@@ -106,7 +106,7 @@ declare const withCalendarState: <P extends object>(Calendar: ComponentType<P>) 
         initiallyFocusedDate: null;
         markToday: boolean;
         markOutsideDays: boolean;
-        rowHeight?: number;
+        customRowHeight?: number;
     };
     contextType?: import("react").Context<any> | undefined;
 };
@@ -159,7 +159,7 @@ declare const _default: {
         initiallyFocusedDate: null;
         markToday: boolean;
         markOutsideDays: boolean;
-        rowHeight?: number;
+        customRowHeight?: number;
     };
     contextType?: import("react").Context<any> | undefined;
 };

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.d.ts
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.d.ts
@@ -41,7 +41,7 @@ export type Props = {
     initiallyFocusedDate?: Date | null;
     markToday?: boolean;
     markOutsideDays?: boolean;
-    monthHeight?: number;
+    rowHeight?: number;
 };
 type InjectedProps = {
     onDateClick: ((date: Date) => void) | null;
@@ -106,7 +106,7 @@ declare const withCalendarState: <P extends object>(Calendar: ComponentType<P>) 
         initiallyFocusedDate: null;
         markToday: boolean;
         markOutsideDays: boolean;
-        monthHeight?: number;
+        rowHeight?: number;
     };
     contextType?: import("react").Context<any> | undefined;
 };
@@ -159,7 +159,7 @@ declare const _default: {
         initiallyFocusedDate: null;
         markToday: boolean;
         markOutsideDays: boolean;
-        monthHeight?: number;
+        rowHeight?: number;
     };
     contextType?: import("react").Context<any> | undefined;
 };

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.d.ts
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.d.ts
@@ -41,6 +41,7 @@ export type Props = {
     initiallyFocusedDate?: Date | null;
     markToday?: boolean;
     markOutsideDays?: boolean;
+    monthHeight?: number;
 };
 type InjectedProps = {
     onDateClick: ((date: Date) => void) | null;
@@ -105,6 +106,7 @@ declare const withCalendarState: <P extends object>(Calendar: ComponentType<P>) 
         initiallyFocusedDate: null;
         markToday: boolean;
         markOutsideDays: boolean;
+        monthHeight?: number;
     };
     contextType?: import("react").Context<any> | undefined;
 };
@@ -157,6 +159,7 @@ declare const _default: {
         initiallyFocusedDate: null;
         markToday: boolean;
         markOutsideDays: boolean;
+        monthHeight?: number;
     };
     contextType?: import("react").Context<any> | undefined;
 };

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
@@ -66,6 +66,9 @@ export type Props = {
   initiallyFocusedDate?: Date | null;
   markToday?: boolean;
   markOutsideDays?: boolean;
+  /**
+   * Use this prop to set the height of month rows in 'rem' units. If not specified, the default value of `2.75rem` will be used.
+   */
   customRowHeight?: number;
 };
 

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
@@ -66,6 +66,7 @@ export type Props = {
   initiallyFocusedDate?: Date | null;
   markToday?: boolean;
   markOutsideDays?: boolean;
+  monthHeight?: number;
 };
 
 type InjectedProps = {

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
@@ -67,7 +67,7 @@ export type Props = {
   markToday?: boolean;
   markOutsideDays?: boolean;
   /**
-   * Use this prop to set the height of month rows in 'rem' units. If not specified, the default value of `2.75rem` will be used.
+   * Sets the height of month rows in 'rem' units. If not specified, the default value of `2.75rem` will be used.
    */
   customRowHeight?: number;
 };

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
@@ -66,7 +66,7 @@ export type Props = {
   initiallyFocusedDate?: Date | null;
   markToday?: boolean;
   markOutsideDays?: boolean;
-  monthHeight?: number;
+  rowHeight?: number;
 };
 
 type InjectedProps = {

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
@@ -66,7 +66,7 @@ export type Props = {
   initiallyFocusedDate?: Date | null;
   markToday?: boolean;
   markOutsideDays?: boolean;
-  rowHeight?: number;
+  customRowHeight?: number;
 };
 
 type InjectedProps = {

--- a/packages/bpk-component-calendar/src/composeCalendar.d.ts
+++ b/packages/bpk-component-calendar/src/composeCalendar.d.ts
@@ -71,7 +71,7 @@ export type Props = {
     preventKeyboardFocus?: boolean;
     selectionConfiguration?: SelectionConfiguration;
     gridClassName?: string | null;
-    rowHeight?: number;
+    customRowHeight?: number;
     /**
      * Key to be used to pick the desired weekDay format from the `daysOfWeek` object, for example: `nameAbbr` or `nameNarrow`.
      */

--- a/packages/bpk-component-calendar/src/composeCalendar.d.ts
+++ b/packages/bpk-component-calendar/src/composeCalendar.d.ts
@@ -71,6 +71,7 @@ export type Props = {
     preventKeyboardFocus?: boolean;
     selectionConfiguration?: SelectionConfiguration;
     gridClassName?: string | null;
+    monthHeight?: number;
     /**
      * Key to be used to pick the desired weekDay format from the `daysOfWeek` object, for example: `nameAbbr` or `nameNarrow`.
      */

--- a/packages/bpk-component-calendar/src/composeCalendar.d.ts
+++ b/packages/bpk-component-calendar/src/composeCalendar.d.ts
@@ -71,7 +71,7 @@ export type Props = {
     preventKeyboardFocus?: boolean;
     selectionConfiguration?: SelectionConfiguration;
     gridClassName?: string | null;
-    monthHeight?: number;
+    rowHeight?: number;
     /**
      * Key to be used to pick the desired weekDay format from the `daysOfWeek` object, for example: `nameAbbr` or `nameNarrow`.
      */

--- a/packages/bpk-component-calendar/src/composeCalendar.tsx
+++ b/packages/bpk-component-calendar/src/composeCalendar.tsx
@@ -86,7 +86,7 @@ export type Props = {
   selectionConfiguration?: SelectionConfiguration;
   gridClassName?: string | null;
   /**
-   * Use this prop to set the height of month rows in 'rem' units. If not specified, the default value of `2.75rem` will be used.
+   * Sets the height of month rows in 'rem' units. If not specified, the default value of `2.75rem` will be used.
    */
   customRowHeight?: number;
   /**

--- a/packages/bpk-component-calendar/src/composeCalendar.tsx
+++ b/packages/bpk-component-calendar/src/composeCalendar.tsx
@@ -85,6 +85,9 @@ export type Props = {
   preventKeyboardFocus?: boolean;
   selectionConfiguration?: SelectionConfiguration;
   gridClassName?: string | null;
+  /**
+   * Use this prop to set the height of month rows in 'rem' units. If not specified, the default value of `2.75rem` will be used.
+   */
   customRowHeight?: number;
   /**
    * Key to be used to pick the desired weekDay format from the `daysOfWeek` object, for example: `nameAbbr` or `nameNarrow`.

--- a/packages/bpk-component-calendar/src/composeCalendar.tsx
+++ b/packages/bpk-component-calendar/src/composeCalendar.tsx
@@ -85,7 +85,7 @@ export type Props = {
   preventKeyboardFocus?: boolean;
   selectionConfiguration?: SelectionConfiguration;
   gridClassName?: string | null;
-  monthHeight?: number;
+  rowHeight?: number;
   /**
    * Key to be used to pick the desired weekDay format from the `daysOfWeek` object, for example: `nameAbbr` or `nameNarrow`.
    */
@@ -133,7 +133,6 @@ const composeCalendar = (
     maxDate,
     minDate,
     month,
-    monthHeight,
     navProps = {},
     nextMonthLabel = null,
     onDateClick = null,
@@ -141,6 +140,7 @@ const composeCalendar = (
     onMonthChange = null,
     preventKeyboardFocus = false,
     previousMonthLabel = null,
+    rowHeight,
     selectionConfiguration = {
       type: CALENDAR_SELECTION_TYPE.single,
       date: null,
@@ -218,7 +218,7 @@ const composeCalendar = (
           className={gridClasses.join(' ')}
           dateProps={dateProps}
           selectionConfiguration={selectionConfiguration}
-          monthHeight={monthHeight}
+          rowHeight={rowHeight}
           {...gridProps}
         />
       </div>

--- a/packages/bpk-component-calendar/src/composeCalendar.tsx
+++ b/packages/bpk-component-calendar/src/composeCalendar.tsx
@@ -85,6 +85,7 @@ export type Props = {
   preventKeyboardFocus?: boolean;
   selectionConfiguration?: SelectionConfiguration;
   gridClassName?: string | null;
+  monthHeight?: number;
   /**
    * Key to be used to pick the desired weekDay format from the `daysOfWeek` object, for example: `nameAbbr` or `nameNarrow`.
    */
@@ -132,6 +133,7 @@ const composeCalendar = (
     maxDate,
     minDate,
     month,
+    monthHeight,
     navProps = {},
     nextMonthLabel = null,
     onDateClick = null,
@@ -216,6 +218,7 @@ const composeCalendar = (
           className={gridClasses.join(' ')}
           dateProps={dateProps}
           selectionConfiguration={selectionConfiguration}
+          monthHeight={monthHeight}
           {...gridProps}
         />
       </div>

--- a/packages/bpk-component-calendar/src/composeCalendar.tsx
+++ b/packages/bpk-component-calendar/src/composeCalendar.tsx
@@ -85,7 +85,7 @@ export type Props = {
   preventKeyboardFocus?: boolean;
   selectionConfiguration?: SelectionConfiguration;
   gridClassName?: string | null;
-  rowHeight?: number;
+  customRowHeight?: number;
   /**
    * Key to be used to pick the desired weekDay format from the `daysOfWeek` object, for example: `nameAbbr` or `nameNarrow`.
    */
@@ -117,6 +117,7 @@ const composeCalendar = (
   const BpkCalendar = ({
     changeMonthLabel = null,
     className = null,
+    customRowHeight,
     dateModifiers = {},
     dateProps = {},
     daysOfWeek,
@@ -140,7 +141,6 @@ const composeCalendar = (
     onMonthChange = null,
     preventKeyboardFocus = false,
     previousMonthLabel = null,
-    rowHeight,
     selectionConfiguration = {
       type: CALENDAR_SELECTION_TYPE.single,
       date: null,
@@ -218,7 +218,7 @@ const composeCalendar = (
           className={gridClasses.join(' ')}
           dateProps={dateProps}
           selectionConfiguration={selectionConfiguration}
-          rowHeight={rowHeight}
+          customRowHeight={customRowHeight}
           {...gridProps}
         />
       </div>

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.tsx
@@ -80,6 +80,22 @@ describe('BpkCalendarScrollGridList', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  it('should render correctly with a custom "monthHeight" attribute', () => {
+    const { asFragment } = render(
+      <BpkScrollableCalendarGridList
+        minDate={DateUtils.addDays(testDate, -1)}
+        maxDate={DateUtils.addMonths(testDate, 12)}
+        month={testDate}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        DateComponent={BpkCalendarScrollDate}
+        weekStartsOn={0}
+        monthHeight={10}
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it('should render correctly with a custom date component', () => {
     const MyCustomDate = (props: any) => {
       const cx = {

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.tsx
@@ -80,7 +80,7 @@ describe('BpkCalendarScrollGridList', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render correctly with a custom "monthHeight" attribute', () => {
+  it('should render correctly with a custom "rowHeight" attribute', () => {
     const { asFragment } = render(
       <BpkScrollableCalendarGridList
         minDate={DateUtils.addDays(testDate, -1)}
@@ -90,7 +90,7 @@ describe('BpkCalendarScrollGridList', () => {
         formatDateFull={formatDateFull}
         DateComponent={BpkCalendarScrollDate}
         weekStartsOn={0}
-        monthHeight={10}
+        rowHeight={3}
       />,
     );
     expect(asFragment()).toMatchSnapshot();

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList-test.tsx
@@ -80,7 +80,7 @@ describe('BpkCalendarScrollGridList', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render correctly with a custom "rowHeight" attribute', () => {
+  it('should render correctly with a custom "customRowHeight" attribute', () => {
     const { asFragment } = render(
       <BpkScrollableCalendarGridList
         minDate={DateUtils.addDays(testDate, -1)}
@@ -90,7 +90,7 @@ describe('BpkCalendarScrollGridList', () => {
         formatDateFull={formatDateFull}
         DateComponent={BpkCalendarScrollDate}
         weekStartsOn={0}
-        rowHeight={3}
+        customRowHeight={3}
       />,
     );
     expect(asFragment()).toMatchSnapshot();

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.d.ts
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.d.ts
@@ -29,7 +29,7 @@ type Props = Partial<BpkCalendarGridProps> & {
     focusedDate?: Date | null;
     selectionConfiguration?: SelectionConfiguration;
     className?: string | null;
-    monthHeight?: number;
+    rowHeight?: number;
 };
 declare const BpkScrollableCalendarGridList: (props: Props) => JSX.Element;
 export default BpkScrollableCalendarGridList;

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.d.ts
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.d.ts
@@ -29,7 +29,7 @@ type Props = Partial<BpkCalendarGridProps> & {
     focusedDate?: Date | null;
     selectionConfiguration?: SelectionConfiguration;
     className?: string | null;
-    rowHeight?: number;
+    customRowHeight?: number;
 };
 declare const BpkScrollableCalendarGridList: (props: Props) => JSX.Element;
 export default BpkScrollableCalendarGridList;

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.d.ts
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.d.ts
@@ -29,6 +29,7 @@ type Props = Partial<BpkCalendarGridProps> & {
     focusedDate?: Date | null;
     selectionConfiguration?: SelectionConfiguration;
     className?: string | null;
+    monthHeight?: number;
 };
 declare const BpkScrollableCalendarGridList: (props: Props) => JSX.Element;
 export default BpkScrollableCalendarGridList;

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
@@ -55,15 +55,15 @@ type Props = Partial<BpkCalendarGridProps> & {
   focusedDate?: Date | null;
   selectionConfiguration?: SelectionConfiguration;
   className?: string | null;
-  rowHeight?: number;
+  customRowHeight?: number;
 };
 
 const BpkScrollableCalendarGridList = (props: Props) => {
   const {
     className = null,
+    customRowHeight = 2.75,
     focusedDate = null,
     minDate,
-    rowHeight = 2.75,
     selectionConfiguration,
     ...rest
   } = props;
@@ -73,7 +73,7 @@ const BpkScrollableCalendarGridList = (props: Props) => {
   const monthsCount = DateUtils.differenceInCalendarMonths(endDate, startDate);
 
   // Row and month item heights are defined in rem to support text scaling
-  const ROW_HEIGHT = rowHeight;
+  const ROW_HEIGHT = customRowHeight;
   // Most calendar grids have 5 rows. Calculate height in px as this is what react-window expects.
   const ESTIMATED_MONTH_ITEM_HEIGHT =
     (BASE_MONTH_ITEM_HEIGHT + 5 * ROW_HEIGHT) * DEFAULT_ROOT_FONT_SIZE;

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
@@ -55,6 +55,9 @@ type Props = Partial<BpkCalendarGridProps> & {
   focusedDate?: Date | null;
   selectionConfiguration?: SelectionConfiguration;
   className?: string | null;
+  /**
+   * Use this prop to set the height of month rows in 'rem' units. If not specified, the default value of `2.75rem` will be used.
+   */
   customRowHeight?: number;
 };
 

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
@@ -35,6 +35,15 @@ import { getMonthsArray, getMonthItemHeights } from './utils';
 
 const getClassName = cssModules(STYLES);
 
+// These constants are here to facilitate calculating the height
+// This is the additional height of each grid without any rows.
+const BASE_MONTH_ITEM_HEIGHT = 8.125;
+const COLUMN_COUNT = 7;
+// Most browsers have by default 16px root font size
+const DEFAULT_ROOT_FONT_SIZE = 16;
+// Minimum month item width (useful for server-side rendering. This value will be overridden with an accurate width after mounting)
+const ESTIMATED_MONTH_ITEM_WIDTH = BASE_MONTH_ITEM_HEIGHT * 7 * DEFAULT_ROOT_FONT_SIZE;
+
 type Props = Partial<BpkCalendarGridProps> & {
   minDate: Date;
   maxDate: Date;
@@ -46,7 +55,7 @@ type Props = Partial<BpkCalendarGridProps> & {
   focusedDate?: Date | null;
   selectionConfiguration?: SelectionConfiguration;
   className?: string | null;
-  monthHeight?: number;
+  rowHeight?: number;
 };
 
 const BpkScrollableCalendarGridList = (props: Props) => {
@@ -54,7 +63,7 @@ const BpkScrollableCalendarGridList = (props: Props) => {
     className = null,
     focusedDate = null,
     minDate,
-    monthHeight = 8.125,
+    rowHeight = 2.75,
     selectionConfiguration,
     ...rest
   } = props;
@@ -63,19 +72,11 @@ const BpkScrollableCalendarGridList = (props: Props) => {
   const endDate = startOfDay(startOfMonth(rest.maxDate));
   const monthsCount = DateUtils.differenceInCalendarMonths(endDate, startDate);
 
-  // These constants are here to facilitate calculating the height
   // Row and month item heights are defined in rem to support text scaling
-  const ROW_HEIGHT = 2.75;
-  // This is the additional height of each grid without any rows.
-  const BASE_MONTH_ITEM_HEIGHT = monthHeight;
-  const COLUMN_COUNT = 7;
-  // Most browsers have by default 16px root font size
-  const DEFAULT_ROOT_FONT_SIZE = 16;
+  const ROW_HEIGHT = rowHeight;
   // Most calendar grids have 5 rows. Calculate height in px as this is what react-window expects.
   const ESTIMATED_MONTH_ITEM_HEIGHT =
     (BASE_MONTH_ITEM_HEIGHT + 5 * ROW_HEIGHT) * DEFAULT_ROOT_FONT_SIZE;
-  // Minimum month item width (useful for server-side rendering. This value will be overridden with an accurate width after mounting)
-  const ESTIMATED_MONTH_ITEM_WIDTH = BASE_MONTH_ITEM_HEIGHT * 7 * DEFAULT_ROOT_FONT_SIZE;
 
   const getInitialRootFontSize = () =>
     parseFloat(getComputedStyle(document.documentElement).fontSize) ||

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
@@ -35,20 +35,6 @@ import { getMonthsArray, getMonthItemHeights } from './utils';
 
 const getClassName = cssModules(STYLES);
 
-// These constants are here to facilitate calculating the height
-// Row and month item heights are defined in rem to support text scaling
-const ROW_HEIGHT = 2.75;
-// This is the additional height of each grid without any rows.
-const BASE_MONTH_ITEM_HEIGHT = 8.125;
-const COLUMN_COUNT = 7;
-// Most browsers have by default 16px root font size
-const DEFAULT_ROOT_FONT_SIZE = 16;
-// Most calendar grids have 5 rows. Calculate height in px as this is what react-window expects.
-const ESTIMATED_MONTH_ITEM_HEIGHT =
-  (BASE_MONTH_ITEM_HEIGHT + 5 * ROW_HEIGHT) * DEFAULT_ROOT_FONT_SIZE;
-// Minimum month item width (useful for server-side rendering. This value will be overridden with an accurate width after mounting)
-const ESTIMATED_MONTH_ITEM_WIDTH = BASE_MONTH_ITEM_HEIGHT * 7 * DEFAULT_ROOT_FONT_SIZE;
-
 type Props = Partial<BpkCalendarGridProps> & {
   minDate: Date;
   maxDate: Date;
@@ -60,6 +46,7 @@ type Props = Partial<BpkCalendarGridProps> & {
   focusedDate?: Date | null;
   selectionConfiguration?: SelectionConfiguration;
   className?: string | null;
+  monthHeight?: number;
 };
 
 const BpkScrollableCalendarGridList = (props: Props) => {
@@ -67,6 +54,7 @@ const BpkScrollableCalendarGridList = (props: Props) => {
     className = null,
     focusedDate = null,
     minDate,
+    monthHeight = 8.125,
     selectionConfiguration,
     ...rest
   } = props;
@@ -74,6 +62,20 @@ const BpkScrollableCalendarGridList = (props: Props) => {
   const startDate = startOfDay(startOfMonth(minDate));
   const endDate = startOfDay(startOfMonth(rest.maxDate));
   const monthsCount = DateUtils.differenceInCalendarMonths(endDate, startDate);
+
+  // These constants are here to facilitate calculating the height
+  // Row and month item heights are defined in rem to support text scaling
+  const ROW_HEIGHT = 2.75;
+  // This is the additional height of each grid without any rows.
+  const BASE_MONTH_ITEM_HEIGHT = monthHeight;
+  const COLUMN_COUNT = 7;
+  // Most browsers have by default 16px root font size
+  const DEFAULT_ROOT_FONT_SIZE = 16;
+  // Most calendar grids have 5 rows. Calculate height in px as this is what react-window expects.
+  const ESTIMATED_MONTH_ITEM_HEIGHT =
+    (BASE_MONTH_ITEM_HEIGHT + 5 * ROW_HEIGHT) * DEFAULT_ROOT_FONT_SIZE;
+  // Minimum month item width (useful for server-side rendering. This value will be overridden with an accurate width after mounting)
+  const ESTIMATED_MONTH_ITEM_WIDTH = BASE_MONTH_ITEM_HEIGHT * 7 * DEFAULT_ROOT_FONT_SIZE;
 
   const getInitialRootFontSize = () =>
     parseFloat(getComputedStyle(document.documentElement).fontSize) ||

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
@@ -73,10 +73,10 @@ const BpkScrollableCalendarGridList = (props: Props) => {
   const monthsCount = DateUtils.differenceInCalendarMonths(endDate, startDate);
 
   // Row and month item heights are defined in rem to support text scaling
-  const ROW_HEIGHT = customRowHeight;
+  const rowHeight = customRowHeight;
   // Most calendar grids have 5 rows. Calculate height in px as this is what react-window expects.
-  const ESTIMATED_MONTH_ITEM_HEIGHT =
-    (BASE_MONTH_ITEM_HEIGHT + 5 * ROW_HEIGHT) * DEFAULT_ROOT_FONT_SIZE;
+  const estimatedMonthItemHeight = 
+    (BASE_MONTH_ITEM_HEIGHT + 5 * rowHeight) * DEFAULT_ROOT_FONT_SIZE;
 
   const getInitialRootFontSize = () =>
     parseFloat(getComputedStyle(document.documentElement).fontSize) ||
@@ -114,7 +114,7 @@ const BpkScrollableCalendarGridList = (props: Props) => {
     typeof document !== 'undefined' ? document.querySelector('html') : {};
 
   const getItemSize = (index: number) =>
-    monthItemHeights[index] || ESTIMATED_MONTH_ITEM_HEIGHT;
+    monthItemHeights[index] || estimatedMonthItemHeight;
 
   const rowRenderer = ({ index, style }: { index: number; style: {} }) => (
     <div style={style}>
@@ -161,7 +161,7 @@ const BpkScrollableCalendarGridList = (props: Props) => {
     >
       <AutoSizer
         onResize={onResize}
-        defaultHeight={ESTIMATED_MONTH_ITEM_HEIGHT}
+        defaultHeight={estimatedMonthItemHeight}
         defaultWidth={ESTIMATED_MONTH_ITEM_WIDTH}
       >
         {({ height, width }: { height: number | string, width: number | string}) => (
@@ -173,7 +173,7 @@ const BpkScrollableCalendarGridList = (props: Props) => {
             }
             width={width}
             height={height}
-            estimatedItemSize={ESTIMATED_MONTH_ITEM_HEIGHT}
+            estimatedItemSize={estimatedMonthItemHeight}
             itemSize={getItemSize}
             itemCount={months.length}
             overscanCount={1}

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
@@ -56,7 +56,7 @@ type Props = Partial<BpkCalendarGridProps> & {
   selectionConfiguration?: SelectionConfiguration;
   className?: string | null;
   /**
-   * Use this prop to set the height of month rows in 'rem' units. If not specified, the default value of `2.75rem` will be used.
+   * Sets the height of month rows in 'rem' units. If not specified, the default value of `2.75rem` will be used.
    */
   customRowHeight?: number;
 };

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGridList.tsx
@@ -97,7 +97,7 @@ const BpkScrollableCalendarGridList = (props: Props) => {
         months,
         rest.weekStartsOn,
         COLUMN_COUNT,
-        ROW_HEIGHT * rootFontSize,
+        rowHeight * rootFontSize,
         BASE_MONTH_ITEM_HEIGHT * rootFontSize,
       ),
     [rootFontSize, months, rest.weekStartsOn],

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
@@ -1261,7 +1261,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
 </DocumentFragment>
 `;
 
-exports[`BpkCalendarScrollGridList should render correctly with a custom "rowHeight" attribute 1`] = `
+exports[`BpkCalendarScrollGridList should render correctly with a custom "customRowHeight" attribute 1`] = `
 <DocumentFragment>
   <div
     class="bpk-scrollable-calendar-grid-list"

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
@@ -1261,6 +1261,1299 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
 </DocumentFragment>
 `;
 
+exports[`BpkCalendarScrollGridList should render correctly with a custom "monthHeight" attribute 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-scrollable-calendar-grid-list"
+  >
+    <div
+      style="overflow: visible; height: 0px; width: 0px;"
+    >
+      <div
+        style="position: relative; height: 380px; width: 1120px; overflow: auto; will-change: transform; direction: ltr;"
+      >
+        <div
+          style="height: 4940px; width: 100%;"
+        >
+          <div
+            style="position: absolute; left: 0px; top: 0px; height: 380px; width: 100%;"
+          >
+            <div
+              class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"
+            >
+              <h1
+                class="bpk-text bpk-text--heading-4 bpk-scrollable-calendar-grid__title"
+              >
+                February 2010
+              </h1>
+              <div
+                aria-hidden="false"
+                class="bpk-calendar-grid"
+              >
+                <div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Monday, 1st February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          1
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Tuesday, 2nd February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          2
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Wednesday, 3rd February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          3
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Thursday, 4th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          4
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Friday, 5th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          5
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Saturday, 6th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          6
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Sunday, 7th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          7
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Monday, 8th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          8
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Tuesday, 9th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          9
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Wednesday, 10th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          10
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Thursday, 11th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          11
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Friday, 12th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          12
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="true"
+                        aria-label="Saturday, 13th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date bpk-calendar-date--blocked"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          13
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 14th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          14
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 15th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          15
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 16th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          16
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 17th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          17
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 18th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          18
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 19th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          19
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 20th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          20
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 21st February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          21
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 22nd February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          22
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 23rd February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          23
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 24th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          24
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 25th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          25
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 26th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          26
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 27th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          27
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 28th February 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          28
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style="position: absolute; left: 0px; top: 380px; height: 380px; width: 100%;"
+          >
+            <div
+              class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"
+            >
+              <h1
+                class="bpk-text bpk-text--heading-4 bpk-scrollable-calendar-grid__title"
+              >
+                March 2010
+              </h1>
+              <div
+                aria-hidden="false"
+                class="bpk-calendar-grid"
+              >
+                <div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 1st March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          1
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 2nd March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          2
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 3rd March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          3
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 4th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          4
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 5th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          5
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 6th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          6
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 7th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          7
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 8th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          8
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 9th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          9
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 10th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          10
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 11th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          11
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 12th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          12
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 13th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          13
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 14th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          14
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 15th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          15
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 16th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          16
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 17th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          17
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 18th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          18
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 19th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          19
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 20th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          20
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 21st March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          21
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 22nd March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          22
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 23rd March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          23
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 24th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          24
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Thursday, 25th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          25
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Friday, 26th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          26
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Saturday, 27th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          27
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="bpk-calendar-grid__week"
+                  >
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Sunday, 28th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          28
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Monday, 29th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          29
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Tuesday, 30th March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          30
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="false"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    >
+                      <button
+                        aria-hidden="false"
+                        aria-label="Wednesday, 31st March 2010"
+                        aria-pressed="false"
+                        class="bpk-calendar-date"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                        >
+                          31
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="bpk-calendar-grid__date bpk-calendar-grid__date--none"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="resize-triggers"
+    >
+      <div
+        class="expand-trigger"
+      >
+        <div
+          style="width: 1px; height: 1px;"
+        />
+      </div>
+      <div
+        class="contract-trigger"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`BpkCalendarScrollGridList should render correctly with a custom date component 1`] = `
 <DocumentFragment>
   <div

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
@@ -1261,7 +1261,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
 </DocumentFragment>
 `;
 
-exports[`BpkCalendarScrollGridList should render correctly with a custom "monthHeight" attribute 1`] = `
+exports[`BpkCalendarScrollGridList should render correctly with a custom "rowHeight" attribute 1`] = `
 <DocumentFragment>
   <div
     class="bpk-scrollable-calendar-grid-list"
@@ -1270,13 +1270,13 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom "monthH
       style="overflow: visible; height: 0px; width: 0px;"
     >
       <div
-        style="position: relative; height: 380px; width: 1120px; overflow: auto; will-change: transform; direction: ltr;"
+        style="position: relative; height: 370px; width: 910px; overflow: auto; will-change: transform; direction: ltr;"
       >
         <div
-          style="height: 4940px; width: 100%;"
+          style="height: 4810px; width: 100%;"
         >
           <div
-            style="position: absolute; left: 0px; top: 0px; height: 380px; width: 100%;"
+            style="position: absolute; left: 0px; top: 0px; height: 370px; width: 100%;"
           >
             <div
               class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"
@@ -1889,7 +1889,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom "monthH
             </div>
           </div>
           <div
-            style="position: absolute; left: 0px; top: 380px; height: 380px; width: 100%;"
+            style="position: absolute; left: 0px; top: 370px; height: 370px; width: 100%;"
           >
             <div
               class="bpk-scrollable-calendar-grid bpk-scrollable-calendar-grid-list__item"


### PR DESCRIPTION
We want to be able to pass an optional heigh prop to add extra whitespace between months.

See the images below for reference.

![Screenshot 2023-11-02 at 14 19 19](https://github.com/Skyscanner/backpack/assets/37026035/e64dccb1-6614-43af-ae45-a47cc04063b8)


![Screenshot 2023-11-02 at 14 18 45](https://github.com/Skyscanner/backpack/assets/37026035/d79a1ae1-d779-4560-96ca-e3ee82bbefc2)


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here