### PR TITLE
ST-5444 Updating npm version to match LTS/Node stable pairing 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@percy/cli": "^1.27.7",
         "@percy/storybook": "^4.3.6",
         "@skyscanner/bpk-foundations-web": "^17.8.0",
-        "@skyscanner/bpk-svgs": "^19.0.0",
+        "@skyscanner/bpk-svgs": "^19.0.1",
         "@skyscanner/stylelint-config-skyscanner": "^10.0.0",
         "@storybook/addon-a11y": "^7.6.8",
         "@storybook/addon-actions": "^7.6.10",
@@ -46,7 +46,7 @@
         "babel-plugin-module-resolver": "^5.0.0",
         "babel-plugin-react-docgen": "^4.2.1",
         "babel-plugin-require-context-hook": "^1.0.0",
-        "backpack-node-sass": "^1.1.1",
+        "backpack-node-sass": "^1.1.2",
         "core-js": "^3.0.0",
         "css-loader": "^6.9.0",
         "d3-scale": "^4.0.2",
@@ -82,7 +82,7 @@
       },
       "engines": {
         "node": "^18.16.0",
-        "npm": "^9.5.1"
+        "npm": "^9.5.1 || ^10.2.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4535,12 +4535,13 @@
       }
     },
     "node_modules/@skyscanner/bpk-svgs": {
-      "version": "19.0.0",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-19.0.1.tgz",
+      "integrity": "sha512-G/y56QufVCuHbnnGqPQYjHfoygmNWxSHSAZU/Ynz/hmhx5g/Sldr4wTa4FRXcSD9hK920y26s/zGv2Zb8m6oCA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.16.0",
-        "npm": "^9.5.1"
+        "npm": "^9.5.1 || ^10.2.5"
       }
     },
     "node_modules/@skyscanner/eslint-config-skyscanner": {
@@ -11905,9 +11906,9 @@
       }
     },
     "node_modules/backpack-node-sass": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/backpack-node-sass/-/backpack-node-sass-1.1.1.tgz",
-      "integrity": "sha512-8ui5523mkxDOFlDGHcJEiZAXDDV6ujcebMBEmQfOfB3tg5Kadc1ETXhghyxbZg5Cer1G8DvXebLTAS0gDOvQcg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/backpack-node-sass/-/backpack-node-sass-1.1.2.tgz",
+      "integrity": "sha512-8nw2Fm8E7sq1DTlj+dvwEllvYQ/juWzHCDPErFOfJ4MHIHvZudzxpHNw3zTb/y2A/cwMJ0z0WgiByWxHb4+ScQ==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.3",
@@ -11923,7 +11924,7 @@
       },
       "engines": {
         "node": "^18.0.0",
-        "npm": "^9.0.0"
+        "npm": "^9.0.0 || ^10.2.5"
       }
     },
     "node_modules/backpack-node-sass/node_modules/@npmcli/fs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
       },
       "engines": {
         "node": "^18.16.0",
-        "npm": "^9.5.1 || ^10.2.5"
+        "npm": ">=9.5.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "engines": {
     "node": "^18.16.0",
-    "npm": "^9.5.1"
+    "npm": "^9.5.1 || ^10.2.5"
   },
   "repository": {
     "type": "git",
@@ -122,7 +122,7 @@
     "@percy/cli": "^1.27.7",
     "@percy/storybook": "^4.3.6",
     "@skyscanner/bpk-foundations-web": "^17.8.0",
-    "@skyscanner/bpk-svgs": "^19.0.0",
+    "@skyscanner/bpk-svgs": "^19.0.1",
     "@skyscanner/stylelint-config-skyscanner": "^10.0.0",
     "@storybook/addon-a11y": "^7.6.8",
     "@storybook/addon-actions": "^7.6.10",
@@ -145,7 +145,7 @@
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-plugin-react-docgen": "^4.2.1",
     "babel-plugin-require-context-hook": "^1.0.0",
-    "backpack-node-sass": "^1.1.1",
+    "backpack-node-sass": "^1.1.2",
     "core-js": "^3.0.0",
     "css-loader": "^6.9.0",
     "d3-scale": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "engines": {
     "node": "^18.16.0",
-    "npm": "^9.5.1 || ^10.2.5"
+    "npm": ">=9.5.1"
   },
   "repository": {
     "type": "git",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -12,7 +12,7 @@
         "@popperjs/core": "^2.11.5",
         "@react-google-maps/api": "^2.12.0",
         "@skyscanner/bpk-foundations-web": "^17.5.3",
-        "@skyscanner/bpk-svgs": "^19.0.0",
+        "@skyscanner/bpk-svgs": "^19.0.1",
         "a11y-focus-scope": "^1.1.3",
         "a11y-focus-store": "^1.0.0",
         "d3-path": "^2.0.0",
@@ -236,12 +236,12 @@
       }
     },
     "node_modules/@skyscanner/bpk-svgs": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-svgs/-/bpk-svgs-19.0.0.tgz",
-      "integrity": "sha512-dg/XsraLVEjCa2SknqEmxMTuqf7AlRDHOVPMksLyUpHyNkEBKLcbjBOZoE0A646V9vYk8+7bzW4Znl1syZ2//A==",
+      "version": "19.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-svgs/-/bpk-svgs-19.0.1.tgz",
+      "integrity": "sha512-G/y56QufVCuHbnnGqPQYjHfoygmNWxSHSAZU/Ynz/hmhx5g/Sldr4wTa4FRXcSD9hK920y26s/zGv2Zb8m6oCA==",
       "engines": {
         "node": "^18.16.0",
-        "npm": "^9.5.1"
+        "npm": "^9.5.1 || ^10.2.5"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/packages/package.json
+++ b/packages/package.json
@@ -25,7 +25,7 @@
     "@popperjs/core": "^2.11.5",
     "@react-google-maps/api": "^2.12.0",
     "@skyscanner/bpk-foundations-web": "^17.5.3",
-    "@skyscanner/bpk-svgs": "^19.0.0",
+    "@skyscanner/bpk-svgs": "^19.0.1",
     "a11y-focus-scope": "^1.1.3",
     "a11y-focus-store": "^1.0.0",
     "d3-path": "^2.0.0",


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.



Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

The current Internal node stable version includes an update to npm 10. Additionally, the .nvmrc file pins the LTS/hydrogen version - which too expects npm 10 as a pairing.

I have previously updated [backpack-node-sass](https://github.com/Skyscanner/backpack-node-sass/pull/58) and [bpk-svgs](https://github.com/Skyscanner/bpk-svgs/pull/44). These 

The change is backwards compatible and thus this should only be a minor bump.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
