### PR TITLE
[NO JIRA][BpkPopover]: Check for onClick property in the target

### DIFF
--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -160,17 +160,15 @@ const BpkPopover = ({
     dismiss,
   ]);
 
-  const targetClick = target.props.onClick;
-  const referenceProps = getReferenceProps(
-    {
-      onClick: (event) => {
-        if (targetClick) {
-          event.stopPropagation();
-          targetClick(event);
-        }
-      },
+  const targetClick = target?.props?.onClick;
+  const referenceProps = targetClick ? getReferenceProps({
+    onClick: event => {
+      if (targetClick) {
+        event.stopPropagation();
+        targetClick(event);
+      }
     }
-  )
+}) : getReferenceProps();
 
   const targetElement = isValidElement(target) ? (
     cloneElement(target, {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Within #3495 it was added to propagate the onClick to floating UI, however there was no check to see if there is an onClick present so currently if there is an onClick not provided it can cause an issue with a failure as the onClick property is not available, we don't see this as a widespread issue because when using the BpkPopover it would be expected that the target that the popover is using would have an onClick to set the state of open or not.

We saw this issue more in tests rather than in actual production issues.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here