### PR TITLE
[NO-JIRA]: Correct logic for when to skip Percy

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -39,6 +39,8 @@ jobs:
         run: echo "requires_visual_tests=${{ steps.changed-files.outputs.examples_any_changed == 'true' || steps.changed-files.outputs.components_any_changed == 'true'}}" >> "$GITHUB_OUTPUT"
 
       - name: Report percy/backpack to pass
+        # Only run on pull_requests and when specific changes to files have occurred.
+        if: ${{ github.event_name == 'pull_request' && steps.changed-files.outputs.examples_any_changed != 'true' || steps.changed-files.outputs.components_any_changed != 'true' }}
         run: |
           curl --request POST \
           --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Previously without the checking logic when PRs were merged to main it would attempt to skip Percy tests but fail because there is no `pr_sha` to be able to update the reference for.

However we always want to run visual tests on main and not skip them at all, so we need to add the logic for only running on PRs and when no visual affecting files have been changed.