### PR TITLE
[LUNA-2015][BpkSwitch] Adds focus indicator

### DIFF
--- a/packages/bpk-component-switch/src/BpkSwitch.module.scss
+++ b/packages/bpk-component-switch/src/BpkSwitch.module.scss
@@ -27,7 +27,12 @@ $border-width: tokens.$bpk-one-pixel-rem * 2;
 .bpk-switch {
   position: relative;
   display: flex;
+  width: fit-content;
   align-items: center;
+
+  &:focus-within {
+    @include utils.bpk-focus-indicator;
+  }
 
   // Checkbox is invisible so the switch element can be the visual element.
   &__checkbox {


### PR DESCRIPTION
Adding focus indicator round switch component

**Before**

https://github.com/user-attachments/assets/39613b00-8127-4bca-a4a6-f10727f592ef

**After**

https://github.com/user-attachments/assets/7501841d-af4e-4a1a-97a1-8e57ccc3cf1e



Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here