### PR TITLE
[GRAV-1370] [BpkOverlay] Add video overlay style

### DIFF
--- a/examples/bpk-component-overlay/examples.js
+++ b/examples/bpk-component-overlay/examples.js
@@ -211,7 +211,7 @@ const VideoOverlayExamples = () => {
             <BpkImage
               src={VIDEO_IMG_SRC}
               altText="Sail boat"
-              aspectRatio={0.6}
+              aspectRatio={360 / 640}
             />
           </BpkOverlay>
           <div className={getClassName('bpk-overlay-stories__overlay--name')}>
@@ -227,7 +227,7 @@ const VideoOverlayExamples = () => {
             <BpkImage
               src={VIDEO_IMG_SRC}
               altText="Sail boat"
-              aspectRatio={0.6}
+              aspectRatio={360 / 640}
             />
           </BpkOverlay>
         </BpkOverlay>

--- a/examples/bpk-component-overlay/examples.js
+++ b/examples/bpk-component-overlay/examples.js
@@ -30,7 +30,7 @@ import STYLES from './examples.module.scss';
 const IMAGE_SRC =
   'https://content.skyscnr.com/m/1c8c6338a92a7a94/original/matt-hardy-6ArTTluciuA-unsplash.jpg';
 const VIDEO_IMG_SRC =
-  'https://content.skyscnr.com/m/ecf210e9214ce0/original/37866_PH_20211029_001_story.jpg';
+  'https://content.skyscnr.com/m/2af45124245b6759/original/SOCIAL9.png';
 
 const getClassName = cssModules(STYLES);
 
@@ -200,17 +200,42 @@ const VignetteExample = () => {
   );
 };
 
-const VideoOverlayExample = () => {
-  const overlayType = OVERLAY_TYPES.videoOverlay;
+const VideoOverlayExamples = () => {
+  const overlayTypeTop = OVERLAY_TYPES.videoTop;
+  const overlayTypeBottom = OVERLAY_TYPES.videoBottom;
   return (
-    <div className={getClassName('bpk-overlay-stories__overlay-story')}>
-      <BpkOverlay overlayType={overlayType}>
-        <BpkImage src={VIDEO_IMG_SRC} altText="Mountains" aspectRatio={0.6} />
-      </BpkOverlay>
-      <div className={getClassName('bpk-overlay-stories__overlay--name')}>
-        <BpkText textStyle={TEXT_STYLES.xl}>
-          {OverlayName({ overlayType })}
-        </BpkText>
+    <div className={getClassName('bpk-overlay-stories')}>
+      {[overlayTypeTop, overlayTypeBottom].map((overlayType) => (
+        <div className={getClassName('bpk-overlay-stories__overlay-story')}>
+          <BpkOverlay overlayType={overlayType}>
+            <BpkImage
+              src={VIDEO_IMG_SRC}
+              altText="Sail boat"
+              aspectRatio={0.6}
+            />
+          </BpkOverlay>
+          <div className={getClassName('bpk-overlay-stories__overlay--name')}>
+            <BpkText textStyle={TEXT_STYLES.xl}>
+              {OverlayName({ overlayType })}
+            </BpkText>
+          </div>
+        </div>
+      ))}
+      <div className={getClassName('bpk-overlay-stories__overlay-story')}>
+        <BpkOverlay overlayType={overlayTypeTop}>
+          <BpkOverlay overlayType={overlayTypeBottom}>
+            <BpkImage
+              src={VIDEO_IMG_SRC}
+              altText="Sail boat"
+              aspectRatio={0.6}
+            />
+          </BpkOverlay>
+        </BpkOverlay>
+        <div className={getClassName('bpk-overlay-stories__overlay--name')}>
+          <BpkText textStyle={TEXT_STYLES.xl}>
+            {overlayTypeTop} & {overlayTypeBottom}
+          </BpkText>
+        </div>
       </div>
     </div>
   );
@@ -258,7 +283,7 @@ export {
   LeftExamples,
   RightExamples,
   VignetteExample,
-  VideoOverlayExample,
+  VideoOverlayExamples,
   WithForegroundContentExample,
   MixedExample,
 };

--- a/examples/bpk-component-overlay/examples.js
+++ b/examples/bpk-component-overlay/examples.js
@@ -29,6 +29,8 @@ import STYLES from './examples.module.scss';
 
 const IMAGE_SRC =
   'https://content.skyscnr.com/m/1c8c6338a92a7a94/original/matt-hardy-6ArTTluciuA-unsplash.jpg';
+const VIDEO_IMG_SRC =
+  'https://content.skyscnr.com/m/ecf210e9214ce0/original/37866_PH_20211029_001_story.jpg';
 
 const getClassName = cssModules(STYLES);
 
@@ -198,6 +200,22 @@ const VignetteExample = () => {
   );
 };
 
+const VideoOverlayExample = () => {
+  const overlayType = OVERLAY_TYPES.videoOverlay;
+  return (
+    <div className={getClassName('bpk-overlay-stories__overlay-story')}>
+      <BpkOverlay overlayType={overlayType}>
+        <BpkImage src={VIDEO_IMG_SRC} altText="Mountains" aspectRatio={0.6} />
+      </BpkOverlay>
+      <div className={getClassName('bpk-overlay-stories__overlay--name')}>
+        <BpkText textStyle={TEXT_STYLES.xl}>
+          {OverlayName({ overlayType })}
+        </BpkText>
+      </div>
+    </div>
+  );
+};
+
 const WithForegroundContentExample = () => (
   <BpkOverlay
     overlayType={OVERLAY_TYPES.solidHigh}
@@ -240,6 +258,7 @@ export {
   LeftExamples,
   RightExamples,
   VignetteExample,
+  VideoOverlayExample,
   WithForegroundContentExample,
   MixedExample,
 };

--- a/examples/bpk-component-overlay/stories.tsx
+++ b/examples/bpk-component-overlay/stories.tsx
@@ -24,6 +24,7 @@ import {
   BottomExamples,
   LeftExamples,
   RightExamples,
+  VideoOverlayExample,
   VignetteExample,
   WithForegroundContentExample,
   MixedExample,
@@ -41,6 +42,7 @@ export const Bottom = BottomExamples;
 export const Left = LeftExamples;
 export const Right = RightExamples;
 export const Vignette = VignetteExample;
+export const VideoOverlay = VideoOverlayExample;
 
 export const WithForegroundContent = WithForegroundContentExample;
 
@@ -48,6 +50,6 @@ export const VisualTest = MixedExample;
 export const VisualTestWithZoom = {
   render: VisualTest,
   args: {
-    zoomEnabled: true
-  }
-}
+    zoomEnabled: true,
+  },
+};

--- a/examples/bpk-component-overlay/stories.tsx
+++ b/examples/bpk-component-overlay/stories.tsx
@@ -24,7 +24,7 @@ import {
   BottomExamples,
   LeftExamples,
   RightExamples,
-  VideoOverlayExample,
+  VideoOverlayExamples,
   VignetteExample,
   WithForegroundContentExample,
   MixedExample,
@@ -42,7 +42,7 @@ export const Bottom = BottomExamples;
 export const Left = LeftExamples;
 export const Right = RightExamples;
 export const Vignette = VignetteExample;
-export const VideoOverlay = VideoOverlayExample;
+export const VideoOverlays = VideoOverlayExamples;
 
 export const WithForegroundContent = WithForegroundContentExample;
 

--- a/packages/bpk-component-overlay/src/BpkOverlay.module.scss
+++ b/packages/bpk-component-overlay/src/BpkOverlay.module.scss
@@ -160,14 +160,24 @@
       box-shadow: inset 0 0 50px rgba(tokens.$bpk-text-primary-day, 0.12);
     }
 
-    &--video-overlay {
-      background: linear-gradient(
-        180deg,
-        rgba(tokens.$bpk-text-primary-day, 0.45) 0%,
-        rgba(tokens.$bpk-text-primary-day, 0) 40%,
-        rgba(tokens.$bpk-text-primary-day, 0) 60%,
-        rgba(tokens.$bpk-text-primary-day, 0.9) 100%
-      );
+    &--video {
+      &-top {
+        background: linear-gradient(
+          180deg,
+          rgba(tokens.$bpk-text-primary-day, 0.45) 0%,
+          rgba(tokens.$bpk-text-primary-day, 0) 40%,
+          rgba(tokens.$bpk-text-primary-day, 0) 100%
+        );
+      }
+
+      &-bottom {
+        background: linear-gradient(
+          180deg,
+          rgba(tokens.$bpk-text-primary-day, 0) 0%,
+          rgba(tokens.$bpk-text-primary-day, 0) 60%,
+          rgba(tokens.$bpk-text-primary-day, 0.9) 100%
+        );
+      }
     }
   }
 }

--- a/packages/bpk-component-overlay/src/BpkOverlay.module.scss
+++ b/packages/bpk-component-overlay/src/BpkOverlay.module.scss
@@ -159,5 +159,15 @@
     &--vignette {
       box-shadow: inset 0 0 50px rgba(tokens.$bpk-text-primary-day, 0.12);
     }
+
+    &--video-overlay {
+      background: linear-gradient(
+        180deg,
+        rgba(tokens.$bpk-text-primary-day, 0.45) 0%,
+        rgba(tokens.$bpk-text-primary-day, 0) 40%,
+        rgba(tokens.$bpk-text-primary-day, 0) 60%,
+        rgba(tokens.$bpk-text-primary-day, 0.9) 100%
+      );
+    }
   }
 }

