### PR TITLE
[NOJIRA][BpkBreakpoint]: fix ssr re-render behaviour

### DIFF
--- a/packages/bpk-component-breakpoint/src/BpkBreakpoint-test.tsx
+++ b/packages/bpk-component-breakpoint/src/BpkBreakpoint-test.tsx
@@ -100,7 +100,7 @@ describe('BpkBreakpoint', () => {
       const BpkBreakpoint = require('./BpkBreakpoint').default; // eslint-disable-line global-require
 
       ReactDOMServer.renderToString(
-        <BpkBreakpoint query={BREAKPOINTS.MOBILE} matchSSR />,
+        <BpkBreakpoint query={BREAKPOINTS.MOBILE} matchSSR >rendered</BpkBreakpoint>,
       );
 
       expect(mockUseMediaQuery).toHaveBeenCalledWith(BREAKPOINTS.MOBILE, true);


### PR DESCRIPTION
BpkBreakpoint, prior to https://github.com/Skyscanner/backpack/pull/3299 would re-render on client. This would ensure that any server rendered content would be replaced with the up to date client content. 

After the linked change this behaviour was removed, it wasn't well documented or tested for. 

This PR aims to replace that behaviour and add more comments within the code to prevent accidental removal in the future. 

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
