### PR TITLE
[maintenance][ARGG-1144]: Move Percy later in the CI as last step

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -61,42 +61,6 @@ jobs:
           name: ${{env.BUILD_LOGS}}
           path: ${{env.BUILD_LOGS}}.tar.br
 
-  PercyTests:
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Restore Cache
-        uses: actions/cache/restore@v4.0.2
-        id: npm-cache
-        with:
-          path: |
-            node_modules/
-            packages/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/package-lock.json') }}
-
-      - name: Restore Cache
-        uses: actions/cache/restore@v4.0.2
-        id: storybook-dist-cache
-        with:
-          path: dist-storybook/
-          key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/**', 'examples/**') }}
-
-      - name: Percy Test
-        run: npm run percy-test
-        if: ( github.ref == 'refs/heads/main' || github.repository == github.event.pull_request.head.repo.full_name) && github.actor != 'dependabot[bot]'
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-
   Danger:
     runs-on: ubuntu-latest
     needs: Build
@@ -137,3 +101,40 @@ jobs:
         if: github.ref != 'refs/heads/main' && github.repository == github.event.pull_request.head.repo.full_name
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  PercyTests:
+    runs-on: ubuntu-latest
+    needs: Danger
+    permissions:
+      statuses: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Restore Cache
+        uses: actions/cache/restore@v4.0.2
+        id: npm-cache
+        with:
+          path: |
+            node_modules/
+            packages/node_modules/
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/package-lock.json') }}
+
+      - name: Restore Cache
+        uses: actions/cache/restore@v4.0.2
+        id: storybook-dist-cache
+        with:
+          path: dist-storybook/
+          key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/**', 'examples/**') }}
+
+      - name: Percy Test
+        run: npm run percy-test
+        if: ( github.ref == 'refs/heads/main' || github.repository == github.event.pull_request.head.repo.full_name) && github.actor != 'dependabot[bot]'
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR moves Percy later in the CI process once all other testing has passed. The reason to move this to not be parallel or leave where it is, so to reduce usage of Percy to only be run once other testing is green, instead of having it run but tests fail and then having to run it again once other testing has been fixed. 

Essentially moving this to once per PR.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
