### PR TITLE
LOOM-1274 BpkBreadcrumb Class 2 Overrides

### DIFF
--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
@@ -48,14 +48,8 @@ const BpkBreadcrumbItem = (props: Props) => {
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
     <li className={getClassName('bpk-breadcrumb-item', className)} {...rest}>
       {active ? (
-        // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
         <span className={getClassName('bpk-breadcrumb-item__active-item')}>
-          <BpkText
-            aria-current="page"
-            {...linkProps}
-          >
-            {children}
-          </BpkText>
+          {children}
         </span>
       ) : (
         // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import type { Node } from 'react';
 
 import BpkLink from '../../bpk-component-link';
+import BpkText from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
 import { withRtlSupport } from '../../bpk-component-icon';
 import ArrowRight from '../../bpk-component-icon/sm/arrow-right';
@@ -47,25 +48,25 @@ const BpkBreadcrumbItem = (props: Props) => {
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
     <li className={getClassName('bpk-breadcrumb-item', className)} {...rest}>
       {active ? (
-        <div className={getClassName('bpk-breadcrumb-item__active-item')}>
+        <span className={getClassName('bpk-breadcrumb-item__active-item')}>
           {children}
-        </div>
+        </span>
       ) : (
         // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
-        <div className={getClassName('bpk-breadcrumb-item__link')}>
+        <span className={getClassName('bpk-breadcrumb-item__link')}>
           <BpkLink
             href={href}
             {...linkProps}
           >
             {children}
           </BpkLink>
-        </div>
+        </span>
       )}
-      <div className={getClassName('bpk-breadcrumb-item__arrow')}>
+      <span className={getClassName('bpk-breadcrumb-item__arrow')}>
         {!active && (
           <RtlSupportedArrowRight/>
         )}
-      </div>
+      </span>
     </li>
   );
 };

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import type { Node } from 'react';
 
 import BpkLink from '../../bpk-component-link';
+import BpkText from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
 import { withRtlSupport } from '../../bpk-component-icon';
 import ArrowRight from '../../bpk-component-icon/sm/arrow-right';
@@ -47,25 +48,31 @@ const BpkBreadcrumbItem = (props: Props) => {
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
     <li className={getClassName('bpk-breadcrumb-item', className)} {...rest}>
       {active ? (
-        <span className={getClassName('bpk-breadcrumb-item__active-item')}>
-          {children}
-        </span>
+        // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
+        <div className={getClassName('bpk-breadcrumb-item__active-item')}>
+          <BpkText
+            aria-current="page"
+            {...linkProps}
+          >
+            {children}
+          </BpkText>
+        </div>
       ) : (
         // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
-        <span className={getClassName('bpk-breadcrumb-item__link')}>
+        <div className={getClassName('bpk-breadcrumb-item__link')}>
           <BpkLink
             href={href}
             {...linkProps}
           >
             {children}
           </BpkLink>
-        </span>
+        </div>
       )}
-      <span className={getClassName('bpk-breadcrumb-item__arrow')}>
+      <div className={getClassName('bpk-breadcrumb-item__arrow')}>
         {!active && (
           <RtlSupportedArrowRight/>
         )}
-      </span>
+      </div>
     </li>
   );
 };

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
@@ -22,7 +22,6 @@ import PropTypes from 'prop-types';
 import type { Node } from 'react';
 
 import BpkLink from '../../bpk-component-link';
-import BpkText from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
 import { withRtlSupport } from '../../bpk-component-icon';
 import ArrowRight from '../../bpk-component-icon/sm/arrow-right';

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
@@ -22,7 +22,6 @@ import PropTypes from 'prop-types';
 import type { Node } from 'react';
 
 import BpkLink from '../../bpk-component-link';
-import BpkText from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
 import { withRtlSupport } from '../../bpk-component-icon';
 import ArrowRight from '../../bpk-component-icon/sm/arrow-right';
@@ -48,25 +47,25 @@ const BpkBreadcrumbItem = (props: Props) => {
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
     <li className={getClassName('bpk-breadcrumb-item', className)} {...rest}>
       {active ? (
-        <span className={getClassName('bpk-breadcrumb-item__active-item')}>
+        <div className={getClassName('bpk-breadcrumb-item__active-item')}>
           {children}
-        </span>
+        </div>
       ) : (
         // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
-        <span className={getClassName('bpk-breadcrumb-item__link')}>
+        <div className={getClassName('bpk-breadcrumb-item__link')}>
           <BpkLink
             href={href}
             {...linkProps}
           >
             {children}
           </BpkLink>
-        </span>
+        </div>
       )}
-      <span className={getClassName('bpk-breadcrumb-item__arrow')}>
+      <div className={getClassName('bpk-breadcrumb-item__arrow')}>
         {!active && (
           <RtlSupportedArrowRight/>
         )}
-      </span>
+      </div>
     </li>
   );
 };

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.js
@@ -49,28 +49,30 @@ const BpkBreadcrumbItem = (props: Props) => {
     <li className={getClassName('bpk-breadcrumb-item', className)} {...rest}>
       {active ? (
         // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
-        <BpkText
-          className={getClassName('bpk-breadcrumb-item__active-item')}
-          aria-current="page"
-          {...linkProps}
-        >
-          {children}
-        </BpkText>
+        <span className={getClassName('bpk-breadcrumb-item__active-item')}>
+          <BpkText
+            aria-current="page"
+            {...linkProps}
+          >
+            {children}
+          </BpkText>
+        </span>
       ) : (
         // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'.
-        <BpkLink
-          href={href}
-          className={getClassName('bpk-breadcrumb-item__link')}
-          {...linkProps}
-        >
-          {children}
-        </BpkLink>
+        <span className={getClassName('bpk-breadcrumb-item__link')}>
+          <BpkLink
+            href={href}
+            {...linkProps}
+          >
+            {children}
+          </BpkLink>
+        </span>
       )}
-      {!active && (
-        <RtlSupportedArrowRight
-          className={getClassName('bpk-breadcrumb-item__arrow')}
-        />
-      )}
+      <span className={getClassName('bpk-breadcrumb-item__arrow')}>
+        {!active && (
+          <RtlSupportedArrowRight/>
+        )}
+      </span>
     </li>
   );
 };

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -1,20 +1,20 @@
 /*
-* Backpack - Skyscanner's Design System
-*
-* Copyright 2016 Skyscanner Ltd
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 @use '../../unstable__bpk-mixins/tokens';
 @use '../../unstable__bpk-mixins/typography';

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -19,8 +19,7 @@
 @use '../../unstable__bpk-mixins/tokens';
 @use '../../unstable__bpk-mixins/typography';
 
-/* stylelint-disable unit-disallowed-list */
-$icon-height: 0;
+$icon-height: tokens.$bpk-line-height-xs / 2;
 
 .bpk-breadcrumb-item {
   display: flex;

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -24,7 +24,7 @@ $icon-height: 16px;
 
 .bpk-breadcrumb-item {
   display: flex;
-  margin-top: tokens.bpk-spacing-sm() / 2;
+  margin-top: tokens.bpk-spacing-sm() / 4;
   align-items: center;
   white-space: nowrap;
 

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -33,6 +33,7 @@
   }
 
   &__arrow {
+    line-height: 16px;
     margin: 0 tokens.bpk-spacing-sm();
     fill: tokens.$bpk-text-disabled-day;
   }

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -33,8 +33,9 @@
   }
 
   &__arrow {
+    display: flex;
     margin: 0 tokens.bpk-spacing-sm();
-    line-height: tokens.$bpk-line-height-lg;
+    line-height: tokens.$bpk-line-height-xs;
     fill: tokens.$bpk-text-disabled-day;
   }
 }

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -37,7 +37,7 @@ $icon-height: 16px;
   }
 
   &__arrow {
-    margin: tokens.bpk-spacing-sm() / 8 tokens.bpk-spacing-sm() 0;
+    margin: 0 tokens.bpk-spacing-sm();
     line-height: $icon-height;
     fill: tokens.$bpk-text-disabled-day;
   }

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -19,6 +19,9 @@
 @use '../../unstable__bpk-mixins/tokens';
 @use '../../unstable__bpk-mixins/typography';
 
