### PR TITLE
[PANGOO-2581][BpkNavigationTabGroup]Add Extra Props in BPK NavTabGroup

### DIFF
--- a/examples/bpk-component-navigation-tab-group/examples.tsx
+++ b/examples/bpk-component-navigation-tab-group/examples.tsx
@@ -47,10 +47,10 @@ const tabs: BpkNavigationTabGroupProps['tabs'] = [
 ];
 
 const tabsWithIcon: BpkNavigationTabGroupProps['tabs'] = [
-  { id: 'air', text: 'Flights', href: '/', icon: flightIcons, dataCy:'flight-feature', dataAnalyticsName:'flights' },
-  { id: 'hotel', text: 'Hotels', href: '/hotel', icon: hotelIcons, dataCy:'hotel-feature', dataAnalyticsName:'hotels' },
-  { id: 'car', text: 'Car hire', href: '/carhire', icon: carIcons, dataCy:'carhire-feature', dataAnalyticsName:'car hire' },
-  { id: 'explore', text: 'Explore', href: '/Explore', icon: exploreIcons, dataCy:'explore-feature', dataAnalyticsName:'explore' },
+  { id: 'air', text: 'Flights', href: '/', icon: flightIcons, dataCypress:'flight-feature', dataAnalyticsName:'flights' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', icon: hotelIcons, dataCypress:'hotel-feature', dataAnalyticsName:'hotels' },
+  { id: 'car', text: 'Car hire', href: '/carhire', icon: carIcons, dataCypress:'carhire-feature', dataAnalyticsName:'car hire' },
+  { id: 'explore', text: 'Explore', href: '/Explore', icon: exploreIcons, dataCypress:'explore-feature', dataAnalyticsName:'explore' },
 ];
 
 const tabsNoHref: BpkNavigationTabGroupProps['tabs'] = [

--- a/examples/bpk-component-navigation-tab-group/examples.tsx
+++ b/examples/bpk-component-navigation-tab-group/examples.tsx
@@ -47,10 +47,10 @@ const tabs: BpkNavigationTabGroupProps['tabs'] = [
 ];
 
 const tabsWithIcon: BpkNavigationTabGroupProps['tabs'] = [
-  { id: 'air', text: 'Flights', href: '/', icon: flightIcons, dataCypress:'flight-feature', dataAnalyticsName:'flights' },
-  { id: 'hotel', text: 'Hotels', href: '/hotel', icon: hotelIcons, dataCypress:'hotel-feature', dataAnalyticsName:'hotels' },
-  { id: 'car', text: 'Car hire', href: '/carhire', icon: carIcons, dataCypress:'carhire-feature', dataAnalyticsName:'car hire' },
-  { id: 'explore', text: 'Explore', href: '/Explore', icon: exploreIcons, dataCypress:'explore-feature', dataAnalyticsName:'explore' },
+  { id: 'air', text: 'Flights', href: '/', icon: flightIcons, 'data-Cy':'flight-feature', 'data-Analytics':'flights' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', icon: hotelIcons, 'data-Cy':'hotel-feature', 'data-Analytics':'hotels' },
+  { id: 'car', text: 'Car hire', href: '/carhire', icon: carIcons, 'data-Cy':'carhire-feature', 'data-Analytics':'car hire' },
+  { id: 'explore', text: 'Explore', href: '/Explore', icon: exploreIcons, 'data-Cy':'explore-feature', 'data-Analytics':'explore' },
 ];
 
 const tabsNoHref: BpkNavigationTabGroupProps['tabs'] = [

--- a/examples/bpk-component-navigation-tab-group/examples.tsx
+++ b/examples/bpk-component-navigation-tab-group/examples.tsx
@@ -40,37 +40,38 @@ const carIcons = withRtlSupport(Car);
 const flightIcons = withRtlSupport(Flight);
 
 const tabs: BpkNavigationTabGroupProps['tabs'] = [
-  { text: 'Flights', href: '/' },
-  { text: 'Hotels', href: '/hotel' },
-  { text: 'Car hire', href: '/carhire' },
-  { text: 'Explore', href: '/Explore' },
+  { id: 'air', text: 'Flights', href: '/' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel' },
+  { id: 'car', text: 'Car hire', href: '/carhire' },
+  { id: 'explore', text: 'Explore', href: '/Explore' },
 ];
 
 const tabsWithIcon: BpkNavigationTabGroupProps['tabs'] = [
-  { text: 'Flights', href: '/', icon: flightIcons },
-  { text: 'Hotels', href: '/hotel', icon: hotelIcons },
-  { text: 'Car hire', href: '/carhire', icon: carIcons },
-  { text: 'Explore', href: '/Explore', icon: exploreIcons },
+  { id: 'air', text: 'Flights', href: '/', icon: flightIcons, dataCy:'flight-feature', dataAnalyticsName:'flights' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', icon: hotelIcons, dataCy:'hotel-feature', dataAnalyticsName:'hotels' },
+  { id: 'car', text: 'Car hire', href: '/carhire', icon: carIcons, dataCy:'carhire-feature', dataAnalyticsName:'car hire' },
+  { id: 'explore', text: 'Explore', href: '/Explore', icon: exploreIcons, dataCy:'explore-feature', dataAnalyticsName:'explore' },
 ];
 
 const tabsNoHref: BpkNavigationTabGroupProps['tabs'] = [
-  { text: 'Flights', icon: flightIcons },
-  { text: 'Hotels', icon: hotelIcons },
-  { text: 'Car hire', icon: carIcons },
-  { text: 'Explore', icon: exploreIcons },
+  { id: 'air', text: 'Flights', icon: flightIcons },
+  { id: 'hotel', text: 'Hotels', icon: hotelIcons },
+  { id: 'carhire', text: 'Car hire', icon: carIcons },
+  { id: 'explore', text: 'Explore', icon: exploreIcons },
 ];
 
 const tabsOnlyText: BpkNavigationTabGroupProps['tabs'] = [
-  { text: 'Flights'},
-  { text: 'Hotels' },
-  { text: 'Car hire'},
-  { text: 'Explore'},
+  { id: 'air', text: 'Flights'},
+  { id: 'hotel', text: 'Hotels' },
+  { id: 'carhire', text: 'Car hire'},
+  { id: 'explore', text: 'Explore'},
 ];
 
 // Simple Navigation Tab Group
 const SimpleSurfaceContrast = () => (
   <div className={getClassNames('bpk-navigation-tab-group-story')}>
     <BpkNavigationTabGroup
+      id='navExample'
       tabs={tabs}
       onItemClick={() => {}}
       selectedIndex={2}
@@ -86,6 +87,7 @@ const SimpleCanvasDefault = () => (
     className={getClassNames('bpk-navigation-tab-group-story__canvas-default')}
   >
     <BpkNavigationTabGroup
+      id='navExample'
       tabs={tabs}
       onItemClick={() => {}}
       selectedIndex={0}
@@ -98,6 +100,7 @@ const SimpleCanvasDefault = () => (
 const WithIconSurfaceContrastForExample = () => (
   <div className={getClassNames('bpk-navigation-tab-group-story')}>
     <BpkNavigationTabGroup
+      id='navExample'
       tabs={tabsWithIcon}
       onItemClick={() => {}}
       selectedIndex={0}
@@ -111,6 +114,7 @@ const WithIconSurfaceContrastForExample = () => (
 const WithIconCanvasDefaultForExample = () => (
   <div>
     <BpkNavigationTabGroup
+      id='navExample'
       tabs={tabsWithIcon}
       onItemClick={() => {}}
       selectedIndex={0}
@@ -124,6 +128,7 @@ const WithIconCanvasDefaultForExample = () => (
 const TabsNoHrefSurfaceContrastForExample = () => (
   <div className={getClassNames('bpk-navigation-tab-group-story')}>
   <BpkNavigationTabGroup
+    id='navExample'
     tabs={tabsNoHref}
     onItemClick={() => {}}
     selectedIndex={0}
@@ -137,6 +142,7 @@ const TabsNoHrefSurfaceContrastForExample = () => (
 const TabsNoHrefCanvasDefaultForExample = () => (
   <div>
     <BpkNavigationTabGroup
+      id='navExample'
       tabs={tabsNoHref}
       onItemClick={() => {}}
       selectedIndex={0}
@@ -150,6 +156,7 @@ const TabsNoHrefCanvasDefaultForExample = () => (
 const TabsOnlyTextSurfaceContrastForExample = () => (
   <div className={getClassNames('bpk-navigation-tab-group-story')}>
   <BpkNavigationTabGroup
+    id='navExample'
     tabs={tabsOnlyText}
     onItemClick={() => {}}
     selectedIndex={0}
@@ -163,6 +170,7 @@ const TabsOnlyTextSurfaceContrastForExample = () => (
 const TabsOnlyTextCanvasDefaultForExample = () => (
   <div>
     <BpkNavigationTabGroup
+      id='navExample'
       tabs={tabsOnlyText}
       onItemClick={() => {}}
       selectedIndex={0}

--- a/packages/bpk-component-navigation-tab-group/README.md
+++ b/packages/bpk-component-navigation-tab-group/README.md
@@ -31,14 +31,15 @@ const carIcons = withRtlSupport(Car);
 const flightIcons = withRtlSupport(Flight);
 
 const tabs: BpkNavigationTabGroupProps['tabs'] = [
-  { text: 'Flights', href: '/', icon: flightIcons },
-  { text: 'Hotels', href: '/hotel', icon: hotelIcons },
-  { text: 'Car hire', href: '/carhire', icon: carIcons },
-  { text: 'Explore', href: '/Explore', icon: exploreIcons },
+  { id: 'airli', text: 'Flights', href: '/', icon: flightIcons },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', icon: hotelIcons },
+  { id: 'carhire', text: 'Car hire', href: '/carhire', icon: carIcons },
+  { id: 'explore', text: 'Explore', href: '/Explore', icon: exploreIcons },
 ];
 
 export default () => (
   <BpkNavigationTabGroup
+    id='navExample'
     tabs={tabs}
     onItemClick={() => {}}
     selectedIndex={0}

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
@@ -30,9 +30,9 @@ const tabs: Props['tabs'] = [
 ];
 
 const tabsWithAnalytics: Props['tabs'] = [
-  { id: 'air', text: 'Flights', href: '/', dataCypress:'flight-feature', dataAnalyticsName:'flights' },
-  { id: 'hotel', text: 'Hotels', href: '/hotel', dataCypress:'hotel-feature', dataAnalyticsName:'hotels' },
-  { id: 'car', text: 'Car hire', href: '/carhire', dataCypress:'carhire-feature', dataAnalyticsName:'car hire' },
+  { id: 'air', text: 'Flights', href: '/', 'data-Cy':'flight-feature', 'data-analytics-name':'flight' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', 'data-Cy':'hotel-feature', 'data-analytics-name':'hotel' },
+  { id: 'car', text: 'Car hire', href: '/carhire', 'data-Cy':'carhire-feature', 'data-analytics-name':'car hire' },
 ];
 
 describe('BpkNavigationTabGroup', () => {

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
@@ -24,9 +24,15 @@ import BpkNavigationTabGroup, { NAVIGATION_TAB_GROUP_TYPES } from './BpkNavigati
 import type { Props } from './BpkNavigationTabGroup';
 
 const tabs: Props['tabs'] = [
-  { text: 'Flights', href: '/' },
-  { text: 'Hotels', href: '/hotel' },
-  { text: 'Car hire', href: '/carhire' },
+  { id: 'air', text: 'Flights', href: '/' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel' },
+  { id: 'car', text: 'Car hire', href: '/carhire' },
+];
+
+const tabsWithAnalytics: Props['tabs'] = [
+  { id: 'air', text: 'Flights', href: '/', dataCy:'flight-feature', dataAnalyticsName:'flights' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', dataCy:'hotel-feature', dataAnalyticsName:'hotels' },
+  { id: 'car', text: 'Car hire', href: '/carhire', dataCy:'carhire-feature', dataAnalyticsName:'car hire' },
 ];
 
 describe('BpkNavigationTabGroup', () => {
@@ -41,6 +47,7 @@ describe('BpkNavigationTabGroup', () => {
   it('should render correctly', () => {
     render(
       <BpkNavigationTabGroup
+        id = "navTest"
         tabs={tabs}
         onItemClick={() => {}}
         selectedIndex={0}
@@ -57,6 +64,7 @@ describe('BpkNavigationTabGroup', () => {
   it('should render selected link', () => {
     render(
       <BpkNavigationTabGroup
+        id = "navTest"
         tabs={tabs}
         onItemClick={() => {}}
         selectedIndex={0}
@@ -79,6 +87,7 @@ describe('BpkNavigationTabGroup', () => {
 
     render(
       <BpkNavigationTabGroup
+        id = "navTest"
         tabs={tabs}
         onItemClick={onItemClick}
         selectedIndex={0}
@@ -90,7 +99,8 @@ describe('BpkNavigationTabGroup', () => {
 
     expect(onItemClick).toHaveBeenCalledTimes(1);
     expect(onItemClick).toHaveBeenCalledWith(
-      { text: 'Hotels', href: '/hotel' },
+      expect.any(Object),
+      { id:'hotel', text: 'Hotels', href: '/hotel' },
       1,
     );
   });
@@ -98,6 +108,7 @@ describe('BpkNavigationTabGroup', () => {
   it('should render correctly when type is CanvasDefault', () => {
     render(
       <BpkNavigationTabGroup
+        id = "navTest"
         tabs={tabs}
         onItemClick={() => {}}
         selectedIndex={0}
@@ -110,5 +121,45 @@ describe('BpkNavigationTabGroup', () => {
     const flightLink = flightTextElement.closest('a');
 
     expect(flightLink).toHaveClass('bpk-navigation-tab-wrap--canvas-default');
+  });
+
+  it('should render correctly props when tab props with data analytics', () => {
+    render(
+      <BpkNavigationTabGroup
+        id = "navTest"
+        tabs={tabsWithAnalytics}
+        onItemClick={() => {}}
+        selectedIndex={0}
+        type={NAVIGATION_TAB_GROUP_TYPES.CanvasDefault}
+        ariaLabel="Navigation tabs"
+      />,
+    );
+
+    const flightTextElement = screen.getByText('Flights');
+    const flightLink = flightTextElement.closest('a');
+
+    expect(flightLink).toHaveAttribute('id', 'air');
+    expect(flightLink).toHaveAttribute('data-cy', 'flight-feature');
+    expect(flightLink).toHaveAttribute('data-analytics-name', 'flights');
+  });
+
+  it('should render correctly props when tab props without data analytics', () => {
+    render(
+      <BpkNavigationTabGroup
+        id = "navTest"
+        tabs={tabs}
+        onItemClick={() => {}}
+        selectedIndex={0}
+        type={NAVIGATION_TAB_GROUP_TYPES.CanvasDefault}
+        ariaLabel="Navigation tabs"
+      />,
+    );
+
+    const flightTextElement = screen.getByText('Flights');
+    const flightLink = flightTextElement.closest('a');
+
+    expect(flightLink).toHaveAttribute('id', 'air');
+    expect(flightLink).not.toHaveAttribute('data-cy');
+    expect(flightLink).not.toHaveAttribute('data-analytics-name');
   });
 });

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
@@ -140,7 +140,7 @@ describe('BpkNavigationTabGroup', () => {
 
     expect(flightLink).toHaveAttribute('id', 'air');
     expect(flightLink).toHaveAttribute('data-cy', 'flight-feature');
-    expect(flightLink).toHaveAttribute('data-analytics-name', 'flights');
+    expect(flightLink).toHaveAttribute('data-analytics-name', 'flight');
   });
 
   it('should render correctly props when tab props without data analytics', () => {

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
@@ -30,9 +30,9 @@ const tabs: Props['tabs'] = [
 ];
 
 const tabsWithAnalytics: Props['tabs'] = [
-  { id: 'air', text: 'Flights', href: '/', dataCy:'flight-feature', dataAnalyticsName:'flights' },
-  { id: 'hotel', text: 'Hotels', href: '/hotel', dataCy:'hotel-feature', dataAnalyticsName:'hotels' },
-  { id: 'car', text: 'Car hire', href: '/carhire', dataCy:'carhire-feature', dataAnalyticsName:'car hire' },
+  { id: 'air', text: 'Flights', href: '/', dataCypress:'flight-feature', dataAnalyticsName:'flights' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', dataCypress:'hotel-feature', dataAnalyticsName:'hotels' },
+  { id: 'car', text: 'Car hire', href: '/carhire', dataCypress:'carhire-feature', dataAnalyticsName:'car hire' },
 ];
 
 describe('BpkNavigationTabGroup', () => {

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { FunctionComponent, ReactElement } from 'react';
+import type { MouseEvent, FunctionComponent, ReactElement } from 'react';
 import { useState } from 'react';
 
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
@@ -34,17 +34,21 @@ export type NavigationTabGroupTypes =
   (typeof NAVIGATION_TAB_GROUP_TYPES)[keyof typeof NAVIGATION_TAB_GROUP_TYPES];
 
 type TabItem = {
+  id: string;
   text: string;
   icon?: FunctionComponent<any> | null;
   href?: string;
+  dataCy?: string;
+  dataAnalyticsName?: string;
 };
 export type Props = {
+  id: string;
   tabs: TabItem[];
   type?: NavigationTabGroupTypes;
   /*
    * Index parameter to track which is clicked
    */
-  onItemClick: (tab: TabItem, index: number) => void;
+  onItemClick: (e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>,tab: TabItem, index: number) => void;
   selectedIndex: number;
   ariaLabel: string;
 };
@@ -54,7 +58,7 @@ type TabWrapProps = {
   type: NavigationTabGroupTypes;
   selected: boolean;
   children: ReactElement;
-  onClick: () => void;
+  onClick: (e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
 };
 
 const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
@@ -64,22 +68,29 @@ const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
     selected && `bpk-navigation-tab-wrap--${type}-selected`,
   );
 
+  const tabProps = {
+    ...(tab.dataCy && { 'data-cy': tab.dataCy }),
+    ...(tab.dataAnalyticsName && { 'data-analytics-name': tab.dataAnalyticsName }),
+    id: tab.id,
+    className: tabStyling,
+  };
+
   return tab.href ? (
     <a
-      className={tabStyling}
+      {...tabProps}
       href={tab.href}
-      onClick={onClick}
+      onClick={(e: MouseEvent<HTMLAnchorElement>) => onClick(e)}
       aria-current={selected ? 'page' : false}
     >
       {children}
     </a>
   ) : (
     <button
-      className={tabStyling}
+      {...tabProps}
       type="button"
-      onClick={onClick}
-      aria-current={selected ? 'page' : false}
+      onClick={(e: MouseEvent<HTMLButtonElement>) => onClick(e)}
       role="link"
+      aria-current={selected ? 'page' : false}
     >
       {children}
     </button>
@@ -88,23 +99,25 @@ const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
 
 const BpkNavigationTabGroup = ({
   ariaLabel,
+  id,
   onItemClick,
   selectedIndex,
   tabs,
   type = NAVIGATION_TAB_GROUP_TYPES.SurfaceContrast,
 }: Props) => {
   const [selectedTab, setSelectedTab] = useState(selectedIndex);
-  const handleButtonClick = (tab: TabItem, index: number) => {
+  const handleButtonClick = (e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>, tab: TabItem, index: number) => {
     if (index !== selectedTab) {
       setSelectedTab(index);
     }
-    onItemClick(tab, index);
+    onItemClick(e, tab, index);
   };
 
   const containerStyling = getClassName('bpk-navigation-tab-group');
 
   return (
     <nav
+      id={id}
       className={containerStyling}
       role="navigation"
       aria-label={ariaLabel}
@@ -117,7 +130,7 @@ const BpkNavigationTabGroup = ({
             key={`index-${index.toString()}`}
             tab={tab}
             selected={selected}
-            onClick={() => handleButtonClick(tab, index)}
+            onClick={(e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => handleButtonClick(e, tab, index)}
             type={type}
           >
             <>

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
@@ -38,7 +38,7 @@ type TabItem = {
   text: string;
   icon?: FunctionComponent<any> | null;
   href?: string;
-  dataCy?: string;
+  dataCypress?: string;
   dataAnalyticsName?: string;
 };
 export type Props = {
@@ -69,7 +69,7 @@ const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
   );
 
   const tabProps = {
-    ...(tab.dataCy && { 'data-cy': tab.dataCy }),
+    ...(tab.dataCypress && { 'data-cy': tab.dataCypress }),
     ...(tab.dataAnalyticsName && { 'data-analytics-name': tab.dataAnalyticsName }),
     id: tab.id,
     className: tabStyling,

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
@@ -38,8 +38,7 @@ type TabItem = {
   text: string;
   icon?: FunctionComponent<any> | null;
   href?: string;
-  dataCypress?: string;
-  dataAnalyticsName?: string;
+  [rest: string]: any;
 };
 export type Props = {
   id: string;
@@ -68,16 +67,11 @@ const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
     selected && `bpk-navigation-tab-wrap--${type}-selected`,
   );
 
-  const tabProps = {
-    ...(tab.dataCypress && { 'data-cy': tab.dataCypress }),
-    ...(tab.dataAnalyticsName && { 'data-analytics-name': tab.dataAnalyticsName }),
-    id: tab.id,
-    className: tabStyling,
-  };
-
   return tab.href ? (
     <a
-      {...tabProps}
+      {...tab}
+      id={tab.id}
+      className={tabStyling}
       href={tab.href}
       onClick={(e: MouseEvent<HTMLAnchorElement>) => onClick(e)}
       aria-current={selected ? 'page' : false}
@@ -86,7 +80,9 @@ const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
     </a>
   ) : (
     <button
-      {...tabProps}
+      {...tab}
+      id={tab.id}
+      className={tabStyling}
       type="button"
       onClick={(e: MouseEvent<HTMLButtonElement>) => onClick(e)}
       role="link"

--- a/packages/bpk-component-navigation-tab-group/src/accessibility-test.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/accessibility-test.tsx
@@ -24,21 +24,22 @@ import BpkNavigationTabGroup from './BpkNavigationTabGroup';
 import type { Props } from './BpkNavigationTabGroup';
 
 const tabs: Props['tabs'] = [
-  { text: 'Flights', href: '/' },
-  { text: 'Hotels', href: '/hotel' },
-  { text: 'Car hire', href: '/carhire' },
+  { id: 'air', text: 'Flights', href: '/' },
+  { id: 'hotel',text: 'Hotels', href: '/hotel' },
+  { id: 'car', text: 'Car hire', href: '/carhire' },
 ];
 
 const tabsNoHref: Props['tabs'] = [
-  { text: 'Flights'},
-  { text: 'Hotels'},
-  { text: 'Car hire'},
+  { id: 'air', text: 'Flights'},
+  { id: 'hotel', text: 'Hotels'},
+  { id: 'car', text: 'Car hire'},
 ];
 
 describe('BpkNavigationTabGroup accessibility tests', () => {
   it('should not have programmatically-detectable accessibility issues', async () => {
     const { container } = render(
       <BpkNavigationTabGroup
+        id = "navTest"
         tabs={tabs}
         onItemClick={() => {}}
         selectedIndex={0}
@@ -52,6 +53,7 @@ describe('BpkNavigationTabGroup accessibility tests', () => {
   it('should not have programmatically-detectable accessibility issues without href', async () => {
     const { container } = render(
       <BpkNavigationTabGroup
+        id = "navTest"
         tabs={tabsNoHref}
         onItemClick={() => {}}
         selectedIndex={0}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
When using BPK Nav tabs in GC header, we found MouseEvent need pass  from  BPK NavTabs

There is click event function in GC header to handle all click event in Header .

And also need tab id and nav id pros in BPK NavTabs.  For data analytics, nav tabs also need data analytics props as optional.  

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here