### PR TITLE
CAPY-889 Add xsmall to BpkPrice component

### DIFF
--- a/examples/bpk-component-price/examples.js
+++ b/examples/bpk-component-price/examples.js
@@ -20,6 +20,61 @@ import BpkPrice, { SIZES, ALIGNS } from '../../packages/bpk-component-price';
 
 const XSmallExample = () => <BpkPrice size={SIZES.xsmall} price="£1,830" />;
 
+const XSmallWithTrailingTextExample = () => (
+  <BpkPrice size={SIZES.xsmall} price="£1,830" trailingText="per day" />
+);
+
+const XSmallWithLeadingAndTrailingTextExample = () => (
+  <BpkPrice
+    size={SIZES.xsmall}
+    leadingText="from"
+    price="£1,830"
+    trailingText="per day"
+  />
+);
+
+const XSmallWithPreviousPriceExample = () => (
+  <BpkPrice
+    size={SIZES.xsmall}
+    previousPrice="£2,033"
+    price="£1,830"
+    trailingText="per day"
+  />
+);
+
+const XSmallWithPreviousPriceLeadingTextExample = () => (
+  <BpkPrice
+    size={SIZES.xsmall}
+    previousPrice="£2,033"
+    leadingText="Web only deal"
+    price="£1,830"
+    trailingText="per day"
+  />
+);
+
+const XSmallRightExample = () => (
+  <BpkPrice size={SIZES.xsmall} price="£1,830" align={ALIGNS.right} />
+);
+
+const XSmallRightWithTrailingTextExample = () => (
+  <BpkPrice
+    size={SIZES.xsmall}
+    price="£1,830"
+    trailingText="per day"
+    align={ALIGNS.right}
+  />
+);
+
+const XSmallRightWithLeadingandTrailingTextExample = () => (
+  <BpkPrice
+    size={SIZES.xsmall}
+    leadingText="from"
+    price="£1,830"
+    trailingText="per day"
+    align={ALIGNS.right}
+  />
+);
+
 const SmallExample = () => <BpkPrice price="£1,830" />;
 
 const SmallWithTrailingTextExample = () => (
@@ -124,6 +179,13 @@ const LargeLongPriceExample = () => (
 const MixedExample = () => (
   <div>
     <XSmallExample />
+    <XSmallWithTrailingTextExample />
+    <XSmallWithLeadingAndTrailingTextExample />
+    <XSmallWithPreviousPriceExample />
+    <XSmallWithPreviousPriceLeadingTextExample />
+    <XSmallRightExample />
+    <XSmallRightWithTrailingTextExample />
+    <XSmallRightWithLeadingandTrailingTextExample />
     <SmallExample />
     <SmallWithTrailingTextExample />
     <SmallWithLeadingAndTrailingTextExample />
@@ -144,6 +206,13 @@ const MixedExample = () => (
 
 export {
   XSmallExample,
+  XSmallWithTrailingTextExample,
+  XSmallWithLeadingAndTrailingTextExample,
+  XSmallWithPreviousPriceExample,
+  XSmallWithPreviousPriceLeadingTextExample,
+  XSmallRightExample,
+  XSmallRightWithTrailingTextExample,
+  XSmallRightWithLeadingandTrailingTextExample,
   SmallExample,
   SmallWithTrailingTextExample,
   SmallWithLeadingAndTrailingTextExample,

--- a/examples/bpk-component-price/examples.js
+++ b/examples/bpk-component-price/examples.js
@@ -18,6 +18,8 @@
 
 import BpkPrice, { SIZES, ALIGNS } from '../../packages/bpk-component-price';
 
+const XSmallExample = () => <BpkPrice size={SIZES.xsmall} price="£1,830" />;
+
 const SmallExample = () => <BpkPrice price="£1,830" />;
 
 const SmallWithTrailingTextExample = () => (
@@ -103,7 +105,6 @@ const LargeWithPreviousPriceLeadingTextExample = () => (
 );
 
 const LargeLongPriceExample = () => (
-   
   <div style={{ width: 184 }}>
     <BpkPrice
       size={SIZES.large}
@@ -122,6 +123,7 @@ const LargeLongPriceExample = () => (
 
 const MixedExample = () => (
   <div>
+    <XSmallExample />
     <SmallExample />
     <SmallWithTrailingTextExample />
     <SmallWithLeadingAndTrailingTextExample />
@@ -141,6 +143,7 @@ const MixedExample = () => (
 );
 
 export {
+  XSmallExample,
   SmallExample,
   SmallWithTrailingTextExample,
   SmallWithLeadingAndTrailingTextExample,

--- a/examples/bpk-component-price/stories.js
+++ b/examples/bpk-component-price/stories.js
@@ -19,6 +19,7 @@
 import BpkPrice from '../../packages/bpk-component-price/src/BpkPrice';
 
 import {
+  XSmallExample,
   SmallExample,
   SmallWithTrailingTextExample,
   SmallWithLeadingAndTrailingTextExample,
@@ -42,6 +43,7 @@ export default {
   component: BpkPrice,
 };
 
+export const XSmall = XSmallExample;
 export const Small = SmallExample;
 export const SmallWithTrailingText = SmallWithTrailingTextExample;
 export const SmallWithLeadingAndTrailingText =
@@ -66,5 +68,5 @@ export const LargeLongPrice = LargeLongPriceExample;
 export const VisualTest = MixedExample;
 export const VisualTestWithZoom = VisualTest.bind({});
 VisualTestWithZoom.args = {
-  zoomEnabled: true
+  zoomEnabled: true,
 };

--- a/examples/bpk-component-price/stories.js
+++ b/examples/bpk-component-price/stories.js
@@ -20,6 +20,13 @@ import BpkPrice from '../../packages/bpk-component-price/src/BpkPrice';
 
 import {
   XSmallExample,
+  XSmallWithTrailingTextExample,
+  XSmallWithLeadingAndTrailingTextExample,
+  XSmallWithPreviousPriceExample,
+  XSmallWithPreviousPriceLeadingTextExample,
+  XSmallRightExample,
+  XSmallRightWithTrailingTextExample,
+  XSmallRightWithLeadingandTrailingTextExample,
   SmallExample,
   SmallWithTrailingTextExample,
   SmallWithLeadingAndTrailingTextExample,
@@ -44,6 +51,16 @@ export default {
 };
 
 export const XSmall = XSmallExample;
+export const XSmallWithTrailingText = XSmallWithTrailingTextExample;
+export const XSmallWithLeadingAndTrailingText =
+  XSmallWithLeadingAndTrailingTextExample;
+export const XSmallWithPreviousPrice = XSmallWithPreviousPriceExample;
+export const XSmallWithPreviousPriceLeadingText =
+  XSmallWithPreviousPriceLeadingTextExample;
+export const XSmallRight = XSmallRightExample;
+export const XSmallRightWithTrailingText = XSmallRightWithTrailingTextExample;
+export const XSmallRightWithLeadingandTrailingText =
+  XSmallRightWithLeadingandTrailingTextExample;
 export const Small = SmallExample;
 export const SmallWithTrailingText = SmallWithTrailingTextExample;
 export const SmallWithLeadingAndTrailingText =

--- a/packages/bpk-component-price/src/BpkPrice-test.js
+++ b/packages/bpk-component-price/src/BpkPrice-test.js
@@ -29,6 +29,7 @@ const trailingText = 'per day';
 let props;
 
 describe.each([
+  [SIZES.xsmall, ALIGNS.left],
   [SIZES.small, ALIGNS.left],
   [SIZES.large, ALIGNS.left],
   [SIZES.small, ALIGNS.right],

--- a/packages/bpk-component-price/src/BpkPrice.js
+++ b/packages/bpk-component-price/src/BpkPrice.js
@@ -37,7 +37,7 @@ type Props = {
    * Use with caution.
    */
   leadingClassName: ?string,
-  railingText: ?string,
+  trailingText: ?string,
   previousPrice: ?string,
 };
 

--- a/packages/bpk-component-price/src/BpkPrice.js
+++ b/packages/bpk-component-price/src/BpkPrice.js
@@ -37,11 +37,31 @@ type Props = {
    * Use with caution.
    */
   leadingClassName: ?string,
-  trailingText: ?string,
+  railingText: ?string,
   previousPrice: ?string,
 };
 
 const getClassName = cssModules(STYLES);
+
+const getPriceTextStyle = (size: $Values<typeof SIZES>) => {
+  if (size === SIZES.small) {
+    return TEXT_STYLES.heading4;
+  }
+
+  if (size === SIZES.large) {
+    return TEXT_STYLES.xxl;
+  }
+
+  return TEXT_STYLES.heading5;
+};
+
+const getDefaultTextStyle = (size: $Values<typeof SIZES>) => {
+  if (size === SIZES.large) {
+    return TEXT_STYLES.sm;
+  }
+
+  return TEXT_STYLES.xs;
+};
 
 const BpkPrice = (props: Props) => {
   const {
@@ -56,7 +76,8 @@ const BpkPrice = (props: Props) => {
     ...rest
   } = props;
 
-  const isSmall = size === SIZES.small;
+  const defaultTextStyle = getDefaultTextStyle(size);
+  const priceTextStyle = getPriceTextStyle(size);
   const isAlignRight = align === ALIGNS.right;
 
   return (
@@ -78,30 +99,21 @@ const BpkPrice = (props: Props) => {
       >
         {previousPrice && (
           <span className={getClassName('bpk-price__previous-price')}>
-            <BpkText
-              textStyle={isSmall ? TEXT_STYLES.xs : TEXT_STYLES.sm}
-              tagName="span"
-            >
+            <BpkText textStyle={defaultTextStyle} tagName="span">
               {previousPrice}
             </BpkText>
           </span>
         )}
         {previousPrice && leadingText && (
           <span className={getClassName('bpk-price__separator')}>
-            <BpkText
-              textStyle={isSmall ? TEXT_STYLES.xs : TEXT_STYLES.sm}
-              tagName="span"
-            >
+            <BpkText textStyle={defaultTextStyle} tagName="span">
               &#67871;
             </BpkText>
           </span>
         )}
 
         {leadingText && (
-          <BpkText
-            textStyle={isSmall ? TEXT_STYLES.xs : TEXT_STYLES.sm}
-            tagName="span"
-          >
+          <BpkText textStyle={defaultTextStyle} tagName="span">
             {leadingText}
           </BpkText>
         )}
@@ -109,20 +121,19 @@ const BpkPrice = (props: Props) => {
       <div
         className={getClassName(isAlignRight && 'bpk-price__column-container')}
       >
-        <span className={getClassName('bpk-price__price', !isAlignRight && 'bpk-price__spacing')}>
-          <BpkText
-            textStyle={isSmall ? TEXT_STYLES.heading4 : TEXT_STYLES.xxl}
-            tagName="span"
-          >
+        <span
+          className={getClassName(
+            'bpk-price__price',
+            !isAlignRight && 'bpk-price__spacing',
+          )}
+        >
+          <BpkText textStyle={priceTextStyle} tagName="span">
             {price}
           </BpkText>
         </span>
         {trailingText && (
           <span className={getClassName('bpk-price__trailing')}>
-            <BpkText
-              textStyle={isSmall ? TEXT_STYLES.xs : TEXT_STYLES.sm}
-              tagName="span"
-            >
+            <BpkText textStyle={defaultTextStyle} tagName="span">
               {trailingText}
             </BpkText>
           </span>

--- a/packages/bpk-component-price/src/__snapshots__/BpkPrice-test.js.snap
+++ b/packages/bpk-component-price/src/__snapshots__/BpkPrice-test.js.snap
@@ -725,3 +725,245 @@ exports[`small right view should support trailing text attribute 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`xsmall left view should render correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-price"
+  >
+    <div
+      class=""
+    />
+    <div
+      class=""
+    >
+      <span
+        class="bpk-price__price bpk-price__spacing"
+      >
+        <span
+          class="bpk-text bpk-text--heading-5"
+        >
+          £1,830
+        </span>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`xsmall left view should support custom class names 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-price custom-classname"
+  >
+    <div
+      class=""
+    />
+    <div
+      class=""
+    >
+      <span
+        class="bpk-price__price bpk-price__spacing"
+      >
+        <span
+          class="bpk-text bpk-text--heading-5"
+        >
+          £1,830
+        </span>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`xsmall left view should support custom leading class names 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-price"
+  >
+    <div
+      class="leading-classname"
+    />
+    <div
+      class=""
+    >
+      <span
+        class="bpk-price__price bpk-price__spacing"
+      >
+        <span
+          class="bpk-text bpk-text--heading-5"
+        >
+          £1,830
+        </span>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`xsmall left view should support leading text attribute 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-price"
+  >
+    <div
+      class=""
+    >
+      <span
+        class="bpk-text bpk-text--xs"
+      >
+        from
+      </span>
+    </div>
+    <div
+      class=""
+    >
+      <span
+        class="bpk-price__price bpk-price__spacing"
+      >
+        <span
+          class="bpk-text bpk-text--heading-5"
+        >
+          £1,830
+        </span>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`xsmall left view should support previous price attribute 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-price"
+  >
+    <div
+      class="bpk-price__leading"
+    >
+      <span
+        class="bpk-price__previous-price"
+      >
+        <span
+          class="bpk-text bpk-text--xs"
+        >
+          £2,000
+        </span>
+      </span>
+    </div>
+    <div
+      class=""
+    >
+      <span
+        class="bpk-price__price bpk-price__spacing"
+      >
+        <span
+          class="bpk-text bpk-text--heading-5"
+        >
+          £1,830
+        </span>
+      </span>
+      <span
+        class="bpk-price__trailing"
+      >
+        <span
+          class="bpk-text bpk-text--xs"
+        >
+          per day
+        </span>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`xsmall left view should support previous price with leading text attribute 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-price"
+  >
+    <div
+      class="bpk-price__leading"
+    >
+      <span
+        class="bpk-price__previous-price"
+      >
+        <span
+          class="bpk-text bpk-text--xs"
+        >
+          £2,000
+        </span>
+      </span>
+      <span
+        class="bpk-price__separator"
+      >
+        <span
+          class="bpk-text bpk-text--xs"
+        >
+          𐤟
+        </span>
+      </span>
+      <span
+        class="bpk-text bpk-text--xs"
+      >
+        from
+      </span>
+    </div>
+    <div
+      class=""
+    >
+      <span
+        class="bpk-price__price bpk-price__spacing"
+      >
+        <span
+          class="bpk-text bpk-text--heading-5"
+        >
+          £1,830
+        </span>
+      </span>
+      <span
+        class="bpk-price__trailing"
+      >
+        <span
+          class="bpk-text bpk-text--xs"
+        >
+          per day
+        </span>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`xsmall left view should support trailing text attribute 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-price"
+  >
+    <div
+      class=""
+    />
+    <div
+      class=""
+    >
+      <span
+        class="bpk-price__price bpk-price__spacing"
+      >
+        <span
+          class="bpk-text bpk-text--heading-5"
+        >
+          £1,830
+        </span>
+      </span>
+      <span
+        class="bpk-price__trailing"
+      >
+        <span
+          class="bpk-text bpk-text--xs"
+        >
+          per day
+        </span>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/bpk-component-price/src/common-types.js
+++ b/packages/bpk-component-price/src/common-types.js
@@ -19,6 +19,7 @@
 /* @flow strict */
 
 export const SIZES = {
+  xsmall: 'xsmall',
   small: 'small',
   large: 'large',
 };


### PR DESCRIPTION
**Description**
Currently, 16px is not available in Backpack Price. The minimun font-size available is 20px.
In this task, we should contribute to Backpack to include the 16px option, to be able to use it in our new Unified xSell components

- Added `xsmall` type and include new size in `BpkPrice`
- Updated unit test
- Updated snapshots
- Added stories

| BpkPrice xsmall | styles |
| ----------- | ----------- |
| <img width="110" alt="Screenshot 2024-10-16 at 16 12 50" src="https://github.com/user-attachments/assets/7551938e-5df5-481b-8d41-c010a5084809"> | <img width="337" alt="Screenshot 2024-10-16 at 16 12 59" src="https://github.com/user-attachments/assets/25304d42-6a77-480a-b4d8-6eae5f8372d0"> |




Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here