+/* After adding the wrapper around the icon, need to set the line
+    height to stop the 16x16 or 32x32(zoomed) icon from expanding
+    verically past it's 16 or 32 pixels height */
 $icon-height: tokens.$bpk-line-height-xs / 2;
 
 .bpk-breadcrumb-item {

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -24,7 +24,7 @@ $icon-height: 16px;
 
 .bpk-breadcrumb-item {
   display: flex;
-  margin-top: tokens.bpk-spacing-sm() / 4;
+  margin-top: tokens.bpk-spacing-sm() / 2;
   align-items: center;
   white-space: nowrap;
 
@@ -37,7 +37,7 @@ $icon-height: 16px;
   }
 
   &__arrow {
-    margin: tokens.bpk-spacing-sm() / 2 tokens.bpk-spacing-sm() 0;
+    margin: tokens.bpk-spacing-sm() / 8 tokens.bpk-spacing-sm() 0;
     line-height: $icon-height;
     fill: tokens.$bpk-text-disabled-day;
   }

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -24,7 +24,7 @@ $icon-height: 16px;
 
 .bpk-breadcrumb-item {
   display: flex;
-  margin-top: tokens.bpk-spacing-sm() / 4;
+  margin-top: tokens.bpk-spacing-sm() / 8;
   align-items: center;
   white-space: nowrap;
 

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -29,13 +29,15 @@
   }
 
   &__active-item {
+    margin-top: tokens.bpk-spacing-base() * 0.125;
     color: tokens.$bpk-text-secondary-day;
   }
 
   &__arrow {
     display: flex;
-    margin: 0 tokens.bpk-spacing-sm();
-    line-height: tokens.$bpk-line-height-xs;
+    margin-top: tokens.bpk-spacing-base() * 0.1;
+    margin-right: tokens.bpk-spacing-sm();
+    margin-left: tokens.bpk-spacing-sm();
     fill: tokens.$bpk-text-disabled-day;
   }
 }

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -20,11 +20,10 @@
 @use '../../unstable__bpk-mixins/typography';
 
 /* stylelint-disable unit-disallowed-list */
