### PR TITLE
[Nojira] Improve BpkSlider onChange type

### DIFF
--- a/packages/bpk-component-slider/src/BpkSlider.tsx
+++ b/packages/bpk-component-slider/src/BpkSlider.tsx
@@ -32,13 +32,13 @@ import STYLES from './BpkSlider.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-export type Props = {
+export type Props<T extends number | number[]>  = {
   max: number;
   min: number;
   minDistance?: number;
   step?: number;
-  onChange: (value: number[] | number) => void;
-  onAfterChange?: (value: number[] | number) => void;
+  onChange: (value: T) => void;
+  onAfterChange?: (value: T) => void;
   value: number[] | number;
   ariaLabel: string[];
   ariaValuetext?: string[];
@@ -48,7 +48,7 @@ export type Props = {
   [rest: string]: any;
 };
 
-const BpkSlider = ({
+const BpkSlider = <T extends number | number[]>({
   ariaLabel,
   ariaValuetext,
   inputProps,
@@ -60,17 +60,17 @@ const BpkSlider = ({
   step,
   value,
   ...rest
-}: Props) => {
+}: Props<T>) => {
   const invert = isRTL();
   const currentValue = Array.isArray(value) ? value : [value];
 
   const processSliderValues = (
     sliderValues: number[],
-    callback?: (val: number | number[]) => void,
+    callback?: (val: T) => void,
   ) => {
     const val = sliderValues.length === 1 ? sliderValues[0] : sliderValues;
     if (callback) {
-      callback(val);
+      callback(val as T);
     }
   };
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

The parameter type of the BpkSlider `onChange` function is `number[] | number`, while it will be only one of them for usage, same as the  value

Before:
![Pasted Graphic](https://github.com/user-attachments/assets/1ed85be5-0e0e-4aad-8b05-17513c20e062)

After:
![Pasted Graphic 1](https://github.com/user-attachments/assets/88b0a1a2-a9f8-4669-8ddf-84c187c69a20)

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here