### PR TITLE
[NO-JIRA] [BpkInsetBanner] Add classname and rest props

### DIFF
--- a/examples/bpk-component-inset-banner/examples.module.scss
+++ b/examples/bpk-component-inset-banner/examples.module.scss
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../packages/unstable__bpk-mixins/tokens';
+
+.bpk-custom-padding {
+  padding: tokens.$bpk-one-pixel-rem * 12;
+}

--- a/examples/bpk-component-inset-banner/examples.tsx
+++ b/examples/bpk-component-inset-banner/examples.tsx
@@ -19,6 +19,11 @@
 import BpkInsetBanner, {
   VARIANT,
 } from '../../packages/bpk-component-inset-banner';
+import { cssModules } from '../../packages/bpk-react-utils';
+
+import STYLES from './examples.module.scss';
+
+const getClassName = cssModules(STYLES);
 
 const DefaultExampleTitleOnly = () => (
   <BpkInsetBanner
@@ -48,6 +53,18 @@ const WithLogoAndCtaTextExampleLight = () => (
     backgroundColor="#94C3FF"
     variant={VARIANT.onLight}
     accessibilityLabel="Sponsored by Skyscanner"
+  />
+);
+
+const WithCustomPadding = () => (
+  <BpkInsetBanner
+    logo="https://content.skyscnr.com/m/23c24b7080cfe18a/Medium-Skyscanner-Vertical-Blue.png"
+    callToAction={{
+      text: 'Promoted',
+    }}
+    backgroundColor="#94C3FF"
+    variant={VARIANT.onLight}
+    className={getClassName('bpk-custom-padding')}
   />
 );
 
@@ -91,4 +108,5 @@ export {
   WithLogoAndCtaTextExampleLight,
   WithBodyTextExampleLight,
   WithBodyTextAndLinkExampleDark,
+  WithCustomPadding,
 };

--- a/examples/bpk-component-inset-banner/stories.ts
+++ b/examples/bpk-component-inset-banner/stories.ts
@@ -24,6 +24,7 @@ import {
   WithLogoAndCtaTextExampleLight,
   WithBodyTextExampleLight,
   WithBodyTextAndLinkExampleDark,
+  WithCustomPadding,
 } from './examples';
 
 export default {
@@ -38,3 +39,4 @@ export const WithBodyTextLight = WithBodyTextExampleLight;
 export const WithBodyTextAndLinkDark = WithBodyTextAndLinkExampleDark;
 export const VisualTestDark = WithBodyTextAndLinkExampleDark;
 export const VisualTestLight = WithLogoAndCtaTextExampleLight;
+export const WithCustomClassPadding = WithCustomPadding;

--- a/packages/bpk-component-inset-banner/README.md
+++ b/packages/bpk-component-inset-banner/README.md
@@ -23,6 +23,7 @@ export default () => (
     callToAction={{
       text: 'Sponsored',
     }}
+    className="my-classname"
     logo="logo.png"
     subheadline="My subheadline"
     title="My title"

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner-test.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner-test.tsx
@@ -72,4 +72,23 @@ describe('BpkInsetBanner', () => {
       'bpk-inset-banner-body-container--link-text',
     );
   });
+
+  it('should use custom class if provided', () => {
+    const { container } = render(
+      <BpkInsetBanner
+        title="Lorem ipsum"
+        subheadline="Lorem ipsum dolor sit amet"
+        logo="https://content.skyscnr.com/m/7950ed6f30581485/Medium-Skyscanner-Vertical-White.png"
+        backgroundColor="#F55D42"
+        className="custom-class"
+        variant={VARIANT.onDark}
+      />,
+    );
+
+    const containerDiv = container.querySelector('div.bpk-inset-banner');
+
+    expect(containerDiv).toHaveClass(
+      'bpk-inset-banner bpk-inset-banner--on-dark custom-class',
+    );
+  });
 });

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
@@ -46,7 +46,7 @@ export type Props = {
   subheadline?: string;
   title?: string;
   variant?: (typeof VARIANT)[keyof typeof VARIANT];
-  [rest: string]: any;
+  [rest: string]: any; // Inexact rest. See decisions/inexact-rest.md
 };
 
 const BpkInsetBanner = ({

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
@@ -41,10 +41,12 @@ export type Props = {
   callToAction?: {
     text?: string;
   };
+  className?: string;
   logo?: string;
   subheadline?: string;
   title?: string;
   variant?: (typeof VARIANT)[keyof typeof VARIANT];
+  [rest: string]: any;
 };
 
 const BpkInsetBanner = ({
@@ -52,19 +54,22 @@ const BpkInsetBanner = ({
   backgroundColor = surfaceHighlightDay,
   body,
   callToAction,
+  className,
   logo,
   subheadline,
   title,
   variant = VARIANT.onLight,
+  ...rest
 }: Props) => {
   const classNames = getClassName(
     'bpk-inset-banner',
     `bpk-inset-banner--${variant}`,
     body && 'bpk-inset-banner--with-body',
+    className,
   );
 
   return (
-    <div>
+    <div {...rest}>
       <div
         aria-label={accessibilityLabel}
         className={classNames}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
Added the `className` and `rest` props to BpkInsetBanner as we need them for the usage in the sponsored booking panel ad.

- `className` prop:
   - While adding the `BpkInsetBanner` component in the sponsored booking ad to replace the custom made banner, I noticed that the padding for the custom banner is different than the backpack component. 
   - Since the banner UI has to match the one of the current custom banner in the sponsored booking panel ad, I added the `className` prop so that a custom class can be passed to the banner container. 
   - With this solution we can pass a className to change the padding of the inset banner in the sponsored booking panel ad, instead of changing the padding directly in the backpack component as it would unalign the padding with the [BpkInsetBanner designs](https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=38191-5527&t=McTTZOu8DoQfEzg9-4).
- `rest` props:
   - Added the `rest` prop to allow any additional props that might be needed to be passed.
   - For the sponsored booking panel ad we need to add an `onClick` prop to the banner, so adding `rest` props allows us to do this without setting up a dedicated `onClick` prop and click handling in the backpack component (since the whole banner isn't intended to be clicked in most cases).

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here