### PR TITLE
[WALL-1807][BpkText] Update hero text styles

### DIFF
--- a/examples/bpk-component-text/examples.js
+++ b/examples/bpk-component-text/examples.js
@@ -87,6 +87,9 @@ const HeroStylesExample = () => (
     <BpkText textStyle={TEXT_STYLES.hero5} tagName="h5">
       Hero 5
     </BpkText>
+    <BpkText textStyle={TEXT_STYLES.hero6} tagName="h6">
+      Hero 6
+    </BpkText>
   </div>
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/register": "^7.23.7",
         "@percy/cli": "^1.28.2",
         "@percy/storybook": "^5.0.1",
-        "@skyscanner/bpk-foundations-web": "^17.14.0",
+        "@skyscanner/bpk-foundations-web": "^18.0.0",
         "@skyscanner/bpk-svgs": "^19.3.0",
         "@skyscanner/eslint-config-skyscanner": "^18.0.0",
         "@skyscanner/stylelint-config-skyscanner": "^11.1.0",
@@ -4619,9 +4619,9 @@
       }
     },
     "node_modules/@skyscanner/bpk-foundations-common": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-6.11.0.tgz",
-      "integrity": "sha512-mhLB1PzuivgCXj+3G7Z4VsBNR8eZpuVAlxCWVsKA/qfFHuRuPEf2Q8GGz3hEwDi81+sTtZNOWJVJgJ6rEAZO3A==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-6.12.0.tgz",
+      "integrity": "sha512-YoNyWk7OuOiGZYowcrUx7AOxnKlGadzimfiSAAiGa08eqrQ1P7c9sxRiKjodvuVhy3xi9WMQWRe8Km64EnMHQQ==",
       "dev": true,
       "dependencies": {
         "color": "^4.2.3"
@@ -4641,12 +4641,12 @@
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "17.14.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-17.14.0.tgz",
-      "integrity": "sha512-jE3audhl02WQ3lrSpvaziUCWaCjkgmILADHCVMI3MDYUkHfquaRcqoJKFFyTeyM+sjkrRvRX52J8ipAbqaiKvA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-18.0.0.tgz",
+      "integrity": "sha512-NO24qM6jR3WZqU6f9jQ1cJLwI62uYN6HZ+3DPELk4W2Y1cUQvcyAZtwZ3fPaADL8AluvG+0RuGTsqCuk9C+aJA==",
       "dev": true,
       "dependencies": {
-        "@skyscanner/bpk-foundations-common": "^6.11.0",
+        "@skyscanner/bpk-foundations-common": "^6.12.0",
         "color": "^4.2.3"
       }
     },
@@ -14894,6 +14894,29 @@
       "engines": {
         "node": ">=16.13.0",
         "npm": ">=8.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-backpack/node_modules/@skyscanner/bpk-foundations-web": {
+      "version": "17.14.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-17.14.0.tgz",
+      "integrity": "sha512-jE3audhl02WQ3lrSpvaziUCWaCjkgmILADHCVMI3MDYUkHfquaRcqoJKFFyTeyM+sjkrRvRX52J8ipAbqaiKvA==",
+      "dev": true,
+      "dependencies": {
+        "@skyscanner/bpk-foundations-common": "^6.11.0",
+        "color": "^4.2.3"
+      }
+    },
+    "node_modules/eslint-plugin-backpack/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
       }
     },
     "node_modules/eslint-plugin-eslint-comments": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/register": "^7.23.7",
         "@percy/cli": "^1.28.2",
         "@percy/storybook": "^5.0.1",
-        "@skyscanner/bpk-foundations-web": "^18.0.0",
+        "@skyscanner/bpk-foundations-web": "^18.1.0",
         "@skyscanner/bpk-svgs": "^19.3.0",
         "@skyscanner/eslint-config-skyscanner": "^18.0.0",
         "@skyscanner/stylelint-config-skyscanner": "^11.1.0",
