### PR TITLE
[NO JIRA][FloatingNotification]: Update floating notification dismiss timeout

### DIFF
--- a/examples/bpk-component-floating-notification/examples.tsx
+++ b/examples/bpk-component-floating-notification/examples.tsx
@@ -20,25 +20,16 @@ import BpkFloatingNotification from '../../packages/bpk-component-floating-notif
 import BpkIconHeart from '../../packages/bpk-component-icon/sm/heart';
 import BpkIconInformationCircle from '../../packages/bpk-component-icon/sm/information-circle';
 
-const hideAfterHack = {
-  // Apply a exceptionally large number to hideAfter to effectively keep the UI around forever
-  hideAfter: 2_147_483_647, // largest 32 bit signed integer, maximum value for setTimeout. Around 28 days. :)
-};
-
 const DefaultExample = () => (
-  <BpkFloatingNotification text="Saved" {...hideAfterHack} />
+  <BpkFloatingNotification text="Saved" hideAfter={8000} />
 );
 
 const IconExample = () => (
-  <BpkFloatingNotification
-    icon={BpkIconHeart}
-    text="Saved"
-    {...hideAfterHack}
-  />
+  <BpkFloatingNotification icon={BpkIconHeart} text="Saved" hideAfter={8000} />
 );
 
 const CtaExample = () => (
-  <BpkFloatingNotification ctaText="View" text="Saved" {...hideAfterHack} />
+  <BpkFloatingNotification ctaText="View" text="Saved" hideAfter={8000} />
 );
 
 const CtaIconLongTextExample = () => (
@@ -46,7 +37,7 @@ const CtaIconLongTextExample = () => (
     ctaText="View"
     icon={BpkIconHeart}
     text="Killer Combo saved to New York and Miami 🎉"
-    {...hideAfterHack}
+    hideAfter={8000}
   />
 );
 
@@ -55,7 +46,9 @@ const VisualTestExample = () => (
     animateOnEnter
     animateOnExit
     ctaText="View"
-    {...hideAfterHack}
+    // Apply a exceptionally large number to hideAfter to effectively keep the UI around forever
+    // largest 32 bit signed integer, maximum value for setTimeout. Around 28 days. :)
+    hideAfter={2_147_483_647}
     icon={BpkIconInformationCircle}
     text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
   />


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

A request from design has come up for the examples which are used in our documentation site don't want to persist forever and disappear just a bit longer than the default `hideAfter` value.

So this PR changes the docs sites examples from 28days to 8 seconds.

We haven't touched the values for the visual tests just so that it doesn't become flaky in Percy tests

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here