### PR TITLE
LOOM-1281 BpkDialog className moved to new wrapper span

### DIFF
--- a/packages/bpk-component-dialog/src/BpkDialog.module.scss
+++ b/packages/bpk-component-dialog/src/BpkDialog.module.scss
@@ -32,11 +32,13 @@
 
   &__close-button {
     float: right;
-    margin: 0 0 tokens.bpk-spacing-base() tokens.bpk-spacing-base();
+    margin: 0 calc(tokens.bpk-spacing-sm() / 2) tokens.bpk-spacing-base()
+      tokens.bpk-spacing-base();
 
     @include utils.bpk-rtl {
       float: left;
-      margin: 0 tokens.bpk-spacing-base() tokens.bpk-spacing-base() 0;
+      margin: 0 tokens.bpk-spacing-base() tokens.bpk-spacing-base()
+        calc(tokens.bpk-spacing-sm() / 2);
     }
   }
 

--- a/packages/bpk-component-dialog/src/BpkDialog.tsx
+++ b/packages/bpk-component-dialog/src/BpkDialog.tsx
@@ -46,9 +46,11 @@ const BpkDialog = ({
   );
   const closeButtonClassNames = getClassName('bpk-dialog__close-button');
 
-  if(!onClose && dismissible === true) {
+  if (!onClose && dismissible === true) {
     // eslint-disable-next-line no-console
-    console.warn('BpkDialog: dismissible is true but no onClose prop was provided. Dialog will not be dismissible.');
+    console.warn(
+      'BpkDialog: dismissible is true but no onClose prop was provided. Dialog will not be dismissible.',
+    );
   }
 
   return (
@@ -69,11 +71,9 @@ const BpkDialog = ({
       >
         {headerIcon && <div className={headerIconClassNames}>{headerIcon}</div>}
         {dismissible && (
-          <BpkCloseButton
-            className={closeButtonClassNames}
-            label={closeLabel}
-            onClick={onClose}
-          />
+          <span className={closeButtonClassNames}>
+            <BpkCloseButton label={closeLabel} onClick={onClose} />
+          </span>
         )}
         {children}
       </BpkDialogInner>

--- a/packages/bpk-component-dialog/src/__snapshots__/BpkDialog-test.tsx.snap
+++ b/packages/bpk-component-dialog/src/__snapshots__/BpkDialog-test.tsx.snap
@@ -26,27 +26,31 @@ exports[`BpkDialog should render correctly in the given target if renderTarget i
           <div
             class="bpk-dialog-inner__content"
           >
-            <button
-              aria-label="Close"
-              class="bpk-close-button bpk-dialog__close-button"
-              title="Close"
-              type="button"
+            <span
+              class="bpk-dialog__close-button"
             >
-              <span
-                class="bpk-close-button__icon"
+              <button
+                aria-label="Close"
+                class="bpk-close-button"
+                title="Close"
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  style="width: 1rem; height: 1rem;"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  class="bpk-close-button__icon"
                 >
-                  <path
-                    d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
-                  />
-                </svg>
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    style="width: 1rem; height: 1rem;"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
             Dialog content inside a custom target
           </div>
         </section>
@@ -303,27 +307,31 @@ exports[`BpkDialog should render with flare dialog 2`] = `
           <div
             class="bpk-dialog-inner__content"
           >
-            <button
-              aria-label=""
-              class="bpk-close-button bpk-dialog__close-button"
-              title=""
-              type="button"
+            <span
+              class="bpk-dialog__close-button"
             >
-              <span
-                class="bpk-close-button__icon"
+              <button
+                aria-label=""
+                class="bpk-close-button"
+                title=""
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  style="width: 1rem; height: 1rem;"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  class="bpk-close-button__icon"
                 >
-                  <path
-                    d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
-                  />
-                </svg>
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    style="width: 1rem; height: 1rem;"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
             Dialog content inside a custom target
           </div>
         </section>
@@ -398,27 +406,31 @@ exports[`BpkDialog should render with flare dialog with flareClassName 2`] = `
           <div
             class="bpk-dialog-inner__content"
           >
-            <button
-              aria-label=""
-              class="bpk-close-button bpk-dialog__close-button"
-              title=""
-              type="button"
+            <span
+              class="bpk-dialog__close-button"
             >
-              <span
-                class="bpk-close-button__icon"
+              <button
+                aria-label=""
+                class="bpk-close-button"
+                title=""
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  style="width: 1rem; height: 1rem;"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  class="bpk-close-button__icon"
                 >
-                  <path
-                    d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
-                  />
-                </svg>
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    style="width: 1rem; height: 1rem;"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
             Dialog content inside a custom target
           </div>
         </section>


### PR DESCRIPTION
Part of work moving className usage out of backpack components.
Moved className from BpkCloseButton out to wrapper span, adjusted margins slightly to compensate shift

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
