### PR TITLE
[NOJIRA][BpkPopover] Fix Popover cannot be closed by changing `isOpen`

### DIFF
--- a/packages/bpk-component-popover/src/BpkPopover-test.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover-test.tsx
@@ -46,6 +46,29 @@ describe('BpkPopover', () => {
     expect(screen.getByText('My popover content')).toBeVisible();
   });
 
+  it('should rerender correctly with "isOpen" provided', () => {
+    const props = {
+      id: 'my-popover',
+      onClose: () => null,
+      label: 'My popover',
+      closeButtonLabel: 'Close',
+      target: <button type="button">My target</button>,
+    };
+    const { rerender } = render(
+      <BpkPopover {...props} isOpen>
+        My popover content
+      </BpkPopover>,
+    );
+
+    rerender(
+      <BpkPopover {...props} isOpen={false}>
+        My popover content
+      </BpkPopover>,
+    );
+
+    expect(screen.queryByRole('My popover content')).not.toBeInTheDocument();
+  });
+
   it('should render without an arrow', () => {
     const target = (<button type="button">My target</button>);
     render(

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -17,7 +17,7 @@
  */
 
 import type { SyntheticEvent, ReactNode, ReactElement } from 'react';
-import { useState, useRef, cloneElement, isValidElement } from 'react';
+import { useState, useEffect, useRef, cloneElement, isValidElement } from 'react';
 
 import {
   useFloating,
@@ -125,6 +125,13 @@ const BpkPopover = ({
   ...rest
 }: Props) => {
   const [isOpenState, setIsOpenState] = useState(isOpen);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsOpenState(false)
+    }
+  }, [isOpen]);
+
   const arrowRef = useRef(null);
 
   const { context, floatingStyles, refs } = useFloating({


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

After merging the [PR](https://github.com/Skyscanner/backpack/pull/3390), we cannot close `BpkPopover` when changing `isOpen` to false, in the previous implementation, it handles in [componentDidUpdate](https://github.com/Skyscanner/backpack/blob/main/packages/bpk-react-utils/src/Portal.tsx#L116) in the Portal component

It was caused a bug in the BpkDatepicker, the calendar cannot be closed after selecting a date even it called [onClose](https://github.com/Skyscanner/backpack/blob/main/packages/bpk-component-datepicker/src/BpkDatepicker.tsx#L169) to set `isOpen` to `false`
 
Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
