### PR TITLE
[NO JIRA][BpkPopover]: Make popover hoverable

### DIFF
--- a/examples/bpk-component-popover/examples.js
+++ b/examples/bpk-component-popover/examples.js
@@ -151,6 +151,12 @@ const WithCustomRenderTargetExample = () => (
   </Spacer>
 );
 
+const HoverExample = () => (
+  <Spacer>
+    <PopoverContainer id="my-popover-1" hoverable />
+  </Spacer>
+);
+
 const WithoutArrowExample = () => (
   <Spacer>
     <PopoverContainer id="my-popover-2" displayArrow={false} />
@@ -196,6 +202,7 @@ const VisualExample = () => (
 export {
   DefaultExample,
   WithCustomRenderTargetExample,
+  HoverExample,
   WithoutArrowExample,
   WithLabelAsTitleExample,
   WithNoCloseButtonIconExample,

--- a/examples/bpk-component-popover/stories.js
+++ b/examples/bpk-component-popover/stories.js
@@ -22,6 +22,7 @@ import BpkPopover from '../../packages/bpk-component-popover';
 import {
   DefaultExample,
   WithCustomRenderTargetExample,
+  HoverExample,
   WithoutArrowExample,
   WithLabelAsTitleExample,
   OnTheSideExample,
@@ -38,6 +39,7 @@ export default {
 
 export const Default = DefaultExample;
 export const WithCustomRenderTarget = WithCustomRenderTargetExample;
+export const Hover = HoverExample;
 export const WithoutArrow = WithoutArrowExample;
 export const WithLabelAsTitle = WithLabelAsTitleExample;
 export const WithNoCloseButtonIcon =

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -37,6 +37,8 @@ import {
   arrow,
   FloatingArrow,
   shift,
+  useHover,
+  safePolygon,
 } from '@floating-ui/react';
 
 import { surfaceHighlightDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
@@ -98,6 +100,7 @@ export type Props = CloseButtonProps & {
   className?: string | null;
   closeButtonIcon?: boolean;
   closeButtonProps?: Object;
+  hoverable?: boolean;
   isOpen?: boolean;
   labelAsTitle?: boolean;
   padded?: boolean;
@@ -118,6 +121,7 @@ const BpkPopover = ({
   closeButtonLabel,
   closeButtonProps = {},
   closeButtonText,
+  hoverable = false,
   id,
   isOpen = false,
   label,
@@ -155,12 +159,16 @@ const BpkPopover = ({
 
   const click = useClick(context);
   const dismiss = useDismiss(context);
+  const hover = useHover(context, {
+    enabled: hoverable,
+    mouseOnly: true,
+    handleClose: safePolygon({
+      requireIntent: false,
+    }),
+  });
 
   // Merge all the interactions into prop getters
-  const { getFloatingProps, getReferenceProps } = useInteractions([
-    click,
-    dismiss,
-  ]);
+  const { getFloatingProps, getReferenceProps } = useInteractions([click, dismiss, hover]);
 
   const targetClick = target?.props?.onClick;
   const referenceProps = targetClick ? getReferenceProps({


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Adds a new prop to make the popover have the ability to be triggered on hover `hoverable` by default is set to false and is just triggered by clicking the desired action.

When the property is set to `true` a user is able to hover over the popover and trigger it to open, then interact with any of the content inside.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here