### PR TITLE
[COR-177][JourneyArrow] Add new JourneyArrow component with stop count

### DIFF
--- a/examples/bpk-component-journey-arrow/example.tsx
+++ b/examples/bpk-component-journey-arrow/example.tsx
@@ -1,0 +1,41 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2022 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import JourneyArrow from '../../packages/bpk-component-journey-arrow';
+import BpkText from '../../packages/bpk-component-text';
+
+import type { Props } from '../../packages/bpk-component-journey-arrow/src/BpkJourneyArrow';
+import type { Meta } from '@storybook/react';
+
+const JourneyArrowExample = ({stops}: Props) => {
+  const widths = ["25%", "50%", "100%"]
+  return (<>
+      {widths.map((width) =>
+        <div style={{display: "flex", alignItems: 'center', width}}>
+        <BpkText>Origin</BpkText>
+        <JourneyArrow stops={stops} />
+        <BpkText>Destination</BpkText>
+      </div>
+    )}
+    </>
+  )
+};
+
+
+export default JourneyArrowExample;

--- a/examples/bpk-component-journey-arrow/stories.tsx
+++ b/examples/bpk-component-journey-arrow/stories.tsx
@@ -1,0 +1,46 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2022 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BpkComponentJourneyArrow from '../../packages/bpk-component-journey-arrow';
+
+import JourneyArrowExample from './example'
+
+import type { BpkJourneyArrowProps } from '../../packages/bpk-component-journey-arrow';
+import type { Meta } from '@storybook/react';
+
+const defaultProps = { stops: 1 };
+
+export default {
+  title: 'bpk-component-journey-arrow',
+  component: BpkComponentJourneyArrow,
+};
+
+export const VisualTest = {
+  title: 'Journey Arrow',
+  component: BpkComponentJourneyArrow,
+  render: (args: BpkJourneyArrowProps) => <JourneyArrowExample {...args} />,
+  args: { ...defaultProps }
+};
+
+
+export const VisualTestWithZoom = {
+  title: 'bpk-component-journey-arrow-zoom',
+  component: BpkComponentJourneyArrow,
+  render: (args: BpkJourneyArrowProps) => <JourneyArrowExample {...args} />,
+  args: { zoomEnabled: true, ...defaultProps }
+};

--- a/packages/bpk-component-journey-arrow/README.md
+++ b/packages/bpk-component-journey-arrow/README.md
@@ -1,0 +1,23 @@
+# bpk-component-journey-arrow
+
+> Backpack journey arrow component.
+
+## Installation
+
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
+
+## Usage
+
+### Default
+```ts
+import BpkJourneyArrow from '@skyscanner/backpack-web/bpk-component-journey-arrow';
+
+export default () => <BpkJourneyArrow />;
+```
+
+### With stops count
+```ts
+import BpkJourneyArrow from '@skyscanner/backpack-web/bpk-component-journey-arrow';
+
+export default () => <BpkJourneyArrow stops={3} />;
+```

--- a/packages/bpk-component-journey-arrow/index.ts
+++ b/packages/bpk-component-journey-arrow/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BpkJourneyArrow, {
+  type Props as BpkJourneyArrowProps,
+} from './src/BpkJourneyArrow';
+
+export type { BpkJourneyArrowProps };
+export default BpkJourneyArrow;

