### PR TITLE
[ACC-568][BpkSaveButton] Accessibility improvements

### DIFF
--- a/examples/bpk-component-card-button/examples.tsx
+++ b/examples/bpk-component-card-button/examples.tsx
@@ -60,7 +60,7 @@ const SaveButtonContainer = ({
   return (
     <BpkSaveButton
       checked={checkedStatus}
-      accessibilityLabel={`Click to ${checkedStatus ? 'remove save' : 'save'}`}
+      accessibilityLabel="Save cosy Amsterdam hostel"
       onCheckedChange={asyncWithError ? onSyncCheckedChange : onCheckedChange}
       size={size}
       style={style}

--- a/examples/bpk-component-card-button/examples.tsx
+++ b/examples/bpk-component-card-button/examples.tsx
@@ -60,7 +60,7 @@ const SaveButtonContainer = ({
   return (
     <BpkSaveButton
       checked={checkedStatus}
-      accessibilityLabel="Save cosy Amsterdam hostel"
+      accessibilityLabel="Save Amsterdam hostel"
       onCheckedChange={asyncWithError ? onSyncCheckedChange : onCheckedChange}
       size={size}
       style={style}

--- a/packages/bpk-component-card-button/README.md
+++ b/packages/bpk-component-card-button/README.md
@@ -20,7 +20,7 @@ import {
 export default () =>
   <BpkSaveButton
     checked={false}
-    accessibilityLabel="Save flight option 1"
+    accessibilityLabel="Save cosy Amsterdam hotel"
     onCheckedChange={() => {
       console.log('save status changed!');
     }}
@@ -36,7 +36,15 @@ on the page. we need to ensure there is enough context to understand what the bu
 Therefore, the accessibility label of the button should be short and unique.
 Usually it will take the form of `{verb} {unique name}`.
 
-**Example:** `Save flight option 1`
+When the related item has a unique title, you can use this as a unique name.
+
+**Example:** `Save cosy Amsterdam hostel`
+
+If the title of your related item is not
+unique, you can fall back to a more generic 'option' identifier,
+as long as this identifier is part of the item title as well.
+
+**Example:** `Save option 1`
 
 > [!TIP]
 > Avoid adding punctuation to the label, this causes the screen reader to pause unnecessarily.

--- a/packages/bpk-component-card-button/README.md
+++ b/packages/bpk-component-card-button/README.md
@@ -20,7 +20,7 @@ import {
 export default () =>
   <BpkSaveButton
     checked={false}
-    accessibilityLabel="Save cosy Amsterdam hotel"
+    accessibilityLabel="Save Amsterdam hotel"
     onCheckedChange={() => {
       console.log('save status changed!');
     }}
@@ -38,7 +38,7 @@ Usually it will take the form of `{verb} {unique name}`.
 
 When the related item has a unique title, you can use this as a unique name.
 
-**Example:** `Save cosy Amsterdam hostel`
+**Example:** `Save Amsterdam hostel`
 
 If the title of your related item is not
 unique, you can fall back to a more generic 'option' identifier,

--- a/packages/bpk-component-card-button/README.md
+++ b/packages/bpk-component-card-button/README.md
@@ -20,7 +20,7 @@ import {
 export default () =>
   <BpkSaveButton
     checked={false}
-    accessibilityLabel="Click to save"
+    accessibilityLabel="Save flight option 1"
     onCheckedChange={() => {
       console.log('save status changed!');
     }}
@@ -28,6 +28,23 @@ export default () =>
     style={STYLE_TYPES.contained}
   />;
 ```
+
+#### Accessibility
+When someone with a screen reader navigates the page by buttons, they will see a list of all the button names available
+on the page. we need to ensure there is enough context to understand what the button will do without being overly wordy.
+
+Therefore, the accessibility label of the button should be short and unique.
+Usually it will take the form of `{verb} {unique name}`.
+
+**Example:** `Save flight option 1`
+
+> [!TIP]
+> Avoid adding punctuation to the label, this causes the screen reader to pause unnecessarily.
+
+> [!CAUTION]
+> Do not adjust the accesibility label based on the state of the button. This can be disruptive or
+> cause confusion for people using a screen reader.
+> The button will anounced 'selected' or 'toggle button' based on the state on its own.
 
 ## Props
 

--- a/packages/bpk-component-card-button/README.md
+++ b/packages/bpk-component-card-button/README.md
@@ -42,9 +42,9 @@ Usually it will take the form of `{verb} {unique name}`.
 > Avoid adding punctuation to the label, this causes the screen reader to pause unnecessarily.
 
 > [!CAUTION]
-> Do not adjust the accesibility label based on the state of the button. This can be disruptive or
+> Do not adjust the accessibility label based on the state of the button. This can be disruptive or
 > cause confusion for people using a screen reader.
-> The button will anounced 'selected' or 'toggle button' based on the state on its own.
+> The button will announce 'selected' or 'toggle button' based on the state on its own.
 
 ## Props
 

--- a/packages/bpk-component-card-button/README.md
+++ b/packages/bpk-component-card-button/README.md
@@ -20,7 +20,7 @@ import {
 export default () =>
   <BpkSaveButton
     checked={false}
-    accessibilityLabel="Save Amsterdam hotel"
+    accessibilityLabel="Save Amsterdam hostel"
     onCheckedChange={() => {
       console.log('save status changed!');
     }}

--- a/packages/bpk-component-card-button/src/BpkSaveButton.tsx
+++ b/packages/bpk-component-card-button/src/BpkSaveButton.tsx
@@ -79,6 +79,7 @@ const BpkSaveButton = ({
     <button
       type="button"
       aria-label={accessibilityLabel}
+      aria-pressed={checked}
       className={getClassName(
         'bpk-save-button',
         smallSize && 'bpk-save-button__small',

--- a/packages/bpk-component-card-button/src/__snapshots__/BpkSaveButton-test.tsx.snap
+++ b/packages/bpk-component-card-button/src/__snapshots__/BpkSaveButton-test.tsx.snap
@@ -4,6 +4,7 @@ exports[`BpkSaveButton should render correctly 1`] = `
 <DocumentFragment>
   <button
     aria-label="Click to save"
+    aria-pressed="false"
     class="bpk-save-button bpk-save-button__default"
     type="button"
   >
@@ -48,6 +49,7 @@ exports[`BpkSaveButton should render correctly with "checked" is true 1`] = `
 <DocumentFragment>
   <button
     aria-label="Click to remove save"
+    aria-pressed="true"
     class="bpk-save-button bpk-save-button__default"
     type="button"
   >
@@ -92,6 +94,7 @@ exports[`BpkSaveButton should render correctly with a "size" prop 1`] = `
 <DocumentFragment>
   <button
     aria-label="Click to save"
+    aria-pressed="false"
     class="bpk-save-button bpk-save-button__small bpk-save-button__default"
     type="button"
   >
@@ -136,6 +139,7 @@ exports[`BpkSaveButton should render correctly with a "style" prop 1`] = `
 <DocumentFragment>
   <button
     aria-label="Click to save"
+    aria-pressed="false"
     class="bpk-save-button bpk-save-button__contained"
     type="button"
   >


### PR DESCRIPTION
# BpkSaveButton

The save button behaves like a toggle button, so we should add aria-pressed to clarify this. As a benefit, we don't have to change the aria-label based on the state of the button.

Aria-label changes are poorly communicated and can confuse people using screen readers. 

- Add 'aria-pressed' to the button
- Update documentation
- Update storybook

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here