@@ -4641,9 +4641,9 @@
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-18.0.0.tgz",
-      "integrity": "sha512-NO24qM6jR3WZqU6f9jQ1cJLwI62uYN6HZ+3DPELk4W2Y1cUQvcyAZtwZ3fPaADL8AluvG+0RuGTsqCuk9C+aJA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-18.1.0.tgz",
+      "integrity": "sha512-h2wYfN8AEBQCZbje1PAueFdz9mlfCFNrZP4piXPPaROY3gOs3R+f6tcLofiHkFE+NexyzkFeBU9Boyo8vLRMXw==",
       "dev": true,
       "dependencies": {
         "@skyscanner/bpk-foundations-common": "^6.12.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@babel/register": "^7.23.7",
     "@percy/cli": "^1.28.2",
     "@percy/storybook": "^5.0.1",
-    "@skyscanner/bpk-foundations-web": "^18.0.0",
+    "@skyscanner/bpk-foundations-web": "^18.1.0",
     "@skyscanner/bpk-svgs": "^19.3.0",
     "@skyscanner/eslint-config-skyscanner": "^18.0.0",
     "@skyscanner/stylelint-config-skyscanner": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@babel/register": "^7.23.7",
     "@percy/cli": "^1.28.2",
     "@percy/storybook": "^5.0.1",
-    "@skyscanner/bpk-foundations-web": "^17.14.0",
+    "@skyscanner/bpk-foundations-web": "^18.0.0",
     "@skyscanner/bpk-svgs": "^19.3.0",
     "@skyscanner/eslint-config-skyscanner": "^18.0.0",
     "@skyscanner/stylelint-config-skyscanner": "^11.1.0",

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -129,6 +129,10 @@
     @include typography.bpk-hero-5;
   }
 
+  &--hero-6 {
+    @include typography.bpk-hero-6;
+  }
+
   &--editorial-1 {
     @include typography.bpk-editorial-1;
   }

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -52,6 +52,7 @@ export const TEXT_STYLES = {
   hero3: 'hero-3',
   hero4: 'hero-4',
   hero5: 'hero-5',
+  hero6: 'hero-6',
   editorial1: 'editorial-1',
   editorial2: 'editorial-2',
   editorial3: 'editorial-3',

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -607,7 +607,7 @@
 @mixin bpk-hero-4 {
   @include _bpk-text-factory(
     $bpk-font-size-xxxxxl,
-    $bpk-line-height-xxxxxl-tight,
+    $bpk-line-height-xxxxxl,
     $bpk-font-weight-black,
     $bpk-letter-spacing-tight
   );

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -591,7 +591,7 @@
 @mixin bpk-hero-3 {
   @include _bpk-text-factory(
     $bpk-font-size-6-xl,
-    $bpk-line-height-6-xl, // TODO: Update this
+    $bpk-line-height-6-xl,
     $bpk-font-weight-black,
     $bpk-letter-spacing-tight
   );
@@ -607,7 +607,7 @@
 @mixin bpk-hero-4 {
   @include _bpk-text-factory(
     $bpk-font-size-xxxxxl,
-    $bpk-line-height-xxxxxl, // TODO: Update this
+    $bpk-line-height-xxxxxl-tight,
     $bpk-font-weight-black,
     $bpk-letter-spacing-tight
   );
@@ -623,7 +623,7 @@
 @mixin bpk-hero-5 {
   @include _bpk-text-factory(
     $bpk-font-size-xxxxl,
-    $bpk-line-height-xxxxl, // TODO: Update this
+    $bpk-line-height-xxxl,
     $bpk-font-weight-black,
     $bpk-letter-spacing-tight
   );

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -560,7 +560,7 @@
   @include _bpk-text-factory(
     $bpk-font-size-8-xl,
     $bpk-line-height-8-xl,
-    $bpk-font-weight-bold,
+    $bpk-font-weight-black,
     $bpk-letter-spacing-tight
   );
 }
@@ -576,7 +576,7 @@
   @include _bpk-text-factory(
     $bpk-font-size-7-xl,
     $bpk-line-height-7-xl,
-    $bpk-font-weight-bold,
+    $bpk-font-weight-black,
     $bpk-letter-spacing-tight
   );
 }
@@ -591,8 +591,8 @@
 @mixin bpk-hero-3 {
   @include _bpk-text-factory(
     $bpk-font-size-6-xl,
-    $bpk-line-height-6-xl,
-    $bpk-font-weight-bold,
+    $bpk-line-height-6-xl, // TODO: Update this
+    $bpk-font-weight-black,
     $bpk-letter-spacing-tight
   );
 }
@@ -607,8 +607,8 @@
 @mixin bpk-hero-4 {
   @include _bpk-text-factory(
     $bpk-font-size-xxxxxl,
-    $bpk-line-height-xxxxxl,
-    $bpk-font-weight-bold,
+    $bpk-line-height-xxxxxl, // TODO: Update this
+    $bpk-font-weight-black,
     $bpk-letter-spacing-tight
   );
 }
@@ -623,8 +623,24 @@
 @mixin bpk-hero-5 {
   @include _bpk-text-factory(
     $bpk-font-size-xxxxl,
-    $bpk-line-height-xxxxl,
-    $bpk-font-weight-bold,
+    $bpk-line-height-xxxxl, // TODO: Update this
+    $bpk-font-weight-black,
+    $bpk-letter-spacing-tight
+  );
+}
+
+/// Hero 6 text style
+///
+/// @example scss
+///   .selector {
+///     @include bpk-hero-6;
+///   }
+
+@mixin bpk-hero-6 {
+  @include _bpk-text-factory(
+    $bpk-font-size-xxxl,
+    $bpk-line-height-xxl,
+    $bpk-font-weight-black,
     $bpk-letter-spacing-tight
   );
 }

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -561,7 +561,7 @@
     $bpk-font-size-8-xl,
     $bpk-line-height-8-xl,
     $bpk-font-weight-black,
-    $bpk-letter-spacing-tight
+    $bpk-letter-spacing-hero
   );
 }
 
@@ -577,7 +577,7 @@
     $bpk-font-size-7-xl,
     $bpk-line-height-7-xl,
     $bpk-font-weight-black,
-    $bpk-letter-spacing-tight
+    $bpk-letter-spacing-hero
   );
 }
 
