### PR TITLE
[BpkAutosuggest]: Fixing autosuggest component

### DIFF
--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion.js
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestSuggestion.js
@@ -36,7 +36,7 @@ type Props = {
   tertiaryLabel: ?string,
 };
 
-const BpkSuggestion = (props: Props) => {
+const BpkAutosuggestSuggestion = (props: Props) => {
   const classNames = [getClassName('bpk-autosuggest__suggestion')];
   const { className, icon, indent, subHeading, tertiaryLabel, value, ...rest } =
     props;
@@ -87,7 +87,7 @@ const BpkSuggestion = (props: Props) => {
   );
 };
 
-BpkSuggestion.propTypes = {
+BpkAutosuggestSuggestion.propTypes = {
   value: PropTypes.node.isRequired,
   subHeading: PropTypes.node,
   tertiaryLabel: PropTypes.string,
@@ -96,7 +96,7 @@ BpkSuggestion.propTypes = {
   className: PropTypes.string,
 };
 
-BpkSuggestion.defaultProps = {
+BpkAutosuggestSuggestion.defaultProps = {
   subHeading: null,
   tertiaryLabel: null,
   icon: null,
@@ -104,4 +104,4 @@ BpkSuggestion.defaultProps = {
   className: null,
 };
 
-export default BpkSuggestion;
+export default BpkAutosuggestSuggestion;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This change fixes the name of the exported component of the `BpkAutosuggestSuggestion` component, which currently causes our docs to crash as this component can't be found, See here: https://www.skyscanner.design/latest/components/autosuggest/web-1dnVX8RX

This is a strange one of how this has been working for years without modification as nothing has recently changed with this component and the naming hasn't been an issue but there is a mismatch in namings which causes storybook to not render the story. See here: https://backpack.github.io/storybook 

This fix then aligns all the naming as per our docs and fixes the error with storybook not rendering.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
