### PR TITLE
[NOJIRA][BpkBreakpoint]: add isClient defensively around useEffect & add test

### DIFF
--- a/packages/bpk-component-breakpoint/src/UnmockedBpkBreakpoint-test.tsx
+++ b/packages/bpk-component-breakpoint/src/UnmockedBpkBreakpoint-test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+
+import BpkBreakpoint, { BREAKPOINTS } from "./BpkBreakpoint";
+
+
+describe('BpkBreakpoint', () => {
+  it('should not render when breakpoint is not mocked within tests', () => {
+    const { asFragment } = render(
+      <BpkBreakpoint query={BREAKPOINTS.MOBILE}>
+        <div>doesnt match</div>
+      </BpkBreakpoint>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+})

--- a/packages/bpk-component-breakpoint/src/__snapshots__/UnmockedBpkBreakpoint-test.tsx.snap
+++ b/packages/bpk-component-breakpoint/src/__snapshots__/UnmockedBpkBreakpoint-test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkBreakpoint should not render when breakpoint is not mocked within tests 1`] = `<DocumentFragment />`;

--- a/packages/bpk-component-breakpoint/src/useMediaQuery.ts
+++ b/packages/bpk-component-breakpoint/src/useMediaQuery.ts
@@ -26,14 +26,17 @@ const useMediaQuery = (query: string, matchSSR = false): boolean => {
   );
 
   useEffect(() => {
-    const media = window.matchMedia(query);
-    setMatches(media.matches);
-    const listener = () => {
+    if(isClient){
+      const media = window.matchMedia(query);
       setMatches(media.matches);
-    };
-    media.addEventListener('change', listener);
-    return () => media.removeEventListener('change', listener);
-  }, [query]);
+      const listener = () => {
+        setMatches(media.matches);
+      };
+      media.addEventListener('change', listener);
+      return () => media.removeEventListener('change', listener);
+    }
+    return () => {}
+  }, [query, isClient]);
 
   return matches;
 };


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
