### PR TITLE
BpKContentCards LOOM-1276

### DIFF
--- a/packages/bpk-component-content-cards/src/BpkContentCards.js
+++ b/packages/bpk-component-content-cards/src/BpkContentCards.js
@@ -18,9 +18,12 @@
 /* eslint react/no-array-index-key: 0 */
 
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import BpkText from '../../bpk-component-text';
+import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import { cssModules } from '../../bpk-react-utils';
+import BpkBreakpoint, {
+  BREAKPOINTS,
+} from "../../bpk-component-breakpoint";
 
 import BpkContentCard from './BpkContentCard';
 import STYLES from './BpkContentCards.module.scss';
@@ -47,12 +50,25 @@ const BpkContentCards = ({ cards, heading }: Props) => {
 
   return (
     <div>
-      <BpkText
-        tagName="h2"
-        className={getClassName('bpk-content-cards--header-text')}
-      >
-        {heading}
-      </BpkText>
+      <div className={getClassName('bpk-content-cards--header')}>
+        <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
+            {isActive => (isActive ?
+              <BpkText
+                tagName="h3"
+                textStyle={TEXT_STYLES.heading3}
+              >
+                {heading}
+              </BpkText>
+            :
+              <BpkText
+                tagName="h2"
+                textStyle={TEXT_STYLES.heading2}
+              >
+                {heading}
+              </BpkText>
+            )}
+        </BpkBreakpoint>
+      </div>
       <div role="list" className={getClassName('bpk-content-cards--layout')}>
         {cards.map((card, index) => (
           <div role="listitem" key={index}>

--- a/packages/bpk-component-content-cards/src/BpkContentCards.module.scss
+++ b/packages/bpk-component-content-cards/src/BpkContentCards.module.scss
@@ -24,14 +24,8 @@
 @use '../../unstable__bpk-mixins/typography';
 
 .bpk-content-cards {
-  &--header-text {
+  &--header {
     margin-bottom: tokens.bpk-spacing-base();
-
-    @include typography.bpk-heading-2;
-
-    @include breakpoints.bpk-breakpoint-mobile {
-      @include typography.bpk-heading-3;
-    }
   }
 
   &--layout {


### PR DESCRIPTION
CSS non-determinism / Class 2 - BackPack overrides:

Moving the margin into new parent <div>
Also converted conditional breakpoint styling from scss into a regular breakpoint.

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
