### PR TITLE
[NO JIRA] [maintenance]: Update dist clean command as we never had rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "percy-test": "percy storybook ./dist-storybook -i '/Visual\\stest\\s?([a-z]*)?/i'",
     "ts-migrate": "ts-migrate",
     "transpile": "npm run build && run-s transpile:*",
-    "transpile:clean": "rimraf ./dist",
+    "transpile:clean": "rm -rf ./dist",
     "transpile:js": "BABEL_ENV=dev babel packages --ignore ./packages/bpk-stylesheets --out-dir dist --extensions \".ts,.tsx,.js,.jsx\" --config-file ./babel.config.js",
     "transpile:imports": "node scripts/transpilation/transform-js-scss-css-imports.js",
     "transpile:copy-css": "node scripts/transpilation/copy-css.js",


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Turns out when we made Backpack transpiled we were using `rimraf` to clean the dist folder but never had it installed directly to use.
I think this may have 'worked' because the dependency was being pulled as indirect and was local for folks who had existing clones it worked for with the dep.

However with a fresh install and setup of the repo it fails when running `npm run transpile` because the `rimraf` command isn't available. To avoid having to maintain another dep, I have switched this command to do a simple `rm -rf` for the dist folder.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] Type declaration (`.d.ts`) files updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
