### PR TITLE
[NOJIRA]: add mini-css-extract-plugin

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -20,6 +20,7 @@ const fs = require('fs');
 const path = require('path');
 
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
 const sassFunctions = require('../packages/bpk-mixins/sass-functions');
 const postCssPlugins = require('../scripts/webpack/postCssPlugins');
 

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -19,13 +19,16 @@
 const fs = require('fs');
 const path = require('path');
 
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const sassFunctions = require('../packages/bpk-mixins/sass-functions');
 const postCssPlugins = require('../scripts/webpack/postCssPlugins');
 
 const { BPK_TOKENS } = process.env;
 const rootDir = path.resolve(__dirname, '../');
+const devMode = process.env.NODE_ENV !== "production";
 
 module.exports = ({ config }) => {
+  config.plugins.push(new MiniCssExtractPlugin());
   config.module.rules.push({
     test: /\.[jt]sx?$/,
     exclude: /node_modules\/(?!bpk-).*/,
@@ -61,7 +64,7 @@ module.exports = ({ config }) => {
     test: /\.css/,
     use: [
       {
-        loader: 'style-loader',
+        loader: devMode ? "style-loader" : MiniCssExtractPlugin.loader,
       },
       {
         loader: 'css-loader',
@@ -86,7 +89,7 @@ module.exports = ({ config }) => {
     test: /\.scss$/,
     use: [
       {
-        loader: 'style-loader',
+        loader: devMode ? "style-loader" : MiniCssExtractPlugin.loader,
       },
       {
         loader: 'css-loader',

--- a/examples/bpk-component-datepicker/examples.js
+++ b/examples/bpk-component-datepicker/examples.js
@@ -635,28 +635,28 @@ const DefaultVisualExample = () => (
 );
 
 const VisualRangeExample = () => (
-  <div id="application-element">
-    <CalendarContainer
-      id="myDatepicker"
-      closeButtonText="Close"
-      daysOfWeek={weekDays}
-      weekStartsOn={1}
-      changeMonthLabel="Change month"
-      previousMonthLabel="Go to previous month"
-      nextMonthLabel="Go to next month"
-      title="Departure date"
-      formatDate={formatDate}
-      formatMonth={formatMonth}
-      formatDateFull={formatDateFull}
-      selectionConfiguration={{
-        type: 'range',
-        startDate: new Date(2020, 3, 8),
-        endDate: new Date(2020, 3, 15),
-      }}
-      minDate={new Date(2020, 3, 1)}
-      isOpen
-    />
-  </div>
+    <div id="application-element">
+      <CalendarContainer
+        id="myDatepicker"
+        closeButtonText="Close"
+        daysOfWeek={weekDays}
+        weekStartsOn={1}
+        changeMonthLabel="Change month"
+        previousMonthLabel="Go to previous month"
+        nextMonthLabel="Go to next month"
+        title="Departure date"
+        formatDate={formatDate}
+        formatMonth={formatMonth}
+        formatDateFull={formatDateFull}
+        selectionConfiguration={{
+          type: 'range',
+          startDate: new Date(2020, 3, 8),
+          endDate: new Date(2020, 3, 15),
+        }}
+        minDate={new Date(2020, 3, 1)}
+        isOpen
+      />
+    </div>
 );
 
 export {

--- a/examples/bpk-component-grid-toggle/stories.js
+++ b/examples/bpk-component-grid-toggle/stories.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import BpkGridToggle from '../../packages/bpk-component-grid-toggle/src/BpkGridToggle';
+import BpkGridToggle from '../../packages/bpk-component-grid-toggle';
 
 import DefaultExample from './examples';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25672,7 +25672,7 @@
     },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.7.6",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
       "integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
       "dev": true,
       "dependencies": {
@@ -25680,6 +25680,10 @@
       },
       "engines": {
         "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
         "webpack": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25672,17 +25672,14 @@
     },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.7.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
+      "integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "schema-utils": "^4.0.0"
       },
       "engines": {
         "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
         "webpack": "^5.0.0"

--- a/packages/bpk-component-grid-toggle/index.js
+++ b/packages/bpk-component-grid-toggle/index.js
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
 
-import component from './src/BpkGridToggle';
+import BpkGridToggle from './src/BpkGridToggle';
 
-export default component;
+export default BpkGridToggle;


### PR DESCRIPTION
Adds mini css extract plugin to drastically reduce the bundlesize. This ultimately allows for enableJavascript to be added to Percy config, before the JS asset was too large and presumably errors occured in upload or parsing on Percy side.