### PR TITLE
[NO-JIRA] [BpkInsetBanner] Update stories UI styles to match docs

### DIFF
--- a/examples/bpk-component-inset-banner/examples.tsx
+++ b/examples/bpk-component-inset-banner/examples.tsx
@@ -23,7 +23,7 @@ import BpkInsetBanner, {
 const DefaultExampleTitleOnly = () => (
   <BpkInsetBanner
     title="Lorem ipsum"
-    backgroundColor="#054184"
+    backgroundColor="#FF6601"
     variant={VARIANT.onDark}
   />
 );
@@ -32,7 +32,7 @@ const DefaultExampleTitleAndSubheadline = () => (
   <BpkInsetBanner
     title="Lorem ipsum"
     subheadline="Lorem ipsum dolor sit amet"
-    backgroundColor="#054184"
+    backgroundColor="#FF6601"
     variant={VARIANT.onDark}
   />
 );
@@ -41,11 +41,11 @@ const WithLogoAndCtaTextExampleLight = () => (
   <BpkInsetBanner
     title="Lorem ipsum"
     subheadline="Lorem ipsum dolor sit amet"
-    logo="https://content.skyscnr.com/m/23c24b7080cfe18a/Medium-Skyscanner-Vertical-Blue.png"
+    logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
     callToAction={{
       text: 'Sponsored',
     }}
-    backgroundColor="#94C3FF"
+    backgroundColor="#FFE300"
     variant={VARIANT.onLight}
     accessibilityLabel="Sponsored by Skyscanner"
   />
@@ -55,8 +55,8 @@ const WithBodyTextExampleLight = () => (
   <BpkInsetBanner
     title="Lorem ipsum"
     subheadline="Lorem ipsum dolor sit amet"
-    logo="https://content.skyscnr.com/m/23c24b7080cfe18a/Medium-Skyscanner-Vertical-Blue.png"
-    backgroundColor="#94C3FF"
+    logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
+    backgroundColor="#FFE300"
     callToAction={{
       text: 'Sponsored',
     }}
@@ -71,8 +71,8 @@ const WithBodyTextAndLinkExampleDark = () => (
   <BpkInsetBanner
     title="Lorem ipsum"
     subheadline="Lorem ipsum dolor sit amet"
-    logo="https://content.skyscnr.com/m/7950ed6f30581485/Medium-Skyscanner-Vertical-White.png"
-    backgroundColor="#054184"
+    logo="https://content.skyscnr.com/m/3f4dadbd41da8235/original/Skyland_White_172x96.png"
+    backgroundColor="#FF6601"
     callToAction={{
       text: 'Sponsored',
     }}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
The storybook stories defined for the `bpk-component-inset-banner` component are using different UI styles (banner colour and logo) than the inset banner app components. This makes the styles not aligned in the backpack docs, so we want to update the styles to match the ones used by the app versions of the component.
- [Web inset banner docs](https://www.skyscanner.design/latest/components/inset-banner/web-QHUmIW4g)
- [App inset banner docs](https://www.skyscanner.design/latest/components/inset-banner/compose-SIxM16J2)

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here