--- a/packages/bpk-component-overlay/src/BpkOverlay.tsx
+++ b/packages/bpk-component-overlay/src/BpkOverlay.tsx
@@ -41,6 +41,7 @@ export const OVERLAY_TYPES = {
   rightMedium: 'rightMedium',
   rightHigh: 'rightHigh',
   vignette: 'vignette',
+  videoOverlay: 'videoOverlay',
   off: 'off',
 } as const;
 
@@ -61,6 +62,7 @@ const overlayTypeClassSuffixes = {
   [OVERLAY_TYPES.rightMedium]: 'right-medium',
   [OVERLAY_TYPES.rightHigh]: 'right-high',
   [OVERLAY_TYPES.vignette]: 'vignette',
+  [OVERLAY_TYPES.videoOverlay]: 'video-overlay',
   [OVERLAY_TYPES.off]: 'off',
 } as const;
 

--- a/packages/bpk-component-overlay/src/BpkOverlay.tsx
+++ b/packages/bpk-component-overlay/src/BpkOverlay.tsx
@@ -41,7 +41,8 @@ export const OVERLAY_TYPES = {
   rightMedium: 'rightMedium',
   rightHigh: 'rightHigh',
   vignette: 'vignette',
-  videoOverlay: 'videoOverlay',
+  videoTop: 'videoTop',
+  videoBottom: 'videoBottom',
   off: 'off',
 } as const;
 