-$icon-height: 16px;
+$icon-height: 0;
 
 .bpk-breadcrumb-item {
   display: flex;
-  margin-top: tokens.bpk-spacing-sm() / 8;
   align-items: center;
   white-space: nowrap;
 

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -1,25 +1,26 @@
 /*
- * Backpack - Skyscanner's Design System
- *
- * Copyright 2016 Skyscanner Ltd
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Backpack - Skyscanner's Design System
+*
+* Copyright 2016 Skyscanner Ltd
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 @use '../../unstable__bpk-mixins/tokens';
 @use '../../unstable__bpk-mixins/typography';
 
-$icon-height: tokens.$bpk-line-height-xs / 2;
+/* stylelint-disable unit-disallowed-list */
+$icon-height: 16px;
 
 .bpk-breadcrumb-item {
   display: flex;
@@ -31,11 +32,12 @@ $icon-height: tokens.$bpk-line-height-xs / 2;
   }
 
   &__active-item {
+    margin-top: tokens.bpk-spacing-sm() / 2;
     color: tokens.$bpk-text-secondary-day;
   }
 
   &__arrow {
-    margin: 0 tokens.bpk-spacing-sm();
+    margin: tokens.bpk-spacing-sm() / 2 tokens.bpk-spacing-sm() 0;
     line-height: $icon-height;
     fill: tokens.$bpk-text-disabled-day;
   }

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -24,6 +24,7 @@ $icon-height: 16px;
 
 .bpk-breadcrumb-item {
   display: flex;
+  margin-top: tokens.bpk-spacing-sm() / 4;
   align-items: center;
   white-space: nowrap;
 
@@ -32,7 +33,6 @@ $icon-height: 16px;
   }
 
   &__active-item {
-    margin-top: tokens.bpk-spacing-sm() / 2;
     color: tokens.$bpk-text-secondary-day;
   }
 

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -19,6 +19,8 @@
 @use '../../unstable__bpk-mixins/tokens';
 @use '../../unstable__bpk-mixins/typography';
 
+$icon-height: tokens.$bpk-line-height-xs / 2;
+
 .bpk-breadcrumb-item {
   display: flex;
   align-items: center;
@@ -26,19 +28,15 @@
 
   &__link {
     @include typography.bpk-text;
-    margin-top: tokens.bpk-spacing-base() * 0.125;
   }
 
   &__active-item {
-    margin-top: tokens.bpk-spacing-base() * 0.125;
     color: tokens.$bpk-text-secondary-day;
   }
 
   &__arrow {
-    display: flex;
-    margin-top: tokens.bpk-spacing-base() * 0.1;
-    margin-right: tokens.bpk-spacing-sm();
-    margin-left: tokens.bpk-spacing-sm();
+    margin: 0 tokens.bpk-spacing-sm();
+    line-height: $icon-height;
     fill: tokens.$bpk-text-disabled-day;
   }
 }

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -26,6 +26,7 @@
 
   &__link {
     @include typography.bpk-text;
+    margin-top: tokens.bpk-spacing-base() * 0.125;
   }
 
   &__active-item {

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -34,7 +34,7 @@
 
   &__arrow {
     margin: 0 tokens.bpk-spacing-sm();
-    line-height: tokens.$bpk-line-height-xs;
+    line-height: tokens.$bpk-line-height-lg;
     fill: tokens.$bpk-text-disabled-day;
   }
 }

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -34,7 +34,7 @@
 
   &__arrow {
     margin: 0 tokens.bpk-spacing-sm();
-    line-height: $bpk-line-height-xs;
+    line-height: tokens.$bpk-line-height-xs;
     fill: tokens.$bpk-text-disabled-day;
   }
 }

