### PR TITLE
[NO-JIRA][BpkSwitch] Adds optional label position prop 

### DIFF
--- a/examples/bpk-component-switch/examples.js
+++ b/examples/bpk-component-switch/examples.js
@@ -27,6 +27,10 @@ const SmallExample = ({ ...rest }: {}) => (
   <BpkSwitch small {...rest} label="Backpack" />
 );
 
+const LabelonRightExample =({ ...rest }: {}) => (
+  <BpkSwitch {...rest} label="Backpack" labelPosition="right" />
+);
+
 // Putting the switch in a container which we know is too small to contain the label and the switch
 const ReducedSpaceExample =  ({ ...rest }: {}) => (
   <div style={{ width: "4rem" }}>
@@ -47,4 +51,4 @@ const MixedExample = () => (
 );
 
 
-export { DefaultExample, SmallExample, MixedExample, ReducedSpaceExample };
+export { DefaultExample, SmallExample, MixedExample, ReducedSpaceExample, LabelonRightExample };

--- a/examples/bpk-component-switch/stories.js
+++ b/examples/bpk-component-switch/stories.js
@@ -21,7 +21,7 @@ import { Title, Markdown, PRIMARY_STORY } from '@storybook/blocks';
 
 import BpkSwitch from '../../packages/bpk-component-switch/src/BpkSwitch';
 
-import { DefaultExample, SmallExample, MixedExample, ReducedSpaceExample } from './examples';
+import { DefaultExample, SmallExample, MixedExample, ReducedSpaceExample, LabelonRightExample } from './examples';
 
 export default {
   title: 'bpk-component-switch',
@@ -46,6 +46,7 @@ export default {
 export const Default = DefaultExample;
 export const Small = SmallExample;
 export const ReducedSpace = ReducedSpaceExample;
+export const LabelOnRight = LabelonRightExample;
 
 export const VisualTest = MixedExample;
 export const VisualTestWithZoom = VisualTest.bind({});

--- a/packages/bpk-component-switch/src/BpkSwitch.js
+++ b/packages/bpk-component-switch/src/BpkSwitch.js
@@ -29,10 +29,11 @@ const getClassName = cssModules(STYLES);
 export type Props = {
   label: Node,
   className: ?string,
+  labelPosition: ?'left' | 'right',
 };
 
 const BpkSwitch = (props: Props) => {
-  const { className, label, small, ...rest } = props;
+  const { className, label, labelPosition = 'left', small, ...rest } = props;
 
   const switchClassNames = getClassName(
     'bpk-switch__switch',
@@ -40,7 +41,7 @@ const BpkSwitch = (props: Props) => {
   );
 
   return (
-    <label className={getClassName('bpk-switch', className)}>
+    <label className={getClassName('bpk-switch', `bpk-switch-label-position--${labelPosition}`, className)}>
       {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'decisions/flowfixme.md'. */}
       <input
         type="checkbox"

--- a/packages/bpk-component-switch/src/BpkSwitch.module.scss
+++ b/packages/bpk-component-switch/src/BpkSwitch.module.scss
@@ -27,6 +27,7 @@ $border-width: tokens.$bpk-one-pixel-rem * 2;
 .bpk-switch {
   position: relative;
   display: flex;
+  width: fit-content;
   align-items: center;
 
   // Checkbox is invisible so the switch element can be the visual element.
@@ -89,6 +90,17 @@ $border-width: tokens.$bpk-one-pixel-rem * 2;
         width: tokens.bpk-spacing-base();
         height: tokens.bpk-spacing-base();
       }
+    }
+  }
+}
+
+.bpk-switch-label-position {
+  &--right {
+    flex-direction: row-reverse;
+
+    .bpk-switch__label {
+      margin-inline-end: 0;
+      margin-inline-start: tokens.bpk-spacing-md();
     }
   }
 }

--- a/packages/bpk-component-switch/src/BpkSwitch.module.scss
+++ b/packages/bpk-component-switch/src/BpkSwitch.module.scss
@@ -27,7 +27,6 @@ $border-width: tokens.$bpk-one-pixel-rem * 2;
 .bpk-switch {
   position: relative;
   display: flex;
-  width: fit-content;
   align-items: center;
 
   // Checkbox is invisible so the switch element can be the visual element.

--- a/packages/bpk-component-switch/src/__snapshots__/BpkSwitch-test.js.snap
+++ b/packages/bpk-component-switch/src/__snapshots__/BpkSwitch-test.js.snap
@@ -3,7 +3,7 @@
 exports[`BpkSwitch should render correctly 1`] = `
 <DocumentFragment>
   <label
-    class="bpk-switch"
+    class="bpk-switch bpk-switch-label-position--left"
   >
     <input
       aria-label="Switch"
@@ -27,7 +27,7 @@ exports[`BpkSwitch should render correctly 1`] = `
 exports[`BpkSwitch should render correctly when checked 1`] = `
 <DocumentFragment>
   <label
-    class="bpk-switch"
+    class="bpk-switch bpk-switch-label-position--left"
   >
     <input
       aria-label="Switch"
@@ -52,7 +52,7 @@ exports[`BpkSwitch should render correctly when checked 1`] = `
 exports[`BpkSwitch should render small switch 1`] = `
 <DocumentFragment>
   <label
-    class="bpk-switch"
+    class="bpk-switch bpk-switch-label-position--left"
   >
     <input
       aria-label="Switch"
@@ -76,7 +76,7 @@ exports[`BpkSwitch should render small switch 1`] = `
 exports[`BpkSwitch should support arbitrary props 1`] = `
 <DocumentFragment>
   <label
-    class="bpk-switch"
+    class="bpk-switch bpk-switch-label-position--left"
   >
     <input
       aria-label="Switch"
@@ -101,7 +101,7 @@ exports[`BpkSwitch should support arbitrary props 1`] = `
 exports[`BpkSwitch should support custom class names 1`] = `
 <DocumentFragment>
   <label
-    class="bpk-switch custom-classname"
+    class="bpk-switch bpk-switch-label-position--left custom-classname"
   >
     <input
       aria-label="Switch"


### PR DESCRIPTION
To satisfy this design in the soon to be released Flexible Price Grid feature we need to allow for the label to sit on the right hand side of the switch

<img width="208" alt="Screenshot 2024-08-08 at 09 24 46" src="https://github.com/user-attachments/assets/732be194-7f6d-4033-9bd5-36b4ee6828f4">


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here