### PR TITLE
NOJIRA: Add rating example with stars

### DIFF
--- a/examples/bpk-component-rating/examples.js
+++ b/examples/bpk-component-rating/examples.js
@@ -21,6 +21,7 @@ import BpkRating, {
   RATING_SIZES,
   RATING_SCALES,
 } from '../../packages/bpk-component-rating';
+import BpkStarRating from '../../packages/bpk-component-star-rating';
 import { cssModules } from '../../packages/bpk-react-utils';
 
 import STYLES from './examples.module.scss';
@@ -56,6 +57,15 @@ const LargeImageTitle = (
   />
 );
 
+const ThreeStars = (
+  <BpkStarRating
+    rating={3}
+    ratingLabel={(rating: number, maxRating: number) =>
+      `Rated ${rating} out of ${maxRating} stars`
+    }
+  />
+);
+
 const LargeTripImageTitle = (
   <img
     alt="rating 4.5"
@@ -86,6 +96,13 @@ const DefaultExample = () => (
       value={4.5}
       title={TripImageTitle}
       subtitle="818 reviews"
+    />
+    <br />
+    <BpkRating
+      ariaLabel="3 Average 1,230 reviews"
+      value={3}
+      title={ThreeStars}
+      subtitle="1,230 reviews"
     />
     <br />
   </div>
@@ -124,6 +141,14 @@ const LargeSizeExample = () => (
       title={LargeTripImageTitle}
       subtitle="6,170 reviews"
       size={RATING_SIZES.large}
+    />
+    <br />
+    <BpkRating
+      ariaLabel="3 Average 1,230 reviews"
+      value={3}
+      size={RATING_SIZES.large}
+      title={ThreeStars}
+      subtitle="1,230 reviews"
     />
     <br />
   </div>
@@ -273,6 +298,21 @@ const MixedExample = () => (
       title={LargeTripImageTitle}
       subtitle="6,170 reviews"
       size={RATING_SIZES.large}
+    />
+    <br />
+    <BpkRating
+      ariaLabel="3 Average 1,230 reviews"
+      value={3}
+      title={ThreeStars}
+      subtitle="1,230 reviews"
+    />
+    <br />
+    <BpkRating
+      ariaLabel="3 Average 1,230 reviews"
+      value={3}
+      size={RATING_SIZES.large}
+      title={ThreeStars}
+      subtitle="1,230 reviews"
     />
     <br />
     <BpkRating ariaLabel="2.3 Bad" title="Bad" value={2.3} />

--- a/packages/bpk-component-rating/README.md
+++ b/packages/bpk-component-rating/README.md
@@ -67,6 +67,21 @@ export default () => (
     value={9.9}
     ratingScale={RATING_SCALES.zeroToTen}
   />
+
+  // With a React Node element as the title
+  <BpkRating
+    ariaLabel="3 Average 1,230 reviews"
+    value={3}
+    title={
+      <BpkStarRating
+        rating={3}
+        ratingLabel={(rating: number, maxRating: number) =>
+          `Rated ${rating} out of ${maxRating} stars`
+        }
+      />
+    }
+    subtitle="1,230 reviews"
+  />
 );
 ```
 


### PR DESCRIPTION
It's not immediately obvious that the title attribute of the BpkRating can accept any React Node. The only 2 examples of this are images. 

<img width="309" alt="image" src="https://github.com/Skyscanner/backpack/assets/1532576/a71358b4-71dd-4a58-85ed-9392b4b0d316">


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
