### PR TITLE
LOOM-1301 BpkNavigationBar Class 2 Overrides

### DIFF
--- a/packages/bpk-component-bottom-sheet/src/__snapshots__/BpkBottomSheet-test.tsx.snap
+++ b/packages/bpk-component-bottom-sheet/src/__snapshots__/BpkBottomSheet-test.tsx.snap
@@ -48,9 +48,13 @@ exports[`BpkBottomSheet renders correctly with action props 1`] = `
               </button>
             </div>
             <span
-              class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
-              id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
-            />
+              class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
+            >
+              <span
+                class="bpk-text bpk-text--heading-5"
+                id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
+              />
+            </span>
             <div
               class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
             >
@@ -122,9 +126,13 @@ exports[`BpkBottomSheet renders correctly with minimum prop 1`] = `
               </button>
             </div>
             <span
-              class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
-              id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
-            />
+              class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
+            >
+              <span
+                class="bpk-text bpk-text--heading-5"
+                id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
+              />
+            </span>
           </nav>
         </header>
         <div
@@ -186,9 +194,13 @@ exports[`BpkBottomSheet renders correctly with wide prop 1`] = `
               </button>
             </div>
             <span
-              class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
-              id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
-            />
+              class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
+            >
+              <span
+                class="bpk-text bpk-text--heading-5"
+                id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
+              />
+            </span>
           </nav>
         </header>
         <div

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
@@ -17,7 +17,7 @@
  */
 
 import type { ReactElement, ReactNode } from 'react';
-import { cloneElement } from 'react';
+// import { cloneElement } from 'react';
 
 import { cssModules } from '../../bpk-react-utils';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
@@ -82,16 +82,17 @@ const BpkNavigationBar = (props: Props) => {
         </div>
       )}
       {typeof title === 'string' ? (
-        <BpkText
-          id={titleId}
-          textStyle={TEXT_STYLES.heading5}
-          className={getClassNames(
-            'bpk-navigation-bar__title',
-            `bpk-navigation-bar__title--${barStyle}`,
-          )}
-        >
-          {title}
-        </BpkText>
+        <span className={getClassNames(
+          'bpk-navigation-bar__title',
+          `bpk-navigation-bar__title--${barStyle}`,
+        )}>
+          <BpkText
+            id={titleId}
+            textStyle={TEXT_STYLES.heading5}
+          >
+            {title}
+          </BpkText>
+        </span>
       ) : (
         title
       )}

--- a/packages/bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.tsx.snap
+++ b/packages/bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.tsx.snap
@@ -7,10 +7,14 @@ exports[`BpkNavigationBar should render correctly 1`] = `
     class="bpk-navigation-bar bpk-navigation-bar--default"
   >
     <span
-      class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
-      id="test-bpk-navigation-bar-title"
+      class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
     >
-      test
+      <span
+        class="bpk-text bpk-text--heading-5"
+        id="test-bpk-navigation-bar-title"
+      >
+        test
+      </span>
     </span>
   </nav>
 </DocumentFragment>
@@ -23,10 +27,14 @@ exports[`BpkNavigationBar should render correctly when sticky 1`] = `
     class="bpk-navigation-bar bpk-navigation-bar--default bpk-navigation-bar__sticky"
   >
     <span
-      class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
-      id="test-bpk-navigation-bar-title"
+      class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
     >
-      test
+      <span
+        class="bpk-text bpk-text--heading-5"
+        id="test-bpk-navigation-bar-title"
+      >
+        test
+      </span>
     </span>
   </nav>
 </DocumentFragment>
@@ -55,10 +63,14 @@ exports[`BpkNavigationBar should render correctly with a "leadingButton" attribu
       </button>
     </div>
     <span
-      class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
-      id="test-bpk-navigation-bar-title"
+      class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
     >
-      test
+      <span
+        class="bpk-text bpk-text--heading-5"
+        id="test-bpk-navigation-bar-title"
+      >
+        test
+      </span>
     </span>
   </nav>
 </DocumentFragment>
@@ -71,10 +83,14 @@ exports[`BpkNavigationBar should render correctly with a "traillingButton" attri
     class="bpk-navigation-bar bpk-navigation-bar--default"
   >
     <span
-      class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
-      id="test-bpk-navigation-bar-title"
+      class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
     >
-      test
+      <span
+        class="bpk-text bpk-text--heading-5"
+        id="test-bpk-navigation-bar-title"
+      >
+        test
+      </span>
     </span>
     <div
       class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
@@ -133,10 +149,14 @@ exports[`BpkNavigationBar should render correctly with arbitrary props 1`] = `
     testid="arbitrary value"
   >
     <span
-      class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
-      id="test-bpk-navigation-bar-title"
+      class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
     >
-      test
+      <span
+        class="bpk-text bpk-text--heading-5"
+        id="test-bpk-navigation-bar-title"
+      >
+        test
+      </span>
     </span>
   </nav>
 </DocumentFragment>
@@ -149,10 +169,14 @@ exports[`BpkNavigationBar should render correctly with custom class 1`] = `
     class="bpk-navigation-bar bpk-navigation-bar--default my-custom-class"
   >
     <span
-      class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--default"
-      id="test-bpk-navigation-bar-title"
+      class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
     >
-      test
+      <span
+        class="bpk-text bpk-text--heading-5"
+        id="test-bpk-navigation-bar-title"
+      >
+        test
+      </span>
     </span>
   </nav>
 </DocumentFragment>
@@ -165,10 +189,14 @@ exports[`BpkNavigationBar should render correctly with on-dark style 1`] = `
     class="bpk-navigation-bar bpk-navigation-bar--on-dark"
   >
     <span
-      class="bpk-text bpk-text--heading-5 bpk-navigation-bar__title bpk-navigation-bar__title--on-dark"
-      id="test-bpk-navigation-bar-title"
+      class="bpk-navigation-bar__title bpk-navigation-bar__title--on-dark"
     >
-      test
+      <span
+        class="bpk-text bpk-text--heading-5"
+        id="test-bpk-navigation-bar-title"
+      >
+        test
+      </span>
     </span>
   </nav>
 </DocumentFragment>


### PR DESCRIPTION
**Class 2 Overrides:**

1. Move `<BpkText>` styles to wrapper.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
