### PR TITLE
[BD-9310][BpkMobileScrollContainer] Remove unused scroll indicators

### DIFF
--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.module.scss
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.module.scss
@@ -17,7 +17,6 @@
  */
 
 @use '../../unstable__bpk-mixins/tokens';
-@use '../../unstable__bpk-mixins/scroll-indicators';
 
 .bpk-mobile-scroll-container {
   position: relative;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
### [BD-9310](https://skyscanner.atlassian.net/browse/BD-9310)

We are looking for the reason why the `BpkMobileScrollContainer` component triggers **client crash in iOS Safari 15.x**.
In the last [PR](https://github.com/Skyscanner/backpack/pull/3701) we converted the jsx file to a stable tsx file and fixed some possible bugs, but the client crash still happened when we tried to upgrade to the latest BpkMobileScrollContainer component within the hotels-website. 
We suspected that a potentially problematic scss file was introduced in the scss packaging file, and raised this PR to remove unused `scroll-indicators` in `BpkMobileScrollContainer.module.css`

Have tested in the [storybook](https://backpack.github.io/storybook-prs/3741/?path=/story/bpk-component-mobile-scroll-container--default), won't affect original scroll feature.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here