### PR TITLE
[NO-JIRA][BpkModal] Add custom padding element to scrim util and modal

### DIFF
--- a/packages/bpk-component-modal/README.md
+++ b/packages/bpk-component-modal/README.md
@@ -48,6 +48,7 @@ class App extends Component {
           title="Modal title"
           closeLabel="Close modal"
           getApplicationElement={() => document.getElementById('pagewrap')}
+          getCustomPaddingElement={() => document.getElementById('routes-container')}
           renderTarget={() => document.getElementById('modal-container')}
           accessoryView={
             <BpkNavigationBarButtonLink

--- a/packages/bpk-component-modal/src/BpkModal.tsx
+++ b/packages/bpk-component-modal/src/BpkModal.tsx
@@ -53,6 +53,11 @@ export type Props = Partial<ModalDialogProps> & {
    * The "pagewrap" element id is a convention we use internally at Skyscanner. In most cases it should "just work".
    */
   getApplicationElement: () => HTMLElement | null;
+
+  /**
+   * Sometimes the content is absolutely positioned and we need to specify the element that should have padding added when the modal is open.
+   */
+  getCustomPaddingElement?: () => HTMLElement | null;
 };
 
 const BpkModal = ({

--- a/packages/bpk-scrim-utils/src/scroll-utils.tsx
+++ b/packages/bpk-scrim-utils/src/scroll-utils.tsx
@@ -90,26 +90,28 @@ export const unfixBody = () => {
   body.style.position = '';
 };
 
-export const lockScroll = () => {
+export const lockScroll = (customPaddingElement?: HTMLElement | null) => {
   const body = getBodyElement();
+  const paddingElement = customPaddingElement || body;
 
-  if (!body) {
+  if (!body || !paddingElement) {
     return;
   }
 
   const paddingRight = getScrollBarWidth();
 
   body.style.overflow = 'hidden';
-  body.style.paddingRight = paddingRight;
+  paddingElement.style.paddingRight = paddingRight;
 };
 
-export const unlockScroll = () => {
+export const unlockScroll = (customPaddingElement?: HTMLElement | null) => {
   const body = getBodyElement();
+  const paddingElement = customPaddingElement || body;
 
-  if (!body) {
+  if (!body || !paddingElement) {
     return;
   }
 
   body.style.overflow = '';
-  body.style.paddingRight = '';
+  paddingElement.style.paddingRight = '';
 };

--- a/packages/bpk-scrim-utils/src/withScrim-test.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim-test.tsx
@@ -150,6 +150,8 @@ describe('BpkScrim', () => {
     it('should mount correctly when is not iPhone', () => {
       const mockSetAttribute = jest.fn();
       const mockRemoveAttribute = jest.fn();
+      const mockCustomPaddingElement = document.createElement('div');
+
       render(
         <Component
           onClose={jest.fn()}
@@ -158,11 +160,12 @@ describe('BpkScrim', () => {
             setAttribute: mockSetAttribute,
             removeAttribute: mockRemoveAttribute,
           }))}
+          getCustomPaddingElement={() => mockCustomPaddingElement}
           isIphone={false}
         />,
       );
       jest.runAllTimers();
-      expect(lockScroll).toHaveBeenCalled();
+      expect(lockScroll).toHaveBeenCalledWith(mockCustomPaddingElement);
       expect(focusStore.storeFocus).toHaveBeenCalled();
       expect(storeScroll).not.toHaveBeenCalled();
       expect(fixBody).not.toHaveBeenCalled();
@@ -182,6 +185,7 @@ describe('BpkScrim', () => {
     it('should unmount correctly when is iPhone', async () => {
       const mockSetAttribute = jest.fn();
       const mockRemoveAttribute = jest.fn();
+
       const { unmount } = render(
         <Component
           onClose={jest.fn()}
@@ -206,6 +210,8 @@ describe('BpkScrim', () => {
 
     it('should unmount correctly when is not iPhone', () => {
       const mockRemoveAttribute = jest.fn();
+      const mockCustomPaddingElement = document.createElement('div');
+
       const { unmount } = render(
         <Component
           onClose={jest.fn()}
@@ -214,12 +220,13 @@ describe('BpkScrim', () => {
             setAttribute: jest.fn(),
             removeAttribute: mockRemoveAttribute,
           }))}
+          getCustomPaddingElement={() => mockCustomPaddingElement}
           isIphone={false}
         />,
       );
       unmount();
 
-      expect(unlockScroll).toHaveBeenCalled();
+      expect(unlockScroll).toHaveBeenCalledWith(mockCustomPaddingElement);
       expect(restoreScroll).not.toHaveBeenCalled();
       expect(unfixBody).not.toHaveBeenCalled();
       expect(focusStore.storeFocus).toHaveBeenCalled();

--- a/packages/bpk-scrim-utils/src/withScrim.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim.tsx
@@ -64,6 +64,10 @@ export type Props = {
    */
   containerClassName?: string;
   closeOnScrimClick?: boolean;
+  /**
+   * Can be used to specify which element other than body should the scroll padding be applied to. Defaults to body.
+   */
+  getCustomPaddingElement?: () => HTMLElement | null;
   [rest: string]: any;
 };
 
@@ -84,8 +88,15 @@ const withScrim = <P extends object>(
     };
 
     componentDidMount() {
-      const { getApplicationElement, isIpad, isIphone } = this.props;
+      const {
+        getApplicationElement,
+        getCustomPaddingElement,
+        isIpad,
+        isIphone,
+      } = this.props;
+
       const applicationElement = getApplicationElement();
+      const customPaddingElement = getCustomPaddingElement?.();
 
       requestAnimationFrame(() => {
         /**
@@ -112,7 +123,7 @@ const withScrim = <P extends object>(
          * The desired behaviour is to prevent the user from scrolling content behind the scrim. The above iOS fixes are in place because lockScroll alone does not solve due to iOS specific issues.
          */
 
-        lockScroll();
+        lockScroll(customPaddingElement);
       });
 
       if (applicationElement) {
@@ -125,14 +136,20 @@ const withScrim = <P extends object>(
     }
 
     componentWillUnmount() {
-      const { getApplicationElement, isIpad, isIphone } = this.props;
+      const {
+        getApplicationElement,
+        getCustomPaddingElement,
+        isIpad,
+        isIphone,
+      } = this.props;
       const applicationElement = getApplicationElement();
+      const customPaddingElement = getCustomPaddingElement?.();
 
       if (isIphone || isIpad) {
         setTimeout(restoreScroll, 0);
         unfixBody();
       }
-      unlockScroll();
+      unlockScroll(customPaddingElement);
 
       if (applicationElement) {
         applicationElement.removeAttribute('aria-hidden');


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR adds support to specify a custom padding element to Backpack Modal. 

When a modal is opened, padding is added to the body to prevent the page from horizontally shifting. However, some microsites (like Banana) are setup in a way that has no effect, for example when using an absolutely positioned content.

This addition allows passing in a custom element instead, so that the padding can be applied to the correct element, instead of the body.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here