### PR TITLE
changed typing declarations to match `common-types.ts` file

### DIFF
--- a/packages/bpk-component-info-banner/src/common-types.d.ts
+++ b/packages/bpk-component-info-banner/src/common-types.d.ts
@@ -19,26 +19,32 @@
 import type { FunctionComponent, ReactNode } from 'react';
 
 export declare const ALERT_TYPES: {
-  readonly PRIMARY: 'primary';
-  readonly SUCCESS: 'success';
-  readonly WARN: 'warn';
-  readonly ERROR: 'error';
-  readonly NEUTRAL: 'neutral';
+  readonly SUCCESS: 'success',
+  readonly WARNING: 'warning',
+  readonly ERROR: 'error',
+  readonly INFO: 'info',
+};
+export declare const STYLE_TYPES: {
+  readonly DEFAULT: 'default',
+  readonly ON_CONTRAST: 'onContrast',
 };
 export type AlertTypeValue = (typeof ALERT_TYPES)[keyof typeof ALERT_TYPES];
+export type StyleTypeValue = (typeof STYLE_TYPES)[keyof typeof STYLE_TYPES];
 export type CommonProps = {
-  type: AlertTypeValue;
+  type?: AlertTypeValue;
   message: ReactNode | string;
   animateOnEnter?: boolean;
   animateOnLeave?: boolean;
   show?: boolean;
   bannerClassName?: string | null;
   icon?: FunctionComponent<any> | null;
+  style?: StyleTypeValue;
   [rest: string]: any;
 };
 export type OnExpandToggleHandler =
   | ((expanded: boolean) => void)
   | null
   | undefined;
+export type ExpandableBannerAction = { title: string, callback: () => void } | null | undefined;
 export type OnDismissHandler = (() => void) | null | undefined;
 export type OnHideHandler = (() => void) | null | undefined;


### PR DESCRIPTION
Changed typing declarations in `common-types.d.ts` to match `common-types.ts`

Remember to include the following changes:

- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here