### PR TITLE
[BpkRadio] update Storybook example

### DIFF
--- a/examples/bpk-component-radio/examples.js
+++ b/examples/bpk-component-radio/examples.js
@@ -51,7 +51,7 @@ class GroupExample extends Component<{}, { value: string }> {
             <BpkRadio
               {...rest}
               id={city}
-              name={city}
+              name='group_example'
               label={city}
               onChange={(event) => {
                 this.updateValue(event.target.value);


### PR DESCRIPTION
# BpkRadio Storybook

The Storybook examples used a different `name` property for the radio group. This breaks the interaction with keyboard and doesn't allow for 'tabbing into' the group and then using the arrow keys to navigate around. 

The change I made allows for the correct behaviour to show in our documentation website. In the future we should consider wrapping the example in a fieldset to give a proper Accessible sample. 

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here