### PR TITLE
[ARGG-1349][documentation]: add deprecated-api, future-api and release-schedule documents

### DIFF
--- a/decisions/deprecated-api.md
+++ b/decisions/deprecated-api.md
@@ -1,0 +1,40 @@
+# Deprecated API
+
+## What is it?
+
+Deprecated API is a part of the library that will be **REMOVED** from the Public API (a set of functions, components, variables, types, public properties and methods exposed to consumers) in a following major version.
+
+The main purpose of the Deprecated API is to give consumers enough time to remove their usage of the deprecated API before it's removed from the library.
+
+## How to add/delete?
+
+* You **MUST** always mark any feature that will be removed as deprecated before its removal (e.g., removing a prop of a component, removing a component, etc.).
+* Deprecated props and arguments **MUST** always be optional
+* Deprecated API **MUST** follow the naming convention below
+* Deprecated API will be deleted by the owners of backpack repository when preparing for a major release
+* Deprecating API **MUST** never cause any breaking changes for the consumer
+* There **SHOULD** always be a minimum of 3 months between marking and releasing a feature as deprecated and removing it from the Public API
+
+## How to use?
+* You **SHOULD** aim to move away from Deprecated API as soon as possible
+
+## Naming Convention
+
+* We use `@deprecated - deprecation message` JSDoc or TSDoc comments to mark functions, components, or properties as deprecated
+    * **Component**:
+        ```js
+        /**
+        * @deprecated use ComponentX instead
+        */
+        const ComponentName = (props) => { ... }
+        ```
+    * **Props**:
+        ```js
+        type ComponentProps = {
+            name: string;
+            /**
+            * @deprecated label prop is deprecated
+            */
+            label?: string;
+        }
+        ```

--- a/decisions/future-api.md
+++ b/decisions/future-api.md
@@ -21,7 +21,7 @@ The main purpose of the Future API is to allow for breaking changes to be contri
 ## Naming Convention
 
 * We use `v{number}__` prefix with two underscores (where applicable) to mark functions, tokens and properties as part of the Future API, and
-* We use `V{number}` prefix to mark React components and props as part of the Future API, where `number` represents the GC library version in which the change will be released as a breaking change.
+* We use `V{number}` prefix to mark React components and props as part of the Future API, where `number` represents the backpack library version in which the change will be released as a breaking change.
     * **Component**: `BpkButton` -> `<V10BpkButton />`
         * For any major changes to an existing component where creating a separate component is easier (from consumer or owner perspective) than making the changes directly to the old component e.g. major API rewrite, default style or behaviour of a component changes etc.
     * **Function**: `v10__functionName`

--- a/decisions/future-api.md
+++ b/decisions/future-api.md
@@ -1,0 +1,28 @@
+# Future API
+
+## What is it?
+
+Future API is a part of the library that is expected to become the default **AND BREAKING** in a following major version. It is available for consumption on opt-in basis.
+
+The main purpose of the Future API is to allow for breaking changes to be contributed in a backwards-compatible way, providing consumers with enough time to adopt these changes before they become the default.
+
+## How to add/modify/delete?
+
+* You **MUST** always introduce breaking changes in a backwards-compatible way via the `future` flags (or [deprecated flags](deprecated-api.md) if applicable).
+* Future props and arguments **MUST** always be optional
+* Future API **MUST** follow the naming convention below
+* Future flags will be removed by the owners of backpack repository when preparing for a major release.
+* Future API **MUST NOT** introduce any breaking change to the default behaviour or appearance of any part of the Stable API
+* There **SHOULD** always be a minimum of 3 months between marking and releasing a feature under a `future` flag and releasing it as the default behaviour in a major version; until then both behaviours should coexist simultaneously.
+
+## How to use?
+* You **SHOULD** aim to opt in to Future API as soon as possible
+
+## Naming Convention
+
+* We use `v{number}__` prefix with two underscores (where applicable) to mark functions, tokens and properties as part of the Future API, and
+* We use `V{number}` prefix to mark React components and props as part of the Future API, where `number` represents the GC library version in which the change will be released as a breaking change.
+    * **Component**: `BpkButton` -> `<V10BpkButton />`
+        * For any major changes to an existing component where creating a separate component is easier (from consumer or owner perspective) than making the changes directly to the old component e.g. major API rewrite, default style or behaviour of a component changes etc.
+    * **Function**: `v10__functionName`
+    * **Props**: `v10__propertyName?: value;` for a prop that will be required in the next major version

--- a/decisions/release-schedule.md
+++ b/decisions/release-schedule.md
@@ -1,0 +1,38 @@
+# Release Schedule
+
+## Decision
+Starting Q4 2024, a major version of the @skyscanner/backpack-web package is released approximately every 3 months, typically at the end of each quarter.
+
+### Current Release Schedule
+
+### 2024-2025
+
+| Major Changes Window | Release Window | Backpack-web      |
+|----------------------|----------------|-------------------|
+| Sep 2024 and before  | December 2024  | 36.x              |
+| Sep - Dec 2024       | March 2025     | 37.x              |
+| Jan - March 2025     | June 2025      | 38.x              |
+| Apr - June 2025      | Sep 2025       | 39.x              |
+| July - Sep 2025      | December 2025  | 40.x              |
+
+!!! note
+    The first column of the table above indicates the period during which a major change might be introduced into the code in a backwards-compatible way before being released in a major version. However, this period may vary depending on the complexity of the change, and a change might be introduced *before* the specified period, allowing consumers a longer adoption period.
+
+## FAQ
+
+### What about minor and patch releases?
+
+Minor and patch versions are released throughout the year whenever requested by consumers.
+
+### I want to contribute a breaking change to a backpack component. What should I do?
+
+Major changes **MUST** always be introduced in a backwards-compatible manner using [future](future-api.md) or a [deprecated](deprecated-api.md) flags. These changes **MUST** only be released as part of a major release during the designated time for major releases.
+
+### I want to contribute a breaking change to a backpack component  and start using it immediately. What should I do?
+
+You can use [future flags](future-api.md) to contribute your change and adopt it without waiting for the next major release.
+
+### When will these changes become the default?
+
+There **MUST** be a minimum of 3 months between the introduction of a change under a `future` or `deprecated` flag and its release in a major version.
+

--- a/decisions/release-schedule.md
+++ b/decisions/release-schedule.md
@@ -15,8 +15,8 @@ Starting Q4 2024, a major version of the @skyscanner/backpack-web package is rel
 | Apr - June 2025      | Sep 2025       | 39.x              |
 | July - Sep 2025      | December 2025  | 40.x              |
 
-!!! note
-    The first column of the table above indicates the period during which a major change might be introduced into the code in a backwards-compatible way before being released in a major version. However, this period may vary depending on the complexity of the change, and a change might be introduced *before* the specified period, allowing consumers a longer adoption period.
+The first column of the table above indicates the period during which a major change might be introduced into the code in a backwards-compatible way before being released in a major version.
+However, this period may vary depending on the complexity of the change, and a change might be introduced *before* the specified period, allowing consumers a longer adoption period.
 
 ## FAQ
 


### PR DESCRIPTION
Adding documentation on new release schedule & the required deprecated api and future api to handle these changes across versions.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here