### PR TITLE
[NO JIRA][BpkPopover]: Reinstate renderTarget prop for rendering in DOM at specific location

### DIFF
--- a/examples/bpk-component-popover/examples.js
+++ b/examples/bpk-component-popover/examples.js
@@ -144,6 +144,13 @@ const DefaultExample = () => (
   </Spacer>
 );
 
+const WithCustomRenderTargetExample = () => (
+  <Spacer>
+    <div id="my-target" />
+    <PopoverContainer id="my-popover-1" renderTarget={() => document.getElementById('my-target')} />
+  </Spacer>
+);
+
 const WithoutArrowExample = () => (
   <Spacer>
     <PopoverContainer id="my-popover-2" displayArrow={false} />
@@ -176,7 +183,7 @@ const InputTriggerExample = () => (
 
 const WithActionButtonExample = () => (
   <Spacer>
-    <PopoverContainer id="my-popover" actionText="Action" onAction={() => {}} />
+    <PopoverContainer id="my-popover" actionText="Action" onAction={() => { }} />
   </Spacer>
 );
 
@@ -188,6 +195,7 @@ const VisualExample = () => (
 
 export {
   DefaultExample,
+  WithCustomRenderTargetExample,
   WithoutArrowExample,
   WithLabelAsTitleExample,
   WithNoCloseButtonIconExample,

--- a/examples/bpk-component-popover/stories.js
+++ b/examples/bpk-component-popover/stories.js
@@ -21,6 +21,7 @@ import BpkPopover from '../../packages/bpk-component-popover';
 
 import {
   DefaultExample,
+  WithCustomRenderTargetExample,
   WithoutArrowExample,
   WithLabelAsTitleExample,
   OnTheSideExample,
@@ -36,6 +37,7 @@ export default {
 };
 
 export const Default = DefaultExample;
+export const WithCustomRenderTarget = WithCustomRenderTargetExample;
 export const WithoutArrow = WithoutArrowExample;
 export const WithLabelAsTitle = WithLabelAsTitleExample;
 export const WithNoCloseButtonIcon =

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -107,6 +107,7 @@ export type Props = CloseButtonProps & {
   closeButtonLabel?: string;
   actionText?: string;
   onAction?: () => void;
+  renderTarget?: () => HTMLElement | HTMLElement | null;
 };
 
 const BpkPopover = ({
@@ -125,6 +126,7 @@ const BpkPopover = ({
   onClose,
   padded = true,
   placement = 'bottom',
+  renderTarget = () => null,
   showArrow = true,
   target,
   ...rest
@@ -186,12 +188,13 @@ const BpkPopover = ({
   const bodyClassNames = getClassName(padded && 'bpk-popover__body--padded');
 
   const labelId = `bpk-popover-label-${id}`;
+  const renderElement = typeof renderTarget === 'function' ? renderTarget() : renderTarget;
 
   return (
     <>
       {targetElement}
       {isOpenState && (
-        <FloatingPortal>
+        <FloatingPortal root={renderElement}>
           <FloatingFocusManager context={context}>
             <div
               className={getClassName('bpk-popover--container')}


### PR DESCRIPTION
We had an issue where when a popover is used within a modal that meant that the popover would render outside of the modal and to the main page below, meaning it would be hidden from the view and rendered behind.

This is due to the default behvaiour without specification to render to the body. So to solve this we return a previously removed property in v34 `renderTarget`.

This property is used to specify to the `FloatingPortal`, where to attach the popover giving consumers the previous ability to specify where in the DOM to place the component when its time to render meaning that it can then be displayed within the modal and not to content behind

![Screenshot 2024-07-10 at 09 38 26](https://github.com/Skyscanner/backpack/assets/8831547/6b1208ee-a145-4668-8fb9-de8492aa3212)

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here