### PR TITLE
[DTO-4949][BpkNavigationBar] Remove prop-types from navbar

### DIFF
--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
@@ -18,7 +18,6 @@
 
 import type { ReactElement, ReactNode } from 'react';
 import { cloneElement } from 'react';
-import PropTypes from 'prop-types';
 
 import { cssModules } from '../../bpk-react-utils';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
@@ -105,16 +104,6 @@ const BpkNavigationBar = (props: Props) => {
         )}
     </nav>
   );
-};
-
-BpkNavigationBar.propTypes = {
-  id: PropTypes.string.isRequired,
-  title: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  leadingButton: PropTypes.element,
-  trailingButton: PropTypes.element,
-  sticky: PropTypes.bool,
-  barStyle: PropTypes.oneOf(Object.values(BAR_STYLES)),
 };
 
 export default BpkNavigationBar;

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.tsx
@@ -17,7 +17,6 @@
  */
 
 import type { ComponentProps, MouseEvent, ReactNode } from 'react';
-import PropTypes from 'prop-types';
 
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import { BpkButtonLink } from '../../bpk-component-link';
@@ -53,13 +52,5 @@ const BpkNavigationBarButtonLink = ({
     {children}
   </BpkButtonLink>
 );
-
-
-BpkNavigationBarButtonLink.propTypes = {
-  children: PropTypes.node.isRequired,
-  onClick: PropTypes.func.isRequired,
-  className: PropTypes.string,
-  barStyle: PropTypes.oneOf(Object.values(BAR_STYLES)),
-};
 
 export default BpkNavigationBarButtonLink;

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.tsx
@@ -17,7 +17,6 @@
  */
 
 import type { ComponentType, MouseEvent, ReactNode } from 'react';
-import PropTypes from 'prop-types';
 
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkIconButton from '../../bpk-component-close-button';
@@ -49,13 +48,5 @@ const BpkNavigationBarIconButton = ({ barStyle = BAR_STYLES.default, className, 
     {...rest}
   />
 );
-
-BpkNavigationBarIconButton.propTypes = {
-  icon: PropTypes.func.isRequired,
-  label: PropTypes.string.isRequired,
-  onClick: PropTypes.func.isRequired,
-  className: PropTypes.string,
-  barStyle: PropTypes.oneOf(Object.values(BAR_STYLES)),
-};
 
 export default BpkNavigationBarIconButton;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Follow up to #3110 - removing the `propTypes` now we have typescript in the nav bar. Separate PR as we initially thought this was a breaking change, but turns out it's not

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
