### PR TITLE
[NO JIRA][BpkSpinner]: Fix Spinner removing aria-hidden from element

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,5 +5,6 @@ coverage
 /packages/bpk-component-flare/src/__generated__
 /packages/bpk-component-icon/sm
 /packages/bpk-component-icon/lg
+/packages/bpk-component-spinner/src/spinners
 /packages/bpk-stylesheets/base.js
 *.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /dist-storybook
 /coverage
 /packages/bpk-component-icon/*/
+/packages/bpk-component-spinner/src/spinners
 /packages/bpk-component-flare/src/__generated__
 !/packages/bpk-component-icon/src
 node_modules

--- a/gulpfile.js/bpk-component-spinner/gulpfile.babel.js
+++ b/gulpfile.js/bpk-component-spinner/gulpfile.babel.js
@@ -16,4 +16,25 @@
  * limitations under the License.
  */
 
-export default ['spinnerPrimaryColor'];
+const fs = require('fs');
+
+const gulp = require('gulp');
+
+const ICONS_FOLDER_PATH = './node_modules/@skyscanner/bpk-svgs/dist/js/spinners';
+
+const rm = (path, options) =>
+  new Promise((resolve, reject) =>
+    fs.rm(path, options, (err, ...d) => (err ? reject(err) : resolve(...d))),
+  );
+gulp.task('copy', () =>
+  gulp
+    .src(`${ICONS_FOLDER_PATH}/**/*`)
+    .pipe(gulp.dest('./packages/bpk-component-spinner/src/spinners')),
+);
+
+gulp.task('clean', () =>
+  Promise.all([
+    rm('./packages/bpk-component-spinner/src/spinners', { force: true, recursive: true }),
+  ]),
+);
+gulp.task('generateSpinners', gulp.series('clean', 'copy'));

--- a/gulpfile.js/bpk-component-spinner/gulpfile.js
+++ b/gulpfile.js/bpk-component-spinner/gulpfile.js
@@ -16,4 +16,17 @@
  * limitations under the License.
  */
 
-export default ['spinnerPrimaryColor'];
+/*
+In Babel 7+, Babel stops looking for config files once it finds a package.json. As this
+is a monorepo and the Babel config file is in the repo root, we need to tell Babel to go
+upwards up the tree to find it.
+
+Without this, gulp will not run as gulpfile.babel.js won't be transpiled and we'll get syntax
+errors.
+*/
+
+require('@babel/register')({
+  rootMode: 'upward',
+});
+
+require('./gulpfile.babel');

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -20,5 +20,6 @@ const gulp = require('gulp');
 
 require('./bpk-component-flare/gulpfile');
 require('./bpk-component-icon/gulpfile');
+require('./bpk-component-spinner/gulpfile');
 
-gulp.task('default', gulp.series('generateFlare', 'generateIcons'));
+gulp.task('default', gulp.series('generateFlare', 'generateIcons', 'generateSpinners'));

--- a/packages/bpk-component-spinner/src/BpkExtraLargeSpinner.tsx
+++ b/packages/bpk-component-spinner/src/BpkExtraLargeSpinner.tsx
@@ -16,11 +16,11 @@
  * limitations under the License.
  */
 
-import XlSpinner from '@skyscanner/bpk-svgs/dist/js/spinners/xl';
 
 import { cssModules } from '../../bpk-react-utils';
 
 import SPINNER_TYPES from './spinnerTypes';
+import XlSpinner from './spinners/xl';
 
 import type { SpinnerTypes } from './spinnerTypes';
 

--- a/packages/bpk-component-spinner/src/BpkLargeSpinner.tsx
+++ b/packages/bpk-component-spinner/src/BpkLargeSpinner.tsx
@@ -16,11 +16,11 @@
  * limitations under the License.
  */
 
-import LgSpinner from '@skyscanner/bpk-svgs/dist/js/spinners/lg';
 
 import { cssModules } from '../../bpk-react-utils';
 
 import SPINNER_TYPES from './spinnerTypes';
+import LgSpinner from './spinners/lg';
 
 import type { SpinnerTypes } from './spinnerTypes';
 

--- a/packages/bpk-component-spinner/src/BpkSpinner.tsx
+++ b/packages/bpk-component-spinner/src/BpkSpinner.tsx
@@ -16,11 +16,11 @@
  * limitations under the License.
  */
 
-import SmSpinner from '@skyscanner/bpk-svgs/dist/js/spinners/sm';
 
 import { cssModules } from '../../bpk-react-utils';
 
 import SPINNER_TYPES from './spinnerTypes';
+import SmSpinner from './spinners/sm';
 
 import type { SpinnerTypes } from './spinnerTypes';
 

--- a/packages/bpk-component-spinner/src/themeAttributes-test.tsx
+++ b/packages/bpk-component-spinner/src/themeAttributes-test.tsx
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-/* @flow strict */
-
 import themeAttributes from './themeAttributes';
 
 describe('themeAttributes', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR fixes an issue that at generation/transpilation stage of the spinner in Backpack the code to mark the Spinner icons as `aria-hidden` is removed.

To solve this we follow the same process as the bpk-icons where gulp brings them to the project for use rather than them being pulled and transpiled from `bpk-svgs`

| Before | After |
| -- | -- |
| ![Screenshot 2024-11-20 at 15 28 23](https://github.com/user-attachments/assets/c7776e1a-49c5-4ec2-aa98-1fd179623752) | ![Screenshot 2024-11-20 at 15 28 45](https://github.com/user-attachments/assets/c908ee10-c0d9-46d1-9855-1f4fed5b109f) |

## Evidence of previously missing property

![Screenshot 2024-11-20 at 15 44 09](https://github.com/user-attachments/assets/2b07701d-79ce-445b-9622-92bef7a8f1e3)

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here