### PR TITLE
[NO JIRA][BpkNavigationTabGroup]Modify Navigation Tab Group A11Y

### DIFF
--- a/packages/bpk-component-navigation-tab-group/README.md
+++ b/packages/bpk-component-navigation-tab-group/README.md
@@ -51,4 +51,4 @@ export default () => (
 
 ## Props
 
-Check out the full list of props on Skyscanner's [design system documentation website](https://www.skyscanner.design/latest/components/navigation-tab-group/web-4eQsMvYv).
+Check out the full list of props on Skyscanner's [design system documentation website](https://www.skyscanner.design/latest/components/navigation-tab-group/web-4wIhe9UI-4wIhe9UI).

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.module.scss
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.module.scss
@@ -29,6 +29,10 @@
 .bpk-navigation-tab-group {
   display: flex;
 
+  .bpk-navigation-tab-list {
+    display: flex;
+  }
+
   .bpk-navigation-tab-wrap {
     height: tokens.$bpk-one-pixel-rem * 36;
     padding: 0 tokens.bpk-spacing-base();

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
@@ -77,7 +77,8 @@ const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
       className={tabStyling}
       href={tab.href}
       onClick={(e: MouseEvent<HTMLAnchorElement>) => onClick(e)}
-      aria-current={selected ? 'page' : false}
+      role="tab"
+      aria-selected={selected}
     >
       {children}
     </a>
@@ -88,8 +89,8 @@ const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
       className={tabStyling}
       type="button"
       onClick={(e: MouseEvent<HTMLButtonElement>) => onClick(e)}
-      role="link"
-      aria-current={selected ? 'page' : false}
+      role="tab"
+      aria-selected={selected}
     >
       {children}
     </button>
@@ -121,6 +122,7 @@ const BpkNavigationTabGroup = ({
       role="navigation"
       aria-label={ariaLabel}
     >
+    <div role="tablist" className={getClassName('bpk-navigation-tab-list')}>
       {tabs.map((tab, index) => {
         const selected = index === selectedTab;
         const {icon,text,...tabWrapItem} = tab;
@@ -152,6 +154,7 @@ const BpkNavigationTabGroup = ({
           </TabWrap>
         );
       })}
+     </div>
     </nav>
   );
 };


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here