@@ -62,7 +63,8 @@ const overlayTypeClassSuffixes = {
   [OVERLAY_TYPES.rightMedium]: 'right-medium',
   [OVERLAY_TYPES.rightHigh]: 'right-high',
   [OVERLAY_TYPES.vignette]: 'vignette',
-  [OVERLAY_TYPES.videoOverlay]: 'video-overlay',
+  [OVERLAY_TYPES.videoTop]: 'video-top',
+  [OVERLAY_TYPES.videoBottom]: 'video-bottom',
   [OVERLAY_TYPES.off]: 'off',
 } as const;
 

--- a/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
+++ b/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
@@ -274,6 +274,21 @@ exports[`BpkOverlay should render correctly with overlayType={topMedium} 1`] = `
 </DocumentFragment>
 `;
 
+exports[`BpkOverlay should render correctly with overlayType={videoBottom} 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-overlay__wrapper"
+  >
+    <span>
+      Backpack
+    </span>
+    <div
+      class="bpk-overlay__overlay bpk-overlay__overlay--video-bottom"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`BpkOverlay should render correctly with overlayType={videoOverlay} 1`] = `
 <DocumentFragment>
   <div
@@ -284,6 +299,21 @@ exports[`BpkOverlay should render correctly with overlayType={videoOverlay} 1`] 
     </span>
     <div
       class="bpk-overlay__overlay bpk-overlay__overlay--video-overlay"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BpkOverlay should render correctly with overlayType={videoTop} 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-overlay__wrapper"
+  >
+    <span>
+      Backpack
+    </span>
+    <div
+      class="bpk-overlay__overlay bpk-overlay__overlay--video-top"
     />
   </div>
 </DocumentFragment>

--- a/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
+++ b/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
@@ -289,21 +289,6 @@ exports[`BpkOverlay should render correctly with overlayType={videoBottom} 1`] =
 </DocumentFragment>
 `;
 
-exports[`BpkOverlay should render correctly with overlayType={videoOverlay} 1`] = `
-<DocumentFragment>
-  <div
-    class="bpk-overlay__wrapper"
-  >
-    <span>
-      Backpack
-    </span>
-    <div
-      class="bpk-overlay__overlay bpk-overlay__overlay--video-overlay"
-    />
-  </div>
-</DocumentFragment>
-`;
-
 exports[`BpkOverlay should render correctly with overlayType={videoTop} 1`] = `
 <DocumentFragment>
   <div

--- a/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
+++ b/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
@@ -274,6 +274,21 @@ exports[`BpkOverlay should render correctly with overlayType={topMedium} 1`] = `
 </DocumentFragment>
 `;
 
+exports[`BpkOverlay should render correctly with overlayType={videoOverlay} 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-overlay__wrapper"
+  >
+    <span>
+      Backpack
+    </span>
+    <div
+      class="bpk-overlay__overlay bpk-overlay__overlay--video-overlay"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`BpkOverlay should render correctly with overlayType={vignette} 1`] = `
 <DocumentFragment>
   <div


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

JIRA: https://skyscanner.atlassian.net/browse/GRAV-1370

The new homepage hero video ad POC requires a [new video overlay](https://www.figma.com/design/o7vYhyVecpNyC92vTDPNTf/Video-Moments?node-id=2742-4578&m=dev). This PR adds that new overlay type to `BpkOverlay` as `videoTop` and `videoBottom`. 

Link to Figma video overlay design: https://www.figma.com/design/yN0hFyZlKL0Jwbpi0rEKYT/Backpack-Beta?node-id=27362-1451&m=dev 

| No overlay | Video Overlay |
| --- | --- |
| <img width="300" src="https://github.com/user-attachments/assets/c399c1c5-6a5d-4cb7-ae58-505c30d969a8" /> | <img width="1162" alt="Screenshot 2025-01-21 at 15 17 57" src="https://github.com/user-attachments/assets/d0d505d0-3fd9-4f0e-b0fc-49375a22109a" /> |

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here