### PR TITLE
Revert #3467 - Percy file checks

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -13,47 +13,6 @@ env:
   BUILD_LOGS: log-artifacts-build
 
 jobs:
-  CheckVisualTests:
-    runs-on: ubuntu-latest
-    outputs:
-      requires-visual: ${{ steps['visual_tests_check'].outputs['requires_visual_tests'] }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v44
-        with:
-          files_yaml: |
-            examples:
-              - examples/**
-            components:
-              - packages/**
-              - '!packages/**/*-test.js'
-              - '!packages/**/*-test.tsx'
-              - '!packages/**/*.md'
-              - '!packages/*.md'
-
-      - name: Changed files output
-        id: visual_tests_check
-        run: echo "requires_visual_tests=${{ steps.changed-files.outputs.examples_any_changed == 'true' || steps.changed-files.outputs.components_any_changed == 'true'}}" >> "$GITHUB_OUTPUT"
-
-      - name: Report percy/backpack to pass
-        # Only run on pull_requests and when specific changes to files have occurred.
-        if: ${{ github.event_name == 'pull_request' && steps.changed-files.outputs.examples_any_changed != 'true' || steps.changed-files.outputs.components_any_changed != 'true' }}
-        run: |
-          curl --request POST \
-          --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --header 'content-type: application/json' \
-          --data '{
-            "state": "success",
-            "description": "No files requiring visual tests detected. Automatically passing Percy.",
-            "context": "percy/backpack",
-            "target_url": "${{ github.event.workflow_run.html_url }}"
-            }' \
-          --fail
-
   Build:
     runs-on: ubuntu-latest
     permissions:
@@ -144,9 +103,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   PercyTests:
-    if: (needs.CheckVisualTests.outputs.requires-visual == 'true')
     runs-on: ubuntu-latest
-    needs: [Danger, CheckVisualTests]
+    needs: [Danger]
     permissions:
       statuses: write
       pull-requests: write


### PR DESCRIPTION
Reverts #3467 as the logic is a bit complicated and dodgy so might need to rethink or scrap the idea completely. Reverting now as its blocking releases and main CI

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
