### PR TITLE
[NOJIRA][BpkBreakpoint]: Bug fix initial incorrect value of isClient on client rendered applications

### DIFF
--- a/packages/bpk-component-breakpoint/src/BpkBreakpoint-test.tsx
+++ b/packages/bpk-component-breakpoint/src/BpkBreakpoint-test.tsx
@@ -100,7 +100,9 @@ describe('BpkBreakpoint', () => {
       const BpkBreakpoint = require('./BpkBreakpoint').default; // eslint-disable-line global-require
 
       ReactDOMServer.renderToString(
-        <BpkBreakpoint query={BREAKPOINTS.MOBILE} matchSSR >rendered</BpkBreakpoint>,
+        <BpkBreakpoint query={BREAKPOINTS.MOBILE} matchSSR>
+          rendered
+        </BpkBreakpoint>,
       );
 
       expect(mockUseMediaQuery).toHaveBeenCalledWith(BREAKPOINTS.MOBILE, true);


### PR DESCRIPTION
Initially incorrect value (`false`) was used when using BpkBreakpoint on a client rendered application. This was due to the forced re-render functionality also doubling as client environment detection. In this PR they have been separated and thus the issue is removed.

`useEffect and useState` is used to solve forced re-rendering and `typeof window` statement is used to detect the initial `isClient` value. 

Change(s):
- use typeof check rather than boolean to determine if environment is client. Continue to support forced re-renders

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
