### PR TITLE
[ARGG-927][BpkBreakpoint] Update breakpoint to remove hydration mismatch error

### DIFF
--- a/packages/bpk-component-breakpoint/src/BpkBreakpoint.tsx
+++ b/packages/bpk-component-breakpoint/src/BpkBreakpoint.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import { useState, type ReactNode, useEffect } from 'react';
 import MediaQuery from 'react-responsive';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import { breakpoints } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
@@ -50,20 +50,19 @@ const BpkBreakpoint = ({
   matchSSR = false,
   query,
 }: Props) => {
-  const isSSR = () =>
-    !(
-      typeof window !== 'undefined' &&
-      window.document &&
-      window.document.createElement
-    );
+  const [isClient, setIsClient] = useState(false);
 
-  if (!legacy && !Object.values(BREAKPOINTS).includes(query)) {
-    console.warn(
-      `Invalid query ${query}. Use one of the supported queries or pass the legacy prop.`,
-    );
-  }
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
-  if (!isSSR()) {
+  if (isClient) {
+    if (!legacy && !Object.values(BREAKPOINTS).includes(query)) {
+      console.warn(
+        `Invalid query ${query}. Use one of the supported queries or pass the legacy prop.`,
+      );
+    }
+
     return <MediaQuery query={query}>{children}</MediaQuery>;
   }
 

--- a/packages/bpk-component-breakpoint/src/__snapshots__/BpkBreakpoint-test.tsx.snap
+++ b/packages/bpk-component-breakpoint/src/__snapshots__/BpkBreakpoint-test.tsx.snap
@@ -2,9 +2,7 @@
 
 exports[`BpkBreakpoint SSR mode should not render on SSR until hydrated when matchSSR=false: hydrated 1`] = `
 <DocumentFragment>
-  <div
-    data-reactroot=""
-  >
+  <div>
     matches
   </div>
 </DocumentFragment>


### PR DESCRIPTION
Fix hydration mismatch error in BpkBreakpoint component. This change makes the BpkBreakpoint server-side snapshot match the snapshot initially rendered on the client.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
