### PR TITLE
[NO JIRA]: Fix transpilation scripts to capture nested files

### DIFF
--- a/scripts/transpilation/copy-css.js
+++ b/scripts/transpilation/copy-css.js
@@ -33,7 +33,7 @@ cssFiles.map((cssFile) => {
   const componentPath = paths[1].split('/');
 
   // V2 components are nested inside a folder
-  if (paths[1].match(/V2/)) {
+  if (paths[1].match(/\/Bpk.*\//) || paths[1].match(/__generated__/)){
     component = `${componentPath[0]}/${componentPath[1]}/${componentPath[2]}`;
   } else {
     component = `${componentPath[0]}/${componentPath[1]}`;

--- a/scripts/transpilation/copy-types.js
+++ b/scripts/transpilation/copy-types.js
@@ -34,8 +34,8 @@ typeFiles.map((typeFile) => {
   const paths = typeFile.split('packages/');
   const componentPath = paths[1].split('/');
 
-  // V2 components are nested inside a folder
-  if (paths[1].match(/V2/)) {
+  // V2 or some components are nested inside a folder
+  if (paths[1].match(/\/Bpk.*\//) || paths[1].match(/__generated__/)) {
     component = `${componentPath[0]}/${componentPath[1]}/${componentPath[2]}`;
   } else {
     component = `${componentPath[0]}/${componentPath[1]}`;


### PR DESCRIPTION
This PR fixes the transpilation scripts to capture all nested files. Previously the logic only implemented captured those that had the name `V2` in the folder name. Which lead to with the introduction of the `BpkDialogWrapper` the CSS and types files were located in the incorrect place and causes errors at build time.

![Screenshot 2024-03-18 at 12 21 57](https://github.com/Skyscanner/backpack/assets/8831547/ddd91bd7-83af-48d3-8052-3cc6c24b3f72)

This PR now updates the scripts to capture these that don't include `V2` in the name, to correct relocate files

| Script | Before | After |
| -- | -- | -- |
| copy-types | ![copy-types with errors](https://github.com/Skyscanner/backpack/assets/8831547/9ba7893f-2901-4929-b34b-adf6f68c8d68) | ![copy-types with fix](https://github.com/Skyscanner/backpack/assets/8831547/e25163e1-eede-4d72-9af1-a0526f270256) |
| copy-css | ![copy-css with errors](https://github.com/Skyscanner/backpack/assets/8831547/e1c3b8c0-92b5-4933-a458-9b003d95e8fb) | ![copy-css with fix](https://github.com/Skyscanner/backpack/assets/8831547/e7703c6c-656c-4c6e-abca-3fe4dc127951) |



