### PR TITLE
[LOOM-1520][BpkSlider] Fix for Slider to support Form properly

### DIFF
--- a/examples/bpk-component-slider/examples.js
+++ b/examples/bpk-component-slider/examples.js
@@ -69,6 +69,7 @@ class SliderContainer extends Component {
           value={this.state.value}
           ariaLabel={['minimum', 'maximum']}
           ariaValuetext={[this.state.value[0], this.state.value[1]]}
+          inputProps={[{name: 'min'}, {name: 'max'}]}
         />
         <br />
       </div>

--- a/packages/bpk-component-slider/src/BpkSlider.tsx
+++ b/packages/bpk-component-slider/src/BpkSlider.tsx
@@ -15,10 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  forwardRef,
+  useRef,
+  useEffect,
+  type ComponentPropsWithRef,
+} from 'react';
 
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import * as Slider from '@radix-ui/react-slider';
+import { usePrevious } from '@radix-ui/react-use-previous';
 
-import { cssModules, isRTL } from '../../bpk-react-utils';
+import { cssModules, isRTL, setNativeValue } from '../../bpk-react-utils';
 
 import STYLES from './BpkSlider.module.scss';
 
@@ -34,12 +42,14 @@ export type Props = {
   value: number[] | number;
   ariaLabel: string[];
   ariaValuetext?: string[];
+  inputProps?: [{ [key: string]: any }];
   [rest: string]: any;
 };
 
 const BpkSlider = ({
   ariaLabel,
   ariaValuetext,
+  inputProps,
   max,
   min,
   minDistance,
@@ -93,10 +103,54 @@ const BpkSlider = ({
           aria-valuetext={ariaValuetext ? ariaValuetext[index] : val.toString()}
           className={getClassName('bpk-slider__thumb')}
           aria-valuenow={currentValue[index]}
-        />
+          asChild
+        >
+          {/* custom thumb with child input */}
+          <span>
+            <BubbleInput value={currentValue[index]} {...inputProps} />
+          </span>
+        </Slider.Thumb>
       ))}
     </Slider.Root>
   );
 };
+
+// Work around until radix-ui/react-slider is updated to accept an inputRef prop https://github.com/radix-ui/primitives/pull/3033
+const BubbleInput = forwardRef(
+  (props: ComponentPropsWithRef<'input'>, forwardedRef) => {
+    const { value, ...inputProps } = props;
+    const ref = useRef<HTMLInputElement>();
+    const composedRefs = useComposedRefs(forwardedRef, ref);
+
+    const prevValue = usePrevious(value);
+
+    // Bubble value change to parents (e.g form change event)
+    useEffect(() => {
+      const input = ref.current!;
+      if (prevValue !== value) {
+        setNativeValue(input, `${value}`);
+      }
+    }, [prevValue, value]);
+
+    /**
+     * We purposefully do not use `type="hidden"` here otherwise forms that
+     * wrap it will not be able to access its value via the FormData API.
+     *
+     * We purposefully do not add the `value` attribute here to allow the value
+     * to be set programatically and bubble to any parent form `onChange` event.
+     * Adding the `value` will cause React to consider the programatic
+     * dispatch a duplicate and it will get swallowed.
+     */
+    return (
+      <input
+        style={{ display: 'none' }}
+        {...inputProps}
+        ref={composedRefs}
+        type="number"
+        defaultValue={value}
+      />
+    );
+  },
+);
 
 export default BpkSlider;

--- a/packages/bpk-component-slider/src/BpkSlider.tsx
+++ b/packages/bpk-component-slider/src/BpkSlider.tsx
@@ -107,7 +107,7 @@ const BpkSlider = ({
         >
           {/* custom thumb with child input */}
           <span>
-            <BubbleInput value={currentValue[index]} {...inputProps} />
+            <BubbleInput value={currentValue[index]} {...(inputProps && inputProps[index])} />
           </span>
         </Slider.Thumb>
       ))}