--- a/packages/bpk-component-journey-arrow/src/BpkJourneyArrow-test.tsx
+++ b/packages/bpk-component-journey-arrow/src/BpkJourneyArrow-test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+
+import BpkJourneyArrow from './BpkJourneyArrow';
+
+describe('BpkJourneyArrow', () => {
+  it('should render correctly', () => {
+    const { asFragment } = render(<BpkJourneyArrow />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render with stops', () => {
+    const { asFragment } = render(<BpkJourneyArrow stops={3} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should not support custom class names', () => {
+    const { container } = render(
+      <BpkJourneyArrow className="custom-classname" />,
+    );
+    expect(container.className).not.toContain('custom-classname');
+  });
+
+  it('should support arbitrary props', () => {
+    const { getAllByTestId } = render(
+      <BpkJourneyArrow data-testid="123" />,
+    );
+    expect(getAllByTestId('123').length).toBe(1);
+  });
+});

--- a/packages/bpk-component-journey-arrow/src/BpkJourneyArrow.module.scss
+++ b/packages/bpk-component-journey-arrow/src/BpkJourneyArrow.module.scss
@@ -1,0 +1,44 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../../packages/unstable__bpk-mixins/tokens';
+@use '../../../packages/unstable__bpk-mixins/icons';
+
+.bpk-journey-arrow {
+  display: flex;
+  width: 100%;
+  min-width: tokens.bpk-spacing-xxl();
+  height: tokens.bpk-spacing-md();
+  margin: 0 tokens.bpk-spacing-md();
+  justify-content: center;
+  border-width: 0 5 * tokens.$bpk-one-pixel-rem 0 2 * tokens.$bpk-one-pixel-rem;
+  border-style: solid;
+  border-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="8" fill="none" viewBox="0 0 16 8"><path fill="%23C1C7CF" d="M15.69 4.35a.5.5 0 0 0 0-.7L12.51.46a.5.5 0 1 0-.7.71L14.62 4 11.8 6.83a.5.5 0 0 0 .7.7l3.2-3.17m-.7.14v-1H.5a.5.5 0 0 0 0 1Z"/></svg>')
+    0 5 0 2 fill / 1 / 0 stretch;
+
+  @include icons.bpk-icon--rtl-support;
+
+  &__stop {
+    width: tokens.bpk-spacing-md();
+    height: tokens.bpk-spacing-md();
+    border: 2 * tokens.$bpk-one-pixel-rem solid
+      tokens.$bpk-background-light-color;
+    border-radius: tokens.bpk-spacing-sm();
+    background-color: tokens.$bpk-color-system-red;
+  }
+}

--- a/packages/bpk-component-journey-arrow/src/BpkJourneyArrow.tsx
+++ b/packages/bpk-component-journey-arrow/src/BpkJourneyArrow.tsx
@@ -1,0 +1,49 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cssModules } from '../../bpk-react-utils';
+
+import STYLES from './BpkJourneyArrow.module.scss';
+
+const getClassName = cssModules(STYLES);
+
+export type Props = {
+  stopClassName?: string,
+  /** the number of dot stops to display */
+  stops?: number,
+  [rest: string]: any; // Inexact rest. See decisions/inexact-rest.md
+
+};
+const BpkJourneyArrow = ({
+   stopClassName,
+   stops = 0,
+    ...rest
+}: Props) => {
+
+  const dotCount = Math.min(3, Math.max(0, stops));
+  return (
+      <div className={getClassName("bpk-journey-arrow")} {...rest} >
+        {Array.from({ length: dotCount }).map((_, i) => (
+          <div key={i} className={getClassName("bpk-journey-arrow__stop", stopClassName)} /> // eslint-disable-line react/no-array-index-key
+        ))
+        }
+    </div>
+  )
+};
+
+export default BpkJourneyArrow;

--- a/packages/bpk-component-journey-arrow/src/__snapshots__/BpkJourneyArrow-test.tsx.snap
+++ b/packages/bpk-component-journey-arrow/src/__snapshots__/BpkJourneyArrow-test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BpkJourneyArrow should render correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-journey-arrow"
+  />
+</DocumentFragment>
+`;
+
+exports[`BpkJourneyArrow should render with stops 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-journey-arrow"
+  >
+    <div
+      class="bpk-journey-arrow__stop"
+    />
+    <div
+      class="bpk-journey-arrow__stop"
+    />
+    <div
+      class="bpk-journey-arrow__stop"
+    />
+  </div>
+</DocumentFragment>
+`;

--- a/packages/bpk-component-journey-arrow/src/accessibility-test.tsx
+++ b/packages/bpk-component-journey-arrow/src/accessibility-test.tsx
@@ -1,0 +1,30 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import BpkJourneyArrow from './BpkJourneyArrow';
+
+describe('BpkJourneyArrow accessibility tests', () => {
+  it('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(<BpkJourneyArrow />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
Adding this expandable arrow component that can additionally display the number of stops as dots.
![Screenshot 2024-06-20 at 12 55 54](https://github.com/Skyscanner/backpack/assets/19343124/7d92cfc4-b95c-4211-a1e3-ca5a09c16cbe)


- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here