### PR TITLE
LOOM-1282 BkpDrawerContent BpkDrawer Class 2 Overrides

### DIFF
--- a/packages/bpk-component-drawer/src/BpkDrawer.js
+++ b/packages/bpk-component-drawer/src/BpkDrawer.js
@@ -21,14 +21,10 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
-import { Portal, cssModules } from '../../bpk-react-utils';
+import { Portal } from '../../bpk-react-utils';
 import { withScrim } from '../../bpk-scrim-utils';
 
 import BpkDrawerContent from './BpkDrawerContent';
-
-import STYLES from './BpkDrawer.module.scss';
-
-const getClassName = cssModules(STYLES);
 
 const BpkScrimDrawerContent = withScrim(BpkDrawerContent);
 
@@ -87,7 +83,6 @@ class BpkDrawer extends Component<Props, State> {
           isDrawerShown={isDrawerShown}
           onClose={this.hide}
           onCloseAnimationComplete={this.onCloseAnimationComplete}
-          containerClassName={getClassName('bpk-drawer__container')}
           {...rest}
         />
       </Portal>

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.js
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.js
@@ -124,11 +124,12 @@ const BpkDrawerContent = (props: Props) => {
             {closeText ? (
               <BpkButtonLink onClick={onClose}>{closeText}</BpkButtonLink>
             ) : (
-              <BpkCloseButton
-                className={getClassName('bpk-drawer__close-button')}
-                label={closeLabel}
-                onClick={onClose}
-              />
+              <div className={getClassName('bpk-drawer__close-button')}>
+                <BpkCloseButton
+                  label={closeLabel}
+                  onClick={onClose}
+                />
+              </div>
             )}
           </header>
           <div className={contentClassNames.join(' ')}>{children}</div>

--- a/packages/bpk-component-drawer/src/__snapshots__/BpkDrawer-test.js.snap
+++ b/packages/bpk-component-drawer/src/__snapshots__/BpkDrawer-test.js.snap
@@ -33,27 +33,31 @@ exports[`BpkDrawer should render correctly in the given target if renderTarget i
               Drawer title
             </h2>
              
-            <button
-              aria-label="Close"
-              class="bpk-close-button bpk-drawer__close-button"
-              title="Close"
-              type="button"
+            <div
+              class="bpk-drawer__close-button"
             >
-              <span
-                class="bpk-close-button__icon"
+              <button
+                aria-label="Close"
+                class="bpk-close-button"
+                title="Close"
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  style="width: 1rem; height: 1rem;"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  class="bpk-close-button__icon"
                 >
-                  <path
-                    d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
-                  />
-                </svg>
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    style="width: 1rem; height: 1rem;"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
           </header>
           <div
             class="bpk-drawer__content"

--- a/packages/bpk-component-drawer/src/__snapshots__/BpkDrawer-test.js.snap
+++ b/packages/bpk-component-drawer/src/__snapshots__/BpkDrawer-test.js.snap
@@ -10,7 +10,7 @@ exports[`BpkDrawer should render correctly in the given target if renderTarget i
       tabindex="-1"
     >
       <div
-        class="bpk-scrim-content bpk-drawer__container"
+        class="bpk-scrim-content"
       >
         <div
           class="bpk-scrim"

--- a/packages/bpk-component-drawer/src/__snapshots__/BpkDrawerContent-test.js.snap
+++ b/packages/bpk-component-drawer/src/__snapshots__/BpkDrawerContent-test.js.snap
@@ -19,27 +19,31 @@ exports[`BpkDrawerContent should render correctly 1`] = `
         Drawer title
       </h2>
        
-      <button
-        aria-label="Close"
-        class="bpk-close-button bpk-drawer__close-button"
-        title="Close"
-        type="button"
+      <div
+        class="bpk-drawer__close-button"
       >
-        <span
-          class="bpk-close-button__icon"
+        <button
+          aria-label="Close"
+          class="bpk-close-button"
+          title="Close"
+          type="button"
         >
-          <svg
-            aria-hidden="true"
-            style="width: 1rem; height: 1rem;"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            class="bpk-close-button__icon"
           >
-            <path
-              d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
-            />
-          </svg>
-        </span>
-      </button>
+            <svg
+              aria-hidden="true"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
     </header>
     <div
       class="bpk-drawer__content"
@@ -69,27 +73,31 @@ exports[`BpkDrawerContent should render correctly when it has a className 1`] = 
         Drawer title
       </h2>
        
-      <button
-        aria-label="Close"
-        class="bpk-close-button bpk-drawer__close-button"
-        title="Close"
-        type="button"
+      <div
+        class="bpk-drawer__close-button"
       >
-        <span
-          class="bpk-close-button__icon"
+        <button
+          aria-label="Close"
+          class="bpk-close-button"
+          title="Close"
+          type="button"
         >
-          <svg
-            aria-hidden="true"
-            style="width: 1rem; height: 1rem;"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            class="bpk-close-button__icon"
           >
-            <path
-              d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
-            />
-          </svg>
-        </span>
-      </button>
+            <svg
+              aria-hidden="true"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
     </header>
     <div
       class="bpk-drawer__content"
@@ -119,27 +127,31 @@ exports[`BpkDrawerContent should render correctly when it has a contentClassName
         Drawer title
       </h2>
        
-      <button
-        aria-label="Close"
-        class="bpk-close-button bpk-drawer__close-button"
-        title="Close"
-        type="button"
+      <div
+        class="bpk-drawer__close-button"
       >
-        <span
-          class="bpk-close-button__icon"
+        <button
+          aria-label="Close"
+          class="bpk-close-button"
+          title="Close"
+          type="button"
         >
-          <svg
-            aria-hidden="true"
-            style="width: 1rem; height: 1rem;"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            class="bpk-close-button__icon"
           >
-            <path
-              d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
-            />
-          </svg>
-        </span>
-      </button>
+            <svg
+              aria-hidden="true"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
     </header>
     <div
       class="bpk-drawer__content my-classname"
@@ -170,27 +182,31 @@ exports[`BpkDrawerContent should render correctly with arbitrary attributes 1`] 
         Drawer title
       </h2>
        
-      <button
-        aria-label="Close"
-        class="bpk-close-button bpk-drawer__close-button"
-        title="Close"
-        type="button"
+      <div
+        class="bpk-drawer__close-button"
       >
-        <span
-          class="bpk-close-button__icon"
+        <button
+          aria-label="Close"
+          class="bpk-close-button"
+          title="Close"
+          type="button"
         >
-          <svg
-            aria-hidden="true"
-            style="width: 1rem; height: 1rem;"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            class="bpk-close-button__icon"
           >
-            <path
-              d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
-            />
-          </svg>
-        </span>
-      </button>
+            <svg
+              aria-hidden="true"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
     </header>
     <div
       class="bpk-drawer__content"
@@ -220,27 +236,31 @@ exports[`BpkDrawerContent should render correctly with hideTitle 1`] = `
         Drawer title
       </h2>
        
-      <button
-        aria-label="Close"
-        class="bpk-close-button bpk-drawer__close-button"
-        title="Close"
-        type="button"
+      <div
+        class="bpk-drawer__close-button"
       >
-        <span
-          class="bpk-close-button__icon"
+        <button
+          aria-label="Close"
+          class="bpk-close-button"
+          title="Close"
+          type="button"
         >
-          <svg
-            aria-hidden="true"
-            style="width: 1rem; height: 1rem;"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            class="bpk-close-button__icon"
           >
-            <path
-              d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
-            />
-          </svg>
-        </span>
-      </button>
+            <svg
+              aria-hidden="true"
+              style="width: 1rem; height: 1rem;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.587 3.467a1.5 1.5 0 10-2.194 2.046q.036.038.074.074l6.438 6.44-6.44 6.44a1.5 1.5 0 002.122 2.12l6.44-6.438 6.44 6.44a1.5 1.5 0 002.12-2.122l-6.438-6.44 6.44-6.44a1.5 1.5 0 00-2.122-2.12l-6.44 6.438-6.44-6.44z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
     </header>
     <div
       class="bpk-drawer__content"


### PR DESCRIPTION
**Changes:**

1. `BpkDrawer`: duplicate style removed.
2. `BpkDrawerContent`: `BpkCloseButton` styling added to a parent wrapper.

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
