### PR TITLE
LOOM-1365 BpkDialogInner

### DIFF
--- a/packages/bpk-component-dialog/src/BpkDialogInner.module.scss
+++ b/packages/bpk-component-dialog/src/BpkDialogInner.module.scss
@@ -56,6 +56,7 @@
   }
 
   &__flare {
+    display: flex;
     height: tokens.bpk-spacing-lg() * 10;
 
     // We inherit radius from the outer modal so they match and align correctly to the container.

--- a/packages/bpk-component-dialog/src/BpkDialogInner.tsx
+++ b/packages/bpk-component-dialog/src/BpkDialogInner.tsx
@@ -65,10 +65,7 @@ const BpkDialogInner = (props: Props) => {
         className={classNames}
         ref={dialogRef}
       >
-        {flare && <BpkContentBubble
-        // TODO: className to be removed
-        // eslint-disable-next-line @skyscanner/rules/forbid-component-props
-        className={flareClassNames} />}
+        {flare && <div className={flareClassNames}><BpkContentBubble/></div>}
         <div className={contentClassNames}>{children}</div>
       </section>
     </TransitionInitialMount>

--- a/packages/bpk-component-dialog/src/__snapshots__/BpkDialog-test.tsx.snap
+++ b/packages/bpk-component-dialog/src/__snapshots__/BpkDialog-test.tsx.snap
@@ -276,45 +276,49 @@ exports[`BpkDialog should render with flare dialog 2`] = `
           tabindex="-1"
         >
           <div
-            class="bpk-content-bubble__wrapper bpk-content-bubble__wrapper--with-pointer bpk-content-bubble__wrapper--rounded bpk-content-bubble__wrapper--rounded--with-pointer bpk-dialog-inner__flare"
+            class="bpk-dialog-inner__flare"
           >
             <div
-              class="bpk-content-bubble__container"
+              class="bpk-content-bubble__wrapper bpk-content-bubble__wrapper--with-pointer bpk-content-bubble__wrapper--rounded bpk-content-bubble__wrapper--rounded--with-pointer"
             >
               <div
-                class="bpk-content-bubble__content-wrapper"
-              >
-                <svg
-                  class="bpk-content-bubble__rounded-corner"
-                  viewBox="0 0 75 75"
-                >
-                  <path
-                    d="M0 0v75h75C37.5 75 0 37.5 0 0z"
-                  />
-                </svg>
-                <svg
-                  class="bpk-content-bubble__rounded-corner bpk-content-bubble__rounded-corner--trailing"
-                  viewBox="0 0 75 75"
-                >
-                  <path
-                    d="M0 0v75h75C37.5 75 0 37.5 0 0z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="bpk-content-bubble__pointer"
+                class="bpk-content-bubble__container"
               >
                 <div
-                  class="bpk-flare-bar__container"
+                  class="bpk-content-bubble__content-wrapper"
                 >
                   <svg
-                    class="bpk-flare-bar__curve"
-                    viewBox="0 0 14832 55"
+                    class="bpk-content-bubble__rounded-corner"
+                    viewBox="0 0 75 75"
                   >
                     <path
-                      d="M7501.307 8.517l-68.043 39.341c-10.632 6.185-23.795 6.185-34.528 0l-68.144-39.34c-8.91-5.173-18.988-8.215-29.316-8.518H0v55h14832V0H7530.671a63.604 63.604 0 00-29.364 8.517z"
+                      d="M0 0v75h75C37.5 75 0 37.5 0 0z"
                     />
                   </svg>
+                  <svg
+                    class="bpk-content-bubble__rounded-corner bpk-content-bubble__rounded-corner--trailing"
+                    viewBox="0 0 75 75"
+                  >
+                    <path
+                      d="M0 0v75h75C37.5 75 0 37.5 0 0z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="bpk-content-bubble__pointer"
+                >
+                  <div
+                    class="bpk-flare-bar__container"
+                  >
+                    <svg
+                      class="bpk-flare-bar__curve"
+                      viewBox="0 0 14832 55"
+                    >
+                      <path
+                        d="M7501.307 8.517l-68.043 39.341c-10.632 6.185-23.795 6.185-34.528 0l-68.144-39.34c-8.91-5.173-18.988-8.215-29.316-8.518H0v55h14832V0H7530.671a63.604 63.604 0 00-29.364 8.517z"
+                      />
+                    </svg>
+                  </div>
                 </div>
               </div>
             </div>
@@ -382,45 +386,49 @@ exports[`BpkDialog should render with flare dialog with flareClassName 2`] = `
           tabindex="-1"
         >
           <div
-            class="bpk-content-bubble__wrapper bpk-content-bubble__wrapper--with-pointer bpk-content-bubble__wrapper--rounded bpk-content-bubble__wrapper--rounded--with-pointer bpk-dialog-inner__flare my-className"
+            class="bpk-dialog-inner__flare my-className"
           >
             <div
-              class="bpk-content-bubble__container"
+              class="bpk-content-bubble__wrapper bpk-content-bubble__wrapper--with-pointer bpk-content-bubble__wrapper--rounded bpk-content-bubble__wrapper--rounded--with-pointer"
             >
               <div
-                class="bpk-content-bubble__content-wrapper"
-              >
-                <svg
-                  class="bpk-content-bubble__rounded-corner"
-                  viewBox="0 0 75 75"
-                >
-                  <path
-                    d="M0 0v75h75C37.5 75 0 37.5 0 0z"
-                  />
-                </svg>
-                <svg
-                  class="bpk-content-bubble__rounded-corner bpk-content-bubble__rounded-corner--trailing"
-                  viewBox="0 0 75 75"
-                >
-                  <path
-                    d="M0 0v75h75C37.5 75 0 37.5 0 0z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="bpk-content-bubble__pointer"
+                class="bpk-content-bubble__container"
               >
                 <div
-                  class="bpk-flare-bar__container"
+                  class="bpk-content-bubble__content-wrapper"
                 >
                   <svg
-                    class="bpk-flare-bar__curve"
-                    viewBox="0 0 14832 55"
+                    class="bpk-content-bubble__rounded-corner"
+                    viewBox="0 0 75 75"
                   >
                     <path
-                      d="M7501.307 8.517l-68.043 39.341c-10.632 6.185-23.795 6.185-34.528 0l-68.144-39.34c-8.91-5.173-18.988-8.215-29.316-8.518H0v55h14832V0H7530.671a63.604 63.604 0 00-29.364 8.517z"
+                      d="M0 0v75h75C37.5 75 0 37.5 0 0z"
                     />
                   </svg>
+                  <svg
+                    class="bpk-content-bubble__rounded-corner bpk-content-bubble__rounded-corner--trailing"
+                    viewBox="0 0 75 75"
+                  >
+                    <path
+                      d="M0 0v75h75C37.5 75 0 37.5 0 0z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="bpk-content-bubble__pointer"
+                >
+                  <div
+                    class="bpk-flare-bar__container"
+                  >
+                    <svg
+                      class="bpk-flare-bar__curve"
+                      viewBox="0 0 14832 55"
+                    >
+                      <path
+                        d="M7501.307 8.517l-68.043 39.341c-10.632 6.185-23.795 6.185-34.528 0l-68.144-39.34c-8.91-5.173-18.988-8.215-29.316-8.518H0v55h14832V0H7530.671a63.604 63.604 0 00-29.364 8.517z"
+                      />
+                    </svg>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
**Class 2 Overrides**:

- Move flare overrides to wrapper.
- There is no visual test for this yet.  I can add a visual test first and then we can review this change after that if we thinks that's better?
- I've tested locally and the component matches, just needed `display: flex` on the flare:
  - Before:
![Screenshot 2024-05-16 at 14 14 44](https://github.com/Skyscanner/backpack/assets/7976511/873491ed-07a6-4782-8fc8-b4646384dcdd)
  - After:
![Screenshot 2024-05-16 at 15 11 39](https://github.com/Skyscanner/backpack/assets/7976511/9b645466-0017-4dad-8807-cdccaecb096d)

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
