### PR TITLE
[BpkPopover]: Fix popover z-index for rendering over content

### DIFF
--- a/packages/bpk-component-popover/src/BpkPopover.module.scss
+++ b/packages/bpk-component-popover/src/BpkPopover.module.scss
@@ -25,13 +25,8 @@
 
 $arrow-size: tokens.bpk-spacing-lg();
 
-.bpk-popover-portal {
+.bpk-popover-container {
   z-index: tokens.$bpk-zindex-popover;
-
-  @include breakpoints.bpk-breakpoint-mobile {
-    margin-right: tokens.bpk-spacing-base();
-    margin-left: tokens.bpk-spacing-base();
-  }
 }
 
 .bpk-popover {

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -155,6 +155,7 @@ const BpkPopover = ({
       {isOpenState && (
         <FloatingFocusManager context={context} modal={false}>
           <div
+            className={getClassName('bpk-popover--container')}
             ref={refs.setFloating}
             style={floatingStyles}
             {...getFloatingProps()}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Re-adding the popover z-index that was previously accidently removed in the recent popover update which would cause the popover to render under content.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
