### PR TITLE
[Luna 1331] Bpk Checkbox Aria Label prop

### DIFF
--- a/packages/bpk-component-checkbox/src/BpkCheckbox.js
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.js
@@ -37,6 +37,7 @@ type Props = {
   smallLabel: boolean,
   valid: ?boolean,
   checked: boolean,
+  ariaLabel: ?string,
   /**
    * The indeterminate prop is only a visual clue, it does not affect the checked state of the checkbox. If `indeterminate` is flagged then the checkbox will be displayed with a minus sign in the box.  This is used when there is a checkbox group and the parent displays this state when not all child checkboxes are selected.
    */
@@ -45,6 +46,7 @@ type Props = {
 
 const BpkCheckbox = (props: Props) => {
   const {
+    ariaLabel,
     checked,
     className,
     disabled,
@@ -80,6 +82,13 @@ const BpkCheckbox = (props: Props) => {
     indeterminate && 'bpk-checkbox__input-indeterminate',
   );
 
+  const ariaLabelToUse = () => {
+    if (ariaLabel) {
+      return ariaLabel;
+    }
+    return label;
+  }
+
   return (
     <label className={classNames}>
       {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'. */}
@@ -88,7 +97,7 @@ const BpkCheckbox = (props: Props) => {
         className={inputClasses}
         name={name}
         disabled={disabled}
-        aria-label={label}
+        aria-label={ariaLabelToUse()}
         aria-invalid={isInvalid}
         data-indeterminate={indeterminate}
         ref={(e) => {
@@ -113,6 +122,7 @@ const BpkCheckbox = (props: Props) => {
 BpkCheckbox.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
+  ariaLabel: PropTypes.string,
   required: PropTypes.bool,
   disabled: PropTypes.bool,
   white: PropTypes.bool,

--- a/packages/bpk-component-checkbox/src/accessibility-test.js
+++ b/packages/bpk-component-checkbox/src/accessibility-test.js
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-/* @flow strict */
-
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import BpkCheckbox from './BpkCheckbox';
@@ -30,5 +28,17 @@ describe('BpkCheckbox accessibility tests', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('should render using label as aria-label if no ariaLabel prop provided', async () => {
+    render(<BpkCheckbox name="checkbox" label="Prefer directs" />);
+    const checkbox = screen.getByLabelText('Prefer directs');
+    expect(checkbox).toBeInTheDocument();
+  });
+
+  it('should render using ariaLabel prop as aria-label if prop provided', async () => {
+    render(<BpkCheckbox name="checkbox" label="Prefer directs" ariaLabel="aria label test string"/>);
+    const checkbox = screen.getByLabelText('aria label test string');
+    expect(checkbox).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Description

We wanted to add an `aria-label` to the Bpk-Cehckbox used for nearby airports to differentiate .
In doing so I discovered that currently backpack defaults to the checkbox label being the aria-label. 

This PR introduced an optional `ariaLabel` prop which can overwrite the `label` as an `aria-label` if it is passed.

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here