### PR TITLE
[DTO-5004][BpkInfoBanner] Remove Alert Role

### DIFF
--- a/packages/bpk-component-info-banner/src/BpkInfoBanner-test.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBanner-test.tsx
@@ -55,6 +55,6 @@ describe('BpkInfoBanner', () => {
         message={message}
       />,
     );
-    expect(screen.getByRole('alert')).toHaveClass('custom-banner-class-name');
+    expect(screen.getByRole('presentation')).toHaveClass('custom-banner-class-name');
   });
 });

--- a/packages/bpk-component-info-banner/src/BpkInfoBanner.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBanner.tsx
@@ -19,13 +19,6 @@
 import type { CommonProps } from './common-types';
 import BpkInfoBannerInner from './BpkInfoBannerInner';
 
-const defaultProps = {
-  animateOnEnter: false,
-  animateOnLeave: false,
-  show: true,
-  icon: null,
-};
-
 const BpkInfoBanner = ({
   animateOnEnter = false,
   animateOnLeave = false,

--- a/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
@@ -45,7 +45,6 @@ import type {
   CommonProps,
   OnDismissHandler,
   OnExpandToggleHandler,
-  StyleTypeValue,
   ExpandableBannerAction,
 } from './common-types';
 import { ALERT_TYPES, STYLE_TYPES } from './common-types';
@@ -189,7 +188,7 @@ const BpkInfoBannerInner = ({
       show={show}
       {...rest}
     >
-      <section className={sectionClassNames} role="alert">
+      <section className={sectionClassNames} role="presentation">
         <div
           role={isExpandable ? 'button' : undefined}
           className={headerClassNames}

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBanner-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBanner-test.tsx.snap
@@ -9,7 +9,7 @@ exports[`BpkInfoBanner should render correctly 1`] = `
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -68,7 +68,7 @@ exports[`BpkInfoBanner should render correctly with no type specified 1`] = `
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--info bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerDismissable-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerDismissable-test.tsx.snap
@@ -9,7 +9,7 @@ exports[`BpkInfoBannerDismissable should render correctly 1`] = `
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
@@ -9,7 +9,7 @@ exports[`BpkInfoBannerInner should render correctly with "style" attribute equal
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--info bpk-info-banner--style-onContrast"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -66,7 +66,7 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--error bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -123,7 +123,7 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--error bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -180,7 +180,7 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--info bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -237,7 +237,7 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -294,7 +294,7 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -351,7 +351,7 @@ exports[`BpkInfoBannerInner should render correctly with a custom banner-alert c
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default custom-class"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -409,7 +409,7 @@ exports[`BpkInfoBannerInner should render correctly with a custom class name 1`]
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -466,7 +466,7 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header bpk-info-banner__header--expandable"
@@ -558,7 +558,7 @@ exports[`BpkInfoBannerInner should render correctly with animateOnLeave 1`] = `
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -637,7 +637,7 @@ exports[`BpkInfoBannerInner should render correctly with arbitrary props 1`] = `
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -694,7 +694,7 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header bpk-info-banner__header--expandable"
@@ -781,7 +781,7 @@ exports[`BpkInfoBannerInner should render correctly with dismissable option 1`] 
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"

--- a/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
@@ -9,7 +9,7 @@ exports[`withBannerAlertState(BpkInfoBannerDismissable) should render correctly 
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header"
@@ -88,7 +88,7 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header bpk-info-banner__header--expandable"
@@ -180,7 +180,7 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
       <div>
         <section
           class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-          role="alert"
+          role="presentation"
         >
           <div
             class="bpk-info-banner__header bpk-info-banner__header--expandable"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Currently when an info banner is render on a page, the screenreader will immediately switch to reading out the title text. This happens because we treat the info banner as an alert for screen readers. [The documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) says the alert role shouldn’t be used for elements rendered on page load. Since this component is used more as a styling container than an alert dialog it should only be read in the normal page flow.

### Bug caused by alert role (sound on)

https://github.com/Skyscanner/backpack/assets/22656572/e665fc0f-cfd4-440d-bd97-96b61fa4cbf9


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