--- a/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -33,8 +33,8 @@
   }
 
   &__arrow {
-    line-height: 16px;
     margin: 0 tokens.bpk-spacing-sm();
+    line-height: $bpk-line-height-xs;
     fill: tokens.$bpk-text-disabled-day;
   }
 }

--- a/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
+++ b/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
@@ -5,7 +5,7 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
   <li
     class="bpk-breadcrumb-item"
   >
-    <div
+    <span
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -14,8 +14,8 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
       >
         Backpack
       </a>
-    </div>
-    <div
+    </span>
+    <span
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -29,7 +29,7 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </div>
+    </span>
   </li>
 </DocumentFragment>
 `;
@@ -39,12 +39,12 @@ exports[`BpkBreadcrumbItem should render correctly with a "active" prop 1`] = `
   <li
     class="bpk-breadcrumb-item"
   >
-    <div
+    <span
       class="bpk-breadcrumb-item__active-item"
     >
       Backpack
-    </div>
-    <div
+    </span>
+    <span
       class="bpk-breadcrumb-item__arrow"
     />
   </li>
@@ -56,7 +56,7 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
   <li
     class="bpk-breadcrumb-item my-custom-class"
   >
-    <div
+    <span
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -65,8 +65,8 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
       >
         Backpack
       </a>
-    </div>
-    <div
+    </span>
+    <span
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -80,7 +80,7 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </div>
+    </span>
   </li>
 </DocumentFragment>
 `;
@@ -91,7 +91,7 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
     class="bpk-breadcrumb-item"
     testid="arbitrary value"
   >
-    <div
+    <span
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -100,8 +100,8 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
       >
         Backpack
       </a>
-    </div>
-    <div
+    </span>
+    <span
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -115,7 +115,7 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </div>
+    </span>
   </li>
 </DocumentFragment>
 `;
@@ -125,7 +125,7 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
   <li
     class="bpk-breadcrumb-item"
   >
-    <div
+    <span
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -135,8 +135,8 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
       >
         Backpack
       </a>
-    </div>
-    <div
+    </span>
+    <span
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -150,7 +150,7 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </div>
+    </span>
   </li>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
+++ b/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
@@ -5,7 +5,7 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
   <li
     class="bpk-breadcrumb-item"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -14,8 +14,8 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
       >
         Backpack
       </a>
-    </span>
-    <span
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -29,7 +29,7 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </span>
+    </div>
   </li>
 </DocumentFragment>
 `;
@@ -39,12 +39,12 @@ exports[`BpkBreadcrumbItem should render correctly with a "active" prop 1`] = `
   <li
     class="bpk-breadcrumb-item"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__active-item"
     >
       Backpack
-    </span>
-    <span
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     />
   </li>
@@ -56,7 +56,7 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
   <li
     class="bpk-breadcrumb-item my-custom-class"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -65,8 +65,8 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
       >
         Backpack
       </a>
-    </span>
-    <span
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -80,7 +80,7 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </span>
+    </div>
   </li>
 </DocumentFragment>
 `;
@@ -91,7 +91,7 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
     class="bpk-breadcrumb-item"
     testid="arbitrary value"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -100,8 +100,8 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
       >
         Backpack
       </a>
-    </span>
-    <span
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -115,7 +115,7 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </span>
+    </div>
   </li>
 </DocumentFragment>
 `;
