### PR TITLE
[BpkNudger] Fix accessibility issue

### DIFF
--- a/packages/bpk-component-nudger/src/BpkConfigurableNudger.tsx
+++ b/packages/bpk-component-nudger/src/BpkConfigurableNudger.tsx
@@ -102,7 +102,6 @@ const BpkConfigurableNudger = ({
         value={formatValue(value)}
         id={id}
         className={inputStyles}
-        tabIndex={-1}
         {...rest}
       />
       <BpkButtonV2

--- a/packages/bpk-component-nudger/src/__snapshots__/BpkNudger-test.tsx.snap
+++ b/packages/bpk-component-nudger/src/__snapshots__/BpkNudger-test.tsx.snap
@@ -32,7 +32,6 @@ exports[`BpkNudger should render as a configurable nudger correctly 1`] = `
       class="bpk-nudger__input"
       id="nudger"
       readonly=""
-      tabindex="-1"
       type="text"
       value="premium"
     />
@@ -97,7 +96,6 @@ exports[`BpkNudger should render as an on dark nudger correctly 1`] = `
         class="bpk-nudger__input bpk-nudger__input--numeric bpk-nudger__input--secondary-on-dark"
         id="nudger"
         readonly=""
-        tabindex="-1"
         type="text"
         value="2"
       />
@@ -163,7 +161,6 @@ exports[`BpkNudger should render correctly 1`] = `
         class="bpk-nudger__input bpk-nudger__input--numeric"
         id="nudger"
         readonly=""
-        tabindex="-1"
         type="text"
         value="2"
       />
@@ -230,7 +227,6 @@ exports[`BpkNudger should render correctly with a value < min 1`] = `
         class="bpk-nudger__input bpk-nudger__input--numeric"
         id="nudger"
         readonly=""
-        tabindex="-1"
         type="text"
         value="0"
       />
@@ -296,7 +292,6 @@ exports[`BpkNudger should render correctly with a value = max 1`] = `
         class="bpk-nudger__input bpk-nudger__input--numeric"
         id="nudger"
         readonly=""
-        tabindex="-1"
         type="text"
         value="9"
       />
@@ -364,7 +359,6 @@ exports[`BpkNudger should render correctly with a value = min 1`] = `
         class="bpk-nudger__input bpk-nudger__input--numeric"
         id="nudger"
         readonly=""
-        tabindex="-1"
         type="text"
         value="1"
       />
@@ -430,7 +424,6 @@ exports[`BpkNudger should render correctly with a value > max 1`] = `
         class="bpk-nudger__input bpk-nudger__input--numeric"
         id="nudger"
         readonly=""
-        tabindex="-1"
         type="text"
         value="10"
       />


### PR DESCRIPTION
# BpkNudger

Remove `tabIndex=-1` from nudger input component as this is not a valid attribute for an input field. 
This resolves several defects across our pages where nudgers are in use.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
