### PR TITLE
[IRN-5018][BpkNavigationBar][BpkBottomSheet] Add handling for long title text

### DIFF
--- a/examples/bpk-component-bottom-sheet/examples.tsx
+++ b/examples/bpk-component-bottom-sheet/examples.tsx
@@ -184,6 +184,26 @@ const OverflowingExample = () => (
   </BottomSheetContainer>
 );
 
+const WrapHeaderTextExample = () => (
+  <BottomSheetContainer
+    title="Long Bottom Sheet title which wraps"
+    closeLabel="Close Bottom Sheet"
+  >
+    This is a default bottom sheet. You can put anything you want in here.
+  </BottomSheetContainer>
+);
+
+const WrapHeaderTextWithActionButtonExample = () => (
+  <BottomSheetContainer
+    title="Long Bottom Sheet title which wraps"
+    closeLabel="Close Bottom Sheet"
+    actionText="Action"
+    onAction={action('Action clicked')}
+  >
+    This is a default bottom sheet. You can put anything you want in here.
+  </BottomSheetContainer>
+);
+
 const NoHeaderExample = () => (
   <BottomSheetContainer
     closeLabel="Close Bottom Sheet"
@@ -219,8 +239,8 @@ const NestedExample = () => (
     wide
     closeOnEscPressed
     closeOnScrimClick
-    >
-      Outer Bottom Sheet
+  >
+    Outer Bottom Sheet
     <BottomSheetContainer
       title="Inner Bottom Sheet"
       closeLabel="Close Inner Bottom Sheet"
@@ -274,6 +294,8 @@ export {
   BackdropClickCloseExample,
   EscapeCloseExample,
   OverflowingExample,
+  WrapHeaderTextExample,
+  WrapHeaderTextWithActionButtonExample,
   NoHeaderExample,
   NoHeaderWithActionButtonExample,
   ActionButtonExample,

--- a/examples/bpk-component-bottom-sheet/examples.tsx
+++ b/examples/bpk-component-bottom-sheet/examples.tsx
@@ -184,18 +184,18 @@ const OverflowingExample = () => (
   </BottomSheetContainer>
 );
 
-const WrapHeaderTextExample = () => (
+const LongHeaderTextExample = () => (
   <BottomSheetContainer
-    title="Long Bottom Sheet title which wraps"
+    title="Bottom Sheet title which is long"
     closeLabel="Close Bottom Sheet"
   >
     This is a default bottom sheet. You can put anything you want in here.
   </BottomSheetContainer>
 );
 
-const WrapHeaderTextWithActionButtonExample = () => (
+const LongHeaderTextWithActionButtonExample = () => (
   <BottomSheetContainer
-    title="Long Bottom Sheet title which wraps"
+    title="Bottom Sheet title which is long"
     closeLabel="Close Bottom Sheet"
     actionText="Action"
     onAction={action('Action clicked')}
@@ -294,8 +294,8 @@ export {
   BackdropClickCloseExample,
   EscapeCloseExample,
   OverflowingExample,
-  WrapHeaderTextExample,
-  WrapHeaderTextWithActionButtonExample,
+  LongHeaderTextExample,
+  LongHeaderTextWithActionButtonExample,
   NoHeaderExample,
   NoHeaderWithActionButtonExample,
   ActionButtonExample,

--- a/examples/bpk-component-bottom-sheet/stories.js
+++ b/examples/bpk-component-bottom-sheet/stories.js
@@ -23,8 +23,8 @@ import {
   BackdropClickCloseExample,
   EscapeCloseExample,
   OverflowingExample,
-  WrapHeaderTextExample,
-  WrapHeaderTextWithActionButtonExample,
+  LongHeaderTextExample,
+  LongHeaderTextWithActionButtonExample,
   NoHeaderExample,
   NoHeaderWithActionButtonExample,
   ActionButtonExample,
@@ -43,9 +43,9 @@ export const BackdropClickClose = BackdropClickCloseExample;
 export const EscapeClose = EscapeCloseExample;
 export const Overflowing = OverflowingExample;
 
-export const WrapHeaderText = WrapHeaderTextExample;
-export const WrapHeaderTextWithActionButton =
-  WrapHeaderTextWithActionButtonExample;
+export const LongHeaderText = LongHeaderTextExample;
+export const LongHeaderTextWithActionButton =
+  LongHeaderTextWithActionButtonExample;
 
 export const NoHeader = NoHeaderExample;
 export const NoHeaderWithActionButton = NoHeaderWithActionButtonExample;

--- a/examples/bpk-component-bottom-sheet/stories.js
+++ b/examples/bpk-component-bottom-sheet/stories.js
@@ -23,12 +23,14 @@ import {
   BackdropClickCloseExample,
   EscapeCloseExample,
   OverflowingExample,
+  WrapHeaderTextExample,
+  WrapHeaderTextWithActionButtonExample,
   NoHeaderExample,
   NoHeaderWithActionButtonExample,
   ActionButtonExample,
   WideExample,
   NestedExample,
-  MultipleBottomSheetsExample
+  MultipleBottomSheetsExample,
 } from './examples';
 
 export default {
@@ -40,6 +42,10 @@ export const Default = DefaultExample;
 export const BackdropClickClose = BackdropClickCloseExample;
 export const EscapeClose = EscapeCloseExample;
 export const Overflowing = OverflowingExample;
+
+export const WrapHeaderText = WrapHeaderTextExample;
+export const WrapHeaderTextWithActionButton =
+  WrapHeaderTextWithActionButtonExample;
 
 export const NoHeader = NoHeaderExample;
 export const NoHeaderWithActionButton = NoHeaderWithActionButtonExample;

--- a/examples/bpk-component-navigation-bar/examples.js
+++ b/examples/bpk-component-navigation-bar/examples.js
@@ -59,6 +59,29 @@ const DefaultExample = () => (
   </div>
 );
 
+const LongTitleTextExample = () => (
+  <div className={getClassNames('bpk-navigation-bar-story')}>
+    <BpkNavigationBar
+      id="test"
+      title="Backpack navigation bar long title example"
+      leadingButton={
+        <BpkNavigationBarIconButton
+          onClick={action('back clicked')}
+          icon={ArrowIconWithRtl}
+          label="back"
+        />
+      }
+      trailingButton={
+        <BpkNavigationBarIconButton
+          onClick={action('close clicked')}
+          icon={CloseIcon}
+          label="close"
+        />
+      }
+    />
+  </div>
+);
+
 const OnDarkExample = () => (
   <div className={getClassNames('bpk-navigation-bar-story')}>
     <BpkNavigationBar
@@ -241,10 +264,11 @@ const VisualTestExample = () => (
     <OnDarkExample />
     <WithLinksOnDarkExample />
   </div>
-)
+);
 
 export {
   DefaultExample,
+  LongTitleTextExample,
   OnDarkExample,
   LeadingIconOnlyExample,
   TrailingIconOnlyExample,
@@ -252,5 +276,5 @@ export {
   WithLogoExample,
   WithLinksOnDarkExample,
   StickyExample,
-  VisualTestExample
+  VisualTestExample,
 };

--- a/examples/bpk-component-navigation-bar/examples.js
+++ b/examples/bpk-component-navigation-bar/examples.js
@@ -165,7 +165,6 @@ const WithLogoExample = () => (
   <div className={getClassNames('bpk-navigation-bar-story')}>
     <BpkNavigationBar
       id="test"
-      // todo: this needs to justify-self centre to remain centred
       title={<AirlineLogo />}
       leadingButton={
         <BpkNavigationBarIconButton

--- a/examples/bpk-component-navigation-bar/examples.js
+++ b/examples/bpk-component-navigation-bar/examples.js
@@ -165,6 +165,7 @@ const WithLogoExample = () => (
   <div className={getClassNames('bpk-navigation-bar-story')}>
     <BpkNavigationBar
       id="test"
+      // todo: this needs to justify-self centre to remain centred
       title={<AirlineLogo />}
       leadingButton={
         <BpkNavigationBarIconButton

--- a/examples/bpk-component-navigation-bar/stories.js
+++ b/examples/bpk-component-navigation-bar/stories.js
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-
 import BpkNavigationBar from '../../packages/bpk-component-navigation-bar/src/BpkNavigationBar';
 import BpkNavigationBarButtonLink from '../../packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink';
 import BpkNavigationBarIconButton from '../../packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton';
 
 import {
   DefaultExample,
+  LongTitleTextExample,
   LeadingIconOnlyExample,
   TrailingIconOnlyExample,
   WithLinksExample,
@@ -43,6 +43,7 @@ export default {
 };
 
 export const Default = DefaultExample;
+export const LongTitleText = LongTitleTextExample;
 export const OnDark = OnDarkExample;
 export const LeadingIconOnly = LeadingIconOnlyExample;
 
@@ -57,5 +58,5 @@ export const Sticky = StickyExample;
 export const VisualTest = VisualTestExample;
 export const VisualTestWithZoom = VisualTest.bind({});
 VisualTestWithZoom.args = {
-  zoomEnabled: true
+  zoomEnabled: true,
 };

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
@@ -30,6 +30,7 @@
   animation-timing-function: ease-in-out;
 }
 
+// Q: can this be removed?
 $close-button-width: tokens.bpk-spacing-lg() * 2;
 
 .bpk-bottom-sheet {
@@ -96,6 +97,13 @@ $close-button-width: tokens.bpk-spacing-lg() * 2;
     @include breakpoints.bpk-breakpoint-above-mobile {
       animation: none;
     }
+  }
+
+  &--title {
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   &--content {

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
@@ -30,9 +30,6 @@
   animation-timing-function: ease-in-out;
 }
 
-// Q: can this be removed?
-$close-button-width: tokens.bpk-spacing-lg() * 2;
-
 .bpk-bottom-sheet {
   z-index: tokens.$bpk-zindex-modal;
   width: 100%;
@@ -97,10 +94,6 @@ $close-button-width: tokens.bpk-spacing-lg() * 2;
     @include breakpoints.bpk-breakpoint-above-mobile {
       animation: none;
     }
-  }
-
-  &--action {
-    padding-inline-start: tokens.bpk-spacing-lg();
   }
 
   &--content {

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
@@ -99,11 +99,8 @@ $close-button-width: tokens.bpk-spacing-lg() * 2;
     }
   }
 
-  &--title {
-    text-align: center;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+  &--action {
+    padding-inline-start: tokens.bpk-spacing-lg();
   }
 
   &--content {

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
@@ -112,8 +112,13 @@
     position: sticky;
     top: 0;
     z-index: tokens.$bpk-zindex-tooltip - 1;
+    padding: tokens.bpk-spacing-sm() 0;
 
-    @include borders.bpk-border-bottom-sm(tokens.$bpk-line-day);
+    @include utils.bpk-themeable-property(
+      background-color,
+      --bpk-navigation-bar-background-color,
+      tokens.$bpk-surface-default-day
+    );
   }
 
   @keyframes slide-up {

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -117,7 +117,7 @@ const BpkBottomSheet = ({
               id={headingId}
               title={title}
               titleTextStyle={TEXT_STYLES.label1}
-              titleTagName={title ? "h2" : undefined}
+              titleTagName={title ? "h2" : "span"}
               leadingButton={
                 <BpkCloseButton
                   label={closeLabel}

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -24,7 +24,7 @@ import BpkCloseButton from '../../bpk-component-close-button';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import { BpkButtonLink } from '../../bpk-component-link';
 import BpkNavigationBar from "../../bpk-component-navigation-bar";
-import BpkText, { TEXT_STYLES } from "../../bpk-component-text/src/BpkText";
+import { TEXT_STYLES } from "../../bpk-component-text/src/BpkText";
 import { BpkDialogWrapper, cssModules } from "../../bpk-react-utils";
 
 import STYLES from './BpkBottomSheet.module.scss';

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -117,7 +117,7 @@ const BpkBottomSheet = ({
               id={headingId}
               title={title}
               titleTextStyle={TEXT_STYLES.label1}
-              titleTagName="h2"
+              titleTagName={title ? "h2" : undefined}
               leadingButton={
                 <BpkCloseButton
                   label={closeLabel}

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -115,11 +115,9 @@ const BpkBottomSheet = ({
           <header className={getClassName('bpk-bottom-sheet--header')}>
             <BpkNavigationBar
               id={headingId}
-              title={title &&
-                // TBC if do avoid adding class here are we able to clamp the text?
-                // eslint-disable-next-line @skyscanner/rules/forbid-component-props
-                <BpkText className={getClassName('bpk-bottom-sheet--title')} id={headingId} textStyle={TEXT_STYLES.label1} tagName="h2">{title}</BpkText>
-              }
+              title={title}
+              titleTextStyle={TEXT_STYLES.label1}
+              titleTagName="h2"
               leadingButton={
                 <BpkCloseButton
                   label={closeLabel}
@@ -132,11 +130,13 @@ const BpkBottomSheet = ({
               }
               trailingButton={
                 actionText && onAction ? (
-                  <BpkButtonLink
-                    onClick={onAction}
-                  >
-                    {actionText}
-                  </BpkButtonLink>
+                  <div className={getClassName('bpk-bottom-sheet--action')}>
+                    <BpkButtonLink
+                      onClick={onAction}
+                    >
+                      {actionText}
+                    </BpkButtonLink>
+                  </div>
                 ) :
                   null
               }

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -130,13 +130,11 @@ const BpkBottomSheet = ({
               }
               trailingButton={
                 actionText && onAction ? (
-                  <div className={getClassName('bpk-bottom-sheet--action')}>
-                    <BpkButtonLink
-                      onClick={onAction}
-                    >
-                      {actionText}
-                    </BpkButtonLink>
-                  </div>
+                  <BpkButtonLink
+                    onClick={onAction}
+                  >
+                    {actionText}
+                  </BpkButtonLink>
                 ) :
                   null
               }

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -87,63 +87,65 @@ const BpkBottomSheet = ({
   const dialogClassName = getClassName(
     'bpk-bottom-sheet',
     wide && 'bpk-bottom-sheet--wide'
-    );
+  );
 
-    return <BpkBreakpoint query={BREAKPOINTS.ABOVE_MOBILE}>
-      {(isAboveMobile: boolean) =>
+  return <BpkBreakpoint query={BREAKPOINTS.ABOVE_MOBILE}>
+    {(isAboveMobile: boolean) =>
       <BpkDialogWrapper
-      ariaLabelledby={ariaLabelledby}
-      dialogClassName={dialogClassName}
-      id={id}
-      isOpen={isOpen}
-      onClose={(
-        arg0?: TouchEvent | MouseEvent | KeyboardEvent | SyntheticEvent<HTMLDialogElement, Event>,
-        arg1?: {
-          source: 'ESCAPE' | 'DOCUMENT_CLICK';
-        }) => handleClose( isAboveMobile ? 0 : animationTimeout, arg0, arg1)}
-      exiting={exiting}
-      transitionClassNames={{
-        appear: getClassName('bpk-bottom-sheet--appear'),
-        appearActive: getClassName('bpk-bottom-sheet--appear-active'),
-        exit: getClassName('bpk-bottom-sheet--exit')
-      }}
-      closeOnEscPressed={closeOnEscPressed}
-      closeOnScrimClick={closeOnScrimClick}
-      timeout={{appear: animationTimeout, exit: isAboveMobile ? 0 : animationTimeout}}
+        ariaLabelledby={ariaLabelledby}
+        dialogClassName={dialogClassName}
+        id={id}
+        isOpen={isOpen}
+        onClose={(
+          arg0?: TouchEvent | MouseEvent | KeyboardEvent | SyntheticEvent<HTMLDialogElement, Event>,
+          arg1?: {
+            source: 'ESCAPE' | 'DOCUMENT_CLICK';
+          }) => handleClose(isAboveMobile ? 0 : animationTimeout, arg0, arg1)}
+        exiting={exiting}
+        transitionClassNames={{
+          appear: getClassName('bpk-bottom-sheet--appear'),
+          appearActive: getClassName('bpk-bottom-sheet--appear-active'),
+          exit: getClassName('bpk-bottom-sheet--exit')
+        }}
+        closeOnEscPressed={closeOnEscPressed}
+        closeOnScrimClick={closeOnScrimClick}
+        timeout={{ appear: animationTimeout, exit: isAboveMobile ? 0 : animationTimeout }}
       >
-      <>
-        <header className={getClassName('bpk-bottom-sheet--header')}>
-          <BpkNavigationBar
-            id={headingId}
-            title={title &&
-              <BpkText id={headingId} textStyle={TEXT_STYLES.label1} tagName="h2">{title}</BpkText>
-            }
-            leadingButton={
-              <BpkCloseButton
-                label={closeLabel}
-                onClick={(
-                  arg0?: TouchEvent | MouseEvent | KeyboardEvent | SyntheticEvent<HTMLDialogElement, Event>,
-                  arg1?: {
-                    source: 'ESCAPE' | 'DOCUMENT_CLICK';
-                  }) => handleClose( isAboveMobile ? 0 : animationTimeout, arg0, arg1)}
-              />
-            }
-            trailingButton={
-              actionText && onAction ? (
-                <BpkButtonLink
-                  onClick={onAction}
-                >
-                  {actionText}
-                </BpkButtonLink>
-              ) :
-              null
-            }
-          />
-        </header>
-        <div className={getClassName('bpk-bottom-sheet--content')}>{children}</div>
-    </>
-    </BpkDialogWrapper>
-  }
+        <>
+          <header className={getClassName('bpk-bottom-sheet--header')}>
+            <BpkNavigationBar
+              id={headingId}
+              title={title &&
+                // TBC if do avoid adding class here are we able to clamp the text?
+                // eslint-disable-next-line @skyscanner/rules/forbid-component-props
+                <BpkText className={getClassName('bpk-bottom-sheet--title')} id={headingId} textStyle={TEXT_STYLES.label1} tagName="h2">{title}</BpkText>
+              }
+              leadingButton={
+                <BpkCloseButton
+                  label={closeLabel}
+                  onClick={(
+                    arg0?: TouchEvent | MouseEvent | KeyboardEvent | SyntheticEvent<HTMLDialogElement, Event>,
+                    arg1?: {
+                      source: 'ESCAPE' | 'DOCUMENT_CLICK';
+                    }) => handleClose(isAboveMobile ? 0 : animationTimeout, arg0, arg1)}
+                />
+              }
+              trailingButton={
+                actionText && onAction ? (
+                  <BpkButtonLink
+                    onClick={onAction}
+                  >
+                    {actionText}
+                  </BpkButtonLink>
+                ) :
+                  null
+              }
+            />
+          </header>
+          <div className={getClassName('bpk-bottom-sheet--content')}>{children}</div>
+        </>
+      </BpkDialogWrapper>
+    }
   </BpkBreakpoint>
 }
 

--- a/packages/bpk-component-bottom-sheet/src/__snapshots__/BpkBottomSheet-test.tsx.snap
+++ b/packages/bpk-component-bottom-sheet/src/__snapshots__/BpkBottomSheet-test.tsx.snap
@@ -52,7 +52,7 @@ exports[`BpkBottomSheet renders correctly with action props 1`] = `
               class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
             >
               <span
-                class="bpk-text bpk-text--heading-5"
+                class="bpk-text bpk-text--label-1"
                 id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
               />
             </span>
@@ -131,7 +131,7 @@ exports[`BpkBottomSheet renders correctly with minimum prop 1`] = `
               class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
             >
               <span
-                class="bpk-text bpk-text--heading-5"
+                class="bpk-text bpk-text--label-1"
                 id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
               />
             </span>
@@ -200,7 +200,7 @@ exports[`BpkBottomSheet renders correctly with wide prop 1`] = `
               class="bpk-navigation-bar__title bpk-navigation-bar__title--default"
             >
               <span
-                class="bpk-text bpk-text--heading-5"
+                class="bpk-text bpk-text--label-1"
                 id="bpk-bottom-sheet-heading-my-bottom-sheet-bpk-navigation-bar-title"
               />
             </span>

--- a/packages/bpk-component-modal/src/__snapshots__/BpkModal-test.tsx.snap
+++ b/packages/bpk-component-modal/src/__snapshots__/BpkModal-test.tsx.snap
@@ -30,12 +30,16 @@ exports[`BpkModal should render correctly in the given target if renderTarget is
               aria-labelledby="bpk-modal-heading-my-modal"
               class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
             >
-              <h2
-                class="bpk-modal__heading"
-                id="bpk-modal-heading-my-modal"
+              <div
+                class="bpk-navigation-bar__title-container"
               >
-                Modal title
-              </h2>
+                <h2
+                  class="bpk-modal__heading"
+                  id="bpk-modal-heading-my-modal"
+                >
+                  Modal title
+                </h2>
+              </div>
               <div
                 class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
               >

--- a/packages/bpk-component-modal/src/__snapshots__/BpkModalInner-test.tsx.snap
+++ b/packages/bpk-component-modal/src/__snapshots__/BpkModalInner-test.tsx.snap
@@ -16,12 +16,16 @@ exports[`BpkModalInner should render correctly 1`] = `
         aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
       >
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >
@@ -75,12 +79,16 @@ exports[`BpkModalInner should render correctly when is iPhone 1`] = `
         aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
       >
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >
@@ -134,12 +142,16 @@ exports[`BpkModalInner should render correctly when it does not fills the screen
         aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
       >
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >
@@ -193,12 +205,16 @@ exports[`BpkModalInner should render correctly when it has a className 1`] = `
         aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
       >
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >
@@ -252,12 +268,16 @@ exports[`BpkModalInner should render correctly when it is fullscreen 1`] = `
         aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
       >
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >
@@ -311,12 +331,16 @@ exports[`BpkModalInner should render correctly with a custom content classname 1
         aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
       >
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >
@@ -391,12 +415,16 @@ exports[`BpkModalInner should render correctly with an accessory view 1`] = `
             </span>
           </span>
         </div>
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >
@@ -450,12 +478,16 @@ exports[`BpkModalInner should render correctly with closeText prop 1`] = `
         aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
       >
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >
@@ -493,12 +525,16 @@ exports[`BpkModalInner should render correctly with no padding 1`] = `
         aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
       >
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >
@@ -552,12 +588,16 @@ exports[`BpkModalInner should render correctly with wide prop 1`] = `
         aria-labelledby="bpk-modal-heading-my-modal"
         class="bpk-navigation-bar bpk-navigation-bar--default bpk-modal__navigation"
       >
-        <h2
-          class="bpk-modal__heading"
-          id="bpk-modal-heading-my-modal"
+        <div
+          class="bpk-navigation-bar__title-container"
         >
-          Modal title
-        </h2>
+          <h2
+            class="bpk-modal__heading"
+            id="bpk-modal-heading-my-modal"
+          >
+            Modal title
+          </h2>
+        </div>
         <div
           class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
         >

--- a/packages/bpk-component-navigation-bar/index.d.ts
+++ b/packages/bpk-component-navigation-bar/index.d.ts
@@ -1,0 +1,41 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BpkNavigationBar, {
+  type Props as BpkNavigationBarProps,
+  BAR_STYLES,
+} from './src/BpkNavigationBar';
+import BpkNavigationBarButtonLink, {
+  type Props as BpkNavigationBarButtonLinkProps,
+} from './src/BpkNavigationBarButtonLink';
+import BpkNavigationBarIconButton, {
+  type Props as BpkNavigationBarIconButtonProps,
+} from './src/BpkNavigationBarIconButton';
+import themeAttributes from './src/themeAttributes';
+export type {
+  BpkNavigationBarProps,
+  BpkNavigationBarIconButtonProps,
+  BpkNavigationBarButtonLinkProps,
+};
+export {
+  BpkNavigationBarIconButton,
+  BpkNavigationBarButtonLink,
+  themeAttributes,
+  BAR_STYLES,
+};
+export default BpkNavigationBar;

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.d.ts
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.d.ts
@@ -1,0 +1,39 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import type { Tag, TextStyle } from '../../bpk-component-text/src/BpkText';
+export declare const BAR_STYLES: {
+    default: string;
+    onDark: string;
+};
+export type BarStyle = (typeof BAR_STYLES)[keyof typeof BAR_STYLES];
+export type Props = {
+    id: string;
+    title: ReactNode;
+    titleTextStyle?: TextStyle;
+    titleTagName?: Tag;
+    className?: string;
+    leadingButton?: ReactElement | null;
+    trailingButton?: ReactElement | null;
+    sticky?: boolean;
+    barStyle?: BarStyle;
+    [rest: string]: any;
+};
+declare const BpkNavigationBar: (props: Props) => JSX.Element;
+export default BpkNavigationBar;

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
@@ -23,11 +23,17 @@
 
 .bpk-navigation-bar {
   position: relative;
-  display: flex;
+  display: grid;
   min-height: tokens.bpk-spacing-xl() + tokens.bpk-spacing-lg();
   padding: tokens.bpk-spacing-base();
-  flex-direction: row;
-  justify-content: center;
+  grid-template-rows: auto;
+
+  // TBC how generally applicable these min sizes are when no button present
+  grid-template-columns: minmax(tokens.bpk-spacing-lg(), auto) 1fr minmax(
+      tokens.bpk-spacing-lg(),
+      auto
+    );
+  justify-content: space-between;
   align-items: center;
 
   @include utils.bpk-themeable-property(
@@ -41,6 +47,12 @@
   }
 
   &__title {
+    grid-column: 2;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+
     @include utils.bpk-themeable-property(
       color,
       --bpk-navigation-bar-title-color,
@@ -54,26 +66,32 @@
 
   &__leading-item,
   &__trailing-item {
-    position: absolute;
+    // position: absolute;
 
     @include typography.bpk-label-2;
   }
 
   &__leading-item {
-    left: tokens.bpk-spacing-base();
+    grid-column: 1;
+    justify-self: start;
+
+    // left: tokens.bpk-spacing-base();
 
     @include utils.bpk-rtl {
-      right: tokens.bpk-spacing-base();
-      left: auto;
+      // right: tokens.bpk-spacing-base();
+      // left: auto;
     }
   }
 
   &__trailing-item {
-    right: tokens.bpk-spacing-base();
+    grid-column: 3;
+    justify-self: end;
+
+    // right: tokens.bpk-spacing-base();
 
     @include utils.bpk-rtl {
-      right: auto;
-      left: tokens.bpk-spacing-base();
+      // right: auto;
+      // left: tokens.bpk-spacing-base();
     }
   }
 

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
@@ -25,14 +25,17 @@
   position: relative;
   display: grid;
   min-height: tokens.bpk-spacing-xl() + tokens.bpk-spacing-lg();
-  padding: tokens.bpk-spacing-base();
+  padding: tokens.bpk-spacing-lg();
   grid-template-rows: auto;
-  grid-template-columns: minmax(tokens.bpk-spacing-xxl(), auto) 1fr minmax(
-      tokens.bpk-spacing-xxl(),
-      auto
-    );
+
+  // 3 columns allowing for buttons at either side and a title then taking the available space in between
+  // min sizes to preserve margins when buttons omitted and ensure some text still shown under extreme zoom
+  grid-template-columns:
+    minmax(tokens.bpk-spacing-lg(), auto) minmax(tokens.bpk-spacing-base(), 1fr)
+    minmax(tokens.bpk-spacing-lg(), auto);
   justify-content: space-between;
   align-items: center;
+  gap: tokens.bpk-spacing-base();
 
   @include utils.bpk-themeable-property(
     background-color,
@@ -57,6 +60,7 @@
       tokens.$bpk-text-primary-day
     );
 
+    // ensure we still apply ellipsis overflow when a custom title element is specified e.g. h2
     :first-child {
       display: inline;
     }

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
@@ -27,10 +27,8 @@
   min-height: tokens.bpk-spacing-xl() + tokens.bpk-spacing-lg();
   padding: tokens.bpk-spacing-base();
   grid-template-rows: auto;
-
-  // TBC how generally applicable these min sizes are when no button present
-  grid-template-columns: minmax(tokens.bpk-spacing-lg(), auto) 1fr minmax(
-      tokens.bpk-spacing-lg(),
+  grid-template-columns: minmax(tokens.bpk-spacing-xxl(), auto) 1fr minmax(
+      tokens.bpk-spacing-xxl(),
       auto
     );
   justify-content: space-between;
@@ -59,40 +57,32 @@
       tokens.$bpk-text-primary-day
     );
 
+    :first-child {
+      display: inline;
+    }
+
     &--on-dark {
       color: tokens.$bpk-text-primary-inverse-day;
     }
   }
 
+  &__title-container {
+    justify-self: center;
+  }
+
   &__leading-item,
   &__trailing-item {
-    // position: absolute;
-
     @include typography.bpk-label-2;
   }
 
   &__leading-item {
     grid-column: 1;
     justify-self: start;
-
-    // left: tokens.bpk-spacing-base();
-
-    @include utils.bpk-rtl {
-      // right: tokens.bpk-spacing-base();
-      // left: auto;
-    }
   }
 
   &__trailing-item {
     grid-column: 3;
     justify-self: end;
-
-    // right: tokens.bpk-spacing-base();
-
-    @include utils.bpk-rtl {
-      // right: auto;
-      // left: tokens.bpk-spacing-base();
-    }
   }
 
   &__sticky {

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
@@ -25,7 +25,7 @@
   position: relative;
   display: grid;
   min-height: tokens.bpk-spacing-xl() + tokens.bpk-spacing-lg();
-  padding: tokens.bpk-spacing-lg();
+  padding: tokens.bpk-spacing-base();
   grid-template-rows: auto;
 
   // 3 columns allowing for buttons at either side and a title then taking the available space in between

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
@@ -54,8 +54,8 @@ const BpkNavigationBar = (props: Props) => {
     leadingButton,
     sticky = false,
     title,
-    titleTagName,
-    titleTextStyle,
+    titleTagName = "span",
+    titleTextStyle = TEXT_STYLES.heading5,
     trailingButton,
     ...rest
   } = props;
@@ -93,7 +93,7 @@ const BpkNavigationBar = (props: Props) => {
         )}>
           <BpkText
             id={titleId}
-            textStyle={titleTextStyle ?? TEXT_STYLES.heading5}
+            textStyle={titleTextStyle}
             tagName={titleTagName}
           >
             {title}

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
@@ -21,6 +21,8 @@ import type { ReactElement, ReactNode } from 'react';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
 
+import type { Tag, TextStyle } from '../../bpk-component-text/src/BpkText';
+
 import STYLES from './BpkNavigationBar.module.scss';
 
 const getClassNames = cssModules(STYLES);
@@ -34,6 +36,8 @@ export type BarStyle = (typeof BAR_STYLES)[keyof typeof BAR_STYLES];
 export type Props = {
   id: string;
   title: ReactNode;
+  titleTextStyle?: TextStyle;
+  titleTagName?: Tag;
   className?: string;
   leadingButton?: ReactElement | null;
   trailingButton?: ReactElement | null;
@@ -50,6 +54,8 @@ const BpkNavigationBar = (props: Props) => {
     leadingButton,
     sticky = false,
     title,
+    titleTagName,
+    titleTextStyle,
     trailingButton,
     ...rest
   } = props;
@@ -87,13 +93,14 @@ const BpkNavigationBar = (props: Props) => {
         )}>
           <BpkText
             id={titleId}
-            textStyle={TEXT_STYLES.heading5}
+            textStyle={titleTextStyle ?? TEXT_STYLES.heading5}
+            tagName={titleTagName}
           >
             {title}
           </BpkText>
         </span>
       ) : (
-        title
+        <div className={getClassNames('bpk-navigation-bar__title-container')}>{title}</div>
       )}
       {trailingButton && (
         <div

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.d.ts
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarButtonLink.d.ts
@@ -1,0 +1,35 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ComponentProps, MouseEvent, ReactNode } from 'react';
+import { BpkButtonLink } from '../../bpk-component-link';
+import { type BarStyle } from './BpkNavigationBar';
+export interface Props extends ComponentProps<BpkButtonLink> {
+  children: ReactNode;
+  onClick: (event: MouseEvent<HTMLElement>) => void;
+  className?: string;
+  barStyle?: BarStyle;
+  [rest: string]: any;
+}
+declare const BpkNavigationBarButtonLink: ({
+  barStyle,
+  children,
+  className,
+  ...rest
+}: Props) => JSX.Element;
+export default BpkNavigationBarButtonLink;

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.d.ts
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.d.ts
@@ -1,0 +1,36 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ComponentType, MouseEvent, ReactNode } from 'react';
+import { type BarStyle } from './BpkNavigationBar';
+export type Props = {
+  icon: ComponentType<any>;
+  label: string;
+  onClick: (event: MouseEvent<HTMLElement>) => void;
+  className?: string;
+  barStyle?: BarStyle;
+  children?: ReactNode;
+  [rest: string]: any;
+};
+declare const BpkNavigationBarIconButton: ({
+  barStyle,
+  className,
+  icon,
+  ...rest
+}: Props) => JSX.Element;
+export default BpkNavigationBarIconButton;

--- a/packages/bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.tsx.snap
+++ b/packages/bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.tsx.snap
@@ -122,9 +122,13 @@ exports[`BpkNavigationBar should render correctly with an element for the title 
     aria-labelledby="test"
     class="bpk-navigation-bar bpk-navigation-bar--default"
   >
-    <span>
-      test
-    </span>
+    <div
+      class="bpk-navigation-bar__title-container"
+    >
+      <span>
+        test
+      </span>
+    </div>
     <div
       class="bpk-navigation-bar__trailing-item bpk-navigation-bar__trailing-item-default"
     >

--- a/packages/bpk-component-navigation-bar/src/themeAttributes.d.ts
+++ b/packages/bpk-component-navigation-bar/src/themeAttributes.d.ts
@@ -1,0 +1,20 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare const _default: string[];
+export default _default;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

It was discovered that long titles overlap the buttons on the BpkBottomSheet component. The issue arises from the underlying BpkNavigationBar component lacking handling for this scenario.
Fix improves layout based on design requirement to clamp the text with ellipsis when there is not enough space to fit without encroaching on buttons or wrapping to an additional line.

# Screenshots

## Issue of long heading overlapping buttons
![image](https://github.com/Skyscanner/backpack/assets/3943125/8e233c45-e39a-4db6-ba4c-8643054038ba)

## Design guidance on expected layout
![image](https://github.com/Skyscanner/backpack/assets/3943125/2fc75fc3-4948-4b97-9c0a-574a293f994b)

## Examples after fix
* Navigation Bar
* BottomSheet

| Tablet  | Large Mobile | Small Mobile |
| ------------- | ------------- |------------- |
| <img src="https://github.com/Skyscanner/backpack/assets/3943125/b654f195-f1dc-4d2b-a567-3ec5a62e9068" width="250"/> | <img src="https://github.com/Skyscanner/backpack/assets/3943125/810a17a9-e422-4868-9061-bb805072ba90" width="250"/> | <img src="https://github.com/Skyscanner/backpack/assets/3943125/1064bbab-90d4-4b3d-b352-5aa5d3e37c76" width="250"/>  |
| <img src="https://github.com/Skyscanner/backpack/assets/3943125/ee32b81e-7c86-48fb-adc1-a4e6023ad55e" width="250"/>  | <img src="https://github.com/Skyscanner/backpack/assets/3943125/37469aef-2a1f-468e-878d-617fa5a2c05d" width="250"/> | <img src="https://github.com/Skyscanner/backpack/assets/3943125/5a1315ab-d488-4371-a3d1-dd39a551133a" width="250"/>  |

## Other selected cases - Small Mobile
| Action Button  | No Title | Graphic Logo Header |
| ------------- | ------------- |------------- |
| <img src="https://github.com/Skyscanner/backpack/assets/3943125/e0d827e4-c835-4c91-aa6a-cb9e9da32db8" width="250"/> | <img src="https://github.com/Skyscanner/backpack/assets/3943125/8a54268f-266b-46b2-b874-82e8ab646047" width="250"/> | <img src="https://github.com/Skyscanner/backpack/assets/3943125/0bc6ff02-6fc0-4012-94c2-ed59de6eac0a" width="250"/>  |

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
