### PR TITLE
[WALL-1371][BpkText] Add the Noto fallbacks for the Larken font

### DIFF
--- a/examples/bpk-component-text/examples.js
+++ b/examples/bpk-component-text/examples.js
@@ -158,6 +158,24 @@ const LarkenStylesExample = () => (
   </div>
 );
 
+const LarkenFallbackStylesExample = () => (
+  <div>
+    <BpkText textStyle={TEXT_STYLES.editorial2} tagName="p" id="korean">
+      다람쥐 헌 쳇바퀴에 타고파
+    </BpkText>
+    <BpkText textStyle={TEXT_STYLES.editorial2} tagName="p" id="thai">
+      นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด
+      ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ
+    </BpkText>
+    <BpkText textStyle={TEXT_STYLES.editorial2} tagName="p" id="cyrillic">
+      Съешь же ещё этих мягких французских булок да выпей чаю
+    </BpkText>
+    <BpkText textStyle={TEXT_STYLES.editorial2} tagName="p" id="hebrew">
+      עטלף אבק נס דרך מזגן שהתפוצץ כי חם
+    </BpkText>
+  </div>
+);
+
 const MixedExample = () => (
   <div>
     <HeroStylesExample />
@@ -165,6 +183,7 @@ const MixedExample = () => (
     <BodyStylesExample />
     <LabelStylesExample />
     <LarkenStylesExample />
+    <LarkenFallbackStylesExample />
   </div>
 );
 
@@ -178,5 +197,6 @@ export {
   BodyStylesExample,
   LabelStylesExample,
   LarkenStylesExample,
+  LarkenFallbackStylesExample,
   MixedExample,
 };

--- a/examples/bpk-component-text/stories.js
+++ b/examples/bpk-component-text/stories.js
@@ -28,6 +28,7 @@ import {
   BodyStylesExample,
   LabelStylesExample,
   LarkenStylesExample,
+  LarkenFallbackStylesExample,
   MixedExample,
 } from './examples';
 
@@ -47,6 +48,7 @@ export const HeadingStyles = HeadingStylesExample;
 export const BodyStyles = BodyStylesExample;
 export const LabelStyles = LabelStylesExample;
 export const LarkenStyles = LarkenStylesExample;
+export const LarkenFallbackStyles = LarkenFallbackStylesExample;
 
 export const VisualTest = MixedExample;
 export const VisualTestWithZoom = VisualTest.bind({});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/register": "^7.23.7",
         "@percy/cli": "^1.28.2",
         "@percy/storybook": "^5.0.1",
-        "@skyscanner/bpk-foundations-web": "^17.13.0",
+        "@skyscanner/bpk-foundations-web": "^17.14.0",
         "@skyscanner/bpk-svgs": "^19.3.0",
         "@skyscanner/eslint-config-skyscanner": "^18.0.0",
         "@skyscanner/stylelint-config-skyscanner": "^11.1.0",
@@ -4641,9 +4641,9 @@
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "17.13.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-17.13.0.tgz",
-      "integrity": "sha512-AAgIk6QlfZccMeJJvuu0pT9aS3//bLHK6W+nvWuWST4q8DEH26x1Ov6MnWqkxHp42RRL5Ss56MBXEApo38gLnA==",
+      "version": "17.14.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-17.14.0.tgz",
+      "integrity": "sha512-jE3audhl02WQ3lrSpvaziUCWaCjkgmILADHCVMI3MDYUkHfquaRcqoJKFFyTeyM+sjkrRvRX52J8ipAbqaiKvA==",
       "dev": true,
       "dependencies": {
         "@skyscanner/bpk-foundations-common": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@babel/register": "^7.23.7",
     "@percy/cli": "^1.28.2",
     "@percy/storybook": "^5.0.1",
-    "@skyscanner/bpk-foundations-web": "^17.13.0",
+    "@skyscanner/bpk-foundations-web": "^17.14.0",
     "@skyscanner/bpk-svgs": "^19.3.0",
     "@skyscanner/eslint-config-skyscanner": "^18.0.0",
     "@skyscanner/stylelint-config-skyscanner": "^11.1.0",

--- a/packages/bpk-component-text/README.md
+++ b/packages/bpk-component-text/README.md
@@ -24,25 +24,32 @@ When using the same style in many places repeating the `textStyle` and `tagName`
 import BpkText from '@skyscanner/backpack-web/bpk-component-text';
 import { withDefaultProps } from '@skyscanner/backpack-web/bpk-react-utils';
 
-const LargeParagraph = withDefaultProps(BpkText, { textStyle: 'bodyLongform', tagName: 'p' });
-const TinySpan = withDefaultProps(BpkText, { textStyle: 'caption', tagName: 'span' });
+const LargeParagraph = withDefaultProps(BpkText, {
+  textStyle: 'bodyLongform',
+  tagName: 'p',
+});
+const TinySpan = withDefaultProps(BpkText, {
+  textStyle: 'caption',
+  tagName: 'span',
+});
 
 export default () => (
   <div>
     <LargeParagraph>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      Pellentesque imperdiet lobortis tellus, non rhoncus erat tincidunt id.
-      Pellentesque consectetur, dolor nec vulputate vehicula, ex metus mattis ante,
-      non dictum mi ante eu arcu.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+      imperdiet lobortis tellus, non rhoncus erat tincidunt id. Pellentesque
+      consectetur, dolor nec vulputate vehicula, ex metus mattis ante, non
+      dictum mi ante eu arcu.
     </LargeParagraph>
     <LargeParagraph>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        Pellentesque imperdiet lobortis tellus, non rhoncus erat tincidunt id.
-        Pellentesque consectetur, dolor nec vulputate vehicula, ex metus mattis ante,
-        non dictum mi ante eu arcu.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+      imperdiet lobortis tellus, non rhoncus erat tincidunt id. Pellentesque
+      consectetur, dolor nec vulputate vehicula, ex metus mattis ante, non
+      dictum mi ante eu arcu.
     </LargeParagraph>
     <TinySpan>
-      Side effects of Backpack include euphoria, happiness, and increased develpoment velocity.
+      Side effects of Backpack include euphoria, happiness, and increased
+      develpoment velocity.
     </TinySpan>
   </div>
 );
@@ -58,6 +65,22 @@ export default () => (
   <BpkText tagName="h2" textStyle={TEXT_STYLES.subheading}>My subhheading</BpkText>
 );
 ```
+
+### Editorial Text
+
+For use cases where the new Editorial Larken font is required, there are 3 textStyles available to apply this styling.
+
+```javascript
+import BpkText, { TEXT_STYLES } from '@skyscanner/backpack-web/bpk-component-text';
+
+export default () => (
+  <BpkText tagName="h1" textStyle={TEXT_STYLES.editorial1}>Editorial 1</BpkText>
+  <BpkText tagName="h2" textStyle={TEXT_STYLES.editorial2}>Editorial 2</BpkText>
+  <BpkText tagName="p" textStyle={TEXT_STYLES.editorial3}>Editorial 3</BpkText>
+);
+```
+
+For certain langauges/characters that are not supported by Larken, the fonts will use the Noto Sans/Serif fonts defined [here](https://www.skyscanner.design/latest/foundations/product-typography/fallback-fonts-Fx8gulTr)
 
 ## Props
 

--- a/packages/bpk-stylesheets/larken.scss
+++ b/packages/bpk-stylesheets/larken.scss
@@ -35,3 +35,93 @@ $base-url: 'https://js.skyscnr.com/sttc/bpk-fonts';
     url('#{$base-url}/Larken-Regular-3d9dfe29.woff2') format('woff2'),
     url('#{$base-url}/Larken-Regular-626ee28c.woff') format('woff');
 }
+
+@font-face {
+  font-family: 'Noto Sans Arabic';
+  font-style: normal;
+  font-weight: 300;
+  src:
+    url('#{$base-url}/NotoSansArabic-Light-e77dc47a.woff2') format('woff2'),
+    url('#{$base-url}/NotoSansArabic-Light-ea83f673.woff') format('woff'),
+    url('#{$base-url}/NotoSansArabic-Light-b2ff05f9.ttf') format('ttf');
+}
+
+@font-face {
+  font-family: 'Noto Sans Hebrew';
+  font-style: normal;
+  font-weight: 300;
+  src:
+    url('#{$base-url}/NotoSansHebrew-Light-7e3d70ae.woff2') format('woff2'),
+    url('#{$base-url}/NotoSansHebrew-Light-87087c3d.woff') format('woff'),
+    url('#{$base-url}/NotoSansHebrew-Light-7b34032c.ttf') format('ttf');
+}
+
+@font-face {
+  font-family: 'Noto Serif';
+  font-style: normal;
+  font-weight: 300;
+  src:
+    url('#{$base-url}/NotoSerif-Light-46d7aaea.woff2') format('woff2'),
+    url('#{$base-url}/NotoSerif-Light-412a21b9.woff') format('woff'),
+    url('#{$base-url}/NotoSerif-Light-9dbdd5d2.ttf') format('ttf');
+}
+
+@font-face {
+  font-family: 'Noto Serif Devanagari';
+  font-style: normal;
+  font-weight: 300;
+  src:
+    url('#{$base-url}/NotoSerifDevanagari-Light-6f8c3ec2.woff2') format('woff2'),
+    url('#{$base-url}/NotoSerifDevanagari-Light-9e5b16f1.woff') format('woff'),
+    url('#{$base-url}/NotoSerifDevanagari-Light-d396b2f0.ttf') format('ttf');
+}
+
+@font-face {
+  font-family: 'Noto Serif Thai';
+  font-style: normal;
+  font-weight: 300;
+  src:
+    url('#{$base-url}/NotoSerifThai-Light-c19b05eb.woff2') format('woff2'),
+    url('#{$base-url}/NotoSerifThai-Light-c8dd8e9a.woff') format('woff'),
+    url('#{$base-url}/NotoSerifThai-Light-7503fb65.ttf') format('ttf');
+}
+
+@font-face {
+  font-family: 'Noto Sans SC';
+  font-style: normal;
+  font-weight: 300;
+  src:
+    url('#{$base-url}/NotoSansSC-Light-650e8f78.woff2') format('woff2'),
+    url('#{$base-url}/NotoSansSC-Light-562944a8.woff') format('woff'),
+    url('#{$base-url}/NotoSansSC-Light-a73eb63e.ttf') format('ttf');
+}
+
+@font-face {
+  font-family: 'Noto Sans TC';
+  font-style: normal;
+  font-weight: 300;
+  src:
+    url('#{$base-url}/NotoSansTC-Light-44be0b13.woff2') format('woff2'),
+    url('#{$base-url}/NotoSansTC-Light-a8473157.woff') format('woff'),
+    url('#{$base-url}/NotoSansTC-Light-d77339b0.ttf') format('ttf');
+}
+
+@font-face {
+  font-family: 'Noto Sans JP';
+  font-style: normal;
+  font-weight: 300;
+  src:
+    url('#{$base-url}/NotoSansJP-Light-1fed199d.woff2') format('woff2'),
+    url('#{$base-url}/NotoSansJP-Light-828afdbb.woff') format('woff'),
+    url('#{$base-url}/NotoSansJP-Light-477cc6a5.ttf') format('ttf');
+}
+
+@font-face {
+  font-family: 'Noto Sans KR';
+  font-style: normal;
+  font-weight: 300;
+  src:
+    url('#{$base-url}/NotoSansKR-Light-8bef1aea.woff2') format('woff2'),
+    url('#{$base-url}/NotoSansKR-Light-c07b4050.woff') format('woff'),
+    url('#{$base-url}/NotoSansKR-Light-137d0733.ttf') format('ttf');
+}

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -13,7 +13,7 @@
         "@popperjs/core": "^2.11.8",
         "@radix-ui/react-slider": "^1.1.2",
         "@react-google-maps/api": "^2.12.0",
-        "@skyscanner/bpk-foundations-web": "^17.13.0",
+        "@skyscanner/bpk-foundations-web": "^17.14.0",
         "@skyscanner/bpk-svgs": "^19.3.0",
         "a11y-focus-scope": "^1.1.3",
         "a11y-focus-store": "^1.0.0",
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "17.13.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-17.13.0.tgz",
-      "integrity": "sha512-AAgIk6QlfZccMeJJvuu0pT9aS3//bLHK6W+nvWuWST4q8DEH26x1Ov6MnWqkxHp42RRL5Ss56MBXEApo38gLnA==",
+      "version": "17.14.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-17.14.0.tgz",
+      "integrity": "sha512-jE3audhl02WQ3lrSpvaziUCWaCjkgmILADHCVMI3MDYUkHfquaRcqoJKFFyTeyM+sjkrRvRX52J8ipAbqaiKvA==",
       "dependencies": {
         "@skyscanner/bpk-foundations-common": "^6.11.0",
         "color": "^4.2.3"

--- a/packages/package.json
+++ b/packages/package.json
@@ -26,7 +26,7 @@
     "@popperjs/core": "^2.11.8",
     "@radix-ui/react-slider": "^1.1.2",
     "@react-google-maps/api": "^2.12.0",
-    "@skyscanner/bpk-foundations-web": "^17.13.0",
+    "@skyscanner/bpk-foundations-web": "^17.14.0",
     "@skyscanner/bpk-svgs": "^19.3.0",
     "a11y-focus-scope": "^1.1.3",
     "a11y-focus-store": "^1.0.0",


### PR DESCRIPTION
Adds the missing Noto fallback fonts to the new Larken font-family 
(NOTE: just waiting on this PR to update token https://github.com/Skyscanner/backpack-foundations/pull/321 to merge and then can bump the package)

Fallback Fonts info https://skyscanner.atlassian.net/wiki/spaces/PD/pages/722121809/Fallback+fonts

New Larken editorial font
![image](https://github.com/Skyscanner/backpack/assets/19427244/889680d8-2473-4396-bf4c-2e5a83295a61)

New Fallback Fonts in multi language using Pangrams
![image](https://github.com/Skyscanner/backpack/assets/19427244/d8d5feb2-ae63-4348-acea-5142b4fc6d80)


Remember to include the following changes:

- [X] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [X] Component `README.md`
- [ ] Tests
- [X] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
