### PR TITLE
[Luna-1372][BpkAccordion] Remove description filter

### DIFF
--- a/packages/bpk-component-accordion/src/BpkAccordion.js
+++ b/packages/bpk-component-accordion/src/BpkAccordion.js
@@ -35,9 +35,9 @@ const BpkAccordion = (props: Props) => {
 
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
-    <dl className={classNames} {...rest}>
+    <div className={classNames} {...rest}>
       {children}
-    </dl>
+    </div>
   );
 };
 

--- a/packages/bpk-component-accordion/src/BpkAccordion.js
+++ b/packages/bpk-component-accordion/src/BpkAccordion.js
@@ -19,8 +19,9 @@
 /* @flow strict */
 
 import PropTypes from 'prop-types';
-import React, { type Node } from 'react';
-import { cssModules } from 'bpk-react-utils';
+import { createContext, Node } from 'react';
+
+import { cssModules } from '../../bpk-react-utils';
 
 import STYLES from './BpkAccordion.module.scss';
 
@@ -28,26 +29,41 @@ const getClassName = cssModules(STYLES);
 
 type Props = { children: Node, className: ?string };
 
-const BpkAccordion = (props: Props) => {
-  const { children, className, ...rest } = props;
+export const BpkAccordionContext = createContext({
+  onDark: false,
+  divider: true,
+});
 
-  const classNames = getClassName('bpk-accordion', className);
+const BpkAccordion = (props: Props) => {
+  const { children, className, divider, onDark, ...rest } = props;
+
+  const classNames = getClassName(
+    'bpk-accordion',
+    onDark && 'bpk-accordion--on-dark',
+    className,
+  );
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
-    <div className={classNames} {...rest}>
-      {children}
-    </div>
+    <BpkAccordionContext.Provider value={{ onDark, divider }}>
+      {/* // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md */}
+      <div className={classNames} {...rest}>
+        {children}
+      </div>
+    </BpkAccordionContext.Provider>
   );
 };
 
 BpkAccordion.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  onDark: PropTypes.bool,
+  divider: PropTypes.bool,
 };
 
 BpkAccordion.defaultProps = {
   className: null,
+  onDark: false,
+  divider: true,
 };
 
 export default BpkAccordion;

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -19,13 +19,15 @@
 /* @flow strict */
 
 import PropTypes from 'prop-types';
-import React, { type Node, type Element } from 'react';
-import AnimateHeight from 'bpk-animate-height';
-import { withButtonAlignment } from 'bpk-component-icon';
-import ChevronDownIcon from 'bpk-component-icon/sm/chevron-down';
-import BpkText, { TEXT_STYLES } from 'bpk-component-text';
-import { cssModules } from 'bpk-react-utils';
+import { Node, Element, useContext, cloneElement } from 'react';
 
+import AnimateHeight from '../../bpk-animate-height';
+import { withButtonAlignment } from '../../bpk-component-icon';
+import ChevronDownIcon from '../../bpk-component-icon/sm/chevron-down';
+import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
+import { cssModules } from '../../bpk-react-utils';
+
+import { BpkAccordionContext } from './BpkAccordion';
 import STYLES from './BpkAccordionItem.module.scss';
 
 const getClassName = cssModules(STYLES);
