### PR TITLE
[BpkSwitch] Adjust focus behaviour

### DIFF
--- a/packages/bpk-component-switch/src/BpkSwitch.module.scss
+++ b/packages/bpk-component-switch/src/BpkSwitch.module.scss
@@ -31,8 +31,10 @@ $border-width: tokens.$bpk-one-pixel-rem * 2;
   align-items: center;
   border-radius: $height * 0.5;
 
-  input[type="checkbox"]:focus-visible + span {
-    @include utils.bpk-focus-indicator;
+  input[type='checkbox']:focus-visible {
+    & + span {
+      @include utils.bpk-focus-indicator;
+    }
   }
 
   // Checkbox is invisible so the switch element can be the visual element.

--- a/packages/bpk-component-switch/src/BpkSwitch.module.scss
+++ b/packages/bpk-component-switch/src/BpkSwitch.module.scss
@@ -31,12 +31,6 @@ $border-width: tokens.$bpk-one-pixel-rem * 2;
   align-items: center;
   border-radius: $height * 0.5;
 
-  input[type='checkbox']:focus-visible {
-    & + span {
-      @include utils.bpk-focus-indicator;
-    }
-  }
-
   // Checkbox is invisible so the switch element can be the visual element.
   &__checkbox {
     position: absolute;
@@ -52,6 +46,10 @@ $border-width: tokens.$bpk-one-pixel-rem * 2;
       &::before {
         left: ($width - $height) + $border-width;
       }
+    }
+
+    &:focus-visible ~ .bpk-switch__switch {
+      @include utils.bpk-focus-indicator;
     }
   }
 

--- a/packages/bpk-component-switch/src/BpkSwitch.module.scss
+++ b/packages/bpk-component-switch/src/BpkSwitch.module.scss
@@ -29,8 +29,9 @@ $border-width: tokens.$bpk-one-pixel-rem * 2;
   display: flex;
   width: fit-content;
   align-items: center;
+  border-radius: $height * 0.5;
 
-  &:focus-within {
+  input[type="checkbox"]:focus-visible + span {
     @include utils.bpk-focus-indicator;
   }
 


### PR DESCRIPTION
# BpkSwitch
We noticed the focus ring around the BpkSwitch component doesn't follow the component outline. There was also inconsistent behaviour when clicking the component, sporadically showing the focus ring. 

This PR adjusts the focus ring visual style and ensures it will show up when focusing by keyboard navigation only

| Before |  After | 
| --- | --- |
| ![image](https://github.com/user-attachments/assets/1150cc50-d06e-408b-8169-c9b062006d26) | ![image](https://github.com/user-attachments/assets/0a691596-40f0-4c2e-aace-48a770f9c4d2) |

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here