### PR TITLE
[ZOOT-992][BpkFloatingNotification] Increases floating notification's z-index to 2

### DIFF
--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
@@ -25,6 +25,7 @@
   bottom: tokens.bpk-spacing-xl();
   left: 0;
   display: flex;
+  z-index: 2;
   max-width: tokens.bpk-spacing-xxl() * 10;
   margin: auto;
   padding: tokens.bpk-spacing-lg();


### PR DESCRIPTION
## Background:
It was discovered that the floating notification was not positioned above the Saved cards and would go under a toggle and heart buttons. This looks confusing and unfinished.

## Action
In order to address the issue, it was decided to position the toast above other elements. 

## Changes
The change was minimal, the toast style now includes a `z-index` set to `2`, which puts the BPKFloatingNotification above other elements. This works across the whole page and supports RTL.

Please see the video demonstrating the original state (overlapping elements) and the solution proposed in this PR (end of the video with `z-index: 2;`).

https://github.com/Skyscanner/backpack/assets/55076036/4a6fed37-6174-431d-b9e2-54c98c54947d



Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
