### PR TITLE
[THES-158] BpkBottomSheet fix empty heading - accessibility

### DIFF
--- a/examples/bpk-component-bottom-sheet/examples.tsx
+++ b/examples/bpk-component-bottom-sheet/examples.tsx
@@ -166,6 +166,14 @@ const NoHeaderExample = () => (
   </BottomSheetContainer>
 );
 
+const NoHeaderWithActionButtonExample = () => (
+  <BottomSheetContainer
+    closeLabel="Close Bottom Sheet" actionText="Action" onAction={action('Action clicked')}
+  >
+    This is a default bottom sheet. You can put anything you want in here.
+  </BottomSheetContainer>
+);
+
 const ActionButtonExample = () => (
   <BottomSheetContainer title="Bottom Sheet title" closeLabel="Close Bottom Sheet" actionText="Action" onAction={action('Action clicked')}>
     This is a default bottom sheet. You can put anything you want in here.
@@ -183,6 +191,7 @@ export {
   DefaultExample,
   OverflowingExample,
   NoHeaderExample,
+  NoHeaderWithActionButtonExample,
   ActionButtonExample,
   WideExample
 };

--- a/examples/bpk-component-bottom-sheet/stories.js
+++ b/examples/bpk-component-bottom-sheet/stories.js
@@ -16,15 +16,15 @@
  * limitations under the License.
  */
 
-
 import BpkBottomSheet from '../../packages/bpk-component-bottom-sheet';
 
 import {
   DefaultExample,
   OverflowingExample,
   NoHeaderExample,
+  NoHeaderWithActionButtonExample,
   ActionButtonExample,
-  WideExample
+  WideExample,
 } from './examples';
 
 export default {
@@ -36,6 +36,7 @@ export const Default = DefaultExample;
 export const Overflowing = OverflowingExample;
 
 export const NoHeader = NoHeaderExample;
+export const NoHeaderWithActionButton = NoHeaderWithActionButtonExample;
 
 export const ActionButton = ActionButtonExample;
 

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheetInner-test.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheetInner-test.tsx
@@ -71,4 +71,20 @@ describe('BpkBottomSheetInner', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  it('should render correctly without title prop', () => {
+    const { asFragment } = render(
+      <BpkBottomSheetInner
+        id="my-bottom-sheet"
+        title=""
+        dialogRef={jest.fn()}
+        onClose={jest.fn()}
+        actionText="Dismiss"
+        onAction={jest.fn()}
+        exiting={false}
+      >
+        Bottom sheet content
+      </BpkBottomSheetInner>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheetInner-test.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheetInner-test.tsx
@@ -18,6 +18,7 @@
 
 import { render } from '@testing-library/react';
 
+import '@testing-library/jest-dom';
 import BpkBottomSheetInner from './BpkBottomSheetInner';
 
 describe('BpkBottomSheetInner', () => {
@@ -72,7 +73,7 @@ describe('BpkBottomSheetInner', () => {
   });
 
   it('should render correctly without title prop', () => {
-    const { asFragment } = render(
+    const { asFragment, container } = render(
       <BpkBottomSheetInner
         id="my-bottom-sheet"
         title=""
@@ -85,6 +86,10 @@ describe('BpkBottomSheetInner', () => {
         Bottom sheet content
       </BpkBottomSheetInner>,
     );
+
+    const titleElement = container.querySelector('h2');
+    expect(titleElement).not.toBeInTheDocument();
+
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheetInner.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheetInner.tsx
@@ -85,7 +85,7 @@ const BpkBottomSheetInner = ({
       <BpkNavigationBar
         id={headingId}
         className={getClassName('bpk-bottom-sheet--navigation')}
-        title={
+        title={title &&
           <h2
             id={headingId}
             className={getClassName('bpk-bottom-sheet--heading')}

--- a/packages/bpk-component-bottom-sheet/src/__snapshots__/BpkBottomSheetInner-test.tsx.snap
+++ b/packages/bpk-component-bottom-sheet/src/__snapshots__/BpkBottomSheetInner-test.tsx.snap
@@ -164,3 +164,58 @@ exports[`BpkBottomSheetInner should render correctly with wide prop 1`] = `
   </section>
 </DocumentFragment>
 `;
+
+exports[`BpkBottomSheetInner should render correctly without title prop 1`] = `
+<DocumentFragment>
+  <section
+    aria-labelledby="bpk-bottom-sheet-heading-my-bottom-sheet"
+    class="bpk-bottom-sheet"
+    id="my-bottom-sheet"
+    role="dialog"
+    tabindex="-1"
+  >
+    <header
+      class="bpk-bottom-sheet--header"
+    >
+      <nav
+        aria-labelledby="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
+        class="bpk-navigation-bar bpk-navigation-bar--default bpk-bottom-sheet--navigation"
+      >
+        <button
+          aria-label=""
+          class="bpk-close-button bpk-bottom-sheet--close-button bpk-navigation-bar__leading-item bpk-navigation-bar__leading-item--default"
+          title=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="bpk-close-button__icon"
+            style="width: 1rem; height: 1rem;"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+            />
+          </svg>
+        </button>
+        <span
+          class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
+          id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
+        />
+        <button
+          class="bpk-link bpk-bottom-sheet--action-button bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item--default"
+          type="button"
+        >
+          Dismiss
+        </button>
+      </nav>
+    </header>
+    <div
+      class="bpk-bottom-sheet--content"
+    >
+      Bottom sheet content
+    </div>
+  </section>
+</DocumentFragment>
+`;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR fixes the accessibility issue in `BpkBottomSheet` - currently when no `title` is provided to `BpkBottomSheet`, an empty `h2` is rendered. This PR conditionally renders the `h2` tag depending on if `title` is `""` or not. 

Remember to include the following changes:
- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
