### PR TITLE
Update pull_request_template.md to include PR title instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Add `major`, `minor` or `patch` label depending on the change according to [semv
 
 Remember to include the following changes:
 
+- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
 - [ ] `README.md` (If you have created a new component)
 - [ ] Component `README.md`
 - [ ] Tests


### PR DESCRIPTION
Changes the template for consumers to ensure that the PR title includes the component they are changing so as to help with making the autogenerated release notes clear for consumers what each change corresponds to 