### PR TITLE
[NO JIRA][BpkSplitInput]: Fix default state of inputValue

### DIFF
--- a/packages/bpk-component-split-input/src/BpkSplitInput.tsx
+++ b/packages/bpk-component-split-input/src/BpkSplitInput.tsx
@@ -28,14 +28,6 @@ import STYLES from './BpkSplitInput.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-// keyCode constants
-const BACKSPACE = 8;
-const LEFT_ARROW = 37;
-const RIGHT_ARROW = 39;
-const DELETE = 46;
-const SPACEBAR = 32;
-const ENTER = 13;
-
 interface Props {
   type?: string | number;
   id: string;
@@ -65,7 +57,7 @@ class BpkSplitInput extends Component<Props, State> {
     super(props);
     this.state = {
       focusedInput: 0,
-      inputValue: Array(props.inputLength).fill(''),
+      inputValue: [],
     };
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Fixes an issue raised via #3565 that caused the `inputValue` state to always be a string array regardless of the type, this then causes issues whereby when putting in numbers they would be able to populate this value due to incompatible types

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here