### PR TITLE
Creating dependabot group patterns to group dependencies for PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,20 @@ updates:
   versioning-strategy: increase
   allow:
     - dependency-type: "direct"
+  groups:
+    babel:
+      patterns:
+        - "@babel*"
+        - "babel*"
+    storybook:
+      patterns:
+        - "@storybook*"
+        - "storybook*"
+    testing-library:
+      patterns:
+        - "@testing-library*"
+        - "testing-library*"
+        - "jest*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Adding groups for dependabot PRs, the idea with this is to try some of the large groups together to see if PRs will get raised together. In turn this should lead to less overheads for Percy testing and maintainer management of deps

If this proves successful we can move to a layer further where we can bump all devDeps in one group but this does come with a risk (future discussion point)