### PR TITLE
[NOJIRA][BpkFloatingNotification]: Fix CTA position

### DIFF
--- a/examples/bpk-component-floating-notification/examples.tsx
+++ b/examples/bpk-component-floating-notification/examples.tsx
@@ -16,73 +16,48 @@
  * limitations under the License.
  */
 
-import type { ReactElement} from 'react';
-import { cloneElement, useState } from 'react';
-
-import { BpkButtonV2 } from '../../packages/bpk-component-button';
 import BpkFloatingNotification from '../../packages/bpk-component-floating-notification';
 import BpkIconHeart from '../../packages/bpk-component-icon/sm/heart';
 import BpkIconInformationCircle from '../../packages/bpk-component-icon/sm/information-circle';
 
-type Props = {
-  children: ReactElement<{onExit: Function}, string>,
-};
-
-const AlertContainer = ({ children }: Props) => {
-  const [showAlert, setShowAlert] = useState(false);
-
-  return (
-    <>
-      <BpkButtonV2
-        onClick={() => {
-          setShowAlert(true);
-        }}
-      >
-        Trigger alert
-      </BpkButtonV2>
-      {showAlert &&
-        cloneElement(children, { onExit: () => setShowAlert(false) })}
-    </>
-  );
+const hideAfterHack = {
+  // Apply a exceptionally large number to hideAfter to effectively keep the UI around forever
+  hideAfter: 2_147_483_647, // largest 32 bit signed integer, maximum value for setTimeout. Around 28 days. :)
 };
 
 const DefaultExample = () => (
-  <AlertContainer>
-    <BpkFloatingNotification text="Saved" />
-  </AlertContainer>
+  <BpkFloatingNotification text="Saved" {...hideAfterHack} />
 );
 
 const IconExample = () => (
-  <AlertContainer>
-    <BpkFloatingNotification icon={BpkIconHeart} text="Saved" />
-  </AlertContainer>
+  <BpkFloatingNotification
+    icon={BpkIconHeart}
+    text="Saved"
+    {...hideAfterHack}
+  />
 );
 
 const CtaExample = () => (
-  <AlertContainer>
-    <BpkFloatingNotification ctaText="View" text="Saved" />
-  </AlertContainer>
+  <BpkFloatingNotification ctaText="View" text="Saved" {...hideAfterHack} />
 );
 
 const CtaIconLongTextExample = () => (
-  <AlertContainer>
-    <BpkFloatingNotification
-      ctaText="View"
-      icon={BpkIconHeart}
-      text="Killer Combo saved to New York and Miami 🎉"
-    />
-  </AlertContainer>
+  <BpkFloatingNotification
+    ctaText="View"
+    icon={BpkIconHeart}
+    text="Killer Combo saved to New York and Miami 🎉"
+    {...hideAfterHack}
+  />
 );
 
 const VisualTestExample = () => (
   <BpkFloatingNotification
-      animateOnEnter
-      animateOnExit
-      ctaText="View"
-      // @ts-expect-error hideAfter isn't meant to take null, however, we override as we'd like to not hide it in visual testing
-      hideAfter={null} // don't hide the visual test example
-      icon={BpkIconInformationCircle}
-      text="Killer Combo saved to New York and Miami 🎉"
+    animateOnEnter
+    animateOnExit
+    ctaText="View"
+    {...hideAfterHack}
+    icon={BpkIconInformationCircle}
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
   />
 );
 

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
@@ -29,6 +29,7 @@
   max-width: tokens.bpk-spacing-xxl() * 10;
   margin: auto;
   padding: tokens.bpk-spacing-lg();
+  align-items: center;
   transition:
     opacity tokens.$bpk-duration-base ease-in-out,
     transform tokens.$bpk-duration-base ease-in-out;
@@ -77,5 +78,9 @@
 
   &__text {
     margin-inline-end: tokens.bpk-spacing-md();
+  }
+
+  &__cta {
+    margin-inline-start: auto;
   }
 }

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.tsx
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.tsx
@@ -98,20 +98,18 @@ const BpkFloatingNotification = (props: Props) => {
             <Icon aria-hidden />
           </div>
         )}
