### PR TITLE
[NOJIRA][BpkDialog] Added a 'default open' test and duplicate Visual Test for bpk-component-dialog

### DIFF
--- a/examples/bpk-component-dialog/examples.js
+++ b/examples/bpk-component-dialog/examples.js
@@ -46,6 +46,7 @@ type Props = {
   children: Node,
   dismissible: boolean,
   headerIcon: ?Node,
+  startOpen: ?boolean,
 };
 
 type State = {
@@ -63,11 +64,11 @@ class DialogContainer extends Component<Props, State> {
     headerIcon: null,
   };
 
-  constructor() {
+  constructor(props: Props) {
     super();
 
     this.state = {
-      isOpen: false,
+      isOpen: props.startOpen || false,
     };
   }
 
@@ -112,6 +113,14 @@ class DialogContainer extends Component<Props, State> {
 
 const DefaultExample = () => (
   <DialogContainer>
+    <Paragraph>
+      This is a default dialog. You can put anything you want in here.
+    </Paragraph>
+  </DialogContainer>
+);
+
+const StartOpenExample = () => (
+  <DialogContainer startOpen>
     <Paragraph>
       This is a default dialog. You can put anything you want in here.
     </Paragraph>
@@ -179,6 +188,7 @@ const WithFlareExample = () => (
 
 export {
   DefaultExample,
+  StartOpenExample,
   WithIconExample,
   NotDismissibleExample,
   WithFlareExample,

--- a/examples/bpk-component-dialog/stories.js
+++ b/examples/bpk-component-dialog/stories.js
@@ -21,6 +21,7 @@ import BpkDialog from '../../packages/bpk-component-dialog/src/BpkDialog';
 
 import {
   DefaultExample,
+  StartOpenExample,
   WithIconExample,
   NotDismissibleExample,
   WithFlareExample,
@@ -32,8 +33,11 @@ export default {
 };
 
 export const Default = DefaultExample;
+export const DefaultStartOpen = StartOpenExample;
 export const WithAnIcon = WithIconExample;
 
 export const NotDismissible = NotDismissibleExample;
 
 export const WithFlare = WithFlareExample;
+
+export const VisualTest = StartOpenExample;


### PR DESCRIPTION
BpkDialog: Added a 'DefaultStartOpen' test and a duplicate named 'VisualTest' for percy to pick up

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here