### PR TITLE
[BD-8430][BpkHorizontalNav, BpkMobileScrollContainer, withScrim] Resolve reflow impact

### DIFF
--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -65,7 +65,9 @@ class BpkHorizontalNav extends Component<Props> {
   }
 
   componentDidMount() {
-    this.scrollSelectedIntoView(false);
+    requestAnimationFrame(() => {
+      this.scrollSelectedIntoView(false);
+    })
   }
 
   componentDidUpdate() {

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.js
@@ -123,8 +123,10 @@ class BpkMobileScrollContainer extends Component<Props, State> {
   }
 
   componentDidMount() {
-    this.setScrollBarAwareHeight();
-    this.setScrollIndicatorClassName();
+    requestAnimationFrame(() => {
+      this.setScrollBarAwareHeight();
+      this.setScrollIndicatorClassName();
+    });
     window.addEventListener('resize', this.onWindowResize);
   }
 

--- a/packages/bpk-scrim-utils/src/withScrim-test.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim-test.tsx
@@ -118,6 +118,11 @@ describe('BpkScrim', () => {
     beforeEach(() => {
       TestComponent = () => <div>TestComponent</div>;
       Component = withScrim(TestComponent);
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
     });
 
     it('should mount correctly when is iPhone', () => {
@@ -134,6 +139,7 @@ describe('BpkScrim', () => {
           isIphone
         />,
       );
+      jest.runAllTimers();
       expect(storeScroll).toHaveBeenCalled();
       expect(lockScroll).toHaveBeenCalled();
       expect(fixBody).toHaveBeenCalled();
@@ -155,6 +161,7 @@ describe('BpkScrim', () => {
           isIphone={false}
         />,
       );
+      jest.runAllTimers();
       expect(lockScroll).toHaveBeenCalled();
       expect(focusStore.storeFocus).toHaveBeenCalled();
       expect(storeScroll).not.toHaveBeenCalled();

--- a/packages/bpk-scrim-utils/src/withScrim.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim.tsx
@@ -87,31 +87,33 @@ const withScrim = <P extends object>(
       const { getApplicationElement, isIpad, isIphone } = this.props;
       const applicationElement = getApplicationElement();
 
-      /**
-       * iPhones & iPads need to have a fixed body
-       * and scrolling stored to prevent some iOS specific issues occuring
-       *
-       * Issue description:
-       * iOS safari does not prevent scrolling on the underlying content.
-       * Without the below fixes this results in users being able to scroll below any modal or dialog that uses withScrim.
-       *
-       * The fixes can be summaried here: https://markus.oberlehner.net/blog/simple-solution-to-prevent-body-scrolling-on-ios/
-       *
-       * The most dangerous of the fixes below is the fixBody, this function applies changes to the <body> style.
-       * This has the potential to override any custom styles already applied. The assumption here is that no one internally is making these changes to body.
-       *
-       * There is a corresponding set of functions in the componentWillUnmount block that deals with undoing these changes.
-       */
-      if (isIphone || isIpad) {
-        storeScroll();
-        fixBody();
-      }
-      /**
-       * lockScroll and the associated unlockScroll is how we control the scroll behaviour of the application when the scrim is active.
-       * The desired behaviour is to prevent the user from scrolling content behind the scrim. The above iOS fixes are in place because lockScroll alone does not solve due to iOS specific issues.
-       */
+      requestAnimationFrame(() => {
+        /**
+         * iPhones & iPads need to have a fixed body
+         * and scrolling stored to prevent some iOS specific issues occuring
+         *
+         * Issue description:
+         * iOS safari does not prevent scrolling on the underlying content.
+         * Without the below fixes this results in users being able to scroll below any modal or dialog that uses withScrim.
+         *
+         * The fixes can be summaried here: https://markus.oberlehner.net/blog/simple-solution-to-prevent-body-scrolling-on-ios/
+         *
+         * The most dangerous of the fixes below is the fixBody, this function applies changes to the <body> style.
+         * This has the potential to override any custom styles already applied. The assumption here is that no one internally is making these changes to body.
+         *
+         * There is a corresponding set of functions in the componentWillUnmount block that deals with undoing these changes.
+         */
+        if (isIphone || isIpad) {
+          storeScroll();
+          fixBody();
+        }
+        /**
+         * lockScroll and the associated unlockScroll is how we control the scroll behaviour of the application when the scrim is active.
+         * The desired behaviour is to prevent the user from scrolling content behind the scrim. The above iOS fixes are in place because lockScroll alone does not solve due to iOS specific issues.
+         */
 
-      lockScroll();
+        lockScroll();
+      });
 
       if (applicationElement) {
         applicationElement.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
Optimize rendering performance in componentDidMount using requestAnimationFrame

In order to improve the page's INP Score, this PR addresses performance issues related to rendering in the componentDidMount lifecycle method of three components: **BpkHorizontalNav, BpkMobileScrollContainer, and withScrim**.

Previously, the rendering logic in **componentDidMount** could cause **reflows** and impact performance. To mitigate this, **requestAnimationFrame** is now used to defer rendering until the next frame, allowing the browser to optimize layout and painting.

<img width="956" alt="image" src="https://github.com/Skyscanner/backpack/assets/3379411/45f16541-1769-436d-811e-b349b3249da5">

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
