### PR TITLE
[QUAR-642] [BpkCardWrapper] Add more info button and body section to card wrapper

### DIFF
--- a/examples/bpk-component-card/examples.js
+++ b/examples/bpk-component-card/examples.js
@@ -50,6 +50,24 @@ const headerContent = (
     </BpkText>
   </div>
 );
+const adHeaderContent = (
+  <div className={getClassName('bpk-card-examples__ad-header')}>
+    <img
+      className={getClassName('bpk-card-examples__ad-header--logo')}
+      src="https://content.skyscnr.com/m/3f4dadbd41da8235/original/Skyland_White_172x96.png"
+      alt=""
+      aria-hidden
+    />
+    <div className={getClassName('bpk-card-examples__ad-header--title')}>
+      <BpkText tagName="span" textStyle={TEXT_STYLES.label2}>
+        Wrapper title
+      </BpkText>
+      <BpkText tagName="span" textStyle={TEXT_STYLES.caption}>
+        Lorem ipsum dolor sit amet
+      </BpkText>
+    </div>
+  </div>
+);
 const longContent = (
   <Fragment>
     <BpkText
@@ -178,6 +196,27 @@ const WithClassNameWrapperExample = () => (
   />
 );
 
+const WithBodyCardWrapperExample = () => (
+  <BpkCardWrapper
+    backgroundColor={coreAccentDay}
+    body={{
+      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum.',
+      link: 'https://www.skyscanner.es/',
+      linkText: 'Click here',
+      moreInfoBtnColor: 'white',
+    }}
+    card={
+      <BpkCard
+        atomic={false}
+        onClick={() => window.open('https://www.skyscanner.net/')}
+      >
+        {longContent}
+      </BpkCard>
+    }
+    header={adHeaderContent}
+  />
+);
+
 const MixedExample = () => (
   <div>
     <DefaultExample />
@@ -211,5 +250,6 @@ export {
   CardWrapperExample,
   DividedCardWrapperExample,
   WithClassNameWrapperExample,
+  WithBodyCardWrapperExample,
   MixedExample,
 };

--- a/examples/bpk-component-card/examples.js
+++ b/examples/bpk-component-card/examples.js
@@ -201,6 +201,8 @@ const WithBodyCardWrapperExample = () => (
     backgroundColor={coreAccentDay}
     body={{
       text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum.',
+      openBtnLabel: 'More info',
+      closeBtnLabel: 'Less info',
       link: 'https://www.skyscanner.es/',
       linkText: 'Click here',
       moreInfoBtnColor: 'white',

--- a/examples/bpk-component-card/examples.module.scss
+++ b/examples/bpk-component-card/examples.module.scss
@@ -17,6 +17,7 @@
  */
 
 @use '../../packages/unstable__bpk-mixins/tokens';
+@use '../../packages/unstable__bpk-mixins/breakpoints';
 
 .bpk-card-examples {
   &__header {
@@ -26,6 +27,28 @@
     justify-content: space-between;
     align-items: center;
     color: tokens.$bpk-text-on-dark-day;
+  }
+
+  &__ad-header {
+    display: flex;
+    padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
+    color: tokens.$bpk-text-on-dark-day;
+
+    @include breakpoints.bpk-breakpoint-mobile {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    &--logo {
+      max-height: tokens.bpk-spacing-xl();
+      object-fit: contain;
+      padding-inline-end: tokens.bpk-spacing-base();
+    }
+
+    &--title {
+      display: flex;
+      flex-direction: column;
+    }
   }
 
   &__wrapper {

--- a/examples/bpk-component-card/stories.js
+++ b/examples/bpk-component-card/stories.js
@@ -33,6 +33,7 @@ import {
   CardWrapperExample,
   DividedCardWrapperExample,
   WithClassNameWrapperExample,
+  WithBodyCardWrapperExample,
   MixedExample,
 } from './examples';
 
@@ -62,6 +63,7 @@ export const NonElevatedDividedCard = NonElevatedDividedCardExample;
 export const CardWrapper = CardWrapperExample;
 export const DividedCardWrapper = DividedCardWrapperExample;
 export const WithClassNameWrapper = WithClassNameWrapperExample;
+export const WithBodyCardWrapper = WithBodyCardWrapperExample;
 
 export const VisualTest = MixedExample;
 export const VisualTestWithZoom = VisualTest.bind({});

--- a/packages/bpk-component-card/src/BpkCardWrapper-test.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper-test.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { render,screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { coreAccentDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
@@ -73,7 +73,7 @@ describe('BpkCardWrapper', () => {
           openBtnLabel: 'More Info',
           closeBtnLabel: 'Less Info',
         }}
-      />
+      />,
     );
 
     const button = screen.getByRole('button', { name: /more info/i });
@@ -81,5 +81,33 @@ describe('BpkCardWrapper', () => {
 
     expect(screen.getByText('More Info Content')).toBeInTheDocument();
   });
-});
 
+  it('hides card content when Less Info button is clicked', () => {
+    render(
+      <BpkCardWrapper
+        header={headerContent}
+        card={cardContent}
+        backgroundColor={coreAccentDay}
+        body={{
+          text: 'More Info Content',
+          openBtnLabel: 'More Info',
+          closeBtnLabel: 'Less Info',
+        }}
+      />,
+    );
+
+    const openbutton = screen.getByRole('button', { name: /more info/i });
+    fireEvent.click(openbutton);
+
+    expect(screen.getByText('More Info Content')).toBeInTheDocument();
+
+    const closeButton = screen.getByRole('button', { name: /less info/i });
+    fireEvent.click(closeButton);
+
+    // find element that contains the text "More Info Content" and get its closest ancestor with the class "bpk-card-wrapper--body"
+    const contentWrapper = screen.getByText('More Info Content').closest('.bpk-card-wrapper--body');
+
+    // Assert that the found element does NOT have the class "expanded", the content should be collapsed
+    expect(contentWrapper).not.toHaveClass('expanded');
+  });
+});

--- a/packages/bpk-component-card/src/BpkCardWrapper-test.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper-test.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render,screen, fireEvent } from '@testing-library/react';
 
 import { coreAccentDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
@@ -61,4 +61,25 @@ describe('BpkCardWrapper', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('shows card content when More Info button is clicked', () => {
+    render(
+      <BpkCardWrapper
+        header={headerContent}
+        card={cardContent}
+        backgroundColor={coreAccentDay}
+        body={{
+          text: 'More Info Content',
+          openBtnLabel: 'More Info',
+          closeBtnLabel: 'Less Info',
+        }}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /more info/i });
+    fireEvent.click(button);
+
+    expect(screen.getByText('More Info Content')).toBeInTheDocument();
+  });
 });
+

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -97,7 +97,6 @@
       align-items: flex-end;
 
       &--button {
-        cursor: pointer;
         all: unset;
       }
 
@@ -105,6 +104,7 @@
         display: flex;
         margin: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
         align-items: center;
+        cursor: pointer;
 
         &--text {
           margin-inline-end: tokens.bpk-spacing-md();
@@ -113,6 +113,7 @@
     }
 
     &--link-text {
+      width: max-content;
       color: tokens.$bpk-private-button-link-normal-foreground-day;
       text-decoration: none;
 

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -36,15 +36,15 @@
 
   &--content {
     position: relative;
+    transition: border-radius 0.25s ease-in-out;
     border-radius: tokens.$bpk-border-radius-md;
     background-color: tokens.$bpk-private-info-banner-default-day;
-    transition: border-radius 0.25s ease-in-out;
     overflow: hidden;
 
     &-opened {
+      transition: border-radius 0.01s ease-in-out;
       border-radius: 0 0 tokens.$bpk-border-radius-md
         tokens.$bpk-border-radius-md;
-      transition: border-radius 0.01s ease-in-out;
     }
 
     &::before,

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -26,6 +26,7 @@
   padding: tokens.bpk-spacing-sm() * 0.5;
 
   @include cards.bpk-card;
+  border-radius: tokens.$bpk-one-pixel-rem * 14;
 
   &--header {
     border-radius: tokens.$bpk-border-radius-sm tokens.$bpk-border-radius-sm 0 0;

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -23,7 +23,7 @@
 @use '../../unstable__bpk-mixins/utils';
 
 .bpk-card-wrapper {
-  padding: 0.1rem;
+  padding: tokens.bpk-spacing-sm() * 0.5;
 
   @include cards.bpk-card;
   @include borders.bpk-border-lg(var(--background-color), '');

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -62,13 +62,6 @@
       right: 0;
       transform: rotate(-45deg);
     }
-
-    &--body-open {
-      &::before,
-      &::after {
-        box-shadow: none;
-      }
-    }
   }
 
   &:has(.bpk-card-wrapper--header:active) {

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -38,11 +38,13 @@
     position: relative;
     border-radius: tokens.$bpk-border-radius-md;
     background-color: tokens.$bpk-private-info-banner-default-day;
+    transition: border-radius 0.25s ease-in-out;
     overflow: hidden;
 
     &-opened {
       border-radius: 0 0 tokens.$bpk-border-radius-md
         tokens.$bpk-border-radius-md;
+      transition: border-radius 0.01s ease-in-out;
     }
 
     &::before,

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -23,9 +23,10 @@
 @use '../../unstable__bpk-mixins/utils';
 
 .bpk-card-wrapper {
+  padding: 0.1rem;
+
   @include cards.bpk-card;
   @include borders.bpk-border-lg(var(--background-color), '');
-  padding: 0.1rem;
 
   &--header {
     border-radius: tokens.$bpk-border-radius-sm tokens.$bpk-border-radius-sm 0 0;
@@ -37,8 +38,8 @@
   &--content {
     position: relative;
     border-radius: tokens.$bpk-border-radius-md;
-    overflow: hidden;
     background-color: tokens.$bpk-private-info-banner-default-day;
+    overflow: hidden;
 
     &-opened {
       border-radius: 0 0 tokens.$bpk-border-radius-md
@@ -85,6 +86,7 @@
     background-color: tokens.$bpk-private-info-banner-default-day;
     color: tokens.$bpk-text-on-light-day;
     cursor: default;
+
     &--header-container {
       display: flex;
       flex-direction: column;

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -79,6 +79,15 @@
     color: tokens.$bpk-text-on-light-day;
     cursor: default;
 
+    &-opened::after {
+      box-shadow: tokens.bpk-spacing-base() 0 0 0
+        tokens.$bpk-private-info-banner-default-day;
+    }
+    &-opened::before {
+      box-shadow: tokens.bpk-spacing-base() 0 0 0
+        tokens.$bpk-private-info-banner-default-day;
+    }
+
     &--header-container {
       display: flex;
       flex-direction: column;

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -26,7 +26,6 @@
   padding: tokens.bpk-spacing-sm() * 0.5;
 
   @include cards.bpk-card;
-  @include borders.bpk-border-lg(var(--background-color), '');
 
   &--header {
     border-radius: tokens.$bpk-border-radius-sm tokens.$bpk-border-radius-sm 0 0;
@@ -55,7 +54,6 @@
       width: tokens.bpk-spacing-lg();
       height: tokens.bpk-spacing-lg();
       background-color: transparent;
-      box-shadow: tokens.bpk-spacing-base() 0 0 0 var(--background-color);
       overflow: hidden;
 
       @include radii.bpk-border-radius-md;

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -96,8 +96,12 @@
       justify-content: space-between;
       align-items: flex-end;
 
-      &--button {
+      &--button-container {
         margin: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
+        cursor: pointer;
+      }
+
+      &--button {
         all: unset;
 
         &:focus {
@@ -105,10 +109,9 @@
         }
       }
 
-      &--toggleLabel {
+      &--toggle-label {
         display: flex;
         align-items: center;
-        cursor: pointer;
 
         &--text {
           margin-inline-end: tokens.bpk-spacing-md();

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -24,9 +24,9 @@
 
 .bpk-card-wrapper {
   padding: tokens.bpk-spacing-sm() * 0.5;
+  border-radius: tokens.$bpk-one-pixel-rem * 14;
 
   @include cards.bpk-card;
-  border-radius: tokens.$bpk-one-pixel-rem * 14;
 
   &--header {
     border-radius: tokens.$bpk-border-radius-sm tokens.$bpk-border-radius-sm 0 0;

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -20,6 +20,7 @@
 @use '../../unstable__bpk-mixins/borders';
 @use '../../unstable__bpk-mixins/cards';
 @use '../../unstable__bpk-mixins/radii';
+@use '../../unstable__bpk-mixins/utils';
 
 .bpk-card-wrapper {
   @include cards.bpk-card;
@@ -61,12 +62,63 @@
       right: 0;
       transform: rotate(-45deg);
     }
+
+    &--body-open {
+      &::before,
+      &::after {
+        box-shadow: none;
+      }
+    }
   }
 
   &:has(.bpk-card-wrapper--header:active) {
     &::after {
       box-shadow: tokens.$bpk-box-shadow-lg;
       opacity: 1;
+    }
+  }
+
+  &--body {
+    display: flex;
+    padding: tokens.bpk-spacing-base();
+    flex-direction: column;
+    background-color: tokens.$bpk-private-info-banner-default-day;
+    color: tokens.$bpk-text-on-light-day;
+    cursor: default;
+
+    &--header-container {
+      display: flex;
+      flex-direction: column;
+    }
+
+    &--header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+
+      &--button {
+        cursor: pointer;
+        all: unset;
+      }
+
+      &--toggleLabel {
+        display: flex;
+        margin: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
+        align-items: center;
+
+        &--text {
+          margin-inline-end: tokens.bpk-spacing-md();
+        }
+      }
+    }
+
+    &--link-text {
+      color: tokens.$bpk-private-button-link-normal-foreground-day;
+      text-decoration: none;
+
+      @include utils.bpk-hover {
+        color: tokens.$bpk-private-button-link-pressed-foreground-day;
+      }
     }
   }
 }

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -97,12 +97,16 @@
       align-items: flex-end;
 
       &--button {
+        margin: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
         all: unset;
+
+        &:focus {
+          @include utils.bpk-focus-indicator;
+        }
       }
 
       &--toggleLabel {
         display: flex;
-        margin: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
         align-items: center;
         cursor: pointer;
 

--- a/packages/bpk-component-card/src/BpkCardWrapper.module.scss
+++ b/packages/bpk-component-card/src/BpkCardWrapper.module.scss
@@ -25,6 +25,7 @@
 .bpk-card-wrapper {
   @include cards.bpk-card;
   @include borders.bpk-border-lg(var(--background-color), '');
+  padding: 0.1rem;
 
   &--header {
     border-radius: tokens.$bpk-border-radius-sm tokens.$bpk-border-radius-sm 0 0;
@@ -35,8 +36,14 @@
 
   &--content {
     position: relative;
-    border-radius: 0 0 tokens.$bpk-border-radius-md tokens.$bpk-border-radius-md;
+    border-radius: tokens.$bpk-border-radius-md;
     overflow: hidden;
+    background-color: tokens.$bpk-private-info-banner-default-day;
+
+    &-opened {
+      border-radius: 0 0 tokens.$bpk-border-radius-md
+        tokens.$bpk-border-radius-md;
+    }
 
     &::before,
     &::after {
@@ -78,16 +85,6 @@
     background-color: tokens.$bpk-private-info-banner-default-day;
     color: tokens.$bpk-text-on-light-day;
     cursor: default;
-
-    &-opened::after {
-      box-shadow: tokens.bpk-spacing-base() 0 0 0
-        tokens.$bpk-private-info-banner-default-day;
-    }
-    &-opened::before {
-      box-shadow: tokens.bpk-spacing-base() 0 0 0
-        tokens.$bpk-private-info-banner-default-day;
-    }
-
     &--header-container {
       display: flex;
       flex-direction: column;

--- a/packages/bpk-component-card/src/BpkCardWrapper.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper.tsx
@@ -37,6 +37,8 @@ type Props = {
   header: ReactNode;
   body?: {
     text: string;
+    openBtnLabel: string;
+    closeBtnLabel: string;
     link?: string;
     linkText?: string;
     moreInfoBtnColor?: string;
@@ -54,7 +56,7 @@ const BpkCardWrapper = ({
 
   const [isBodyOpen, setIsBodyOpen] = useState(false);
   const toggleExpand = () => setIsBodyOpen(!isBodyOpen);
-  const toggleLabel = isBodyOpen ? 'Less info' : 'More info';
+  const toggleLabel = isBodyOpen ? body?.closeBtnLabel : body?.openBtnLabel;
 
   const moreInfoToggle = (
     <div

--- a/packages/bpk-component-card/src/BpkCardWrapper.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper.tsx
@@ -87,35 +87,31 @@ const BpkCardWrapper = ({
       <div className={getClassName('bpk-card-wrapper--body--header--content')}>
         {header}
       </div>
-      <div>
-        <button
-          type="button"
-          onClick={toggleExpand}
-          className={getClassName('bpk-card-wrapper--body--header--button')}
-        >
-          {moreInfoToggle}
-        </button>
-        <Portal
-          isOpen={isBodyOpen}
-          renderTarget={document.getElementById('body-header')}
-        >
-          <div className={getClassName('bpk-card-wrapper--body')}>
-            <BpkText textStyle={TEXT_STYLES.caption}>{body.text}</BpkText>
-            {body.link && body.linkText && (
-              <a
-                href={body.link}
-                className={getClassName('bpk-card-wrapper--body--link-text')}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <BpkText textStyle={TEXT_STYLES.caption}>
-                  {body.linkText}
-                </BpkText>
-              </a>
-            )}
-          </div>
-        </Portal>
-      </div>
+      <button
+        type="button"
+        onClick={toggleExpand}
+        className={getClassName('bpk-card-wrapper--body--header--button')}
+      >
+        {moreInfoToggle}
+      </button>
+      <Portal
+        isOpen={isBodyOpen}
+        renderTarget={document.getElementById('body-header')}
+      >
+        <div className={getClassName('bpk-card-wrapper--body')}>
+          <BpkText textStyle={TEXT_STYLES.caption}>{body.text}</BpkText>
+          {body.link && body.linkText && (
+            <a
+              href={body.link}
+              className={getClassName('bpk-card-wrapper--body--link-text')}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <BpkText textStyle={TEXT_STYLES.caption}>{body.linkText}</BpkText>
+            </a>
+          )}
+        </div>
+      </Portal>
     </div>
   );
 

--- a/packages/bpk-component-card/src/BpkCardWrapper.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper.tsx
@@ -17,8 +17,10 @@
  */
 
 import type { ReactNode } from 'react';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
+// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
+import AnimateHeight from '../../bpk-animate-height';
 import BpkIconChevronDown from '../../bpk-component-icon/sm/chevron-down';
 import BpkIconChevronUp from '../../bpk-component-icon/sm/chevron-up';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text/src/BpkText';
@@ -55,15 +57,17 @@ const BpkCardWrapper = ({
   const classNames = getClassName('bpk-card-wrapper', className);
 
   const [isBodyOpen, setIsBodyOpen] = useState(false);
-  const toggleExpand = () => setIsBodyOpen(!isBodyOpen);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const toggleExpand = () => {
+    setIsBodyOpen(!isBodyOpen);
+  };
+
   const toggleLabel = isBodyOpen ? body?.closeBtnLabel : body?.openBtnLabel;
 
   const moreInfoToggle = (
     <div
-      style={{
-        fill: body?.moreInfoBtnColor,
-        color: body?.moreInfoBtnColor,
-      }}
+      style={{ fill: body?.moreInfoBtnColor, color: body?.moreInfoBtnColor }}
       className={getClassName('bpk-card-wrapper--body--header--toggle-label')}
     >
       <div
@@ -100,24 +104,33 @@ const BpkCardWrapper = ({
           {moreInfoToggle}
         </button>
       </div>
-      <Portal
-        isOpen={isBodyOpen}
-        renderTarget={document.getElementById('body-header')}
-      >
-        <div className={getClassName('bpk-card-wrapper--body')}>
-          <BpkText textStyle={TEXT_STYLES.caption}>{body.text}</BpkText>
-          {body.link && body.linkText && (
-            <a
-              href={body.link}
-              className={getClassName('bpk-card-wrapper--body--link-text')}
-              target="_blank"
-              rel="noopener noreferrer"
+      {document.getElementById('body-header') && (
+        <Portal isOpen renderTarget={document.getElementById('body-header')}>
+          <AnimateHeight duration={200} height={isBodyOpen ? 'auto' : 0}>
+            <div
+              ref={bodyRef}
+              className={getClassName(
+                'bpk-card-wrapper--body',
+                isBodyOpen && 'expanded',
+              )}
             >
-              <BpkText textStyle={TEXT_STYLES.caption}>{body.linkText}</BpkText>
-            </a>
-          )}
-        </div>
-      </Portal>
+              <BpkText textStyle={TEXT_STYLES.caption}>{body.text}</BpkText>
+              {body.link && body.linkText && (
+                <a
+                  href={body.link}
+                  className={getClassName('bpk-card-wrapper--body--link-text')}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <BpkText textStyle={TEXT_STYLES.caption}>
+                    {body.linkText}
+                  </BpkText>
+                </a>
+              )}
+            </div>
+          </AnimateHeight>
+        </Portal>
+      )}
     </div>
   );
 
@@ -142,13 +155,14 @@ const BpkCardWrapper = ({
             {header}
           </div>
         )}
+
         <div
           className={getClassName(
             'bpk-card-wrapper--content',
             body && isBodyOpen && 'bpk-card-wrapper--content--body-open',
           )}
         >
-          {card}
+          <div className={STYLES.ticketContainer}>{card}</div>
         </div>
       </div>
     </CardContext.Provider>

--- a/packages/bpk-component-card/src/BpkCardWrapper.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper.tsx
@@ -159,7 +159,7 @@ const BpkCardWrapper = ({
         <div
           className={getClassName(
             'bpk-card-wrapper--content',
-            body && isBodyOpen && 'bpk-card-wrapper--content--body-open',
+            body && isBodyOpen && 'bpk-card-wrapper--content-opened',
           )}
         >
           <div className={STYLES.ticketContainer}>{card}</div>

--- a/packages/bpk-component-card/src/BpkCardWrapper.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper.tsx
@@ -106,7 +106,7 @@ const BpkCardWrapper = ({
       </div>
       {document.getElementById('body-header') && (
         <Portal isOpen renderTarget={document.getElementById('body-header')}>
-          <AnimateHeight duration={200} height={isBodyOpen ? 'auto' : 0}>
+          <AnimateHeight duration={80} height={isBodyOpen ? 'auto' : 0}>
             <div
               ref={bodyRef}
               className={getClassName(
@@ -140,7 +140,7 @@ const BpkCardWrapper = ({
         className={classNames}
         style={{
           // @ts-expect-error TS is reporting this incorrectly as --background-color is valid
-          '--background-color': backgroundColor,
+          'background-color': backgroundColor,
         }}
       >
         {body ? (

--- a/packages/bpk-component-card/src/BpkCardWrapper.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper.tsx
@@ -17,8 +17,12 @@
  */
 
 import type { ReactNode } from 'react';
+import { useState } from 'react';
 
-import { cssModules } from '../../bpk-react-utils';
+import BpkIconChevronDown from '../../bpk-component-icon/sm/chevron-down';
+import BpkIconChevronUp from '../../bpk-component-icon/sm/chevron-up';
+import BpkText, { TEXT_STYLES } from '../../bpk-component-text/src/BpkText';
+import { cssModules, Portal } from '../../bpk-react-utils';
 
 import { CardContext } from './CardContext';
 
@@ -31,15 +35,85 @@ type Props = {
   className?: string | null;
   backgroundColor: string;
   header: ReactNode;
+  body?: {
+    text: string;
+    link?: string;
+    linkText?: string;
+    moreInfoBtnColor?: string;
+  };
 };
 
 const BpkCardWrapper = ({
   backgroundColor,
+  body,
   card,
   className = null,
   header,
 }: Props) => {
   const classNames = getClassName('bpk-card-wrapper', className);
+
+  const [isBodyOpen, setIsBodyOpen] = useState(false);
+  const toggleExpand = () => setIsBodyOpen(!isBodyOpen);
+  const toggleLabel = isBodyOpen ? 'Less info' : 'More info';
+
+  const moreInfoToggle = (
+    <div
+      style={{
+        fill: body?.moreInfoBtnColor,
+        color: body?.moreInfoBtnColor,
+      }}
+      className={getClassName('bpk-card-wrapper--body--header--toggleLabel')}
+    >
+      <div
+        className={getClassName(
+          'bpk-card-wrapper--body--header--toggleLabel--text',
+        )}
+      >
+        <BpkText textStyle={TEXT_STYLES.caption}>{toggleLabel}</BpkText>
+      </div>
+      {isBodyOpen ? <BpkIconChevronUp /> : <BpkIconChevronDown />}
+    </div>
+  );
+
+  const headerWithBodyDiv = body && (
+    <div
+      className={getClassName(
+        'bpk-card-wrapper--header',
+        'bpk-card-wrapper--body--header',
+      )}
+    >
+      <div className={getClassName('bpk-card-wrapper--body--header--content')}>
+        {header}
+      </div>
+      <div>
+        <button
+          type="button"
+          onClick={toggleExpand}
+          className={getClassName('bpk-card-wrapper--body--header--button')}
+        >
+          {moreInfoToggle}
+        </button>
+        <Portal
+          isOpen={isBodyOpen}
+          renderTarget={document.getElementById('body-header')}
+        >
+          <div className={getClassName('bpk-card-wrapper--body')}>
+            <BpkText textStyle={TEXT_STYLES.caption}>{body.text}</BpkText>
+            {body.link && body.linkText && (
+              <a
+                href={body.link}
+                className={getClassName('bpk-card-wrapper--body--link-text')}
+              >
+                <BpkText textStyle={TEXT_STYLES.caption}>
+                  {body.linkText}
+                </BpkText>
+              </a>
+            )}
+          </div>
+        </Portal>
+      </div>
+    </div>
+  );
 
   return (
     <CardContext.Provider value={{ elevated: false }}>
@@ -50,8 +124,26 @@ const BpkCardWrapper = ({
           '--background-color': backgroundColor,
         }}
       >
-        <div className={getClassName('bpk-card-wrapper--header')}>{header}</div>
-        <div className={getClassName('bpk-card-wrapper--content')}>{card}</div>
+        {body ? (
+          <div
+            className={getClassName('bpk-card-wrapper--body--header-container')}
+            id="body-header"
+          >
+            {headerWithBodyDiv}
+          </div>
+        ) : (
+          <div className={getClassName('bpk-card-wrapper--header')}>
+            {header}
+          </div>
+        )}
+        <div
+          className={getClassName(
+            'bpk-card-wrapper--content',
+            body && isBodyOpen && 'bpk-card-wrapper--content--body-open',
+          )}
+        >
+          {card}
+        </div>
       </div>
     </CardContext.Provider>
   );

--- a/packages/bpk-component-card/src/BpkCardWrapper.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper.tsx
@@ -103,6 +103,8 @@ const BpkCardWrapper = ({
               <a
                 href={body.link}
                 className={getClassName('bpk-card-wrapper--body--link-text')}
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <BpkText textStyle={TEXT_STYLES.caption}>
                   {body.linkText}

--- a/packages/bpk-component-card/src/BpkCardWrapper.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper.tsx
@@ -64,11 +64,11 @@ const BpkCardWrapper = ({
         fill: body?.moreInfoBtnColor,
         color: body?.moreInfoBtnColor,
       }}
-      className={getClassName('bpk-card-wrapper--body--header--toggleLabel')}
+      className={getClassName('bpk-card-wrapper--body--header--toggle-label')}
     >
       <div
         className={getClassName(
-          'bpk-card-wrapper--body--header--toggleLabel--text',
+          'bpk-card-wrapper--body--header--toggle-label--text',
         )}
       >
         <BpkText textStyle={TEXT_STYLES.caption}>{toggleLabel}</BpkText>
@@ -87,13 +87,19 @@ const BpkCardWrapper = ({
       <div className={getClassName('bpk-card-wrapper--body--header--content')}>
         {header}
       </div>
-      <button
-        type="button"
-        onClick={toggleExpand}
-        className={getClassName('bpk-card-wrapper--body--header--button')}
+      <div
+        className={getClassName(
+          'bpk-card-wrapper--body--header--button-container',
+        )}
       >
-        {moreInfoToggle}
-      </button>
+        <button
+          type="button"
+          onClick={toggleExpand}
+          className={getClassName('bpk-card-wrapper--body--header--button')}
+        >
+          {moreInfoToggle}
+        </button>
+      </div>
       <Portal
         isOpen={isBodyOpen}
         renderTarget={document.getElementById('body-header')}

--- a/packages/bpk-component-card/src/BpkCardWrapper.tsx
+++ b/packages/bpk-component-card/src/BpkCardWrapper.tsx
@@ -136,13 +136,7 @@ const BpkCardWrapper = ({
 
   return (
     <CardContext.Provider value={{ elevated: false }}>
-      <div
-        className={classNames}
-        style={{
-          // @ts-expect-error TS is reporting this incorrectly as --background-color is valid
-          'background-color': backgroundColor,
-        }}
-      >
+      <div className={classNames} style={{ 'backgroundColor': backgroundColor }}>
         {body ? (
           <div
             className={getClassName('bpk-card-wrapper--body--header-container')}

--- a/packages/bpk-component-card/src/__snapshots__/BpkCardWrapper-test.tsx.snap
+++ b/packages/bpk-component-card/src/__snapshots__/BpkCardWrapper-test.tsx.snap
@@ -4,7 +4,7 @@ exports[`BpkCardWrapper should render correctly 1`] = `
 <DocumentFragment>
   <div
     class="bpk-card-wrapper"
-    style="--background-color: rgb(0, 98, 227);"
+    style="background-color: rgb(0, 98, 227);"
   >
     <div
       class="bpk-card-wrapper--header"
@@ -17,7 +17,9 @@ exports[`BpkCardWrapper should render correctly 1`] = `
       class="bpk-card-wrapper--content"
     >
       <div>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at. Mauris porta varius ullamcorper. Sed laoreet libero mauris, non pretium lectus accumsan et. Suspendisse vehicula ullamcorper sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rhoncus. Fusce id enim porttitor, mattis ante in, vestibulum nulla.
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at. Mauris porta varius ullamcorper. Sed laoreet libero mauris, non pretium lectus accumsan et. Suspendisse vehicula ullamcorper sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rhoncus. Fusce id enim porttitor, mattis ante in, vestibulum nulla.
+        </div>
       </div>
     </div>
   </div>
@@ -28,7 +30,7 @@ exports[`BpkCardWrapper should support custom class names 1`] = `
 <DocumentFragment>
   <div
     class="bpk-card-wrapper custom-classname"
-    style="--background-color: rgb(0, 98, 227);"
+    style="background-color: rgb(0, 98, 227);"
   >
     <div
       class="bpk-card-wrapper--header"
@@ -41,7 +43,9 @@ exports[`BpkCardWrapper should support custom class names 1`] = `
       class="bpk-card-wrapper--content"
     >
       <div>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at. Mauris porta varius ullamcorper. Sed laoreet libero mauris, non pretium lectus accumsan et. Suspendisse vehicula ullamcorper sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rhoncus. Fusce id enim porttitor, mattis ante in, vestibulum nulla.
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi. Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at. Mauris porta varius ullamcorper. Sed laoreet libero mauris, non pretium lectus accumsan et. Suspendisse vehicula ullamcorper sapien, et dapibus mi aliquet non. Pellentesque auctor sagittis lectus vitae rhoncus. Fusce id enim porttitor, mattis ante in, vestibulum nulla.
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

https://skyscanner.atlassian.net/browse/QUAR-642

Figma designs: https://www.figma.com/design/22unPHkDCzqJkd9rKzTiGY/T%26Cs-Ads?node-id=79-11694&t=MTrz7gFIDvIgP4k2-4

For the inline ads, we need to have a dropdown box for T&C in the ad card wrapper. We're currently use a [custom component](http://github.skyscannertools.net/skyscanner/banana/blob/main/packages/webapp-acorn/src/components/adverts/FlightsAdvert/ItineraryInlinePlus/ItineraryInlinePlusWrapper/ItineraryInlinePlusWrapper.tsx) to do this for desktop ads, but we need to add it to mobile ads as well. Instead of duplicating the custom wrapper into the mobile web ad components, we want to use the `BpkCardWrapper` component instead. To use it though we need to add the `more info` button and dropdown body element.

## `More Info`
<img width="400" src="https://github.com/user-attachments/assets/53f40a2d-2660-4eb7-817d-bed5a6232000" alt="Before Screenshot" />

## `Less Info`
<img width="400" src="https://github.com/user-attachments/assets/6ccbd22d-116c-4b74-bb4b-7797409aeb14" alt="After Screenshot" />

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here