### PR TITLE
[LOOM-1531] Add form tests for form components

### DIFF
--- a/packages/bpk-component-checkbox/src/form-test.js
+++ b/packages/bpk-component-checkbox/src/form-test.js
@@ -1,0 +1,88 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import BpkCheckbox from './BpkCheckbox';
+
+describe('BpkCheckbox form test', () => {
+  it('should work as a form component in a form', async () => {
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [isChecked, setIsChecked] = useState(false);
+      return (
+        <form data-testid="form">
+          <BpkCheckbox
+            type="checkbox"
+            name="checkbox"
+            checked={isChecked}
+            onChange={() => setIsChecked(!isChecked)}
+            data-testid="mycheckbox"
+          />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+    render(<Wrap />);
+
+    const checkbox = screen.getByTestId('mycheckbox');
+    expect(checkbox).not.toBeChecked();
+
+    await userEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    const formData = new FormData(screen.getByTestId('form'));
+    expect(Object.fromEntries(formData.entries())).toEqual({ checkbox: 'on' });
+  });
+
+  it('should emit change event when toggled', async () => {
+    const formValidation = jest.fn();
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [isChecked, setIsChecked] = useState(false);
+      useEffect(() => {
+        document.addEventListener('change', formValidation);
+      }, []);
+      return (
+        <form data-testid="form">
+          <BpkCheckbox
+            type="checkbox"
+            name="checkbox"
+            checked={isChecked}
+            onChange={() => setIsChecked(!isChecked)}
+            data-testid="mycheckbox"
+          />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+    render(<Wrap />);
+
+    const checkbox = screen.getByTestId('mycheckbox');
+    expect(checkbox).not.toBeChecked();
+    expect(formValidation).not.toHaveBeenCalled();
+
+    await userEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    expect(formValidation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/bpk-component-input/src/form-test.tsx
+++ b/packages/bpk-component-input/src/form-test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import BpkInput from './BpkInput';
+
+describe('BpkInput', () => {
+  it('should work as a form component in a form', async () => {
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [inputTest, setInputTest] = useState('');
+      return (
+        <form data-testid="form">
+          <BpkInput
+            id="test"
+            data-testid="myInput"
+            name="test"
+            value={inputTest}
+            placeholder="Enter a country, city or airport"
+            onChange={(e) => setInputTest(e.target.value)}
+          />
+
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+
+    render(<Wrap />);
+
+    const textInput = screen.getByTestId('myInput');
+    expect(textInput).toHaveValue('');
+
+    await userEvent.click(textInput);
+    await userEvent.keyboard('value');
+
+    expect(textInput).toHaveValue('value');
+
+    const formData = new FormData(
+      screen.getByTestId('form') as HTMLFormElement,
+    );
+    expect(Object.fromEntries(formData.entries())).toEqual({ test: 'value' });
+  });
+
+  it('should emit change event when text has been entered and blurred', async () => {
+    const formValidation = jest.fn();
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [inputTest, setInputTest] = useState('');
+      useEffect(() => {
+        document.addEventListener('change', formValidation);
+      }, []);
+      return (
+        <form data-testid="form">
+          <BpkInput
+            id="test"
+            data-testid="myInput"
+            name="test"
+            value={inputTest}
+            placeholder="Enter a country, city or airport"
+            onChange={(e) => setInputTest(e.target.value)}
+          />
+
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+
+    render(<Wrap />);
+
+    const textInput = screen.getByTestId('myInput');
+    const form = screen.getByTestId('form');
+
+    expect(textInput).toHaveValue('');
+    expect(formValidation).not.toHaveBeenCalled();
+
+    await userEvent.click(textInput);
+    await userEvent.keyboard('value');
+    await userEvent.click(form); // change event emitted on blur
+    expect(textInput).toHaveValue('value');
+
+    expect(formValidation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/bpk-component-nudger/src/form-test.tsx
+++ b/packages/bpk-component-nudger/src/form-test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import BpkNudger from './BpkNudger';
+
+describe('BpkNudger form test', () => {
+  it('should work as a form component in a form', async () => {
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [nudgerValue, setNudgerValue] = useState(5);
+      return (
+        <form data-testid="form">
+          <BpkNudger
+            id="nudger"
+            min={1}
+            max={9}
+            value={nudgerValue}
+            name="test-nudger"
+            onChange={(v) => setNudgerValue(v)}
+            decreaseButtonLabel="Decrease"
+            increaseButtonLabel="Increase"
+            data-testid="myNudger"
+          />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+
+    render(<Wrap />);
+
+    const minusButton = screen.getByRole('button', { name: 'Decrease' });
+
+    const textInput = screen.getByTestId('myNudger');
+    expect(textInput).toHaveValue('5');
+
+    await userEvent.click(minusButton);
+
+    expect(textInput).toHaveValue('4');
+
+    const formData = new FormData(
+      screen.getByTestId('form') as HTMLFormElement,
+    );
+    expect(Object.fromEntries(formData.entries())).toEqual({
+      'test-nudger': '4',
+    });
+  });
+
+  it('should emit change event when nudger value is decreased', async () => {
+    const formValidation = jest.fn();
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [nudgerValue, setNudgerValue] = useState(5);
+      useEffect(() => {
+        document.addEventListener('change', formValidation);
+      }, []);
+      return (
+        <form data-testid="form">
+          <BpkNudger
+            id="nudger"
+            min={1}
+            max={9}
+            value={nudgerValue}
+            name="test-nudger"
+            onChange={(v) => setNudgerValue(v)}
+            decreaseButtonLabel="Decrease"
+            increaseButtonLabel="Increase"
+            data-testid="myNudger"
+          />
+          ,<button type="submit">Submit</button>
+        </form>
+      );
+    };
+
+    render(<Wrap />);
+
+    const minusButton = screen.getByRole('button', { name: 'Decrease' });
+
+    const textInput = screen.getByTestId('myNudger');
+    expect(textInput).toHaveValue('5');
+    expect(formValidation).not.toHaveBeenCalled();
+
+    await userEvent.click(minusButton);
+
+    expect(textInput).toHaveValue('4');
+
+    expect(formValidation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/bpk-component-phone-input/src/form-test.js
+++ b/packages/bpk-component-phone-input/src/form-test.js
@@ -1,0 +1,125 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import BpkPhoneInput from './BpkPhoneInput';
+
+const dialingCodeProps = {
+  id: 'dialing-code',
+  name: 'dialing_code',
+  label: 'Dialing code',
+  className: 'dialing-code',
+  wrapperClassName: 'dialing-wrapper',
+};
+
+const dialingCodes = [
+  { code: '44', description: '+44', numberPrefix: '+44' },
+  { code: '55', description: '+55', numberPrefix: '+55' },
+];
+
+const defaultProps = {
+  id: 'phone-input-id',
+  name: 'telephone_input',
+  label: 'Telephone number',
+  value: '1234',
+  dialingCode: '44',
+  className: 'fancy-input',
+  onChange: () => {},
+  onDialingCodeChange: () => {},
+  dialingCodes,
+  dialingCodeProps,
+};
+
+describe('BpkPhoneInput form test', () => {
+  it('should work as a form component in a form', async () => {
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [inputValue, setInputValue] = useState('');
+      return (
+        <form data-testid="form">
+          <BpkPhoneInput
+            {...defaultProps}
+            data-testid="myInput"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+          />
+
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+
+    render(<Wrap />);
+
+    const textInput = screen.getByTestId('myInput');
+    expect(textInput).toHaveValue('');
+
+    await userEvent.click(textInput);
+    await userEvent.keyboard('555 5555');
+
+    expect(textInput).toHaveValue('555 5555');
+
+    const formData = new FormData(screen.getByTestId('form'));
+    expect(Object.fromEntries(formData.entries())).toEqual({
+      telephone_input: '555 5555',
+      dialing_code: '44',
+    });
+  });
+
+  it('should emit change event when text has been entered and blurred', async () => {
+    const formValidation = jest.fn();
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [inputValue, setInputValue] = useState('');
+      useEffect(() => {
+        document.addEventListener('change', formValidation);
+      }, []);
+      return (
+        <form data-testid="form">
+          <BpkPhoneInput
+            {...defaultProps}
+            data-testid="myInput"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+          />
+
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+
+    render(<Wrap />);
+
+    const phoneInput = screen.getByTestId('myInput');
+    const form = screen.getByTestId('form');
+
+    expect(phoneInput).toHaveValue('');
+    expect(formValidation).not.toHaveBeenCalled();
+
+    await userEvent.click(phoneInput);
+    await userEvent.keyboard('555 5555');
+    await userEvent.click(form); // change event emitted on blur
+    expect(phoneInput).toHaveValue('555 5555');
+
+    expect(formValidation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/bpk-component-radio/src/form-test.js
+++ b/packages/bpk-component-radio/src/form-test.js
@@ -1,0 +1,95 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+import { useEffect } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import '@testing-library/jest-dom';
+
+import BpkRadio from './BpkRadio';
+
+describe('BpkRadio form test', () => {
+  it('should work as a form component in a form', async () => {
+    render(
+      <form data-testid="form">
+        <BpkRadio type="radio" name="radio" data-testid="myradio" />
+        <button type="submit">Submit</button>
+      </form>,
+    );
+
+    const radio = screen.getByTestId('myradio');
+
+    expect(radio).not.toBeChecked();
+
+    await userEvent.click(radio);
+
+    expect(radio).toBeChecked();
+
+    const formData = new FormData(screen.getByTestId('form'));
+
+    expect(Object.fromEntries(formData.entries())).toEqual({ radio: 'on' });
+  });
+
+  it('should emit change event when toggled', async () => {
+    const formValidation = jest.fn();
+    const Wrap = () => {
+      useEffect(() => {
+        document.addEventListener('change', formValidation);
+      }, []);
+      return (
+        <form data-testid="form">
+          <BpkRadio
+            type="radio"
+            name="radio"
+            value="One"
+            data-testid="myradio"
+          />
+          <BpkRadio
+            type="radio"
+            name="radio"
+            value="Two"
+            data-testid="myradio2"
+          />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+    render(<Wrap />);
+
+    const radio = screen.getByTestId('myradio');
+    const radio2 = screen.getByTestId('myradio2');
+
+    expect(radio).not.toBeChecked();
+    expect(formValidation).not.toHaveBeenCalled();
+
+    await userEvent.click(radio);
+
+    expect(radio).toBeChecked();
+    expect(formValidation).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(radio2);
+
+    expect(radio).not.toBeChecked();
+    expect(radio2).toBeChecked();
+    expect(formValidation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/bpk-component-select/src/form-test.js
+++ b/packages/bpk-component-select/src/form-test.js
@@ -1,0 +1,111 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import BpkSelect from './BpkSelect';
+
+describe('BpkSelect form test', () => {
+  it('should work as a form component in a form', async () => {
+    render(
+      <form data-testid="form">
+        <BpkSelect
+          id="fruits"
+          name="fruits"
+          defaultValue="apples"
+          data-testid="myselect"
+        >
+          <option value="apples">Apples</option>
+          <option data-testid="select-option" value="oranges">
+            Oranges
+          </option>
+          <option value="pears">Pears</option>
+          <option value="tomatoes">Tomatoes</option>
+        </BpkSelect>
+        <button type="submit">Submit</button>
+      </form>,
+    );
+
+    const select = screen.getByTestId('myselect');
+    const option = screen.getByTestId('select-option');
+
+    expect(select.options.selectedIndex).toEqual(0);
+
+    expect(screen.getByText('Apples').selected).toBeTruthy();
+
+    await userEvent.selectOptions(select, option);
+
+    expect(option.selected).toBeTruthy();
+    expect(screen.getByText('Apples').selected).toBeFalsy();
+
+    const formData = new FormData(screen.getByTestId('form'));
+
+    expect(Object.fromEntries(formData.entries())).toEqual({
+      fruits: 'oranges',
+    });
+  });
+
+  it('should emit change event on option selection that calls formValidation', async () => {
+    const formValidation = jest.fn();
+    const Wrap = () => {
+      useEffect(() => {
+        document.addEventListener('change', formValidation);
+      }, []);
+      return (
+        <form data-testid="form">
+          <BpkSelect
+            id="fruits"
+            name="fruits"
+            defaultValue="apples"
+            data-testid="myselect"
+          >
+            <option value="apples">Apples</option>
+            <option data-testid="select-option" value="oranges">
+              Oranges
+            </option>
+            <option value="pears">Pears</option>
+            <option value="tomatoes">Tomatoes</option>
+          </BpkSelect>
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+    render(<Wrap />);
+
+    const select = screen.getByTestId('myselect');
+
+    expect(select.options.selectedIndex).toEqual(0);
+    expect(screen.getByText('Apples').selected).toBeTruthy();
+
+    await userEvent.selectOptions(select, 'oranges');
+
+    expect(screen.getByText('Apples').selected).toBeFalsy();
+    expect(screen.getByText('Oranges').selected).toBeTruthy();
+
+    expect(formValidation).toHaveBeenCalledTimes(1);
+
+    await userEvent.selectOptions(select, 'pears');
+
+    expect(screen.getByText('Oranges').selected).toBeFalsy();
+    expect(screen.getByText('Pears').selected).toBeTruthy();
+    expect(formValidation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/bpk-component-switch/src/form-test.js
+++ b/packages/bpk-component-switch/src/form-test.js
@@ -1,0 +1,86 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import BpkSwitch from './BpkSwitch';
+
+describe('BpkSwitch form test', () => {
+  it('should work as a form component in a form', async () => {
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [isChecked, setIsChecked] = useState(false);
+      return (
+        <form data-testid="form">
+          <BpkSwitch
+            name="switch"
+            checked={isChecked}
+            onChange={() => setIsChecked(!isChecked)}
+            data-testid="myswitch"
+          />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+    render(<Wrap />);
+
+    const mySwitch = screen.getByTestId('myswitch');
+    expect(mySwitch).not.toBeChecked();
+
+    await userEvent.click(mySwitch);
+    expect(mySwitch).toBeChecked();
+
+    const formData = new FormData(screen.getByTestId('form'));
+    expect(Object.fromEntries(formData.entries())).toEqual({ switch: 'on' });
+  });
+
+  it('should emit change event when toggled', async () => {
+    const formValidation = jest.fn();
+    const Wrap = () => {
+      // state is required to force react to update and re-render the component.
+      const [isChecked, setIsChecked] = useState(false);
+      useEffect(() => {
+        document.addEventListener('change', formValidation);
+      }, []);
+      return (
+        <form data-testid="form">
+          <BpkSwitch
+            name="switch"
+            checked={isChecked}
+            onChange={() => setIsChecked(!isChecked)}
+            data-testid="myswitch"
+          />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+    render(<Wrap />);
+
+    const mySwitch = screen.getByTestId('myswitch');
+    expect(mySwitch).not.toBeChecked();
+    expect(formValidation).not.toHaveBeenCalled();
+
+    await userEvent.click(mySwitch);
+    expect(mySwitch).toBeChecked();
+
+    expect(formValidation).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Newly added tests under `form-test.[t|j]sx` for the following form components:
- BpkCheckbox
- BpkInput
- BpkNudger
- BpkPhoneInput
- BpkRadio
- BpkSelect
- BpkSwitch

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here