### PR TITLE
NOJIRA - BpkBottomSheet "out" console error fix

### DIFF
--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheetInner.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheetInner.tsx
@@ -68,7 +68,6 @@ const BpkBottomSheetInner = ({
     }}
     in={!exiting}
     appear={!exiting}
-    out={exiting}
     exit={exiting}
     timeout={{appear: 240, exit: 240}}
   >


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

BpkBottomSheet throws an error in the console during use:
![image](https://github.com/Skyscanner/backpack/assets/35368044/88f7f010-f395-485f-9d8a-ac1e8dbc3f2d)

This property in CSSTransition is not actually required for correct functioning of the animations so it is being removed 

-------

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
