### PR TITLE
[LOOM-2050]: Updating docs for different build tools usage

### DIFF
--- a/packages/bpk-stylesheets/README.md
+++ b/packages/bpk-stylesheets/README.md
@@ -10,6 +10,7 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 
 Within your Javascript (usually the entrypoint or top-most JS file)
 
+### Webpack
 ```js
 import '@skyscanner/backpack-web/bpk-stylesheets';
 ```
@@ -27,6 +28,30 @@ For Editorial text, the Larken font will also need to be imported:
 ```js
 import '@skyscanner/backpack-web/bpk-stylesheets/larken';
 ```
+
+### Vite
+
+As Vite will not transpile the SCSS files, you will need to import the CSS files directly:
+
+```js
+import '@skyscanner/backpack-web/bpk-stylesheets/base';
+import '@skyscanner/backpack-web/bpk-stylesheets/base.css';
+```
+
+By default font rendering is not included if you need to include Skyscanner Relative in your styles, import it using the following:
+
+```js
+import '@skyscanner/backpack-web/bpk-stylesheets/font.css';
+```
+
+### Larken font
+
+For Editorial text, the Larken font will also need to be imported:
+
+```js
+import '@skyscanner/backpack-web/bpk-stylesheets/larken.css';
+```
+
 
 ## Contributing
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR updates the docs for use of bpk-stylesheets based on the build tools that we are using in Skyscanner.

By default if you use the default JS export when using say vite it will not transpile the Sass and imports so intead you need to use the pre-transpiled code which exists under the `base.js` and `base.css` files, this is to ensure that in the output bundles the compiled css files have the removed `:global` declarations and operate at a base style