### PR TITLE
[NO JIRA][BpkPopover]: Update popover to attach to body outside of target elements

### DIFF
--- a/packages/bpk-component-popover/src/BpkPopover-test.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover-test.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import BpkPopover from './BpkPopover';
@@ -201,7 +201,7 @@ describe('BpkPopover', () => {
       event.afterStopPropagation = true;
     });
 
-    const { getByRole } = render(
+    render(
       <BpkPopover
         id="my-popover"
         onClose={jest.fn()}
@@ -210,13 +210,12 @@ describe('BpkPopover', () => {
         labelAsTitle
         closeButtonIcon
         target={<button onClick={handleClick} type="button">My target</button>}
-        isOpen
       >
         My popover content
       </BpkPopover>,
     );
 
-    const button = getByRole('button', { name: 'My target' });
+    const button = screen.getByRole('button', { name: 'My target' });
 
     const event = new MouseEvent('click', { bubbles: true });
     jest.spyOn(event, 'stopPropagation');
@@ -226,6 +225,7 @@ describe('BpkPopover', () => {
       expect(handleClick).toHaveBeenCalled();
       expect(event.stopPropagation).toHaveBeenCalled();
       expect(handleClick.mock.calls[0][0].afterStopPropagation).toBe(true);
+      expect(screen.getByText('My popover content')).toBeVisible();
     });
   });
 

--- a/packages/bpk-component-popover/src/BpkPopover-test.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover-test.tsx
@@ -91,12 +91,14 @@ describe('BpkPopover', () => {
   });
 
   it('should render correctly with "closeButtonProps" provided', () => {
-    const {container} = render(
+    render(
       <BpkPopover
         id="my-popover"
         onClose={() => null}
         label="My popover"
+        labelAsTitle
         closeButtonLabel="Close"
+        closeButtonIcon
         target={<button type="button">My target</button>}
         closeButtonProps={{ tabIndex: 0 }}
         isOpen
@@ -105,7 +107,7 @@ describe('BpkPopover', () => {
       </BpkPopover>,
     );
 
-    expect(container.querySelector('[tabindex="0"]')).toBeVisible();
+    expect(screen.getByRole('button', { name: /Close/i, })).toHaveAttribute('tabindex');
   });
 
   it('should render correctly with "padded" attribute equal to false', () => {

--- a/packages/bpk-component-popover/src/BpkPopover-test.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover-test.tsx
@@ -142,7 +142,7 @@ describe('BpkPopover', () => {
       </BpkPopover>,
     );
 
-    const heading = container.querySelector('.bpk-popover__header');
+    const heading = container.getElementsByClassName('.bpk-popover__header');
     expect(heading).toBeTruthy();
   });
 
@@ -162,7 +162,7 @@ describe('BpkPopover', () => {
       </BpkPopover>,
     );
 
-    const actionButton = container.querySelector('.bpk-popover__action');
+    const actionButton = container.getElementsByClassName('.bpk-popover__action');
     expect(actionButton).toBeTruthy();
     expect(screen.getByText('Action')).toBeVisible();
   });

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -17,7 +17,13 @@
  */
 
 import type { SyntheticEvent, ReactNode, ReactElement } from 'react';
-import { useState, useEffect, useRef, cloneElement, isValidElement } from 'react';
+import {
+  useState,
+  useEffect,
+  useRef,
+  cloneElement,
+  isValidElement,
+} from 'react';
 
 import {
   useFloating,
@@ -27,11 +33,11 @@ import {
   useDismiss,
   useInteractions,
   FloatingFocusManager,
+  FloatingPortal,
   arrow,
   FloatingArrow,
   shift,
 } from '@floating-ui/react';
-
 
 import { surfaceHighlightDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
@@ -70,16 +76,16 @@ const bindEventSource = (
   callback(event, { source });
 };
 
-type CloseButtonProps = (
-  {
- /**
-  * @deprecated close button text is deprecated. Instead, please use `closeButtonIcon`, or you may opt not to render a close button at all.
-  */
-    closeButtonText: string;
-  } | {
-    closeButtonText?: never;
-  }
-);
+type CloseButtonProps =
+  | {
+      /**
+       * @deprecated close button text is deprecated. Instead, please use `closeButtonIcon`, or you may opt not to render a close button at all.
+       */
+      closeButtonText: string;
+    }
+  | {
+      closeButtonText?: never;
+    };
 
 export type Props = CloseButtonProps & {
   children: ReactNode;
@@ -127,7 +133,7 @@ const BpkPopover = ({
 
   useEffect(() => {
     if (!isOpen) {
-      setIsOpenState(false)
+      setIsOpenState(false);
     }
   }, [isOpen]);
 
@@ -187,117 +193,123 @@ const BpkPopover = ({
     <>
       {targetElement}
       {isOpenState && (
-        <FloatingFocusManager context={context} modal={false}>
-          <div
-            className={getClassName('bpk-popover--container')}
-            ref={refs.setFloating}
-            style={floatingStyles}
-            {...getFloatingProps()}
-          >
-            <TransitionInitialMount
-              appearClassName={getClassName('bpk-popover--appear')}
-              appearActiveClassName={getClassName('bpk-popover--appear-active')}
-              transitionTimeout={200}
+        <FloatingPortal>
+          <FloatingFocusManager context={context} modal={false}>
+            <div
+              className={getClassName('bpk-popover--container')}
+              ref={refs.setFloating}
+              style={floatingStyles}
+              {...getFloatingProps()}
             >
-              <section
-                id={id}
-                tabIndex={-1}
-                role="dialog"
-                aria-labelledby={labelId}
-                className={classNames}
-                {...rest}
-              >
-                {showArrow && (
-                  <FloatingArrow
-                    ref={arrowRef}
-                    context={context}
-                    id={ARROW_ID}
-                    className={getClassName('bpk-popover__arrow')}
-                    role="presentation"
-                    stroke={surfaceHighlightDay}
-                    strokeWidth={strokeWidth}
-                  />
+              <TransitionInitialMount
+                appearClassName={getClassName('bpk-popover--appear')}
+                appearActiveClassName={getClassName(
+                  'bpk-popover--appear-active',
                 )}
-                {labelAsTitle ? (
-                  <header className={getClassName('bpk-popover__header')}>
-                    <BpkText
-                      tagName="h2"
-                      id={labelId}
-                      textStyle={TEXT_STYLES.label1}
-                    >
-                      {label}
-                    </BpkText>
-                    &nbsp;
-                    {closeButtonIcon ? (
-                      <BpkCloseButton
-                        label={closeButtonText || closeButtonLabel}
-                        onClick={(event: SyntheticEvent<HTMLButtonElement>) => {
-                          bindEventSource(
-                            EVENT_SOURCES.CLOSE_BUTTON,
-                            onClose,
-                            event,
-                          );
-                          setIsOpenState(false);
-                        }}
-                        {...closeButtonProps}
-                      />
-                    ) : (
-                      closeButtonText && (
-                        <BpkButtonLink
-                          onClick={(event: SyntheticEvent<HTMLButtonElement>) => {
+                transitionTimeout={200}
+              >
+                <section
+                  id={id}
+                  tabIndex={-1}
+                  role="dialog"
+                  aria-labelledby={labelId}
+                  className={classNames}
+                  {...rest}
+                >
+                  {showArrow && (
+                    <FloatingArrow
+                      ref={arrowRef}
+                      context={context}
+                      id={ARROW_ID}
+                      className={getClassName('bpk-popover__arrow')}
+                      role="presentation"
+                      stroke={surfaceHighlightDay}
+                      strokeWidth={strokeWidth}
+                    />
+                  )}
+                  {labelAsTitle ? (
+                    <header className={getClassName('bpk-popover__header')}>
+                      <BpkText
+                        tagName="h2"
+                        id={labelId}
+                        textStyle={TEXT_STYLES.label1}
+                      >
+                        {label}
+                      </BpkText>
+                      &nbsp;
+                      {closeButtonIcon ? (
+                        <BpkCloseButton
+                          label={closeButtonText || closeButtonLabel}
+                          onClick={(
+                            event: SyntheticEvent<HTMLButtonElement>,
+                          ) => {
                             bindEventSource(
-                              EVENT_SOURCES.CLOSE_LINK,
+                              EVENT_SOURCES.CLOSE_BUTTON,
                               onClose,
                               event,
                             );
                             setIsOpenState(false);
                           }}
                           {...closeButtonProps}
-                        >
-                          {closeButtonText}
-                        </BpkButtonLink>
-                      )
-                    )}
-                  </header>
-                ) : (
-                  <span
-                    id={labelId}
-                    className={getClassName('bpk-popover__label')}
-                  >
-                    {label}
-                  </span>
-                )}
-                <div className={bodyClassNames}>{children}</div>
-                {actionText && onAction && (
-                  <div className={getClassName('bpk-popover__action')}>
-                    <BpkButtonLink
-                      onClick={onAction}
+                        />
+                      ) : (
+                        closeButtonText && (
+                          <BpkButtonLink
+                            onClick={(
+                              event: SyntheticEvent<HTMLButtonElement>,
+                            ) => {
+                              bindEventSource(
+                                EVENT_SOURCES.CLOSE_LINK,
+                                onClose,
+                                event,
+                              );
+                              setIsOpenState(false);
+                            }}
+                            {...closeButtonProps}
+                          >
+                            {closeButtonText}
+                          </BpkButtonLink>
+                        )
+                      )}
+                    </header>
+                  ) : (
+                    <span
+                      id={labelId}
+                      className={getClassName('bpk-popover__label')}
                     >
-                      {actionText}
-                    </BpkButtonLink>
-                </div>
-                )}
-                {!labelAsTitle && closeButtonText && (
-                  <footer className={getClassName('bpk-popover__footer')}>
-                    <BpkButtonLink
-                      onClick={(event: SyntheticEvent<HTMLButtonElement>) => {
-                        bindEventSource(
-                          EVENT_SOURCES.CLOSE_LINK,
-                          onClose,
-                          event,
-                        );
-                        setIsOpenState(false);
-                      }}
-                      {...closeButtonProps}
-                    >
-                      {closeButtonText}
-                    </BpkButtonLink>
-                  </footer>
-                )}
-              </section>
-            </TransitionInitialMount>
-          </div>
-        </FloatingFocusManager>
+                      {label}
+                    </span>
+                  )}
+                  <div className={bodyClassNames}>{children}</div>
+                  {actionText && onAction && (
+                    <div className={getClassName('bpk-popover__action')}>
+                      <BpkButtonLink onClick={onAction}>
+                        {actionText}
+                      </BpkButtonLink>
+                    </div>
+                  )}
+                  {!labelAsTitle && closeButtonText && (
+                    <footer className={getClassName('bpk-popover__footer')}>
+                      <BpkButtonLink
+                        onClick={(event: SyntheticEvent<HTMLButtonElement>) => {
+                          bindEventSource(
+                            EVENT_SOURCES.CLOSE_LINK,
+                            onClose,
+                            event,
+                          );
+                          setIsOpenState(false);
+                        }}
+                        {...closeButtonProps}
+                      >
+                        {closeButtonText}
+                      </BpkButtonLink>
+                    </footer>
+                  )}
+                </section>
+              </TransitionInitialMount>
+            </div>
+          </FloatingFocusManager>
+        </FloatingPortal>
       )}
     </>
   );

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -194,7 +194,7 @@ const BpkPopover = ({
       {targetElement}
       {isOpenState && (
         <FloatingPortal>
-          <FloatingFocusManager context={context} modal={false}>
+          <FloatingFocusManager context={context}>
             <div
               className={getClassName('bpk-popover--container')}
               ref={refs.setFloating}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Wraps the popover in `FloatingPortal` this is part of the floating ui library that allows you to determine when in the DOM you render the popover to be displayed.

Previously the popover would have been attached to the node directly adjacent to the target that triggers it, this creates an issue whereby when rendered in a small window space would cause the popover to render inside/behind content even with a `z-index` applied.

![Screenshot 2024-06-14 at 15 22 58](https://github.com/Skyscanner/backpack/assets/8831547/b5b57d49-bb66-4c99-be39-cd3edb770ed8)


With adding this new portal to the popover it will now attach the popover to the main `body` in HTML so means it will always display over content regardless of where its contained, fixing the above issue

![Screenshot 2024-06-14 at 15 23 59](https://github.com/Skyscanner/backpack/assets/8831547/b50683c2-915e-466c-b034-b745d760777e)


Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
