### PR TITLE
CAPY[909] Remove min width & height on BpkDividedCard

### DIFF
--- a/examples/bpk-component-card/examples.js
+++ b/examples/bpk-component-card/examples.js
@@ -110,14 +110,11 @@ const DefaultDividedCardExample = () => (
 );
 
 const VerticalDividedCardExample = () => (
-   
-  <div style={{ width: 343 }}>
-    <BpkDividedCard
-      primaryContent={longMessage}
-      secondaryContent={shortContent}
-      orientation={ORIENTATION.vertical}
-    />
-  </div>
+  <BpkDividedCard
+    primaryContent={longMessage}
+    secondaryContent={shortContent}
+    orientation={ORIENTATION.vertical}
+  />
 );
 const WithHrefDividedCardExample = () => (
   <BpkDividedCard
@@ -128,7 +125,6 @@ const WithHrefDividedCardExample = () => (
 );
 
 const NonElevatedDividedCardExample = () => (
-   
   <div style={{ width: 343 }}>
     <BpkDividedCard
       primaryContent={longMessage}

--- a/examples/bpk-component-card/examples.js
+++ b/examples/bpk-component-card/examples.js
@@ -125,14 +125,12 @@ const WithHrefDividedCardExample = () => (
 );
 
 const NonElevatedDividedCardExample = () => (
-  <div style={{ width: 343 }}>
-    <BpkDividedCard
-      primaryContent={longMessage}
-      secondaryContent={shortContent}
-      orientation={ORIENTATION.vertical}
-      isElevated={false}
-    />
-  </div>
+  <BpkDividedCard
+    primaryContent={longMessage}
+    secondaryContent={shortContent}
+    orientation={ORIENTATION.vertical}
+    isElevated={false}
+  />
 );
 
 const CardWrapperExample = () => (

--- a/packages/bpk-component-card/src/BpkDividedCard.module.scss
+++ b/packages/bpk-component-card/src/BpkDividedCard.module.scss
@@ -19,10 +19,6 @@
 @use '../../unstable__bpk-mixins/tokens';
 @use '../../unstable__bpk-mixins/utils';
 
-$min-vertical-width: 240;
-$max-vertical-width: 720;
-$min-horizontal-width: $max-vertical-width + 1;
-$min-horizontal-height: 292;
 $fixed-secondary-width: 216;
 
 .bpk-divided-card {
@@ -38,14 +34,10 @@ $fixed-secondary-width: 216;
 
   &--vertical-container {
     display: flex;
-    min-width: tokens.$bpk-one-pixel-rem * $min-vertical-width;
-    max-width: tokens.$bpk-one-pixel-rem * $max-vertical-width;
   }
 
   &--horizontal-container {
     display: flex;
-    min-width: tokens.$bpk-one-pixel-rem * $min-horizontal-width;
-    min-height: tokens.$bpk-one-pixel-rem * $min-horizontal-height;
   }
 
   &__primary {

--- a/packages/bpk-component-card/src/BpkDividedCard.module.scss
+++ b/packages/bpk-component-card/src/BpkDividedCard.module.scss
@@ -19,12 +19,9 @@
 @use '../../unstable__bpk-mixins/tokens';
 @use '../../unstable__bpk-mixins/utils';
 
-$fixed-secondary-width: 216;
-
 .bpk-divided-card {
   &--content {
     display: flex;
-    height: 100%;
     align-items: stretch;
   }
 
@@ -52,7 +49,6 @@ $fixed-secondary-width: 216;
     }
 
     &--horizontal {
-      width: tokens.$bpk-one-pixel-rem * $fixed-secondary-width;
       border-left: tokens.$bpk-input-border;
 
       @include utils.bpk-rtl {


### PR DESCRIPTION
Removing the `min-height` and `min-width` and therefore letting the content decide those instead.
NOTE: added the label `major` as we are making visual changes. 

| Before | After |
| -------- | -------- |
| <img width="644" alt="Screenshot 2024-10-29 at 15 07 30" src="https://github.com/user-attachments/assets/e7e00d7c-673a-44ce-b243-b3c46470f6db"> | <img width="644" alt="Screenshot 2024-10-29 at 15 06 54" src="https://github.com/user-attachments/assets/0c4307be-2c04-4c01-8b78-b1f1792470c6"> |
| <img width="644" alt="Screenshot 2024-10-29 at 15 07 24" src="https://github.com/user-attachments/assets/70151205-d1ff-4075-9c3e-9f8664c5f47e"> | ![Screenshot 2024-10-29 at 16 03 31](https://github.com/user-attachments/assets/52bd19c0-ff91-4093-930c-a103c0324ee7) |





Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here