### PR TITLE
[Storybook] BpkButton, fix accessibility violation

### DIFF
--- a/examples/bpk-component-button/examples.tsx
+++ b/examples/bpk-component-button/examples.tsx
@@ -97,7 +97,12 @@ const ButtonStory = ({ className, wrapped, ...rest }: StoryProps) => {
         Disabled
       </Wrapped>
       &nbsp;
-      <Wrapped iconOnly onClick={action('Button clicked')} {...rest}>
+      <Wrapped
+        iconOnly
+        onClick={action('Button clicked')}
+        aria-label="Button"
+        {...rest}
+      >
         <AlignedSmallLongArrowRightIcon />
       </Wrapped>
       &nbsp;
@@ -105,6 +110,7 @@ const ButtonStory = ({ className, wrapped, ...rest }: StoryProps) => {
         iconOnly
         size={SIZE_TYPES.large}
         onClick={action('Button clicked')}
+        aria-label="Button"
         {...rest}
       >
         <AlignedLargeLongArrowRightIcon />


### PR DESCRIPTION
# Storybook, BpkButton

- add aria-label to icon only button to resolve accessibility defect.


Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here