@@ -593,7 +593,7 @@
     $bpk-font-size-6-xl,
     $bpk-line-height-6-xl,
     $bpk-font-weight-black,
-    $bpk-letter-spacing-tight
+    $bpk-letter-spacing-hero
   );
 }
 
@@ -609,7 +609,7 @@
     $bpk-font-size-xxxxxl,
     $bpk-line-height-xxxxxl,
     $bpk-font-weight-black,
-    $bpk-letter-spacing-tight
+    $bpk-letter-spacing-hero
   );
 }
 
@@ -625,7 +625,7 @@
     $bpk-font-size-xxxxl,
     $bpk-line-height-xxxl,
     $bpk-font-weight-black,
-    $bpk-letter-spacing-tight
+    $bpk-letter-spacing-hero
   );
 }
 
@@ -641,7 +641,7 @@
     $bpk-font-size-xxxl,
     $bpk-line-height-xxl,
     $bpk-font-weight-black,
-    $bpk-letter-spacing-tight
+    $bpk-letter-spacing-hero
   );
 }
 

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -13,7 +13,7 @@
         "@popperjs/core": "^2.11.8",
         "@radix-ui/react-slider": "^1.1.2",
         "@react-google-maps/api": "^2.12.0",
-        "@skyscanner/bpk-foundations-web": "^17.14.0",
+        "@skyscanner/bpk-foundations-web": "^18.0.0",
         "@skyscanner/bpk-svgs": "^19.3.0",
         "a11y-focus-scope": "^1.1.3",
         "a11y-focus-store": "^1.0.0",
@@ -420,19 +420,19 @@
       "integrity": "sha512-x9ibmsP0ZVqzyCo1Pitbw+4b6iEXRw/r1TCy3vOUR3eKrzWLnHYZMR325BkZW2r8fnuWE/V3Fp4QZOP9qYORCw=="
     },
     "node_modules/@skyscanner/bpk-foundations-common": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-6.11.0.tgz",