@@ -44,7 +46,11 @@ type Props = {
 };
 
 const BpkAccordionItem = (props: Props) => {
+  const { divider, onDark } = useContext(BpkAccordionContext);
   const iconClassNames = [getClassName('bpk-accordion__item-expand-icon')];
+  const titleTextClassNames = [getClassName('bpk-accordion__title-text')];
+  const titleClassNames = [getClassName('bpk-accordion__title')];
+  const contentClassNames = [getClassName('bpk-accordion__content-container')];
   const {
     children,
     expanded,
@@ -63,15 +69,55 @@ const BpkAccordionItem = (props: Props) => {
   // $FlowFixMe[prop-missing] - see above
   delete rest.initiallyExpanded;
 
-  if (expanded) {
+  if (expanded && !onDark) {
     iconClassNames.push(
       getClassName('bpk-accordion__item-expand-icon--flipped'),
     );
+    if (divider) {
+      contentClassNames.push(
+        getClassName('bpk-accordion__content-container--expanded'),
+      );
+    }
+  }
+
+  if (expanded && onDark) {
+    iconClassNames.push(
+      getClassName('bpk-accordion__item-expand-icon--flipped'),
+    );
+    iconClassNames.push(
+      getClassName('bpk-accordion__item-expand-icon--on-dark'),
+    );
+    if (divider) {
+      contentClassNames.push(
+        getClassName('bpk-accordion__content-container--expanded-on-dark'),
+      );
+    }
+    titleTextClassNames.push(
+      getClassName('bpk-accordion__title-text--on-dark'),
+    );
+  }
+
+  if (!expanded && onDark) {
+    iconClassNames.push(
+      getClassName('bpk-accordion__item-expand-icon--on-dark'),
+    );
+    if (divider) {
+      titleClassNames.push(
+        getClassName('bpk-accordion__title--collapsed-on-dark'),
+      );
+    }
+    titleTextClassNames.push(
+      getClassName('bpk-accordion__title-text--on-dark'),
+    );
+  }
+
+  if (!expanded && !onDark && divider) {
+    titleClassNames.push(getClassName('bpk-accordion__title--collapsed'));
   }
 
   const contentId = `${id}_content`;
   const clonedIcon = icon
-    ? React.cloneElement(icon, {
+    ? cloneElement(icon, {
         className: getClassName('bpk-accordion__leading-icon'),
       })
     : null;
@@ -79,10 +125,7 @@ const BpkAccordionItem = (props: Props) => {
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
     <div id={id} {...rest}>
-      <div
-        aria-labelledby={id}
-        className={getClassName('bpk-accordion__title')}
-      >
+      <div className={titleClassNames.join(' ')}>
         <button
           type="button"
           aria-expanded={expanded}
@@ -90,26 +133,24 @@ const BpkAccordionItem = (props: Props) => {
           onClick={onClick}
           className={getClassName('bpk-accordion__toggle-button')}
         >
-          <span className={getClassName('bpk-accordion__flex-container')}>
-            <BpkText
-              textStyle={textStyle}
-              tagName={tagName}
-              className={getClassName('bpk-accordion__title-text')}
+          <div className={`${getClassName('bpk-accordion__flex-container')}`}>
+            <div className={titleTextClassNames.join(' ')}>
+              <BpkText textStyle={textStyle} tagName={tagName}>
+                {clonedIcon}
+                {title}
+              </BpkText>
+            </div>
+            <span
+              className={`${getClassName(
+                'bpk-accordion__icon-wrapper',
+              )} ${iconClassNames.join(' ')}`}
             >
-              {clonedIcon}
-              {title}
-            </BpkText>
-            <span className={getClassName('bpk-accordion__icon-wrapper')}>
-              <ExpandIcon className={iconClassNames.join(' ')} />
+              <ExpandIcon />
             </span>
-          </span>
+          </div>
         </button>
       </div>
-      <div
-        id={contentId}
-        aria-labelledby={contentId}
-        className={getClassName('bpk-accordion__content-container')}
-      >
+      <div id={contentId} className={contentClassNames.join(' ')}>
         <AnimateHeight duration={200} height={expanded ? 'auto' : 0}>
           {children}
         </AnimateHeight>
@@ -133,7 +174,7 @@ BpkAccordionItem.defaultProps = {
   expanded: false,
   icon: null,
   onClick: () => null,
-  tagName: 'span',
+  tagName: 'h3',
   textStyle: TEXT_STYLES.bodyDefault,
 };
 

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -79,7 +79,10 @@ const BpkAccordionItem = (props: Props) => {
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
     <div id={id} {...rest}>
-      <dt aria-labelledby={id} className={getClassName('bpk-accordion__title')}>
+      <div
+        aria-labelledby={id}
+        className={getClassName('bpk-accordion__title')}
+      >
         <button
           type="button"
           aria-expanded={expanded}
@@ -101,8 +104,8 @@ const BpkAccordionItem = (props: Props) => {
             </span>
           </span>
         </button>
-      </dt>
-      <dd
+      </div>
+      <div
         id={contentId}
         aria-labelledby={contentId}
         className={getClassName('bpk-accordion__content-container')}
@@ -110,7 +113,7 @@ const BpkAccordionItem = (props: Props) => {
         <AnimateHeight duration={200} height={expanded ? 'auto' : 0}>
           {children}
         </AnimateHeight>
-      </dd>
+      </div>
     </div>
   );
 };

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordion-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordion-test.js.snap
@@ -2,20 +2,20 @@
 
 exports[`BpkAccordion should render correctly 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion"
   >
     Accordion child
-  </dl>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`BpkAccordion should render correctly with custom "className" prop 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion my-custom-class"
   >
     Accordion child
-  </dl>
+  </div>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -5,7 +5,7 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -45,8 +45,8 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -60,7 +60,7 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -70,7 +70,7 @@ exports[`BpkAccordionItem should render correctly 1`] = `
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -110,8 +110,8 @@ exports[`BpkAccordionItem should render correctly 1`] = `
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -125,7 +125,7 @@ exports[`BpkAccordionItem should render correctly 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -136,7 +136,7 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
     class="my-custom-class"
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -176,8 +176,8 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -191,7 +191,7 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -201,7 +201,7 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -241,8 +241,8 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -254,7 +254,7 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -264,7 +264,7 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -304,8 +304,8 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -319,7 +319,7 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -329,7 +329,7 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -369,8 +369,8 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -384,7 +384,7 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -394,7 +394,7 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -446,8 +446,8 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -461,7 +461,7 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
@@ -5,7 +5,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -45,8 +45,8 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -60,7 +60,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -70,7 +70,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -110,8 +110,8 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -125,7 +125,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -135,7 +135,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       aria-labelledby="my-accordion"
       class="bpk-accordion__title"
     >
@@ -175,8 +175,8 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
           </span>
         </span>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       aria-labelledby="my-accordion_content"
       class="bpk-accordion__content-container"
       id="my-accordion_content"
@@ -188,7 +188,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-accordion/src/__snapshots__/withSingleItemAccordionState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withSingleItemAccordionState-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`withSingleItemAccordionState(BpkAccordion) should render correctly 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion"
   >
     <div>
@@ -14,13 +14,13 @@ exports[`withSingleItemAccordionState(BpkAccordion) should render correctly 1`] 
     <div>
       Accordion Item 3
     </div>
-  </dl>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`withSingleItemAccordionState(BpkAccordion) should render correctly even when multiple items are marked as initially expanded 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion"
   >
     <div>
@@ -32,13 +32,13 @@ exports[`withSingleItemAccordionState(BpkAccordion) should render correctly even
     <div>
       Accordion Item 3
     </div>
-  </dl>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`withSingleItemAccordionState(BpkAccordion) should render correctly with arbitrary props 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion someClass"
     foo="bar"
   >
@@ -51,13 +51,13 @@ exports[`withSingleItemAccordionState(BpkAccordion) should render correctly with
     <div>
       Accordion Item 3
     </div>
-  </dl>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`withSingleItemAccordionState(BpkAccordion) should render correctly with custom initially expanded item 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion"
   >
     <div>
@@ -69,6 +69,6 @@ exports[`withSingleItemAccordionState(BpkAccordion) should render correctly with
     <div>
       Accordion Item 3
     </div>
-  </dl>
+  </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
### Description
🎫 [Luna-1371](https://skyscanner.atlassian.net/browse/LUNA-1371) for reference.

There is an issue on iOS where VoiceOver reads the word "description" as it goes through the flight's filter Accordion.

We have identified that this is due to the usage of `dt` `dl` and `dd` in the component as VioceOver will read the element attached to it.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
### Checklist

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here