### PR TITLE
LOOM-1287 BpkFormValidation moved className

### DIFF
--- a/packages/bpk-component-fieldset/src/__snapshots__/BpkFieldset-test.js.snap
+++ b/packages/bpk-component-fieldset/src/__snapshots__/BpkFieldset-test.js.snap
@@ -212,19 +212,22 @@ exports[`BpkFieldset should render correctly with checkbox component 1`] = `
             id="terms_and_conditions_checkbox_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             You must accept the terms and conditions to continue
           </div>
@@ -278,19 +281,22 @@ exports[`BpkFieldset should render correctly with checkbox component and "requir
             id="terms_and_conditions_checkbox_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             You must accept the terms and conditions to continue
           </div>
@@ -340,19 +346,22 @@ exports[`BpkFieldset should render correctly with input component 1`] = `
             id="name_input_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             Please enter a name
           </div>
@@ -409,19 +418,22 @@ exports[`BpkFieldset should render correctly with input component and "descripti
             id="name_input_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             Please enter a name
           </div>
@@ -471,19 +483,22 @@ exports[`BpkFieldset should render correctly with input component and "disabled"
             id="name_input_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             Please enter a name
           </div>
@@ -538,19 +553,22 @@ exports[`BpkFieldset should render correctly with input component and "required"
             id="name_input_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             Please enter a name
           </div>
@@ -600,19 +618,22 @@ exports[`BpkFieldset should render correctly with input component and "valid" at
             id="name_input_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             Please enter a name
           </div>
@@ -661,19 +682,22 @@ exports[`BpkFieldset should render correctly with input component and "valid" at
             id="name_input_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             Please enter a name
           </div>
@@ -747,19 +771,22 @@ exports[`BpkFieldset should render correctly with select component 1`] = `
             id="fruits_select_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             Please select a fruit
           </div>
@@ -838,19 +865,22 @@ exports[`BpkFieldset should render correctly with select component and "required
             id="fruits_select_validation_message"
           >
             <span
-              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+              class="bpk-form-validation__icon"
             >
-              <svg
-                aria-hidden="true"
-                class="bpk-form-validation__icon"
-                style="width: 1rem; height: 1rem;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
               >
-                <path
-                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  style="width: 1rem; height: 1rem;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                  />
+                </svg>
+              </span>
             </span>
             Please select a fruit
           </div>

--- a/packages/bpk-component-form-validation/src/BpkFormValidation.js
+++ b/packages/bpk-component-form-validation/src/BpkFormValidation.js
@@ -57,9 +57,9 @@ const BpkFormValidation = (props) => {
     >
       <div className={getClassName('bpk-form-validation__container')}>
         <div className={classNames} {...rest}>
-          <AlignedExclamationIcon
-            className={getClassName('bpk-form-validation__icon')}
-          />
+          <span className={getClassName('bpk-form-validation__icon')}>
+            <AlignedExclamationIcon />
+          </span>
           {children}
         </div>
       </div>

--- a/packages/bpk-component-form-validation/src/__snapshots__/BpkFormValidation-test.js.snap
+++ b/packages/bpk-component-form-validation/src/__snapshots__/BpkFormValidation-test.js.snap
@@ -14,19 +14,22 @@ exports[`BpkFormValidation should render correctly 1`] = `
           id="my-form-validation"
         >
           <span
-            style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+            class="bpk-form-validation__icon"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-form-validation__icon"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <span
+              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
             >
-              <path
-                d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                />
+              </svg>
+            </span>
           </span>
           A validation message.
         </div>
@@ -52,19 +55,22 @@ exports[`BpkFormValidation should render correctly with "expanded" equal to fals
           id="my-form-validation"
         >
           <span
-            style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
+            class="bpk-form-validation__icon"
           >
-            <svg
-              aria-hidden="true"
-              class="bpk-form-validation__icon"
-              style="width: 1rem; height: 1rem;"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <span
+              style="line-height: 1rem; display: inline-block; margin-top: 0.125rem; vertical-align: top;"
             >
-              <path
-                d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                style="width: 1rem; height: 1rem;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 1.5A10.5 10.5 0 1022.5 12 10.5 10.5 0 0012 1.5zM12 18a1.5 1.5 0 111.5-1.5A1.5 1.5 0 0112 18zm1.5-6a1.5 1.5 0 01-3 0V7.5a1.5 1.5 0 013 0z"
+                />
+              </svg>
+            </span>
           </span>
           A validation message.
         </div>


### PR DESCRIPTION
LOOM-1287 BpkFormValidation moved className on BpkSmallExclamationIcon to new wrapper span

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
