### PR TITLE
remove layers and resolve issues with on-dark in navbar

### DIFF
--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-@layer component-3, component-2, component-1;
-
-@layer component-1 {
+@layer component {
   @import '../../bpk-mixins/index.scss';
 
   .bpk-navigation-bar {

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.module.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.module.scss
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-@layer component-2 {
+@layer component {
   @import '../../bpk-mixins/index.scss';
 
   .bpk-navigation-bar-button-link {
@@ -49,21 +49,21 @@
         $bpk-text-primary-day
       );
     }
-  }
 
-  &--on-dark {
-    color: $bpk-text-primary-inverse-day;
-
-    @include bpk-hover {
+    &--on-dark {
       color: $bpk-text-primary-inverse-day;
-    }
 
-    &:active {
-      color: $bpk-text-primary-inverse-day;
-    }
+      @include bpk-hover {
+        color: $bpk-text-primary-inverse-day;
+      }
 
-    &:visited {
-      color: $bpk-text-primary-inverse-day;
+      &:active {
+        color: $bpk-text-primary-inverse-day;
+      }
+
+      &:visited {
+        color: $bpk-text-primary-inverse-day;
+      }
     }
   }
 }

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.module.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.module.scss
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-@layer component-3 {
+@layer component {
   @import '../../bpk-mixins/index.scss';
 
   .bpk-navigation-bar-icon-button {
@@ -41,17 +41,17 @@
         $bpk-text-primary-day
       );
     }
-  }
 
-  &--on-dark {
-    color: $bpk-text-primary-inverse-day;
-
-    @include bpk-hover {
+    &--on-dark {
       color: $bpk-text-primary-inverse-day;
-    }
 
-    &:active {
-      color: $bpk-text-primary-inverse-day;
+      @include bpk-hover {
+        color: $bpk-text-primary-inverse-day;
+      }
+
+      &:active {
+        color: $bpk-text-primary-inverse-day;
+      }
     }
   }
 }


### PR DESCRIPTION
Removes the extra component layers that (I think 🤷 ) are no longer required. It resolves the `on-dark` issue where the `&--on-dark` classes have become un-nested.