### PR TITLE
NO-JIRA: Added submit to loading button props

### DIFF
--- a/examples/bpk-component-button/examples.tsx
+++ b/examples/bpk-component-button/examples.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../packages/bpk-component-icon';
 import LargeLongArrowRightIcon from '../../packages/bpk-component-icon/lg/long-arrow-right';
 import SmallLongArrowRightIcon from '../../packages/bpk-component-icon/sm/long-arrow-right';
+import BpkLoadingButton from '../../packages/bpk-component-loading-button';
 import { cssModules } from '../../packages/bpk-react-utils';
 import {
   action,
@@ -176,6 +177,18 @@ const FullWidthExample = (props: any) => (
   </BpkButtonV2>
 );
 
+const SubmitButtonExample = (props: any) => (
+  <BpkButtonV2 submit {...props}>
+    Submit Button
+  </BpkButtonV2>
+);
+
+const SubmitLoadingButtonExample = (props: any) => (
+  <BpkLoadingButton submit {...props}>
+    Submit Loading Button
+  </BpkLoadingButton>
+);
+
 const MixedExample = () => (
   <>
     <PrimaryExample />
@@ -188,6 +201,8 @@ const MixedExample = () => (
     <LinkOnDarkExample />
     <FeaturedExample />
     <FullWidthExample />
+    <SubmitButtonExample />
+    <SubmitLoadingButtonExample />
   </>
 );
 
@@ -218,4 +233,6 @@ export {
   MixedExample,
   AnchorTagsExample,
   FullWidthExample,
+  SubmitButtonExample,
+  SubmitLoadingButtonExample
 };

--- a/examples/bpk-component-button/examples.tsx
+++ b/examples/bpk-component-button/examples.tsx
@@ -28,7 +28,6 @@ import {
 } from '../../packages/bpk-component-icon';
 import LargeLongArrowRightIcon from '../../packages/bpk-component-icon/lg/long-arrow-right';
 import SmallLongArrowRightIcon from '../../packages/bpk-component-icon/sm/long-arrow-right';
-import BpkLoadingButton from '../../packages/bpk-component-loading-button';
 import { cssModules } from '../../packages/bpk-react-utils';
 import {
   action,
@@ -183,12 +182,6 @@ const SubmitButtonExample = (props: any) => (
   </BpkButtonV2>
 );
 
-const SubmitLoadingButtonExample = (props: any) => (
-  <BpkLoadingButton submit {...props}>
-    Submit Loading Button
-  </BpkLoadingButton>
-);
-
 const MixedExample = () => (
   <>
     <PrimaryExample />
@@ -202,7 +195,6 @@ const MixedExample = () => (
     <FeaturedExample />
     <FullWidthExample />
     <SubmitButtonExample />
-    <SubmitLoadingButtonExample />
   </>
 );
 
@@ -234,5 +226,4 @@ export {
   AnchorTagsExample,
   FullWidthExample,
   SubmitButtonExample,
-  SubmitLoadingButtonExample
 };

--- a/examples/bpk-component-button/stories.tsx
+++ b/examples/bpk-component-button/stories.tsx
@@ -31,6 +31,8 @@ import {
   MixedExample,
   AnchorTagsExample,
   FullWidthExample,
+  SubmitButtonExample,
+  SubmitLoadingButtonExample
 } from './examples';
 import { MixedExample as MixedExampleV1 } from './examplesv1';
 
@@ -77,3 +79,5 @@ export const VisualTestV1WithZoom = {
 };
 
 export const FullWidth = () => <FullWidthExample />;
+export const SubmitButton = () => <SubmitButtonExample />;
+export const SubmitLoadingButton = () => <SubmitLoadingButtonExample />;

--- a/examples/bpk-component-button/stories.tsx
+++ b/examples/bpk-component-button/stories.tsx
@@ -32,7 +32,6 @@ import {
   AnchorTagsExample,
   FullWidthExample,
   SubmitButtonExample,
-  SubmitLoadingButtonExample
 } from './examples';
 import { MixedExample as MixedExampleV1 } from './examplesv1';
 
@@ -80,4 +79,3 @@ export const VisualTestV1WithZoom = {
 
 export const FullWidth = () => <FullWidthExample />;
 export const SubmitButton = () => <SubmitButtonExample />;
-export const SubmitLoadingButton = () => <SubmitLoadingButtonExample />;

--- a/examples/bpk-component-button/stories.tsx
+++ b/examples/bpk-component-button/stories.tsx
@@ -76,6 +76,5 @@ export const VisualTestV1WithZoom = {
     zoomEnabled: true,
   },
 };
-
-export const FullWidth = () => <FullWidthExample />;
 export const SubmitButton = () => <SubmitButtonExample />;
+export const FullWidth = () => <FullWidthExample />;

--- a/examples/bpk-component-loading-button/examples.js
+++ b/examples/bpk-component-loading-button/examples.js
@@ -395,6 +395,9 @@ const VisualExample = () => (
     </div>
   </div>
 );
+const SubmitExample = () => (
+  <LoadingButtonStory submit wrapped={BpkLoadingButton} />
+);
 
 export {
   DocsPrimaryExample,
@@ -411,4 +414,5 @@ export {
   AnchorTagsExample,
   CustomIconExample,
   VisualExample,
+  SubmitExample,
 };

--- a/examples/bpk-component-loading-button/stories.js
+++ b/examples/bpk-component-loading-button/stories.js
@@ -34,6 +34,7 @@ import {
   AnchorTagsExample,
   CustomIconExample,
   VisualExample,
+  SubmitExample,
 } from './examples';
 
 export default {
@@ -61,6 +62,7 @@ export const Mixture = MixtureExample;
 export const AnchorTags = AnchorTagsExample;
 
 export const CustomIcon = CustomIconExample;
+export const Submit = SubmitExample;
 export const VisualTest = VisualExample;
 export const VisualTestWithZoom = VisualTest.bind({});
 VisualTestWithZoom.args = {

--- a/packages/bpk-component-loading-button/src/BpkLoadingButton.tsx
+++ b/packages/bpk-component-loading-button/src/BpkLoadingButton.tsx
@@ -20,7 +20,6 @@ import PropTypes from 'prop-types';
 import type { ReactElement, ReactNode } from 'react';
 
 import { BUTTON_TYPES, BpkButtonV2, SIZE_TYPES } from '../../bpk-component-button';
-import type { Props as ButtonProps } from '../../bpk-component-button/src/BpkButtonV2/common-types';
 import {
   withButtonAlignment,
   withLargeButtonAlignment,
@@ -30,6 +29,8 @@ import ArrowIconLg from '../../bpk-component-icon/lg/long-arrow-right';
 import ArrowIconSm from '../../bpk-component-icon/sm/long-arrow-right';
 import { BpkSpinner, BpkLargeSpinner } from '../../bpk-component-spinner';
 import { cssModules } from '../../bpk-react-utils';
+
+import type { Props as ButtonProps } from '../../bpk-component-button/src/BpkButtonV2/common-types';
 
 import STYLES from './BpkLoadingButton.module.scss';
 

--- a/packages/bpk-component-loading-button/src/BpkLoadingButton.tsx
+++ b/packages/bpk-component-loading-button/src/BpkLoadingButton.tsx
@@ -20,6 +20,7 @@ import PropTypes from 'prop-types';
 import type { ReactElement, ReactNode } from 'react';
 
 import { BUTTON_TYPES, BpkButtonV2, SIZE_TYPES } from '../../bpk-component-button';
+import type { Props as ButtonProps } from '../../bpk-component-button/src/BpkButtonV2/common-types';
 import {
   withButtonAlignment,
   withLargeButtonAlignment,
@@ -83,7 +84,7 @@ type LoadingProps = {
   iconPosition: string,
   iconDisabled?: ReactElement<any>,
   iconLoading?: ReactElement<any>,
-};
+} & ButtonProps;
 
 const BpkLoadingButton = (props: LoadingProps) => {
   const {


### PR DESCRIPTION
Minor change to add the submit prop to the loading button props. Due to confusion in the past, it's probably best to make the submit prop type for the loading button explicit for consumers of Backpack as in the past, some users have set the type to be submit without knowing the submit prop exists and inherits the props from BpkButton via ...rest

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here