@@ -125,7 +125,7 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
   <li
     class="bpk-breadcrumb-item"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -135,8 +135,8 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
       >
         Backpack
       </a>
-    </span>
-    <span
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -150,7 +150,7 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </span>
+    </div>
   </li>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
+++ b/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
@@ -5,7 +5,7 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
   <li
     class="bpk-breadcrumb-item"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -14,8 +14,8 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
       >
         Backpack
       </a>
-    </span>
-    <span
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -29,7 +29,7 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </span>
+    </div>
   </li>
 </DocumentFragment>
 `;
@@ -39,12 +39,17 @@ exports[`BpkBreadcrumbItem should render correctly with a "active" prop 1`] = `
   <li
     class="bpk-breadcrumb-item"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__active-item"
     >
-      Backpack
-    </span>
-    <span
+      <span
+        aria-current="page"
+        class="bpk-text bpk-text--body-default"
+      >
+        Backpack
+      </span>
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     />
   </li>
@@ -56,7 +61,7 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
   <li
     class="bpk-breadcrumb-item my-custom-class"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -65,8 +70,8 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
       >
         Backpack
       </a>
-    </span>
-    <span
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -80,7 +85,7 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </span>
+    </div>
   </li>
 </DocumentFragment>
 `;
@@ -91,7 +96,7 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
     class="bpk-breadcrumb-item"
     testid="arbitrary value"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -100,8 +105,8 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
       >
         Backpack
       </a>
-    </span>
-    <span
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -115,7 +120,7 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </span>
+    </div>
   </li>
 </DocumentFragment>
 `;
@@ -125,7 +130,7 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
   <li
     class="bpk-breadcrumb-item"
   >
-    <span
+    <div
       class="bpk-breadcrumb-item__link"
     >
       <a
@@ -135,8 +140,8 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
       >
         Backpack
       </a>
-    </span>
-    <span
+    </div>
+    <div
       class="bpk-breadcrumb-item__arrow"
     >
       <svg
@@ -150,7 +155,7 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
           d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
         />
       </svg>
-    </span>
+    </div>
   </li>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
+++ b/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
@@ -5,23 +5,31 @@ exports[`BpkBreadcrumbItem should render correctly 1`] = `
   <li
     class="bpk-breadcrumb-item"
   >
-    <a
-      class="bpk-link bpk-breadcrumb-item__link"
-      href="https://skyscanner.design/"
+    <span
+      class="bpk-breadcrumb-item__link"
     >
-      Backpack
-    </a>
-    <svg
-      aria-hidden="true"
-      class="bpk-breadcrumb-item__arrow bpk-icon--rtl-support"
-      style="width: 1rem; height: 1rem;"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
+      <a
+        class="bpk-link"
+        href="https://skyscanner.design/"
+      >
+        Backpack
+      </a>
+    </span>
+    <span
+      class="bpk-breadcrumb-item__arrow"
     >
-      <path
-        d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        class="bpk-icon--rtl-support"
+        style="width: 1rem; height: 1rem;"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
+        />
+      </svg>
+    </span>
   </li>
 </DocumentFragment>
 `;
@@ -32,11 +40,18 @@ exports[`BpkBreadcrumbItem should render correctly with a "active" prop 1`] = `
     class="bpk-breadcrumb-item"
   >
     <span
-      aria-current="page"
-      class="bpk-text bpk-text--body-default bpk-breadcrumb-item__active-item"
+      class="bpk-breadcrumb-item__active-item"
     >
-      Backpack
+      <span
+        aria-current="page"
+        class="bpk-text bpk-text--body-default"
+      >
+        Backpack
+      </span>
     </span>
+    <span
+      class="bpk-breadcrumb-item__arrow"
+    />
   </li>
 </DocumentFragment>
 `;
@@ -46,23 +61,31 @@ exports[`BpkBreadcrumbItem should render correctly with a custom class name 1`] 
   <li
     class="bpk-breadcrumb-item my-custom-class"
   >
-    <a
-      class="bpk-link bpk-breadcrumb-item__link"
-      href="https://skyscanner.design/"
+    <span
+      class="bpk-breadcrumb-item__link"
     >
