### PR TITLE
[LOOM-1221][BpkButton]: Add fullWidth prop to BpkButton

### DIFF
--- a/examples/bpk-component-button/examples.js
+++ b/examples/bpk-component-button/examples.js
@@ -175,6 +175,10 @@ const LinkOnDarkExample = (props: {}) => (
   </BpkDarkExampleWrapper>
 );
 
+const FullWidthExample = (props: {}) => (
+  <BpkButtonV2 fullWidth {...props}>Full Width Button</BpkButtonV2>
+);
+
 const MixedExample = () => (
   <>
     <PrimaryExample />
@@ -186,6 +190,7 @@ const MixedExample = () => (
     <LinkExample />
     <LinkOnDarkExample />
     <FeaturedExample />
+    <FullWidthExample />
   </>
 );
 
@@ -215,4 +220,5 @@ export {
   LinkOnDarkExample,
   MixedExample,
   AnchorTagsExample,
+  FullWidthExample,
 };

--- a/examples/bpk-component-button/stories.js
+++ b/examples/bpk-component-button/stories.js
@@ -30,6 +30,7 @@ import {
   LinkOnDarkExample,
   MixedExample,
   AnchorTagsExample,
+  FullWidthExample,
 } from './examples';
 
 export default {
@@ -63,3 +64,5 @@ export const VisualTestWithZoom = VisualTest.bind({});
 VisualTestWithZoom.args = {
   zoomEnabled: true
 };
+
+export const FullWidth = () => <FullWidthExample />;

--- a/packages/bpk-component-button/README.md
+++ b/packages/bpk-component-button/README.md
@@ -29,6 +29,7 @@ export default () => (
       <AlignedArrowIcon />
       <span className="visually-hidden">Search</span>
     </BpkButtonV2>
+    <BpkButtonV2 fullWidth>Full Width</BpkButtonV2>
   </div>
 );
 ```

--- a/packages/bpk-component-button/src/BpkButtonV2/BpkButton-test.tsx
+++ b/packages/bpk-component-button/src/BpkButtonV2/BpkButton-test.tsx
@@ -122,4 +122,14 @@ describe('BpkButtonV2', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('should render with a class name if full width is added', () => {
+    const { container } = render(
+      <BpkButtonV2 fullWidth>
+        My button
+      </BpkButtonV2>,
+    );
+
+    expect(container?.firstElementChild?.classList?.contains('bpk-button--full-width')).toEqual(true);
+  });
 });

--- a/packages/bpk-component-button/src/BpkButtonV2/BpkButton.d.ts
+++ b/packages/bpk-component-button/src/BpkButtonV2/BpkButton.d.ts
@@ -18,4 +18,4 @@
 
 /// <reference types="react" />
 import type { Props } from './common-types';
-export declare const BpkButtonV2: ({ blank, children, className, disabled, href, iconOnly, onClick, rel: propRel, size, submit, type, ...rest }: Props) => JSX.Element;
+export declare const BpkButtonV2: ({ blank, children, className, disabled, fullWidth, href, iconOnly, onClick, rel: propRel, size, submit, type, ...rest }: Props) => JSX.Element;

--- a/packages/bpk-component-button/src/BpkButtonV2/BpkButton.module.scss
+++ b/packages/bpk-component-button/src/BpkButtonV2/BpkButton.module.scss
@@ -71,6 +71,10 @@
     @include buttons.bpk-button--secondary-on-dark;
   }
 
+  &--full-width {
+    @include buttons.bpk-button--full-width;
+  }
+
   /* stylelint-disable selector-max-compound-selectors */
   span > svg {
     display: block;

--- a/packages/bpk-component-button/src/BpkButtonV2/BpkButton.tsx
+++ b/packages/bpk-component-button/src/BpkButtonV2/BpkButton.tsx
@@ -29,6 +29,7 @@ export const BpkButtonV2 = ({
   children,
   className = null,
   disabled = false,
+  fullWidth = false,
   href = null,
   iconOnly = false,
   onClick = () => {},
@@ -44,6 +45,7 @@ export const BpkButtonV2 = ({
     iconOnly && 'bpk-button--icon-only',
     iconOnly && size === SIZE_TYPES.large && 'bpk-button--large-icon-only',
     `bpk-button--${type}`,
+    fullWidth && 'bpk-button--full-width',
     className,
   );
 

--- a/packages/bpk-component-button/src/BpkButtonV2/common-types.d.ts
+++ b/packages/bpk-component-button/src/BpkButtonV2/common-types.d.ts
@@ -41,6 +41,7 @@ export type Props = {
   size?: SizeType;
   className?: string | null;
   disabled?: boolean;
+  fullWidth?: boolean;
   iconOnly?: boolean;
   onClick?: (event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => void;
   rel?: string | undefined;

--- a/packages/bpk-component-button/src/BpkButtonV2/common-types.tsx
+++ b/packages/bpk-component-button/src/BpkButtonV2/common-types.tsx
@@ -44,6 +44,7 @@ export type Props = {
   size?: SizeType;
   className?: string | null;
   disabled?: boolean;
+  fullWidth?: boolean;
   iconOnly?: boolean;
   onClick?: (event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => void;
   rel?: string | undefined;

--- a/packages/bpk-mixins/_buttons.scss
+++ b/packages/bpk-mixins/_buttons.scss
@@ -566,3 +566,18 @@
     color: $bpk-text-disabled-day;
   }
 }
+
+/// Full width button. Modifies the bpk-button to horizontally fill its container
+///
+/// @require {mixin} bpk-button
+///
+/// @example scss
+///   .selector {
+///     @include bpk-button();
+///     @include bpk-button--full-width();
+///   }
+
+@mixin bpk-button--full-width {
+  display: block;
+  width: 100%;
+}


### PR DESCRIPTION
## Background

Currently microsites are overriding the BpkButton styles via classname prop.

This adds the functionality to the component removing the need to use the undesirable classname prop to achieve this

### Screenshot

![image](https://github.com/Skyscanner/backpack/assets/1532576/4c0515b0-fb88-45f7-8e47-7f0aa3b632ca)


## Why should this be added as a prop?

### It's a common button prop in other component libraries

| Library  | Link |
| ------------- | ------------- |
|  Material UI | https://mui.com/material-ui/api/button/ |
| Next UI | https://nextui.org/docs/components/button#button-props |
| Polaris | https://polaris.shopify.com/components/actions/button#props |

### We have plenty of use-cases in Skyscanner

A non-exhaustive list

| Component  | Image |
| ------------- | ------------- |
| Culture Selector  | <img width=300 src="https://github.com/Skyscanner/backpack/assets/1532576/fee33a8d-0c1e-4702-b978-8103fc867b8c" />  |
| Login Modal  | <img width=300 src="https://github.com/Skyscanner/backpack/assets/1532576/2ab3c157-e886-4649-8ae9-d04f770bf4a5" />  |
| Search Controls  | <img width=300 src="https://github.com/Skyscanner/backpack/assets/1532576/fd848404-c1c0-40c7-8683-f9842514ecee)" />  |




Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
