### PR TITLE
[ARGG-851] Fix withScrimmedPortal component for deterministic order of execution

### DIFF
--- a/packages/bpk-scrim-utils/README.md
+++ b/packages/bpk-scrim-utils/README.md
@@ -18,3 +18,29 @@ const Box = props => (
 
 const BoxWithScrim = withScrim(Box);
 ```
+
+The version using a [React portal](https://react.dev/reference/react-dom/createPortal) renders the wrapped component in a different part of the DOM. It also provides an `isPortalReady` prop to notify when the component inside the portal is ready to be used. This may be necessary to interact with the content of the component in a `useEffect` hook, for example to set the focus on mount.
+
+```js
+import { withScrimmedPortal } from '@skyscanner/backpack-web/bpk-scrim-utils';
+
+const Box = props => {
+  const dialogRef = useRef(null);
+  const { isPortalReady, onClose } = props;
+
+  useEffect(() => {
+    if (isPortalReady) {
+      dialogRef.current?.focus();
+    }
+  }, [isPortalReady]);
+
+  return (
+    <div>
+      <BpkButton ref={dialogRef} onClick={onClose}>Close</BpkButton>
+      Hello in a portal
+    </div>
+  );
+};
+
+const BoxWithScrimmedPortal = withScrimmedPortal(Box);
+```

--- a/packages/bpk-scrim-utils/src/__snapshots__/withScrimmedPortal-test.tsx.snap
+++ b/packages/bpk-scrim-utils/src/__snapshots__/withScrimmedPortal-test.tsx.snap
@@ -14,17 +14,15 @@ exports[`withScrimmedPortal renders the wrapped component inside a portal correc
       </div>
     </div>
   </div>
-  <div>
+  <div
+    class="bpk-scrim-content"
+  >
     <div
-      class="bpk-scrim-content"
-    >
-      <div
-        class="bpk-scrim"
-        role="presentation"
-      />
-      <div>
-        Dialog content
-      </div>
+      class="bpk-scrim"
+      role="presentation"
+    />
+    <div>
+      Dialog content
     </div>
   </div>
 </body>
@@ -47,17 +45,15 @@ exports[`withScrimmedPortal renders the wrapped component inside a portal with r
       <div
         id="modal-container"
       >
-        <div>
+        <div
+          class="bpk-scrim-content"
+        >
           <div
-            class="bpk-scrim-content"
-          >
-            <div
-              class="bpk-scrim"
-              role="presentation"
-            />
-            <div>
-              Wrapped Component
-            </div>
+            class="bpk-scrim"
+            role="presentation"
+          />
+          <div>
+            Wrapped Component
           </div>
         </div>
       </div>

--- a/packages/bpk-scrim-utils/src/withScrimmedPortal.tsx
+++ b/packages/bpk-scrim-utils/src/withScrimmedPortal.tsx
@@ -42,13 +42,13 @@ const getPortalElement = (target: (() => HTMLElement | null) | null | undefined)
 
 const withScrimmedPortal = (WrappedComponent: ComponentType<ScrimProps>) => {
     const Scrimmed = withScrim(WrappedComponent);
-    let portalElement = document.body;
 
     const ScrimmedComponent = ({ renderTarget, ...rest}: Props) => {
+        const portalElement = getPortalElement(renderTarget);
+
         const [isPortalReady, setIsPortalReady] = useState(false);
 
         useEffect(() => {
-            portalElement = getPortalElement(renderTarget);
             setIsPortalReady(true);
           }, []);
 

--- a/packages/bpk-scrim-utils/src/withScrimmedPortal.tsx
+++ b/packages/bpk-scrim-utils/src/withScrimmedPortal.tsx
@@ -47,12 +47,6 @@ const withScrimmedPortal = (WrappedComponent: ComponentType<ScrimProps>) => {
     const ScrimmedComponent = ({ renderTarget, ...rest}: Props) => {
         const [isPortalReady, setIsPortalReady] = useState(false);
 
-        const node = useRef<HTMLDivElement | null>(null);
-
-        if (!node.current) {
-            node.current = document.createElement('div');
-        }
-
         useEffect(() => {
             portalElement = getPortalElement(renderTarget);
             setIsPortalReady(true);

--- a/packages/bpk-scrim-utils/src/withScrimmedPortal.tsx
+++ b/packages/bpk-scrim-utils/src/withScrimmedPortal.tsx
@@ -17,7 +17,7 @@
  */
 
 import type { ComponentType} from 'react';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 import withScrim from './withScrim';

--- a/packages/bpk-scrim-utils/src/withScrimmedPortal.tsx
+++ b/packages/bpk-scrim-utils/src/withScrimmedPortal.tsx
@@ -25,7 +25,6 @@ import type { Props as ScrimProps } from './withScrim';
 
 export type Props = ScrimProps & {
     renderTarget?: (() => HTMLElement | null) | null;
-    isPortalReady?: boolean;
 };
 
 const getPortalElement = (target: (() => HTMLElement | null) | null | undefined) => {
@@ -41,7 +40,7 @@ const getPortalElement = (target: (() => HTMLElement | null) | null | undefined)
     throw new Error('Render target and fallback unavailable');
 }
 
-const withScrimmedPortal = (WrappedComponent: ComponentType<Props>) => {
+const withScrimmedPortal = (WrappedComponent: ComponentType<ScrimProps>) => {
     const Scrimmed = withScrim(WrappedComponent);
     let portalElement = document.body;
 


### PR DESCRIPTION
Provide an `isPortalReady` prop to notify when the component inside the portal is ready to be used. This may be necessary to interact with the content of the component in a `useEffect` hook, for example to set the focus on mount.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here