### PR TITLE
LOOM-1277 BpkDataTableHeader

### DIFF
--- a/packages/bpk-component-datatable/src/BpkDataTable-test.tsx
+++ b/packages/bpk-component-datatable/src/BpkDataTable-test.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
- 
+
 
 import { Fragment } from 'react';
 
@@ -119,7 +119,7 @@ describe('BpkDataTable', () => {
           { label: 'Name', accessor: 'name', width: "6.25rem" },
           { label: 'Description', accessor: 'description', width: "6.25rem", flexGrow: 1 },
           { label: 'Bla', accessor: 'bla', width: "6.25rem" },
-        ]} /> 
+        ]} />
     );
     expect(asFragment()).toMatchSnapshot();
   });
@@ -200,7 +200,8 @@ describe('BpkDataTable', () => {
     const sortIconUp = document.getElementsByClassName(
       'bpk-data-table-column__sort-icon--up',
     )[0];
-    await fireEvent.click(sortIconUp);
+    const clickArrow = sortIconUp.querySelector('svg') as SVGSVGElement;
+    await fireEvent.click(clickArrow) ;
 
     const firstRowNameSorted = within(
       screen.getAllByRole('rowgroup')[0],
@@ -236,7 +237,8 @@ describe('BpkDataTable', () => {
     const sortIconDown = document.getElementsByClassName(
       'bpk-data-table-column__sort-icon--down',
     )[0];
-    await fireEvent.click(sortIconDown);
+    const clickArrow = sortIconDown.querySelector('svg') as SVGSVGElement;
+    await fireEvent.click(clickArrow);
 
     const firstRowNameSorted = within(
       screen.getAllByRole('rowgroup')[0],

--- a/packages/bpk-component-datatable/src/BpkDataTableHeader.module.scss
+++ b/packages/bpk-component-datatable/src/BpkDataTableHeader.module.scss
@@ -62,5 +62,5 @@ $bpk-margin-size-sort-icons: tokens.bpk-spacing-sm() + tokens.bpk-spacing-md();
 }
 
 .bpk-data-table-column__sort-icon--up {
-  margin-bottom: -1 * (tokens.bpk-spacing-sm());
+  margin-bottom: -1.75 * (tokens.bpk-spacing-sm());
 }

--- a/packages/bpk-component-datatable/src/BpkDataTableHeader.module.scss
+++ b/packages/bpk-component-datatable/src/BpkDataTableHeader.module.scss
@@ -21,6 +21,7 @@
 @use '../../unstable__bpk-mixins/utils';
 
 $bpk-margin-size-sort-icons: tokens.bpk-spacing-sm() + tokens.bpk-spacing-md();
+$icon-height: tokens.$bpk-line-height-xs / 2;
 
 .bpk-data-table-column__header {
   display: flex;
@@ -47,6 +48,7 @@ $bpk-margin-size-sort-icons: tokens.bpk-spacing-sm() + tokens.bpk-spacing-md();
 
 .bpk-data-table-column__sort-icon {
   display: block;
+  line-height: $icon-height;
   fill: tokens.$bpk-line-day;
 
   &:hover {
@@ -62,5 +64,5 @@ $bpk-margin-size-sort-icons: tokens.bpk-spacing-sm() + tokens.bpk-spacing-md();
 }
 
 .bpk-data-table-column__sort-icon--up {
-  margin-bottom: -1.75 * (tokens.bpk-spacing-sm());
+  margin-bottom: -1 * (tokens.bpk-spacing-sm());
 }

--- a/packages/bpk-component-datatable/src/BpkDataTableHeader.tsx
+++ b/packages/bpk-component-datatable/src/BpkDataTableHeader.tsx
@@ -44,7 +44,7 @@ const KEYCODES = {
  * Internal component to render the header of a column.
  * @returns {JSX.Element} data table header component
  */
-const BpkDataTableHeader = ({ column }: { column: any }) => {  
+const BpkDataTableHeader = ({ column }: { column: any }) => {
   const {
     defaultSortDirection,
     disableSortBy,
@@ -141,14 +141,16 @@ const BpkDataTableHeader = ({ column }: { column: any }) => {
           key="sort"
           aria-hidden
         >
-          <UpIcon
-            onClick={() => column.toggleSortBy(false)}
-            className={upIconClassNames}
-          />
-          <DownIcon
-            onClick={() => column.toggleSortBy(true)}
-            className={downIconClassNames}
-          />
+          <div className={upIconClassNames}>
+            <UpIcon
+              onClick={() => column.toggleSortBy(false)}
+            />
+          </div>
+          <div className={downIconClassNames}>
+            <DownIcon
+              onClick={() => column.toggleSortBy(true)}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.tsx.snap
+++ b/packages/bpk-component-datatable/src/__snapshots__/BpkDataTable-test.tsx.snap
@@ -31,28 +31,36 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -73,28 +81,36 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -115,28 +131,36 @@ exports[`BpkDataTable should render correctly when "onRowClick" is set 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -236,28 +260,36 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -278,28 +310,36 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -320,28 +360,36 @@ exports[`BpkDataTable should render correctly with a custom className 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -441,28 +489,36 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -483,28 +539,36 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -525,28 +589,36 @@ exports[`BpkDataTable should render correctly with a custom headerClassName 1`] 
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -646,28 +718,36 @@ exports[`BpkDataTable should render correctly with a custom rowClassName functio
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -688,28 +768,36 @@ exports[`BpkDataTable should render correctly with a custom rowClassName functio
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -730,28 +818,36 @@ exports[`BpkDataTable should render correctly with a custom rowClassName functio
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -851,28 +947,36 @@ exports[`BpkDataTable should render correctly with a custom rowClassName string 
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -893,28 +997,36 @@ exports[`BpkDataTable should render correctly with a custom rowClassName string 
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -935,28 +1047,36 @@ exports[`BpkDataTable should render correctly with a custom rowClassName string 
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -1056,28 +1176,36 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -1098,28 +1226,36 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -1140,28 +1276,36 @@ exports[`BpkDataTable should render correctly with a specified width 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -1261,28 +1405,36 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -1303,28 +1455,36 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -1345,28 +1505,36 @@ exports[`BpkDataTable should render correctly with multiple columns 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -1466,28 +1634,36 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -1508,28 +1684,36 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
         <div
@@ -1550,28 +1734,36 @@ exports[`BpkDataTable should render correctly with no data; only headers 1`] = `
             aria-hidden="true"
             class="bpk-data-table-column__sort-icons"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+                />
+              </svg>
+            </div>
+            <div
+              class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
             >
-              <path
-                d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="bpk-icon--rtl-support"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/bpk-component-datatable/src/__snapshots__/BpkDataTableHeader-test.tsx.snap
+++ b/packages/bpk-component-datatable/src/__snapshots__/BpkDataTableHeader-test.tsx.snap
@@ -30,28 +30,36 @@ exports[`BpkDataTableHeader renders sort icon with down icon selected 1`] = `
       aria-hidden="true"
       class="bpk-data-table-column__sort-icons"
     >
-      <svg
-        aria-hidden="true"
-        class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-        style="width: 1rem; height: 1rem;"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
       >
-        <path
-          d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-        />
-      </svg>
-      <svg
-        aria-hidden="true"
-        class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-        style="width: 1rem; height: 1rem;"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+        <svg
+          aria-hidden="true"
+          class="bpk-icon--rtl-support"
+          style="width: 1rem; height: 1rem;"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+          />
+        </svg>
+      </div>
+      <div
+        class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
       >
-        <path
-          d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="bpk-icon--rtl-support"
+          style="width: 1rem; height: 1rem;"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+          />
+        </svg>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -72,28 +80,36 @@ exports[`BpkDataTableHeader renders sort icon with up icon selected 1`] = `
       aria-hidden="true"
       class="bpk-data-table-column__sort-icons"
     >
-      <svg
-        aria-hidden="true"
-        class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected bpk-icon--rtl-support"
-        style="width: 1rem; height: 1rem;"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-data-table-column__sort-icon--selected"
       >
-        <path
-          d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-        />
-      </svg>
-      <svg
-        aria-hidden="true"
-        class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-        style="width: 1rem; height: 1rem;"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+        <svg
+          aria-hidden="true"
+          class="bpk-icon--rtl-support"
+          style="width: 1rem; height: 1rem;"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+          />
+        </svg>
+      </div>
+      <div
+        class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
       >
-        <path
-          d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="bpk-icon--rtl-support"
+          style="width: 1rem; height: 1rem;"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+          />
+        </svg>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -114,28 +130,36 @@ exports[`BpkDataTableHeader renders sort icons 1`] = `
       aria-hidden="true"
       class="bpk-data-table-column__sort-icons"
     >
-      <svg
-        aria-hidden="true"
-        class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-        style="width: 1rem; height: 1rem;"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        class="bpk-data-table-column__sort-icon--up bpk-data-table-column__sort-icon"
       >
-        <path
-          d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
-        />
-      </svg>
-      <svg
-        aria-hidden="true"
-        class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon bpk-icon--rtl-support"
-        style="width: 1rem; height: 1rem;"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+        <svg
+          aria-hidden="true"
+          class="bpk-icon--rtl-support"
+          style="width: 1rem; height: 1rem;"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M7.463 15.75h9.074a1.358 1.358 0 001.11-2.251l-4.354-4.77a1.53 1.53 0 00-2.184-.04l-4.718 4.77a1.357 1.357 0 001.072 2.291z"
+          />
+        </svg>
+      </div>
+      <div
+        class="bpk-data-table-column__sort-icon--down bpk-data-table-column__sort-icon"
       >
-        <path
-          d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="bpk-icon--rtl-support"
+          style="width: 1rem; height: 1rem;"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16.537 8.25H7.463a1.358 1.358 0 00-1.11 2.251l4.354 4.77a1.53 1.53 0 002.184.04l4.718-4.77a1.357 1.357 0 00-1.072-2.291z"
+          />
+        </svg>
+      </div>
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
**Class 2 Backpack overrides**

Arrow alignment fixed by setting `line-height`.

Minor update to the test since the arrow up and down (svgs) are now children of the wrapper div and hence the svgs need to be clicked, not the wrapper div.

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
