### PR TITLE
[WOM-5333] Wrap BpkCalendar format date methods with memoize

### DIFF
--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
@@ -19,6 +19,8 @@
 import type { ComponentType } from 'react';
 import { Component } from 'react';
 
+import { memoize } from 'lodash';
+
 import { isRTL } from '../../bpk-react-utils';
 
 import BpkCalendarDate from './BpkCalendarDate';
@@ -367,6 +369,7 @@ const withCalendarState = <P extends object>(Calendar: ComponentType<P>) => {
 
     render() {
       const {
+        formatDateFull,
         maxDate,
         minDate,
         onDateSelect,
@@ -394,6 +397,7 @@ const withCalendarState = <P extends object>(Calendar: ComponentType<P>) => {
           preventKeyboardFocus={this.state.preventKeyboardFocus}
           focusedDate={sanitisedFocusedDate}
           {...(calendarProps as P)}
+          formatDateFull={memoize(formatDateFull)}
           minDate={sanitisedMinDate}
           maxDate={sanitisedMaxDate}
           selectionConfiguration={selectionConfiguration}

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
@@ -19,6 +19,8 @@
 import type { ElementType } from 'react';
 import { Component } from 'react';
 
+import { memoize } from 'lodash';
+
 import { cssModules, isDeviceIos } from '../../bpk-react-utils';
 
 import { addCalendarGridTransition } from './BpkCalendarGridTransition';
@@ -170,7 +172,7 @@ class BpkCalendarGrid extends Component<Props, State> {
               dates={dates}
               onDateClick={onDateClick}
               onDateKeyDown={onDateKeyDown}
-              formatDateFull={formatDateFull}
+              formatDateFull={memoize(formatDateFull)}
               DateComponent={DateComponent}
               dateModifiers={dateModifiers!}
               preventKeyboardFocus={preventKeyboardFocus}

--- a/packages/bpk-component-calendar/src/composeCalendar.tsx
+++ b/packages/bpk-component-calendar/src/composeCalendar.tsx
@@ -18,6 +18,8 @@
 
 import type { ComponentType } from 'react';
 
+import { memoize } from 'lodash';
+
 import { cssModules } from '../../bpk-react-utils';
 
 import { CALENDAR_SELECTION_TYPE } from './custom-proptypes';
@@ -184,7 +186,7 @@ const composeCalendar = (
         {Nav && (
           <Nav
             changeMonthLabel={changeMonthLabel}
-            formatMonth={formatMonth}
+            formatMonth={memoize(formatMonth)}
             id={`${id}__bpk_calendar_nav`}
             maxDate={maxDate}
             minDate={minDate}
@@ -210,8 +212,8 @@ const composeCalendar = (
           DateComponent={CalendarDate}
           dateModifiers={dateModifiers}
           daysOfWeek={daysOfWeek}
-          formatDateFull={formatDateFull}
-          formatMonth={formatMonth}
+          formatDateFull={memoize(formatDateFull)}
+          formatMonth={memoize(formatMonth)}
           month={month}
           onDateClick={onDateClick}
           onDateKeyDown={onDateKeyDown}


### PR DESCRIPTION
Since INP has been introduced as a Core Web Vital (CWV) in March 2024, Skyscanner has struggled to maintain a good rating.

[INP](https://web.dev/articles/inp) stands for “Interaction To Next Paint” and is essentially the time it takes for a UI to respond to a users action (like a press or a click). A lot of evidence suggests that a lot of this is down to the Calendar found in our design system “Backpack”.

Analysis shows that we spend a lot of CPU/compute on formatting dates, which we do multiple times on each render for each date. This compute causes the UI to be slow and unresponsive on CPU limited devices (like your great aunts old Samsung Android Phone).

The theory is that using a Memoize function in front of these expensive functions can bring down this compute cost.