### PR TITLE
[Luna-1372][BpkAccordion] Remove description filter

### DIFF
--- a/packages/bpk-component-accordion/src/BpkAccordion.js
+++ b/packages/bpk-component-accordion/src/BpkAccordion.js
@@ -46,9 +46,9 @@ const BpkAccordion = (props: Props) => {
   return (
     <BpkAccordionContext.Provider value={{ onDark, divider }}>
       {/* // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md */}
-      <dl className={classNames} {...rest}>
+      <div className={classNames} {...rest}>
         {children}
-      </dl>
+      </div>
     </BpkAccordionContext.Provider>
   );
 };

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.js
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.js
@@ -126,7 +126,7 @@ const BpkAccordionItem = (props: Props) => {
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
     <div id={id} {...rest}>
-      <dt className={titleClassNames.join(' ')}>
+      <div className={titleClassNames.join(' ')}>
         <button
           type="button"
           aria-expanded={expanded}
@@ -149,12 +149,12 @@ const BpkAccordionItem = (props: Props) => {
             </span>
           </div>
         </button>
-      </dt>
-      <dd id={contentId} className={contentClassNames.join(' ')}>
+      </div>
+      <div id={contentId} className={contentClassNames.join(' ')}>
         <AnimateHeight duration={200} height={expanded ? 'auto' : 0}>
           {children}
         </AnimateHeight>
-      </dd>
+      </div>
     </div>
   );
 };

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordion-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordion-test.js.snap
@@ -2,20 +2,20 @@
 
 exports[`BpkAccordion should render correctly 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion"
   >
     Accordion child
-  </dl>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`BpkAccordion should render correctly with custom "className" prop 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion my-custom-class"
   >
     Accordion child
-  </dl>
+  </div>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/BpkAccordionItem-test.js.snap
@@ -5,7 +5,7 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
@@ -47,8 +47,8 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -61,7 +61,7 @@ exports[`BpkAccordionItem should not render an "initiallyExpanded" attribute on 
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -71,7 +71,7 @@ exports[`BpkAccordionItem should render correctly 1`] = `
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
@@ -113,8 +113,8 @@ exports[`BpkAccordionItem should render correctly 1`] = `
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -127,7 +127,7 @@ exports[`BpkAccordionItem should render correctly 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -138,7 +138,7 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
     class="my-custom-class"
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
@@ -180,8 +180,8 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -194,7 +194,7 @@ exports[`BpkAccordionItem should render correctly with "className" prop 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -204,7 +204,7 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title"
     >
       <button
@@ -246,8 +246,8 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container bpk-accordion__content-container--expanded"
       id="my-accordion_content"
     >
@@ -258,7 +258,7 @@ exports[`BpkAccordionItem should render correctly with "expanded" prop 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -268,7 +268,7 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
@@ -310,8 +310,8 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -324,7 +324,7 @@ exports[`BpkAccordionItem should render correctly with "tagName" prop set 1`] = 
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -334,7 +334,7 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
@@ -376,8 +376,8 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -390,7 +390,7 @@ exports[`BpkAccordionItem should render correctly with "textStyle" prop set 1`] 
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -400,7 +400,7 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
@@ -454,8 +454,8 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -468,7 +468,7 @@ exports[`BpkAccordionItem should render correctly with an icon set 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -478,7 +478,7 @@ exports[`BpkAccordionItem should render correctly with no divider 1`] = `
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title"
     >
       <button
@@ -520,8 +520,8 @@ exports[`BpkAccordionItem should render correctly with no divider 1`] = `
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -534,7 +534,7 @@ exports[`BpkAccordionItem should render correctly with no divider 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
   ,
 </DocumentFragment>
@@ -545,7 +545,7 @@ exports[`BpkAccordionItem should render correctly with onDark set 1`] = `
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title bpk-accordion__title--collapsed-on-dark"
     >
       <button
@@ -587,8 +587,8 @@ exports[`BpkAccordionItem should render correctly with onDark set 1`] = `
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -601,7 +601,7 @@ exports[`BpkAccordionItem should render correctly with onDark set 1`] = `
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
   ,
 </DocumentFragment>

--- a/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withAccordionItemState-test.js.snap
@@ -5,7 +5,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
@@ -47,8 +47,8 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -61,7 +61,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly 1`] = 
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -71,7 +71,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title bpk-accordion__title--collapsed"
     >
       <button
@@ -113,8 +113,8 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container"
       id="my-accordion_content"
     >
@@ -127,7 +127,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -137,7 +137,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
   <div
     id="my-accordion"
   >
-    <dt
+    <div
       class="bpk-accordion__title"
     >
       <button
@@ -179,8 +179,8 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
           </span>
         </div>
       </button>
-    </dt>
-    <dd
+    </div>
+    <div
       class="bpk-accordion__content-container bpk-accordion__content-container--expanded"
       id="my-accordion_content"
     >
@@ -191,7 +191,7 @@ exports[`withAccordionItemState(BpkAccordionItem) should render correctly with "
           My accordion content
         </div>
       </div>
-    </dd>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-accordion/src/__snapshots__/withSingleItemAccordionState-test.js.snap
+++ b/packages/bpk-component-accordion/src/__snapshots__/withSingleItemAccordionState-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`withSingleItemAccordionState(BpkAccordion) should render correctly 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion"
   >
     <div>
@@ -14,13 +14,13 @@ exports[`withSingleItemAccordionState(BpkAccordion) should render correctly 1`] 
     <div>
       Accordion Item 3
     </div>
-  </dl>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`withSingleItemAccordionState(BpkAccordion) should render correctly even when multiple items are marked as initially expanded 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion"
   >
     <div>
@@ -32,13 +32,13 @@ exports[`withSingleItemAccordionState(BpkAccordion) should render correctly even
     <div>
       Accordion Item 3
     </div>
-  </dl>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`withSingleItemAccordionState(BpkAccordion) should render correctly with arbitrary props 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion someClass"
     foo="bar"
   >
@@ -51,13 +51,13 @@ exports[`withSingleItemAccordionState(BpkAccordion) should render correctly with
     <div>
       Accordion Item 3
     </div>
-  </dl>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`withSingleItemAccordionState(BpkAccordion) should render correctly with custom initially expanded item 1`] = `
 <DocumentFragment>
-  <dl
+  <div
     class="bpk-accordion"
   >
     <div>
@@ -69,6 +69,6 @@ exports[`withSingleItemAccordionState(BpkAccordion) should render correctly with
     <div>
       Accordion Item 3
     </div>
-  </dl>
+  </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
### Description
🎫 [Luna-1371](https://skyscanner.atlassian.net/browse/LUNA-1371) for reference.

There is an issue on iOS where VoiceOver reads the word "description" as it goes through the flight's filter Accordion.

We have identified that this is due to the usage of `dt` `dl` and `dd` in the component as VioceOver will read the element attached to it.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
### Checklist

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here