### PR TITLE
[BD-9128][BpkIconMarkerBackground] Add aria-hidden to fix a11y issue

### DIFF
--- a/packages/bpk-component-map/src/BpkIconMarkerBackground.js
+++ b/packages/bpk-component-map/src/BpkIconMarkerBackground.js
@@ -48,6 +48,7 @@ const BpkIconMarkerBackground = (props: Props) => {
         width="32"
         height="40"
         viewBox="0 0 32 40"
+        aria-hidden="true"
         className={classNames}
         {...rest}
       >
@@ -62,6 +63,7 @@ const BpkIconMarkerBackground = (props: Props) => {
       width="26"
       height="32"
       viewBox="0 0 26 32"
+      aria-hidden="true"
       className={classNames}
       {...rest}
     >

--- a/packages/bpk-component-map/src/__snapshots__/BpkIconMarker-test.js.snap
+++ b/packages/bpk-component-map/src/__snapshots__/BpkIconMarker-test.js.snap
@@ -12,6 +12,7 @@ exports[`BpkIconMarker should render correctly with a "buttonProps" attribute 1`
       type="button"
     >
       <svg
+        aria-hidden="true"
         class="bpk-icon-marker-background"
         height="32"
         viewBox="0 0 26 32"
@@ -45,6 +46,7 @@ exports[`BpkIconMarker should render correctly with a "className" attribute 1`] 
       type="button"
     >
       <svg
+        aria-hidden="true"
         class="bpk-icon-marker-background"
         height="32"
         viewBox="0 0 26 32"
@@ -78,6 +80,7 @@ exports[`BpkIconMarker should render correctly with a "selected" attribute 1`] =
       type="button"
     >
       <svg
+        aria-hidden="true"
         class="bpk-icon-marker-background bpk-icon-marker-background--selected"
         height="40"
         viewBox="0 0 32 40"
@@ -111,6 +114,7 @@ exports[`BpkIconMarker should render properly 1`] = `
       type="button"
     >
       <svg
+        aria-hidden="true"
         class="bpk-icon-marker-background"
         height="32"
         viewBox="0 0 26 32"

--- a/packages/bpk-component-map/src/__snapshots__/BpkIconMarkerBackground-test.js.snap
+++ b/packages/bpk-component-map/src/__snapshots__/BpkIconMarkerBackground-test.js.snap
@@ -3,6 +3,7 @@
 exports[`BpkIconMarkerBackground should render properly 1`] = `
 <DocumentFragment>
   <svg
+    aria-hidden="true"
     class="bpk-icon-marker-background"
     height="32"
     viewBox="0 0 26 32"
@@ -19,6 +20,7 @@ exports[`BpkIconMarkerBackground should render properly 1`] = `
 exports[`BpkIconMarkerBackground should render properly with "disabled" 1`] = `
 <DocumentFragment>
   <svg
+    aria-hidden="true"
     class="bpk-icon-marker-background bpk-icon-marker-background--disabled"
     height="32"
     viewBox="0 0 26 32"
@@ -35,6 +37,7 @@ exports[`BpkIconMarkerBackground should render properly with "disabled" 1`] = `
 exports[`BpkIconMarkerBackground should render properly with "interactive" 1`] = `
 <DocumentFragment>
   <svg
+    aria-hidden="true"
     class="bpk-icon-marker-background bpk-icon-marker-background--interactive"
     height="32"
     viewBox="0 0 26 32"
@@ -51,6 +54,7 @@ exports[`BpkIconMarkerBackground should render properly with "interactive" 1`] =
 exports[`BpkIconMarkerBackground should render properly with "selected" 1`] = `
 <DocumentFragment>
   <svg
+    aria-hidden="true"
     class="bpk-icon-marker-background bpk-icon-marker-background--selected"
     height="40"
     viewBox="0 0 32 40"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here