### PR TITLE
[NOJIRA]: add npmrc to point to public reg

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Add a `.npmrc` file to ensure that the public registry is always pointed to.