-      "integrity": "sha512-mhLB1PzuivgCXj+3G7Z4VsBNR8eZpuVAlxCWVsKA/qfFHuRuPEf2Q8GGz3hEwDi81+sTtZNOWJVJgJ6rEAZO3A==",
+      "version": "6.12.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-6.12.0.tgz",
+      "integrity": "sha512-YoNyWk7OuOiGZYowcrUx7AOxnKlGadzimfiSAAiGa08eqrQ1P7c9sxRiKjodvuVhy3xi9WMQWRe8Km64EnMHQQ==",
       "dependencies": {
         "color": "^4.2.3"
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "17.14.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-17.14.0.tgz",
-      "integrity": "sha512-jE3audhl02WQ3lrSpvaziUCWaCjkgmILADHCVMI3MDYUkHfquaRcqoJKFFyTeyM+sjkrRvRX52J8ipAbqaiKvA==",
+      "version": "18.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-18.0.0.tgz",
+      "integrity": "sha512-NO24qM6jR3WZqU6f9jQ1cJLwI62uYN6HZ+3DPELk4W2Y1cUQvcyAZtwZ3fPaADL8AluvG+0RuGTsqCuk9C+aJA==",
       "dependencies": {
-        "@skyscanner/bpk-foundations-common": "^6.11.0",
+        "@skyscanner/bpk-foundations-common": "^6.12.0",
         "color": "^4.2.3"
       }
     },
@@ -477,7 +477,7 @@
     },
     "node_modules/color": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "dependencies": {
         "color-convert": "^2.0.1",
@@ -489,7 +489,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -500,12 +500,12 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-string": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "dependencies": {
         "color-name": "^1.0.0",
@@ -646,7 +646,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/js-tokens": {
@@ -863,7 +863,7 @@
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "dependencies": {
         "is-arrayish": "^0.3.1"

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -13,7 +13,7 @@
         "@popperjs/core": "^2.11.8",
         "@radix-ui/react-slider": "^1.1.2",
         "@react-google-maps/api": "^2.12.0",
-        "@skyscanner/bpk-foundations-web": "^18.0.0",
+        "@skyscanner/bpk-foundations-web": "^18.1.0",
         "@skyscanner/bpk-svgs": "^19.3.0",
         "a11y-focus-scope": "^1.1.3",
         "a11y-focus-store": "^1.0.0",
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "18.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-18.0.0.tgz",
-      "integrity": "sha512-NO24qM6jR3WZqU6f9jQ1cJLwI62uYN6HZ+3DPELk4W2Y1cUQvcyAZtwZ3fPaADL8AluvG+0RuGTsqCuk9C+aJA==",
+      "version": "18.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-18.1.0.tgz",
+      "integrity": "sha512-h2wYfN8AEBQCZbje1PAueFdz9mlfCFNrZP4piXPPaROY3gOs3R+f6tcLofiHkFE+NexyzkFeBU9Boyo8vLRMXw==",
       "dependencies": {
         "@skyscanner/bpk-foundations-common": "^6.12.0",
         "color": "^4.2.3"

--- a/packages/package.json
+++ b/packages/package.json
@@ -26,7 +26,7 @@
     "@popperjs/core": "^2.11.8",
     "@radix-ui/react-slider": "^1.1.2",
     "@react-google-maps/api": "^2.12.0",
-    "@skyscanner/bpk-foundations-web": "^18.0.0",
+    "@skyscanner/bpk-foundations-web": "^18.1.0",
     "@skyscanner/bpk-svgs": "^19.3.0",
     "a11y-focus-scope": "^1.1.3",
     "a11y-focus-store": "^1.0.0",

--- a/packages/package.json
+++ b/packages/package.json
@@ -26,7 +26,7 @@
     "@popperjs/core": "^2.11.8",
     "@radix-ui/react-slider": "^1.1.2",
     "@react-google-maps/api": "^2.12.0",
-    "@skyscanner/bpk-foundations-web": "^17.14.0",
+    "@skyscanner/bpk-foundations-web": "^18.0.0",
     "@skyscanner/bpk-svgs": "^19.3.0",
     "a11y-focus-scope": "^1.1.3",
     "a11y-focus-store": "^1.0.0",


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR includes typography updates to align Backpack with the latest [Typography Spec](https://skyscanner.atlassian.net/wiki/spaces/PD/pages/670800556/Typography+tokens).

- Updates all existing Hero text styles to match correct weight, size and line-height.
- Adds a new Hero 6 typography style.
- Exposes the new Hero 6 style through `BpkText` as `TEXT_STYLES.hero6`
- Upgrades `@skyscanner/bpk-foundations-web` to `^18.0.0`

<img width="540" alt="Screenshot 2024-05-31 at 14 55 43" src="https://github.com/Skyscanner/backpack/assets/95478345/4ff2f35a-4981-4ece-9911-e18949e642be">

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [ ] Tests
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
