### PR TITLE
[NOJIRA]: Percy add enable-javascript

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,4 +1,6 @@
 version: 2
+snapshot:
+  enable-javascript: true
 discovery:
   user-agent: "percy-backpack"
   allowed-hostnames:


### PR DESCRIPTION
Allowing js execution within Percy evaluation. Ultimately we want to do this as we are seeing inconsistency with some of our snap with components that are particularly reliant on js presence in order to render correctly. 