### PR TITLE
LOOM-1289 BpkGridToggle removed className from BpkButtonLink out to wra…

### DIFF
--- a/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
+++ b/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
@@ -72,13 +72,14 @@ class BpkGridToggle extends Component {
     const onOrOff = gridEnabled ? 'off' : 'on';
 
     return (
-      <BpkButtonLink
-        title="Keyboard Shortcut: ctrl + cmd + g"
-        onClick={this.toggleGrid}
-        className={className}
-      >
-        Baseline grid {onOrOff}
-      </BpkButtonLink>
+      <span className={className}>
+        <BpkButtonLink
+          title="Keyboard Shortcut: ctrl + cmd + g"
+          onClick={this.toggleGrid}
+        >
+          Baseline grid {onOrOff}
+        </BpkButtonLink>
+      </span>
     );
   }
 }

--- a/packages/bpk-component-grid-toggle/src/__snapshots__/BpkGridToggle-test.js.snap
+++ b/packages/bpk-component-grid-toggle/src/__snapshots__/BpkGridToggle-test.js.snap
@@ -2,24 +2,30 @@
 
 exports[`BpkGridToggle should render correctly 1`] = `
 <DocumentFragment>
-  <button
-    class="bpk-link"
-    title="Keyboard Shortcut: ctrl + cmd + g"
-    type="button"
-  >
-    Baseline grid on
-  </button>
+  <span>
+    <button
+      class="bpk-link"
+      title="Keyboard Shortcut: ctrl + cmd + g"
+      type="button"
+    >
+      Baseline grid on
+    </button>
+  </span>
 </DocumentFragment>
 `;
 
 exports[`BpkGridToggle should render correctly with the className prop 1`] = `
 <DocumentFragment>
-  <button
-    class="bpk-link foo"
-    title="Keyboard Shortcut: ctrl + cmd + g"
-    type="button"
+  <span
+    class="foo"
   >
-    Baseline grid on
-  </button>
+    <button
+      class="bpk-link"
+      title="Keyboard Shortcut: ctrl + cmd + g"
+      type="button"
+    >
+      Baseline grid on
+    </button>
+  </span>
 </DocumentFragment>
 `;


### PR DESCRIPTION
BpkGridToggle moved className from BpkButtonLink out to wrapper span

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
