### PR TITLE
[NO JIRA][maintenance] Fix rendering of Map Marker v2 stories

### DIFF
--- a/examples/bpk-component-map/examples.js
+++ b/examples/bpk-component-map/examples.js
@@ -210,7 +210,6 @@ class StatefulBpkPriceMarkerV2 extends Component<
         center={{ latitude: 55.944665, longitude: -3.1964903 }}
       >
         {venues
-          .filter((venue) => venue.disabled === false)
           .map((venue) => (
             <BpkPriceMarkerV2
               id={venue.id}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

**Examples fix**

Mini PR to fix the map marker V2 example, currently the map markers don't render: https://backpack.github.io/storybook/?path=/story/bpk-component-map--price-markers-v-2

This is because for the V2 markers story there is filtering to look for if a venue is `disabled` which is not a property in the list of places which leads to this never matching and no items found, which will then display an empty map.

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
