### PR TITLE
[NO JIRA][BpkPopover]: Fix popover container classname

### DIFF
--- a/packages/bpk-component-popover/src/BpkPopover.module.scss
+++ b/packages/bpk-component-popover/src/BpkPopover.module.scss
@@ -25,7 +25,7 @@
 
 $arrow-size: tokens.bpk-spacing-lg();
 
-.bpk-popover-container {
+.bpk-popover--container {
   z-index: tokens.$bpk-zindex-popover;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Fixes a mismatch between the classname applied to a container and the CSS name as it was incorrect so not applying the CSS

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
