### PR TITLE
Fix async toggle style issue & BpkButton -> BpkButtonV2 in README files

### DIFF
--- a/examples/bpk-component-card-button/examples.tsx
+++ b/examples/bpk-component-card-button/examples.tsx
@@ -120,7 +120,6 @@ const VisualTestExample = () => (
     <SmallContainedExample />
     <SmallOnDarkExample />
     <SmallCheckedExample />
-    <br />
   </>
 );
 

--- a/examples/bpk-component-card-button/examples.tsx
+++ b/examples/bpk-component-card-button/examples.tsx
@@ -35,7 +35,12 @@ type Props = {
   style?: StyleType;
   asyncWithError?: boolean;
 };
-const SaveButtonContainer = ({ asyncWithError = false, checked = false, size, style }: Props) => {
+const SaveButtonContainer = ({
+  asyncWithError = false,
+  checked = false,
+  size,
+  style,
+}: Props) => {
   const [checkedStatus, setCheckedStatus] = useState(checked);
 
   const onCheckedChange = () => {
@@ -47,7 +52,7 @@ const SaveButtonContainer = ({ asyncWithError = false, checked = false, size, st
       await Promise.reject(new Error('mocked example error'));
       setCheckedStatus(!checkedStatus);
     } catch (e) {
-      console.log('save button async error: ', e)// eslint-disable-line no-console
+      console.log('save button async error: ', e); // eslint-disable-line no-console
     }
   };
 
@@ -77,7 +82,9 @@ const OnDarkExample = () => (
 
 const CheckedExample = () => <SaveButtonContainer checked />;
 
-const AsyncWithErrorCheckedExample = () => <SaveButtonContainer checked asyncWithError />;
+const AsyncWithErrorCheckedExample = () => (
+  <SaveButtonContainer checked asyncWithError />
+);
 
 const SmallDefaultExample = () => (
   <SaveButtonContainer size={SIZE_TYPES.small} />

--- a/examples/bpk-component-card-button/examples.tsx
+++ b/examples/bpk-component-card-button/examples.tsx
@@ -33,19 +33,29 @@ type Props = {
   checked?: boolean;
   size?: SizeType;
   style?: StyleType;
+  asyncWithError?: boolean;
 };
-const SaveButtonContainer = ({ checked = false, size, style }: Props) => {
+const SaveButtonContainer = ({ asyncWithError = false, checked = false, size, style }: Props) => {
   const [checkedStatus, setCheckedStatus] = useState(checked);
 
   const onCheckedChange = () => {
     setCheckedStatus(!checkedStatus);
   };
 
+  const onSyncCheckedChange = async () => {
+    try {
+      await Promise.reject(new Error('mocked example error'));
+      setCheckedStatus(!checkedStatus);
+    } catch (e) {
+      console.log('save button async error: ', e)// eslint-disable-line no-console
+    }
+  };
+
   return (
     <BpkSaveButton
       checked={checkedStatus}
       accessibilityLabel={`Click to ${checkedStatus ? 'remove save' : 'save'}`}
-      onCheckedChange={onCheckedChange}
+      onCheckedChange={asyncWithError ? onSyncCheckedChange : onCheckedChange}
       size={size}
       style={style}
     />
@@ -66,6 +76,8 @@ const OnDarkExample = () => (
 );
 
 const CheckedExample = () => <SaveButtonContainer checked />;
+
+const AsyncWithErrorCheckedExample = () => <SaveButtonContainer checked asyncWithError />;
 
 const SmallDefaultExample = () => (
   <SaveButtonContainer size={SIZE_TYPES.small} />
@@ -101,6 +113,7 @@ const VisualTestExample = () => (
     <SmallContainedExample />
     <SmallOnDarkExample />
     <SmallCheckedExample />
+    <br />
   </>
 );
 
@@ -114,4 +127,5 @@ export {
   SmallOnDarkExample,
   VisualTestExample,
   SmallCheckedExample,
+  AsyncWithErrorCheckedExample,
 };

--- a/examples/bpk-component-card-button/stories.ts
+++ b/examples/bpk-component-card-button/stories.ts
@@ -48,5 +48,5 @@ export const SmallChecked = SmallCheckedExample;
 export const VisualTest = VisualTestExample;
 export const VisualTestWithZoom = VisualTest.bind({});
 VisualTestWithZoom.args = {
-  zoomEnabled: true,
+  zoomEnabled: true
 };

--- a/examples/bpk-component-card-button/stories.ts
+++ b/examples/bpk-component-card-button/stories.ts
@@ -48,5 +48,5 @@ export const SmallChecked = SmallCheckedExample;
 export const VisualTest = VisualTestExample;
 export const VisualTestWithZoom = VisualTest.bind({});
 VisualTestWithZoom.args = {
-  zoomEnabled: true
+  zoomEnabled: true,
 };

--- a/examples/bpk-component-card-button/stories.ts
+++ b/examples/bpk-component-card-button/stories.ts
@@ -28,6 +28,7 @@ import {
   SmallOnDarkExample,
   VisualTestExample,
   SmallCheckedExample,
+  AsyncWithErrorCheckedExample,
 } from './examples';
 
 export default {
@@ -39,6 +40,7 @@ export const Default = DefaultExample;
 export const Contained = ContainedExample;
 export const OnDark = OnDarkExample;
 export const Checked = CheckedExample;
+export const AsyncWithErrorChecked = AsyncWithErrorCheckedExample;
 export const SmallDefault = SmallDefaultExample;
 export const SmallContained = SmallContainedExample;
 export const SmallOnDark = SmallOnDarkExample;

--- a/packages/bpk-component-button/README.md
+++ b/packages/bpk-component-button/README.md
@@ -17,18 +17,18 @@ const AlignedArrowIcon = withButtonAlignment(withRtlSupport(ArrowIcon));
 
 export default () => (
   <div>
-    <BpkButton>Primary</BpkButton>
-    <BpkButton size={SIZE_TYPES.large}>Large primary</BpkButton>
-    <BpkButton type={BUTTON_TYPES.secondary}>Secondary</BpkButton>
-    <BpkButton type={BUTTON_TYPES.secondaryOnDark}>SecondaryOnDark</BpkButton>
-    <BpkButton type={BUTTON_TYPES.link}>Link</BpkButton>
-    <BpkButton type={BUTTON_TYPES.linkOnDark}>LinkOnDark</BpkButton>
-    <BpkButton type={BUTTON_TYPES.primaryOnDark}>PrimaryOnDark</BpkButton>
-    <BpkButton type={BUTTON_TYPES.primaryOnLight}>PrimaryOnLight</BpkButton>
-    <BpkButton iconOnly>
+    <BpkButtonV2>Primary</BpkButtonV2>
+    <BpkButtonV2 size={SIZE_TYPES.large}>Large primary</BpkButtonV2>
+    <BpkButtonV2 type={BUTTON_TYPES.secondary}>Secondary</BpkButtonV2>
+    <BpkButtonV2 type={BUTTON_TYPES.secondaryOnDark}>SecondaryOnDark</BpkButtonV2>
+    <BpkButtonV2 type={BUTTON_TYPES.link}>Link</BpkButtonV2>
+    <BpkButtonV2 type={BUTTON_TYPES.linkOnDark}>LinkOnDark</BpkButtonV2>
+    <BpkButtonV2 type={BUTTON_TYPES.primaryOnDark}>PrimaryOnDark</BpkButtonV2>
+    <BpkButtonV2 type={BUTTON_TYPES.primaryOnLight}>PrimaryOnLight</BpkButtonV2>
+    <BpkButtonV2 iconOnly>
       <AlignedArrowIcon />
       <span className="visually-hidden">Search</span>
-    </BpkButton>
+    </BpkButtonV2>
   </div>
 );
 ```

--- a/packages/bpk-component-card-button/src/BpkSaveButton.tsx
+++ b/packages/bpk-component-card-button/src/BpkSaveButton.tsx
@@ -19,7 +19,7 @@
 import type { MouseEvent } from 'react';
 import { useState } from 'react';
 
-import { BpkButtonV2 } from '../../bpk-component-button/src/BpkButtonV2/BpkButton';
+import { BpkButtonV2 } from '../../bpk-component-button';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkHeartIcon from '../../bpk-component-icon/lg/heart';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
@@ -87,8 +87,10 @@ const BpkSaveButton = ({
         `bpk-save-button__${style}`,
       )}
       onClick={(e: MouseEvent) => {
-        setToggle(true);
         onCheckedChange(e);
+        if(!checked) {
+          setToggle(true);
+        }
       }}
       iconOnly
     >

--- a/packages/bpk-component-card-button/src/BpkSaveButton.tsx
+++ b/packages/bpk-component-card-button/src/BpkSaveButton.tsx
@@ -88,7 +88,7 @@ const BpkSaveButton = ({
       )}
       onClick={(e: MouseEvent) => {
         onCheckedChange(e);
-        if(!checked) {
+        if (!checked) {
           setToggle(true);
         }
       }}

--- a/packages/bpk-component-icon/README.md
+++ b/packages/bpk-component-icon/README.md
@@ -38,7 +38,7 @@ export default () => (
 ### Aligning to BpkButton components
 
 ```js
-import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
+import { BpkButtonV2, SIZE_TYPES } from '@skyscanner/backpack-web/bpk-component-button';
 import BpkSmallFlightIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flight';
 import BpkLargeAccessibilityIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/accessibility';
 import { withButtonAlignment, withLargeButtonAlignment } from '@skyscanner/backpack-web/bpk-component-icon';
@@ -48,12 +48,12 @@ const AlignedBpkLargeAccessibilityIcon = withLargeButtonAlignment(BpkLargeAccess
 
 export default () => (
   <div>
-    <BpkButton>
+    <BpkButtonV2>
       <AlignedBpkSmallFlightIcon />
-    </BpkButton>
-    <BpkButton large>
+    </BpkButtonV2>
+    <BpkButtonV2 size={SIZE_TYPES.large}>
       <AlignedBpkLargeAccessibilityIcon />
-    </BpkButton>
+    </BpkButtonV2>
   </div>
 );
 ```


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
### Why Are We Making This Change?

1. When the onCheckedStatus returns async rejection, the toggle style should not take effect.
2. The backpack document remains some old BpkButton usages, which is already been deprecated.

### What Predictions Do We Have About When This Goes Live?

1. When the button is checked and there is async error rejection, the save button should not display toggled animation.
2. The `<BpkButton>` in all readme files should be replaced with `<BpkButtonV2>`

### Change Description

1. fix the button toggle issue when is async with reject
2. fix the typo in README.md since the BpkButton has been deprecated
3. Add new async with error checked example to mock and test the cases.
### Screenshots
The `onCheckedStatus` function will return a `Promise.reject`, the button checked status should not be changed and the toggled zooming anition should not be displayed either.
#### Mobile

| Before                        | After                         |
| ----------------------------- | ----------------------------- |
| <img src="https://github.com/Skyscanner/backpack/assets/86780745/c1f24214-6c75-4530-b0b8-e4432a9c273a" width=300/> | <img src="https://github.com/Skyscanner/backpack/assets/86780745/75eff42b-fbe8-4cab-8f80-65f77e66cbb2" width=300 /> |


#### Desktop
| Before                        | After                         |
| ----------------------------- | ----------------------------- |
| <img src="https://github.com/Skyscanner/backpack/assets/86780745/d3e17355-08cb-43d5-b8d7-702c54042a00" width=300/> | <img src="https://github.com/Skyscanner/backpack/assets/86780745/bfbb1a71-bf21-4e94-b481-a107d21e1b1a" width=300 /> |
| <img src="https://github.com/Skyscanner/backpack/assets/86780745/8f017ea7-902a-47a1-bbcd-54a1620175f2" width=300/> | Replaced with BpkButtonV2  |



Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here