### PR TITLE
[QUAR-497] [BpkInsetBanner] Add CTA button & popover

### DIFF
--- a/examples/bpk-component-inset-banner/examples.tsx
+++ b/examples/bpk-component-inset-banner/examples.tsx
@@ -85,7 +85,7 @@ const WithBodyTextAndLinkExampleDark = () => (
   />
 );
 
-const WitCtaTextAndPopoverExampleLight = () => (
+const WithCtaTextAndPopoverExampleLight = () => (
   <BpkInsetBanner
     title="Lorem ipsum"
     subheadline="Lorem ipsum dolor sit amet"
@@ -111,5 +111,5 @@ export {
   WithLogoAndCtaTextExampleLight,
   WithBodyTextExampleLight,
   WithBodyTextAndLinkExampleDark,
-  WitCtaTextAndPopoverExampleLight,
+  WithCtaTextAndPopoverExampleLight,
 };

--- a/examples/bpk-component-inset-banner/examples.tsx
+++ b/examples/bpk-component-inset-banner/examples.tsx
@@ -43,7 +43,7 @@ const WithLogoAndCtaTextExampleLight = () => (
     subheadline="Lorem ipsum dolor sit amet"
     logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
     callToAction={{
-      ctaText: 'Sponsored',
+      text: 'Sponsored',
     }}
     backgroundColor="#FFE300"
     variant={VARIANT.onLight}
@@ -58,7 +58,7 @@ const WithBodyTextExampleLight = () => (
     logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
     backgroundColor="#FFE300"
     callToAction={{
-      ctaText: 'Sponsored',
+      text: 'Sponsored',
     }}
     body={{
       text: 'You can change your destination, date of travel, or both, with no change fee. Valid for all new bookings made up to 31 May for travel between now and 31 December 2020.',
@@ -74,7 +74,7 @@ const WithBodyTextAndLinkExampleDark = () => (
     logo="https://content.skyscnr.com/m/3f4dadbd41da8235/original/Skyland_White_172x96.png"
     backgroundColor="#FF6601"
     callToAction={{
-      ctaText: 'Sponsored',
+      text: 'Sponsored',
     }}
     body={{
       text: 'You can change your destination, date of travel, or both, with no change fee. Valid for all new bookings made up to 31 May for travel between now and 31 December 2020.',
@@ -91,13 +91,13 @@ const WithCtaTextAndPopoverExampleLight = () => (
     subheadline="Lorem ipsum dolor sit amet"
     logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
     callToAction={{
-      ctaText: 'Sponsored',
-      ctaPopoverMessage: 'This is a popover message',
-      ctaCloseBtnIcon: true,
-      ctaLabelTitle: true,
-      ctaPopverLabel: 'Info',
-      ctaButtonCloseLabel: 'Close',
-      ctaButtonA11yLabel: 'More info',
+      text: 'Sponsored',
+      popoverMessage: 'This is a popover message',
+      closeBtnIcon: true,
+      labelTitle: true,
+      popverLabel: 'Info',
+      buttonCloseLabel: 'Close',
+      buttonA11yLabel: 'More info',
     }}
     backgroundColor="#FFE300"
     variant={VARIANT.onLight}

--- a/examples/bpk-component-inset-banner/examples.tsx
+++ b/examples/bpk-component-inset-banner/examples.tsx
@@ -43,7 +43,7 @@ const WithLogoAndCtaTextExampleLight = () => (
     subheadline="Lorem ipsum dolor sit amet"
     logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
     callToAction={{
-      text: 'Sponsored',
+      ctaText: 'Sponsored',
     }}
     backgroundColor="#FFE300"
     variant={VARIANT.onLight}
@@ -58,7 +58,7 @@ const WithBodyTextExampleLight = () => (
     logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
     backgroundColor="#FFE300"
     callToAction={{
-      text: 'Sponsored',
+      ctaText: 'Sponsored',
     }}
     body={{
       text: 'You can change your destination, date of travel, or both, with no change fee. Valid for all new bookings made up to 31 May for travel between now and 31 December 2020.',
@@ -74,7 +74,7 @@ const WithBodyTextAndLinkExampleDark = () => (
     logo="https://content.skyscnr.com/m/3f4dadbd41da8235/original/Skyland_White_172x96.png"
     backgroundColor="#FF6601"
     callToAction={{
-      text: 'Sponsored',
+      ctaText: 'Sponsored',
     }}
     body={{
       text: 'You can change your destination, date of travel, or both, with no change fee. Valid for all new bookings made up to 31 May for travel between now and 31 December 2020.',
@@ -85,10 +85,31 @@ const WithBodyTextAndLinkExampleDark = () => (
   />
 );
 
+const WitCtaTextAndPopoverExampleLight = () => (
+  <BpkInsetBanner
+    title="Lorem ipsum"
+    subheadline="Lorem ipsum dolor sit amet"
+    logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
+    callToAction={{
+      ctaText: 'Sponsored',
+      ctaPopoverMessage: 'This is a popover message',
+      ctaCloseBtnIcon: true,
+      ctaLabelTitle: true,
+      ctaPopverLabel: 'Info',
+      ctaButtonCloseLabel: 'Close',
+      ctaButtonA11yLabel: 'More info',
+    }}
+    backgroundColor="#FFE300"
+    variant={VARIANT.onLight}
+    accessibilityLabel="Sponsored by Skyscanner"
+  />
+);
+
 export {
   DefaultExampleTitleOnly,
   DefaultExampleTitleAndSubheadline,
   WithLogoAndCtaTextExampleLight,
   WithBodyTextExampleLight,
   WithBodyTextAndLinkExampleDark,
+  WitCtaTextAndPopoverExampleLight,
 };

--- a/examples/bpk-component-inset-banner/stories.ts
+++ b/examples/bpk-component-inset-banner/stories.ts
@@ -24,6 +24,7 @@ import {
   WithLogoAndCtaTextExampleLight,
   WithBodyTextExampleLight,
   WithBodyTextAndLinkExampleDark,
+  WitCtaTextAndPopoverExampleLight,
 } from './examples';
 
 export default {
@@ -38,3 +39,4 @@ export const WithBodyTextLight = WithBodyTextExampleLight;
 export const WithBodyTextAndLinkDark = WithBodyTextAndLinkExampleDark;
 export const VisualTestDark = WithBodyTextAndLinkExampleDark;
 export const VisualTestLight = WithLogoAndCtaTextExampleLight;
+export const WitCtaTextAndPopoverLight = WitCtaTextAndPopoverExampleLight;

--- a/examples/bpk-component-inset-banner/stories.ts
+++ b/examples/bpk-component-inset-banner/stories.ts
@@ -24,7 +24,7 @@ import {
   WithLogoAndCtaTextExampleLight,
   WithBodyTextExampleLight,
   WithBodyTextAndLinkExampleDark,
-  WitCtaTextAndPopoverExampleLight,
+  WithCtaTextAndPopoverExampleLight,
 } from './examples';
 
 export default {
@@ -39,4 +39,4 @@ export const WithBodyTextLight = WithBodyTextExampleLight;
 export const WithBodyTextAndLinkDark = WithBodyTextAndLinkExampleDark;
 export const VisualTestDark = WithBodyTextAndLinkExampleDark;
 export const VisualTestLight = WithLogoAndCtaTextExampleLight;
-export const WitCtaTextAndPopoverLight = WitCtaTextAndPopoverExampleLight;
+export const WithCtaTextAndPopoverLight = WithCtaTextAndPopoverExampleLight;

--- a/packages/bpk-component-inset-banner/README.md
+++ b/packages/bpk-component-inset-banner/README.md
@@ -21,15 +21,15 @@ export default () => (
       link: 'www.skyscanner.net',
     }}
     callToAction={{
-      ctaText: 'Sponsored',
-      ctaPopoverMessage: 'This is a popover message',
-      ctaPopoverPlacement: 'top',
-      ctaButtonCloseLabel: 'Close',
-      ctaButtonA11yLabel: 'More info',
-      ctaPopverLabel: 'More info',
-      ctaPopoverId: 'popover',
-      ctaLabelTitle: true,
-      ctaCloseBtnIcon: false,
+      text: 'Sponsored',
+      popoverMessage: 'This is a popover message',
+      popoverPlacement: 'top',
+      buttonCloseLabel: 'Close',
+      buttonA11yLabel: 'More info',
+      popverLabel: 'More info',
+      popoverId: 'popover',
+      labelTitle: true,
+      closeBtnIcon: false,
     }}
     logo="logo.png"
     subheadline="My subheadline"

--- a/packages/bpk-component-inset-banner/README.md
+++ b/packages/bpk-component-inset-banner/README.md
@@ -21,7 +21,15 @@ export default () => (
       link: 'www.skyscanner.net',
     }}
     callToAction={{
-      text: 'Sponsored',
+      ctaText: 'Sponsored',
+      ctaPopoverMessage: 'This is a popover message',
+      ctaPopoverPlacement: 'top',
+      ctaButtonCloseLabel: 'Close',
+      ctaButtonA11yLabel: 'More info',
+      ctaPopverLabel: 'More info',
+      ctaPopoverId: 'popover',
+      ctaLabelTitle: true,
+      ctaCloseBtnIcon: false,
     }}
     logo="logo.png"
     subheadline="My subheadline"

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner-test.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner-test.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import '@testing-library/jest-dom';
 
@@ -50,6 +50,28 @@ describe('BpkInsetBanner', () => {
     );
 
     expect(getByText('Sponsored')).toBeInTheDocument();
+  });
+
+  it('should render call to action popover text if provided', () => {
+    render(
+      <BpkInsetBanner
+        title="Lorem ipsum"
+        subheadline="Lorem ipsum dolor sit amet"
+        logo="https://content.skyscnr.com/m/7950ed6f30581485/Medium-Skyscanner-Vertical-White.png"
+        backgroundColor="#F55D42"
+        callToAction={{
+          text: 'Sponsored',
+          popoverMessage: 'Popover message',
+        }}
+        variant={VARIANT.onDark}
+      />,
+    );
+
+    const ctaButton = screen.getByTestId('adInfoBtn');
+
+    fireEvent.click(ctaButton);
+
+    expect(screen.getByText('Popover message')).toBeInTheDocument();
   });
 
   it('should render body if provided', () => {

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
@@ -60,6 +60,11 @@
     flex-direction: column;
   }
 
+  &--cta-text {
+    display: flex;
+    align-items: center;
+  }
+
   &--cta-button {
     all: unset;
 

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
@@ -60,9 +60,29 @@
     flex-direction: column;
   }
 
+  &--cta-button {
+    all: unset;
+
+    &:focus {
+      @include utils.bpk-focus-indicator;
+    }
+  }
+
   &--cta-container {
     display: flex;
     align-items: center;
+    cursor: pointer;
+  }
+
+  &--cta-content {
+    display: flex;
+    align-items: center;
+  }
+
+  &--cta-info-icon {
+    display: flex;
+    align-items: center;
+    margin-inline-start: tokens.bpk-spacing-md();
   }
 }
 

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
@@ -63,7 +63,7 @@
   &--cta-button {
     all: unset;
 
-    &:focus {
+    &:focus-visible {
       @include utils.bpk-focus-indicator;
     }
   }

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
@@ -17,8 +17,12 @@
  */
 import { surfaceHighlightDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
+import InfoIcon from '../../bpk-component-icon/sm/information-circle';
+import BpkPopover from '../../bpk-component-popover/src/BpkPopover';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text/src/BpkText';
 import { cssModules } from '../../bpk-react-utils';
+
+import type { Placement } from '@floating-ui/react';
 
 import STYLES from './BpkInsetBanner.module.scss';
 
@@ -37,9 +41,16 @@ export type Props = {
     link?: string;
     linkText?: string;
   };
-  // [TO-DO] In future iteration we will add a button to CTA section with popover functionality
   callToAction?: {
-    text?: string;
+    ctaText?: string;
+    ctaPopoverMessage?: string;
+    ctaPopoverPlacement?: Placement;
+    ctaButtonCloseLabel?: string;
+    ctaButtonA11yLabel?: string;
+    ctaPopverLabel?: string;
+    ctaPopoverId?: string;
+    ctaLabelTitle?: boolean;
+    ctaCloseBtnIcon?: boolean;
   };
   logo?: string;
   subheadline?: string;
@@ -86,13 +97,74 @@ const BpkInsetBanner = ({
             <BpkText textStyle={TEXT_STYLES.caption}>{subheadline}</BpkText>
           </div>
         </div>
-        <div className={getClassName('bpk-inset-banner--cta-container')}>
-          {callToAction?.text && (
-            <BpkText textStyle={TEXT_STYLES.caption}>
-              {callToAction.text}
-            </BpkText>
+        {callToAction && callToAction.ctaPopoverMessage && (
+          <div
+            role="presentation"
+            className={getClassName('bpk-inset-banner--cta-container')}
+            onClick={(e) => {
+              // Do not propagate the click on the trigger OR popover content up the DOM tree.
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+          >
+            <BpkPopover
+              id={callToAction?.ctaPopoverId || ''}
+              label={callToAction?.ctaPopverLabel || ''}
+              placement={callToAction?.ctaPopoverPlacement || 'bottom'}
+              onClose={(e: {
+                stopPropagation: () => void;
+                preventDefault: () => void;
+              }) => {
+                e.stopPropagation();
+                e.preventDefault();
+              }}
+              aria-label={callToAction?.ctaButtonA11yLabel}
+              closeButtonText={callToAction?.ctaButtonCloseLabel}
+              closeButtonIcon={callToAction?.ctaCloseBtnIcon}
+              labelAsTitle={callToAction?.ctaLabelTitle}
+              target={
+                <button
+                  aria-label={callToAction?.ctaButtonA11yLabel}
+                  className={getClassName('bpk-inset-banner--cta-button')}
+                  data-testid="adInfoBtn"
+                  aria-hidden="false"
+                  type="button"
+                >
+                  <div
+                    className={getClassName('bpk-inset-banner--cta-content')}
+                  >
+                    {callToAction?.ctaText && (
+                      <BpkText textStyle={TEXT_STYLES.caption}>
+                        {callToAction.ctaText}
+                      </BpkText>
+                    )}
+
+                    <div
+                      className={getClassName(
+                        'bpk-inset-banner--cta-info-icon',
+                      )}
+                    >
+                      <InfoIcon />
+                    </div>
+                  </div>
+                </button>
+              }
+            >
+              <BpkText tagName="p">{callToAction?.ctaPopoverMessage}</BpkText>
+            </BpkPopover>
+          </div>
+        )}
+        {callToAction &&
+          !callToAction.ctaPopoverMessage &&
+          callToAction.ctaText && (
+            <div className={getClassName('bpk-inset-banner--cta-container')}>
+              {callToAction?.ctaText && (
+                <BpkText textStyle={TEXT_STYLES.caption}>
+                  {callToAction.ctaText}
+                </BpkText>
+              )}
+            </div>
           )}
-        </div>
       </div>
       {body && (
         <div className={getClassName('bpk-inset-banner-body-container')}>

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
@@ -157,7 +157,7 @@ const BpkInsetBanner = ({
         {callToAction &&
           !callToAction.ctaPopoverMessage &&
           callToAction.ctaText && (
-            <div className={getClassName('bpk-inset-banner--cta-container')}>
+            <div className={getClassName('bpk-inset-banner--cta-text')}>
               {callToAction?.ctaText && (
                 <BpkText textStyle={TEXT_STYLES.caption}>
                   {callToAction.ctaText}

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
@@ -42,15 +42,15 @@ export type Props = {
     linkText?: string;
   };
   callToAction?: {
-    ctaText?: string;
-    ctaPopoverMessage?: string;
-    ctaPopoverPlacement?: Placement;
-    ctaButtonCloseLabel?: string;
-    ctaButtonA11yLabel?: string;
-    ctaPopverLabel?: string;
-    ctaPopoverId?: string;
-    ctaLabelTitle?: boolean;
-    ctaCloseBtnIcon?: boolean;
+    text?: string;
+    popoverMessage?: string;
+    popoverPlacement?: Placement;
+    buttonCloseLabel?: string;
+    buttonA11yLabel?: string;
+    popverLabel?: string;
+    popoverId?: string;
+    labelTitle?: boolean;
+    closeBtnIcon?: boolean;
   };
   logo?: string;
   subheadline?: string;
@@ -97,7 +97,7 @@ const BpkInsetBanner = ({
             <BpkText textStyle={TEXT_STYLES.caption}>{subheadline}</BpkText>
           </div>
         </div>
-        {callToAction && callToAction.ctaPopoverMessage && (
+        {callToAction && callToAction.popoverMessage && (
           <div
             role="presentation"
             className={getClassName('bpk-inset-banner--cta-container')}
@@ -108,9 +108,9 @@ const BpkInsetBanner = ({
             }}
           >
             <BpkPopover
-              id={callToAction?.ctaPopoverId || ''}
-              label={callToAction?.ctaPopverLabel || ''}
-              placement={callToAction?.ctaPopoverPlacement || 'bottom'}
+              id={callToAction?.popoverId || ''}
+              label={callToAction?.popverLabel || ''}
+              placement={callToAction?.popoverPlacement || 'bottom'}
               onClose={(e: {
                 stopPropagation: () => void;
                 preventDefault: () => void;
@@ -118,13 +118,13 @@ const BpkInsetBanner = ({
                 e.stopPropagation();
                 e.preventDefault();
               }}
-              aria-label={callToAction?.ctaButtonA11yLabel}
-              closeButtonText={callToAction?.ctaButtonCloseLabel}
-              closeButtonIcon={callToAction?.ctaCloseBtnIcon}
-              labelAsTitle={callToAction?.ctaLabelTitle}
+              aria-label={callToAction?.buttonA11yLabel}
+              closeButtonText={callToAction?.buttonCloseLabel}
+              closeButtonIcon={callToAction?.closeBtnIcon}
+              labelAsTitle={callToAction?.labelTitle}
               target={
                 <button
-                  aria-label={callToAction?.ctaButtonA11yLabel}
+                  aria-label={callToAction?.buttonA11yLabel}
                   className={getClassName('bpk-inset-banner--cta-button')}
                   data-testid="adInfoBtn"
                   aria-hidden="false"
@@ -133,9 +133,9 @@ const BpkInsetBanner = ({
                   <div
                     className={getClassName('bpk-inset-banner--cta-content')}
                   >
-                    {callToAction?.ctaText && (
+                    {callToAction?.text && (
                       <BpkText textStyle={TEXT_STYLES.caption}>
-                        {callToAction.ctaText}
+                        {callToAction.text}
                       </BpkText>
                     )}
 
@@ -150,21 +150,17 @@ const BpkInsetBanner = ({
                 </button>
               }
             >
-              <BpkText tagName="p">{callToAction?.ctaPopoverMessage}</BpkText>
+              <BpkText tagName="p">{callToAction?.popoverMessage}</BpkText>
             </BpkPopover>
           </div>
         )}
-        {callToAction &&
-          !callToAction.ctaPopoverMessage &&
-          callToAction.ctaText && (
-            <div className={getClassName('bpk-inset-banner--cta-text')}>
-              {callToAction?.ctaText && (
-                <BpkText textStyle={TEXT_STYLES.caption}>
-                  {callToAction.ctaText}
-                </BpkText>
-              )}
-            </div>
-          )}
+        {callToAction && !callToAction.popoverMessage && callToAction.text && (
+          <div className={getClassName('bpk-inset-banner--cta-text')}>
+            <BpkText textStyle={TEXT_STYLES.caption}>
+              {callToAction.text}
+            </BpkText>
+          </div>
+        )}
       </div>
       {body && (
         <div className={getClassName('bpk-inset-banner-body-container')}>

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
@@ -118,7 +118,6 @@ const BpkInsetBanner = ({
                 e.stopPropagation();
                 e.preventDefault();
               }}
-              aria-label={callToAction?.buttonA11yLabel}
               closeButtonText={callToAction?.buttonCloseLabel}
               closeButtonIcon={callToAction?.closeBtnIcon}
               labelAsTitle={callToAction?.labelTitle}

--- a/packages/bpk-component-inset-banner/src/accessibility-test.tsx
+++ b/packages/bpk-component-inset-banner/src/accessibility-test.tsx
@@ -31,6 +31,12 @@ describe('BpkInsetBanner accessibility tests', () => {
         backgroundColor="#F55D42"
         callToAction={{
           text: 'Sponsored',
+          popoverMessage: 'This is a popover message',
+          closeBtnIcon: true,
+          labelTitle: true,
+          popverLabel: 'Info',
+          buttonCloseLabel: 'Close',
+          buttonA11yLabel: 'More info',
         }}
         body={{
           text: 'You can change your destination, date of travel, or both, with no change fee. Valid for all new bookings made up to 31 May for travel between now and 31 December 2020.',


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

JIRA: https://skyscanner.atlassian.net/browse/QUAR-497

When the `BpkInsetBanner` component was created last year we added the CTA object prop accepting a text element. Now we need to add the CTA button and popover functionality so that we can add required legal info in the adverts using the inset banner.

Props added to `CallToAction` object prop:
- `popoverMessage`: message that will be displayed inside the popover dialog when the CTA button is clicked.
- `popoverPlacement`: where the popover dialog should appear when CTA button is clicked (ex. 'top', 'bottom', etc).
- `buttonCloseLabel`: text to display in the close button of the popover dialog.
- `buttonA11yLabel`: accessibility aria label for the CTA button.
- `popverLabel`: label of the popover dialog, and if `labelTitle` is true, title to display at the top of the popover dialog.
- `popoverId`: id of the popover dialog.
- `labelTitle`: if true, displays `popoverLabel` as popover title.
- `closeBtnIcon`: if true, displays close icon instead of `buttonCloseLabel` in popover close button.

| Without CTA Popover | With CTA Popover (`onLight` variant) | With CTA Popover (`onDark` variant) | 
| --- | --- | --- |
| <img width="350" alt="Screenshot 2025-02-03 at 16 03 56" src="https://github.com/user-attachments/assets/43efd4d7-0dc7-4ab2-8697-6c4d4d1ae058" /> | <img width="400" alt="Screenshot 2025-02-03 at 16 03 46" src="https://github.com/user-attachments/assets/256b249b-7673-4004-abef-fd5d0e5b0518" /> | <img width="400" alt="Screenshot 2025-02-05 at 18 12 11" src="https://github.com/user-attachments/assets/e94a086c-1c2c-4af8-8e7b-9f3cca3ddf9c" />


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here