### PR TITLE
[NO-JIRA] [BpkSegmentedControl] RTL fix

### DIFF
--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
@@ -88,16 +88,17 @@
 
 // Handle border lines between buttons
 .bpk-segmented-control:not(:first-of-type, [class*='selected']) {
-  border-left: tokens.$bpk-one-pixel-rem solid tokens.$bpk-line-day;
+  border-inline-start: tokens.$bpk-one-pixel-rem solid tokens.$bpk-line-day;
 }
 
 .bpk-segmented-control--surface-contrast:not(
     :first-of-type,
     [class*='selected']
   ) {
-  border-left: tokens.$bpk-one-pixel-rem solid tokens.$bpk-line-on-dark-day;
+  border-inline-start: tokens.$bpk-one-pixel-rem solid
+    tokens.$bpk-line-on-dark-day;
 }
 
 .bpk-segmented-control[class*='rightOfOption'] {
-  border-left: none;
+  border-inline-start: none;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

I noticed that in RTL, the flights tabs using `BpkSegmentedControl` have the border between non-selected segments in the wrong place. I fixed this by using `border-inline-start` instead of `border-left` in the styles, relying on the inline style direction (defined by text orientation) instead of hard-coded left/right styles.

Flights tab in RTL:
<img width="600" alt="Screenshot 2024-07-12 at 12 18 19" src="https://github.com/user-attachments/assets/0ec127e3-60b6-4184-8556-46244924a319">

| Before | After |
| --- | --- |
| <img width="400" alt="Screenshot 2024-07-12 at 12 24 32" src="https://github.com/user-attachments/assets/90420a1e-a24d-4681-a57f-1c489fa36ae7"> | <img width="400" alt="Screenshot 2024-07-12 at 12 24 22" src="https://github.com/user-attachments/assets/f50c3d5e-1beb-4498-9358-16cbce4f3339"> | 

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here