### PR TITLE
[BD-9310][BpkMobileScrollContainer] Optimize the use of debounce for compatibility

### DIFF
--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
@@ -84,12 +84,12 @@ type State = {
 };
 
 class BpkMobileScrollContainer extends Component<Props, State> {
+  debouncedResize: () => void;
+
   static defaultProps: Partial<Props> = {
     innerContainerTagName: 'div',
     showScrollbar: false,
   };
-
-  debouncedResize: () => void;
 
   constructor(props: Props) {
     super(props);

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
@@ -23,6 +23,8 @@ import debounce from 'lodash/debounce';
 
 import { cssModules, isRTL } from '../../bpk-react-utils';
 
+import type { DebouncedFunc } from 'lodash';
+
 import STYLES from './BpkMobileScrollContainer.module.scss';
 
 const getClassName = cssModules(STYLES);
@@ -84,7 +86,7 @@ type State = {
 };
 
 class BpkMobileScrollContainer extends Component<Props, State> {
-  debouncedResize: () => void;
+  debouncedResize:  DebouncedFunc<() => void>
 
   static defaultProps: Partial<Props> = {
     innerContainerTagName: 'div',
@@ -99,18 +101,10 @@ class BpkMobileScrollContainer extends Component<Props, State> {
       scrollIndicatorClassName: null,
     };
 
-    this.debouncedResize = this.onWindowResize;
+    this.debouncedResize = debounce(this.onWindowResize, 100);
   }
 
   componentDidMount() {
-    requestAnimationFrame(() => {
-      this.setScrollBarAwareHeight();
-      this.setScrollIndicatorClassName();
-    });
-    // When the consumer uses the Nx webpack plugins to bundling, debounce may not be a valid function for invalid browser versions in Browserslist (e.g. Safari 15.7.1).
-    if (typeof debounce === 'function') {
-      this.debouncedResize = debounce(this.onWindowResize, 100);
-    }
     window.addEventListener('resize', this.debouncedResize);
   }
 

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
@@ -105,6 +105,10 @@ class BpkMobileScrollContainer extends Component<Props, State> {
   }
 
   componentDidMount() {
+    requestAnimationFrame(() => {
+      this.setScrollBarAwareHeight();
+      this.setScrollIndicatorClassName();
+    });
     window.addEventListener('resize', this.debouncedResize);
   }
 

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
@@ -89,6 +89,8 @@ class BpkMobileScrollContainer extends Component<Props, State> {
     showScrollbar: false,
   };
 
+  debouncedResize: () => void;
+
   constructor(props: Props) {
     super(props);
 
@@ -96,6 +98,8 @@ class BpkMobileScrollContainer extends Component<Props, State> {
       computedHeight: 'auto',
       scrollIndicatorClassName: null,
     };
+
+    this.debouncedResize = this.onWindowResize;
   }
 
   componentDidMount() {
@@ -103,17 +107,21 @@ class BpkMobileScrollContainer extends Component<Props, State> {
       this.setScrollBarAwareHeight();
       this.setScrollIndicatorClassName();
     });
-    window.addEventListener('resize', this.onWindowResize);
+    // When the consumer uses the Nx webpack plugins to bundling, debounce may not be a valid function for invalid browser versions in Browserslist (e.g. Safari 15.7.1).
+    if (typeof debounce === 'function') {
+      this.debouncedResize = debounce(this.onWindowResize, 100);
+    }
+    window.addEventListener('resize', this.debouncedResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.onWindowResize);
+    window.removeEventListener('resize', this.debouncedResize);
   }
 
-  onWindowResize = debounce(() => {
+  onWindowResize = () => {
     this.setScrollBarAwareHeight();
     this.setScrollIndicatorClassName();
-  }, 100);
+  };
 
   setScrollIndicatorClassName = () => {
     const classNames = computeScrollIndicatorClassName(


### PR DESCRIPTION
In some browsers not supported by Browserslist, such as Safari 15.7.1 - it will not appear in the list when configuring [Safari >= 15](https://browsersl.ist/#q=Safari+%3E%3D+15), and after bundling with the [Nx webpack plugins](https://nx.dev/recipes/webpack/webpack-plugins), the reference to `debounce` may be lost, causing an exception error.

To solve the compatibility issue of using `debounce`, bind it to an instance property to ensure that the correct reference can always be obtained.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here