-        <BpkText
-          tagName="p"
-          textStyle={TEXT_STYLES.bodyDefault}
-        >
-          <span className={getClassName('bpk-floating-notification__text')}>{text}</span>
-        </BpkText>
+        <span className={getClassName('bpk-floating-notification__text')}>
+          <BpkText tagName="p" textStyle={TEXT_STYLES.bodyDefault}>
+            {text}
+          </BpkText>
+        </span>
         <BpkAriaLive aria-hidden>{text}</BpkAriaLive>
         {ctaText && (
-          <BpkButtonV2
-            type={BUTTON_TYPES.linkOnDark}
-            onClick={onClick}
-          >
-            {ctaText}
-          </BpkButtonV2>
+          <div className={getClassName('bpk-floating-notification__cta')}>
+            <BpkButtonV2 type={BUTTON_TYPES.linkOnDark} onClick={onClick}>
+              {ctaText}
+            </BpkButtonV2>
+          </div>
         )}
       </div>
     </CSSTransition>

--- a/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.tsx.snap
+++ b/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.tsx.snap
@@ -5,15 +5,15 @@ exports[`BpkFloatingNotification should render correctly 1`] = `
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
   >
-    <p
-      class="bpk-text bpk-text--body-default"
+    <span
+      class="bpk-floating-notification__text"
     >
-      <span
-        class="bpk-floating-notification__text"
+      <p
+        class="bpk-text bpk-text--body-default"
       >
         Saved
-      </span>
-    </p>
+      </p>
+    </span>
     <div
       aria-hidden="true"
       aria-live="polite"
@@ -30,15 +30,15 @@ exports[`BpkFloatingNotification should render correctly with CTA text 1`] = `
   <div
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
   >
-    <p
-      class="bpk-text bpk-text--body-default"
+    <span
+      class="bpk-floating-notification__text"
     >
-      <span
-        class="bpk-floating-notification__text"
+      <p
+        class="bpk-text bpk-text--body-default"
       >
         Saved
-      </span>
-    </p>
+      </p>
+    </span>
     <div
       aria-hidden="true"
       aria-live="polite"
@@ -46,12 +46,16 @@ exports[`BpkFloatingNotification should render correctly with CTA text 1`] = `
     >
       Saved
     </div>
-    <button
-      class="bpk-button bpk-button--link-on-dark"
-      type="button"
+    <div
+      class="bpk-floating-notification__cta"
     >
-      View
-    </button>
+      <button
+        class="bpk-button bpk-button--link-on-dark"
+        type="button"
+      >
+        View
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -76,15 +80,15 @@ exports[`BpkFloatingNotification should render correctly with icon prop 1`] = `
         />
       </svg>
     </div>
-    <p
-      class="bpk-text bpk-text--body-default"
+    <span
+      class="bpk-floating-notification__text"
     >
-      <span
-        class="bpk-floating-notification__text"
+      <p
+        class="bpk-text bpk-text--body-default"
       >
         Saved
-      </span>
-    </p>
+      </p>
+    </span>
     <div
       aria-hidden="true"
       aria-live="polite"
@@ -102,15 +106,15 @@ exports[`BpkFloatingNotification should support arbitrary props 1`] = `
     class="bpk-floating-notification bpk-floating-notification--appear bpk-floating-notification--appear-active"
     testid="123"
   >
-    <p
-      class="bpk-text bpk-text--body-default"
+    <span
+      class="bpk-floating-notification__text"
     >
-      <span
-        class="bpk-floating-notification__text"
+      <p
+        class="bpk-text bpk-text--body-default"
       >
         Saved
-      </span>
-    </p>
+      </p>
+    </span>
     <div
       aria-hidden="true"
       aria-live="polite"
@@ -127,15 +131,15 @@ exports[`BpkFloatingNotification should support custom class names 1`] = `
   <div
     class="bpk-floating-notification custom-classname bpk-floating-notification--appear bpk-floating-notification--appear-active"
   >
-    <p
-      class="bpk-text bpk-text--body-default"
+    <span
+      class="bpk-floating-notification__text"
     >
-      <span
-        class="bpk-floating-notification__text"
+      <p
+        class="bpk-text bpk-text--body-default"
       >
         Saved
-      </span>
-    </p>
+      </p>
+    </span>
     <div
       aria-hidden="true"
       aria-live="polite"


### PR DESCRIPTION

Bug: CTA button incorrectly aligned to the left. 
![Screenshot 2024-05-20 at 17 10 24](https://github.com/Skyscanner/backpack/assets/89925955/a1abfc90-d06b-4edf-9c2f-51305df34113)

Changes: 
- fix floating button cta position, 
- correct margin for text
- all stories render rather directly than require button click

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