-      Backpack
-    </a>
-    <svg
-      aria-hidden="true"
-      class="bpk-breadcrumb-item__arrow bpk-icon--rtl-support"
-      style="width: 1rem; height: 1rem;"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
+      <a
+        class="bpk-link"
+        href="https://skyscanner.design/"
+      >
+        Backpack
+      </a>
+    </span>
+    <span
+      class="bpk-breadcrumb-item__arrow"
     >
-      <path
-        d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        class="bpk-icon--rtl-support"
+        style="width: 1rem; height: 1rem;"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
+        />
+      </svg>
+    </span>
   </li>
 </DocumentFragment>
 `;
@@ -73,23 +96,31 @@ exports[`BpkBreadcrumbItem should render correctly with arbitrary props 1`] = `
     class="bpk-breadcrumb-item"
     testid="arbitrary value"
   >
-    <a
-      class="bpk-link bpk-breadcrumb-item__link"
-      href="https://skyscanner.design/"
+    <span
+      class="bpk-breadcrumb-item__link"
     >
-      Backpack
-    </a>
-    <svg
-      aria-hidden="true"
-      class="bpk-breadcrumb-item__arrow bpk-icon--rtl-support"
-      style="width: 1rem; height: 1rem;"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
+      <a
+        class="bpk-link"
+        href="https://skyscanner.design/"
+      >
+        Backpack
+      </a>
+    </span>
+    <span
+      class="bpk-breadcrumb-item__arrow"
     >
-      <path
-        d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        class="bpk-icon--rtl-support"
+        style="width: 1rem; height: 1rem;"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
+        />
+      </svg>
+    </span>
   </li>
 </DocumentFragment>
 `;
@@ -99,24 +130,32 @@ exports[`BpkBreadcrumbItem should render correctly with with "linkProps" attribu
   <li
     class="bpk-breadcrumb-item"
   >
-    <a
-      class="bpk-link bpk-breadcrumb-item__link"
-      href="https://skyscanner.design/"
-      testid="arbitrary value"
+    <span
+      class="bpk-breadcrumb-item__link"
     >
-      Backpack
-    </a>
-    <svg
-      aria-hidden="true"
-      class="bpk-breadcrumb-item__arrow bpk-icon--rtl-support"
-      style="width: 1rem; height: 1rem;"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
+      <a
+        class="bpk-link"
+        href="https://skyscanner.design/"
+        testid="arbitrary value"
+      >
+        Backpack
+      </a>
+    </span>
+    <span
+      class="bpk-breadcrumb-item__arrow"
     >
-      <path
-        d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        class="bpk-icon--rtl-support"
+        style="width: 1rem; height: 1rem;"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8.25 7.463v9.074a1.358 1.358 0 002.251 1.11l4.77-4.354a1.53 1.53 0 00.04-2.184l-4.77-4.718A1.357 1.357 0 008.25 7.463z"
+        />
+      </svg>
+    </span>
   </li>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
+++ b/packages/bpk-component-breadcrumb/src/__snapshots__/BpkBreadcrumbItem-test.js.snap
@@ -42,12 +42,7 @@ exports[`BpkBreadcrumbItem should render correctly with a "active" prop 1`] = `
     <span
       class="bpk-breadcrumb-item__active-item"
     >
-      <span
-        aria-current="page"
-        class="bpk-text bpk-text--body-default"
-      >
-        Backpack
-      </span>
+      Backpack
     </span>
     <span
       class="bpk-breadcrumb-item__arrow"


### PR DESCRIPTION
**Add existing Bpk child component overrides to wrappers.**

Had to set a specific line height after adding the wrapper around the 16x16 or 32x32(zoomed) icon to retain the correct alignment, i.e. adding the wrapper increases the height of the right arrow icon which then affects the alignment of the right arrow within the breadcrumb.

**Without** the line height fix, the right arrows are vertically shifted up:
<kbd> ![Screenshot 2024-03-28 at 11 37 19](https://github.com/Skyscanner/backpack/assets/7976511/8446a39b-d48a-4558-beac-5113be268225) </kbd>

**With** the line height fix, the right arrows are back to where they should be centrally aligned:
<kbd> ![Screenshot 2024-03-28 at 11 39 05](https://github.com/Skyscanner/backpack/assets/7976511/c27f51f4-8269-4664-9a00-414686f5cc76) </kbd>

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
