### PR TITLE
LOOM-1314 BpkSectionListItem Class 2 Overrides

### DIFF
--- a/packages/bpk-component-section-list/src/BpkSectionListItem.js
+++ b/packages/bpk-component-section-list/src/BpkSectionListItem.js
@@ -63,11 +63,9 @@ const BpkSectionListItem = (props: Props) => {
         {...rest}
       >
         {children}
-        <BpkLargeChevronRightIconWithRtlSupport
-          // TODO: className to be removed
-          // eslint-disable-next-line @skyscanner/rules/forbid-component-props
-          className={getClassName('bpk-section-list-item__chevron')}
-        />
+        <span className={getClassName('bpk-section-list-item__chevron')}>
+          <BpkLargeChevronRightIconWithRtlSupport/>
+        </span>
       </a>
     );
   }
@@ -82,11 +80,9 @@ const BpkSectionListItem = (props: Props) => {
         {...rest}
       >
         {children}
-        <BpkLargeChevronRightIconWithRtlSupport
-          // TODO: className to be removed
-          // eslint-disable-next-line @skyscanner/rules/forbid-component-props
-          className={getClassName('bpk-section-list-item__chevron')}
-        />
+        <span className={getClassName('bpk-section-list-item__chevron')}>
+          <BpkLargeChevronRightIconWithRtlSupport/>
+        </span>
       </button>
     );
   }

--- a/packages/bpk-component-section-list/src/BpkSectionListItem.module.scss
+++ b/packages/bpk-component-section-list/src/BpkSectionListItem.module.scss
@@ -40,6 +40,7 @@
   }
 
   &__chevron {
+    display: contents;
     fill: tokens.$bpk-text-secondary-day;
 
     #{$root}:hover & {

--- a/packages/bpk-component-section-list/src/__snapshots__/BpkSectionListItem-test.js.snap
+++ b/packages/bpk-component-section-list/src/__snapshots__/BpkSectionListItem-test.js.snap
@@ -17,17 +17,21 @@ exports[`BpkSectionListItem should render correctly with a "href" prop 1`] = `
     href="#"
   >
     Hello world
-    <svg
-      aria-hidden="true"
-      class="bpk-section-list-item__chevron bpk-icon--rtl-support"
-      style="width: 1.5rem; height: 1.5rem;"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="bpk-section-list-item__chevron"
     >
-      <path
-        d="M7.8 4.287a1 1 0 000 1.414l6.292 6.293L7.8 18.287a1 1 0 001.39 1.438l.024-.024 7-7a1 1 0 000-1.414l-7-7a1 1 0 00-1.414 0z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        class="bpk-icon--rtl-support"
+        style="width: 1.5rem; height: 1.5rem;"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M7.8 4.287a1 1 0 000 1.414l6.292 6.293L7.8 18.287a1 1 0 001.39 1.438l.024-.024 7-7a1 1 0 000-1.414l-7-7a1 1 0 00-1.414 0z"
+        />
+      </svg>
+    </span>
   </a>
 </DocumentFragment>
 `;
@@ -49,17 +53,21 @@ exports[`BpkSectionListItem should render correctly with an "onClick" prop 1`] =
     type="button"
   >
     Hello world
-    <svg
-      aria-hidden="true"
-      class="bpk-section-list-item__chevron bpk-icon--rtl-support"
-      style="width: 1.5rem; height: 1.5rem;"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="bpk-section-list-item__chevron"
     >
-      <path
-        d="M7.8 4.287a1 1 0 000 1.414l6.292 6.293L7.8 18.287a1 1 0 001.39 1.438l.024-.024 7-7a1 1 0 000-1.414l-7-7a1 1 0 00-1.414 0z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        class="bpk-icon--rtl-support"
+        style="width: 1.5rem; height: 1.5rem;"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M7.8 4.287a1 1 0 000 1.414l6.292 6.293L7.8 18.287a1 1 0 001.39 1.438l.024-.024 7-7a1 1 0 000-1.414l-7-7a1 1 0 00-1.414 0z"
+        />
+      </svg>
+    </span>
   </button>
 </DocumentFragment>
 `;


### PR DESCRIPTION
### Class 2 Overrides:

1. Added `className` override to wrapper for both the `href` and `onClick`.
2. Needed to use `display: contents` on the wrapped style after adding the wrapper to retain the icon alignment.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