--- a/packages/bpk-component-slider/src/__snapshots__/BpkSlider-test.tsx.snap
+++ b/packages/bpk-component-slider/src/__snapshots__/BpkSlider-test.tsx.snap
@@ -35,7 +35,13 @@ exports[`BpkSlider should render correctly 1`] = `
         role="slider"
         style=""
         tabindex="0"
-      />
+      >
+        <input
+          style="display: none;"
+          type="number"
+          value="25"
+        />
+      </span>
     </span>
   </span>
 </DocumentFragment>
@@ -76,7 +82,13 @@ exports[`BpkSlider should render correctly with a "step" attribute 1`] = `
         role="slider"
         style=""
         tabindex="0"
-      />
+      >
+        <input
+          style="display: none;"
+          type="number"
+          value="25"
+        />
+      </span>
     </span>
   </span>
 </DocumentFragment>
@@ -117,7 +129,13 @@ exports[`BpkSlider should render correctly with a minimum distance between contr
         role="slider"
         style=""
         tabindex="0"
-      />
+      >
+        <input
+          style="display: none;"
+          type="number"
+          value="10"
+        />
+      </span>
     </span>
     <span
       style="transform: var(--radix-slider-thumb-transform); position: absolute; left: calc(90% + 0px);"
@@ -135,7 +153,13 @@ exports[`BpkSlider should render correctly with a minimum distance between contr
         role="slider"
         style=""
         tabindex="0"
-      />
+      >
+        <input
+          style="display: none;"
+          type="number"
+          value="90"
+        />
+      </span>
     </span>
   </span>
 </DocumentFragment>
@@ -176,7 +200,13 @@ exports[`BpkSlider should render correctly with a range of values 1`] = `
         role="slider"
         style=""
         tabindex="0"
-      />
+      >
+        <input
+          style="display: none;"
+          type="number"
+          value="10"
+        />
+      </span>
     </span>
     <span
       style="transform: var(--radix-slider-thumb-transform); position: absolute; left: calc(90% + 0px);"
@@ -194,7 +224,13 @@ exports[`BpkSlider should render correctly with a range of values 1`] = `
         role="slider"
         style=""
         tabindex="0"
-      />
+      >
+        <input
+          style="display: none;"
+          type="number"
+          value="90"
+        />
+      </span>
     </span>
   </span>
 </DocumentFragment>

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.12",
         "@popperjs/core": "^2.11.8",
+        "@radix-ui/react-compose-refs": "^1.1.0",
         "@radix-ui/react-slider": "^1.1.2",
+        "@radix-ui/react-use-previous": "^1.1.0",
         "@react-google-maps/api": "^2.19.3",
         "@skyscanner/bpk-foundations-web": "^18.1.0",
         "@skyscanner/bpk-svgs": "^19.3.0",
@@ -180,7 +182,7 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-compose-refs": {
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
       "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
@@ -190,6 +192,20 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -287,6 +303,40 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-previous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
+      "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
@@ -294,6 +344,23 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -358,15 +425,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-previous": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
-      "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0"
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/package.json
+++ b/packages/package.json
@@ -24,7 +24,9 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.12",
     "@popperjs/core": "^2.11.8",
+    "@radix-ui/react-compose-refs": "^1.1.0",
     "@radix-ui/react-slider": "^1.1.2",
+    "@radix-ui/react-use-previous": "^1.1.0",
     "@react-google-maps/api": "^2.19.3",
     "@skyscanner/bpk-foundations-web": "^18.1.0",
     "@skyscanner/bpk-svgs": "^19.3.0",


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

The Slider currently provides a default invisible input when wrapped in a form. We don't want to use this as we can't control any aspects of this input. onChange events, custom attributes like (`type`, `form`) . I've raised a [ticket](https://github.com/radix-ui/primitives/pull/3033) to add support for an inputRef Prop to radix-ui but until then we can rely on using our own composition and defining the BubbleInput ourselves.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here