### PR TITLE
[BD-9484][BpkInfoBannerExpandable] Fix an a11y issue

### DIFF
--- a/packages/bpk-component-info-banner/src/BpkInfoBanner-test.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBanner-test.tsx
@@ -55,6 +55,8 @@ describe('BpkInfoBanner', () => {
         message={message}
       />,
     );
-    expect(screen.getByRole('presentation')).toHaveClass('custom-banner-class-name');
+    expect(screen.getByText(message).parentElement?.parentElement).toHaveClass(
+      'custom-banner-class-name',
+    );
   });
 });

--- a/packages/bpk-component-info-banner/src/BpkInfoBanner.module.scss
+++ b/packages/bpk-component-info-banner/src/BpkInfoBanner.module.scss
@@ -42,6 +42,11 @@
     align-items: flex-start;
 
     &--expandable {
+      width: 100%;
+      padding: 0;
+      border: none;
+      background-color: transparent;
+      text-align: start;
       cursor: pointer;
     }
   }
@@ -78,9 +83,6 @@
     background-color: transparent;
     cursor: pointer;
     appearance: none;
-  }
-
-  &__expand-icon {
     fill: tokens.$bpk-text-secondary-day;
   }
 

--- a/packages/bpk-component-info-banner/src/BpkInfoBannerExpandable-test.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBannerExpandable-test.tsx
@@ -18,6 +18,7 @@
 
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { axe } from 'jest-axe';
 
 import BpkInfoBannerExpandable from './BpkInfoBannerExpandable';
 import { ALERT_TYPES } from './common-types';
@@ -28,15 +29,17 @@ const innerMessage =
   'Quisque sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus.' +
   'Nunc diam augue, egestas id egestas ut, facilisis nec mi.';
 
+const defaultTestProps = {
+  type: ALERT_TYPES.SUCCESS,
+  message,
+  toggleButtonLabel: 'Show details',
+  onExpandToggle: jest.fn(),
+};
+
 describe('BpkInfoBannerExpandable', () => {
   it('should not show inner message when "expanded" is not set to true', () => {
     render(
-      <BpkInfoBannerExpandable
-        type={ALERT_TYPES.SUCCESS}
-        message={message}
-        toggleButtonLabel="Show details"
-        onExpandToggle={jest.fn()}
-      >
+      <BpkInfoBannerExpandable {...defaultTestProps}>
         {innerMessage}
       </BpkInfoBannerExpandable>,
     );
@@ -45,16 +48,20 @@ describe('BpkInfoBannerExpandable', () => {
 
   it('should show inner message when "expanded" is set to true', () => {
     render(
-      <BpkInfoBannerExpandable
-        type={ALERT_TYPES.SUCCESS}
-        message={message}
-        toggleButtonLabel="Show details"
-        onExpandToggle={jest.fn()}
-        expanded
-      >
+      <BpkInfoBannerExpandable {...defaultTestProps} expanded>
         {innerMessage}
       </BpkInfoBannerExpandable>,
     );
     expect(screen.getByText(innerMessage)).toBeVisible();
+  });
+
+  it('should not have programmatically-detectable accessibility issues', async () => {
+    const { container } = render(
+      <BpkInfoBannerExpandable {...defaultTestProps}>
+        {innerMessage}
+      </BpkInfoBannerExpandable>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
@@ -92,13 +92,11 @@ type ToggleButtonProps = {
 };
 
 const ToggleButton = (props: ToggleButtonProps) => (
-    <div
-      className={getClassName('bpk-info-banner__toggle-button')}
-      title={props.label}
-    >
-      {props.expanded ? <CollapseIcon /> : <ExpandIcon />}
-    </div>
-  );
+  <div className={getClassName('bpk-info-banner__toggle-button')}>
+    {props.expanded ? <CollapseIcon /> : <ExpandIcon />}
+    <span className="visually-hidden">{props.label}</span>
+  </div>
+);
 
 type Props = CommonProps & {
   action?: ExpandableBannerAction;
@@ -150,7 +148,7 @@ const BpkInfoBannerInner = ({
   const dismissable = configuration === CONFIGURATION.DISMISSABLE;
   const showChildren = isExpandable && expanded;
 
-  const sectionClassNames = getClassName(
+  const classNames = getClassName(
     'bpk-info-banner',
    `bpk-info-banner--${type}`,
    `bpk-info-banner--style-${style}`,
@@ -168,8 +166,8 @@ const BpkInfoBannerInner = ({
 
   const BannerHeader = isExpandable ? 'button' : 'div';
 
-  // Disabling 'click-events-have-key-events and interactive-supports-focus' because header element is not focusable.
-  // ToggleButton is focusable and works for this.
+  const childrenContainerId = 'children-container';
+
   return (
     <AnimateAndFade
       animateOnEnter={animateOnEnter}
@@ -177,10 +175,10 @@ const BpkInfoBannerInner = ({
       show={show}
       {...rest}
     >
-      <section className={sectionClassNames} role="presentation">
+      <div className={classNames}>
         <BannerHeader
-          aria-label={isExpandable ? toggleButtonLabel : undefined}
           aria-expanded={isExpandable ? expanded : undefined}
+          aria-controls={isExpandable ? childrenContainerId : undefined}
           // BannerHeader is just <button> or <div>, so className should be allowed.
           // eslint-disable-next-line @skyscanner/rules/forbid-component-props
           className={headerClassNames}
@@ -211,7 +209,7 @@ const BpkInfoBannerInner = ({
           duration={parseInt(durationSm, 10)}
           height={showChildren ? 'auto' : 0}
         >
-          <div className={childrenContainerClassName}>
+          <div id={childrenContainerId} className={childrenContainerClassName}>
             {children}
           </div>
           {isExpandable && action && (
@@ -222,10 +220,9 @@ const BpkInfoBannerInner = ({
             </BpkLink>
           )}
         </BpkAnimateHeight>
-      </section>
+      </div>
     </AnimateAndFade>
   );
-
 };
 
 export default BpkInfoBannerInner;

--- a/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
@@ -179,6 +179,7 @@ const BpkInfoBannerInner = ({
         <BannerHeader
           aria-expanded={isExpandable ? expanded : undefined}
           aria-controls={isExpandable ? childrenContainerId : undefined}
+          type={isExpandable ? 'button' : undefined}
           // BannerHeader is just <button> or <div>, so className should be allowed.
           // eslint-disable-next-line @skyscanner/rules/forbid-component-props
           className={headerClassNames}

--- a/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
@@ -91,23 +91,14 @@ type ToggleButtonProps = {
   expanded: boolean;
 };
 
-const ToggleButton = (props: ToggleButtonProps) => {
-  const classNames = getClassName('bpk-info-banner__expand-icon');
-
-  return (
-    <button
-      type="button"
+const ToggleButton = (props: ToggleButtonProps) => (
+    <div
       className={getClassName('bpk-info-banner__toggle-button')}
-      aria-label={props.label}
-      aria-expanded={props.expanded}
       title={props.label}
     >
-      <div className={classNames}>
-        {props.expanded ? <CollapseIcon/> : <ExpandIcon/> }
-      </div>
-    </button>
+      {props.expanded ? <CollapseIcon /> : <ExpandIcon />}
+    </div>
   );
-};
 
 type Props = CommonProps & {
   action?: ExpandableBannerAction;
@@ -175,10 +166,8 @@ const BpkInfoBannerInner = ({
     ? getClassName('bpk-info-banner__children-container--with-action')
     : getClassName('bpk-info-banner__children-container--no-action')
 
-  /* eslint-disable
-    jsx-a11y/no-static-element-interactions,
-    jsx-a11y/click-events-have-key-events,
-    */
+  const BannerHeader = isExpandable ? 'button' : 'div';
+
   // Disabling 'click-events-have-key-events and interactive-supports-focus' because header element is not focusable.
   // ToggleButton is focusable and works for this.
   return (
@@ -189,8 +178,12 @@ const BpkInfoBannerInner = ({
       {...rest}
     >
       <section className={sectionClassNames} role="presentation">
-        <div
+        <BannerHeader
           role={isExpandable ? 'button' : undefined}
+          aria-label={isExpandable ? toggleButtonLabel : undefined}
+          aria-expanded={isExpandable ? expanded : undefined}
+          // BannerHeader is just <button> or <div>, so className should be allowed.
+          // eslint-disable-next-line @skyscanner/rules/forbid-component-props
           className={headerClassNames}
           onClick={onBannerExpandToggle}
         >
@@ -214,7 +207,7 @@ const BpkInfoBannerInner = ({
               />
             </span>
           )}
-        </div>
+        </BannerHeader>
         <BpkAnimateHeight
           duration={parseInt(durationSm, 10)}
           height={showChildren ? 'auto' : 0}
@@ -233,7 +226,7 @@ const BpkInfoBannerInner = ({
       </section>
     </AnimateAndFade>
   );
-  /* eslint-enable */
+
 };
 
 export default BpkInfoBannerInner;

--- a/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
@@ -179,7 +179,6 @@ const BpkInfoBannerInner = ({
     >
       <section className={sectionClassNames} role="presentation">
         <BannerHeader
-          role={isExpandable ? 'button' : undefined}
           aria-label={isExpandable ? toggleButtonLabel : undefined}
           aria-expanded={isExpandable ? expanded : undefined}
           // BannerHeader is just <button> or <div>, so className should be allowed.

--- a/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
@@ -166,8 +166,6 @@ const BpkInfoBannerInner = ({
 
   const BannerHeader = isExpandable ? 'button' : 'div';
 
-  const childrenContainerId = 'children-container';
-
   return (
     <AnimateAndFade
       animateOnEnter={animateOnEnter}
@@ -178,7 +176,6 @@ const BpkInfoBannerInner = ({
       <div className={classNames}>
         <BannerHeader
           aria-expanded={isExpandable ? expanded : undefined}
-          aria-controls={isExpandable ? childrenContainerId : undefined}
           type={isExpandable ? 'button' : undefined}
           // BannerHeader is just <button> or <div>, so className should be allowed.
           // eslint-disable-next-line @skyscanner/rules/forbid-component-props
@@ -210,7 +207,7 @@ const BpkInfoBannerInner = ({
           duration={parseInt(durationSm, 10)}
           height={showChildren ? 'auto' : 0}
         >
-          <div id={childrenContainerId} className={childrenContainerClassName}>
+          <div className={childrenContainerClassName}>
             {children}
           </div>
           {isExpandable && action && (

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBanner-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBanner-test.tsx.snap
@@ -8,9 +8,8 @@ exports[`BpkInfoBanner should render correctly 1`] = `
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -52,10 +51,11 @@ exports[`BpkInfoBanner should render correctly 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -73,9 +73,8 @@ exports[`BpkInfoBanner should render correctly with no type specified 1`] = `
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--info bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -117,10 +116,11 @@ exports[`BpkInfoBanner should render correctly with no type specified 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBanner-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBanner-test.tsx.snap
@@ -51,7 +51,6 @@ exports[`BpkInfoBanner should render correctly 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -116,7 +115,6 @@ exports[`BpkInfoBanner should render correctly with no type specified 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerDismissable-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerDismissable-test.tsx.snap
@@ -77,7 +77,6 @@ exports[`BpkInfoBannerDismissable should render correctly 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerDismissable-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerDismissable-test.tsx.snap
@@ -8,9 +8,8 @@ exports[`BpkInfoBannerDismissable should render correctly 1`] = `
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -78,10 +77,11 @@ exports[`BpkInfoBannerDismissable should render correctly 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
@@ -51,7 +51,6 @@ exports[`BpkInfoBannerInner should render correctly with "style" attribute equal
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -114,7 +113,6 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -177,7 +175,6 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -240,7 +237,6 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -303,7 +299,6 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -366,7 +361,6 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -429,7 +423,6 @@ exports[`BpkInfoBannerInner should render correctly with a custom banner-alert c
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -494,7 +487,6 @@ exports[`BpkInfoBannerInner should render correctly with a custom class name 1`]
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -518,9 +510,9 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
           >
             <button
-              aria-controls="children-container"
               aria-expanded="false"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
+              type="button"
             >
               <span
                 class="bpk-info-banner__icon"
@@ -592,7 +584,6 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 >
                   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
                 </div>
@@ -683,7 +674,6 @@ exports[`BpkInfoBannerInner should render correctly with animateOnLeave 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -746,7 +736,6 @@ exports[`BpkInfoBannerInner should render correctly with arbitrary props 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -770,9 +759,9 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
           >
             <button
-              aria-controls="children-container"
               aria-expanded="false"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
+              type="button"
             >
               <span
                 class="bpk-info-banner__icon"
@@ -839,7 +828,6 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 >
                   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
                 </div>
@@ -930,7 +918,6 @@ exports[`BpkInfoBannerInner should render correctly with dismissable option 1`] 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
@@ -522,7 +522,6 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
               aria-expanded="false"
               aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
-              role="button"
             >
               <span
                 class="bpk-info-banner__icon"
@@ -771,7 +770,6 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
               aria-expanded="false"
               aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
-              role="button"
             >
               <span
                 class="bpk-info-banner__icon"

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
@@ -518,7 +518,9 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
             role="presentation"
           >
-            <div
+            <button
+              aria-expanded="false"
+              aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
               role="button"
             >
@@ -558,35 +560,28 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
               <span
                 class="bpk-info-banner__toggle"
               >
-                <button
-                  aria-expanded="false"
-                  aria-label="View more"
+                <div
                   class="bpk-info-banner__toggle-button"
                   title="View more"
-                  type="button"
                 >
-                  <div
-                    class="bpk-info-banner__expand-icon"
+                  <span
+                    style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
                   >
-                    <span
-                      style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
+                    <svg
+                      aria-hidden="true"
+                      height="1rem"
+                      viewBox="0 0 24 24"
+                      width="1rem"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-hidden="true"
-                        height="1rem"
-                        viewBox="0 0 24 24"
-                        width="1rem"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M19.113 8.095a1.496 1.496 0 0 1 0 2.008l-6.397 5.948a1 1 0 0 1-1.358.003l-6.532-6.01a1.427 1.427 0 0 1 .138-1.949 1.57 1.57 0 0 1 1.997-.103l5.078 4.638 4.97-4.535a1.72 1.72 0 0 1 2.104 0"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
+                      <path
+                        d="M19.113 8.095a1.496 1.496 0 0 1 0 2.008l-6.397 5.948a1 1 0 0 1-1.358.003l-6.532-6.01a1.427 1.427 0 0 1 .138-1.949 1.57 1.57 0 0 1 1.997-.103l5.078 4.638 4.97-4.535a1.72 1.72 0 0 1 2.104 0"
+                      />
+                    </svg>
+                  </span>
+                </div>
               </span>
-            </div>
+            </button>
             <div
               style="height: 0px; overflow: hidden; transition: height 200ms ease;"
             >
@@ -772,7 +767,9 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
             role="presentation"
           >
-            <div
+            <button
+              aria-expanded="false"
+              aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
               role="button"
             >
@@ -807,35 +804,28 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
               <span
                 class="bpk-info-banner__toggle"
               >
-                <button
-                  aria-expanded="false"
-                  aria-label="View more"
+                <div
                   class="bpk-info-banner__toggle-button"
                   title="View more"
-                  type="button"
                 >
-                  <div
-                    class="bpk-info-banner__expand-icon"
+                  <span
+                    style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
                   >
-                    <span
-                      style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
+                    <svg
+                      aria-hidden="true"
+                      height="1rem"
+                      viewBox="0 0 24 24"
+                      width="1rem"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-hidden="true"
-                        height="1rem"
-                        viewBox="0 0 24 24"
-                        width="1rem"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M19.113 8.095a1.496 1.496 0 0 1 0 2.008l-6.397 5.948a1 1 0 0 1-1.358.003l-6.532-6.01a1.427 1.427 0 0 1 .138-1.949 1.57 1.57 0 0 1 1.997-.103l5.078 4.638 4.97-4.535a1.72 1.72 0 0 1 2.104 0"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
+                      <path
+                        d="M19.113 8.095a1.496 1.496 0 0 1 0 2.008l-6.397 5.948a1 1 0 0 1-1.358.003l-6.532-6.01a1.427 1.427 0 0 1 .138-1.949 1.57 1.57 0 0 1 1.997-.103l5.078 4.638 4.97-4.535a1.72 1.72 0 0 1 2.104 0"
+                      />
+                    </svg>
+                  </span>
+                </div>
               </span>
-            </div>
+            </button>
             <div
               style="height: 0px; overflow: hidden; transition: height 200ms ease;"
             >

--- a/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/BpkInfoBannerInner-test.tsx.snap
@@ -8,9 +8,8 @@ exports[`BpkInfoBannerInner should render correctly with "style" attribute equal
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--info bpk-info-banner--style-onContrast"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -52,10 +51,11 @@ exports[`BpkInfoBannerInner should render correctly with "style" attribute equal
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -71,9 +71,8 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--error bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -115,10 +114,11 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -134,9 +134,8 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--error bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -178,10 +177,11 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -197,9 +197,8 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--info bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -241,10 +240,11 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -260,9 +260,8 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -304,10 +303,11 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -323,9 +323,8 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -367,10 +366,11 @@ exports[`BpkInfoBannerInner should render correctly with "type" attribute equal 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -386,9 +386,8 @@ exports[`BpkInfoBannerInner should render correctly with a custom banner-alert c
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default custom-class"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -430,10 +429,11 @@ exports[`BpkInfoBannerInner should render correctly with a custom banner-alert c
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -451,9 +451,8 @@ exports[`BpkInfoBannerInner should render correctly with a custom class name 1`]
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -495,10 +494,11 @@ exports[`BpkInfoBannerInner should render correctly with a custom class name 1`]
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -514,13 +514,12 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-            role="presentation"
           >
             <button
+              aria-controls="children-container"
               aria-expanded="false"
-              aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
             >
               <span
@@ -561,7 +560,6 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
               >
                 <div
                   class="bpk-info-banner__toggle-button"
-                  title="View more"
                 >
                   <span
                     style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
@@ -578,6 +576,11 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
                       />
                     </svg>
                   </span>
+                  <span
+                    class="visually-hidden"
+                  >
+                    View more
+                  </span>
                 </div>
               </span>
             </button>
@@ -589,12 +592,13 @@ exports[`BpkInfoBannerInner should render correctly with a element based message
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 >
                   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
                 </div>
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -610,9 +614,8 @@ exports[`BpkInfoBannerInner should render correctly with animateOnLeave 1`] = `
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -680,10 +683,11 @@ exports[`BpkInfoBannerInner should render correctly with animateOnLeave 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -699,9 +703,8 @@ exports[`BpkInfoBannerInner should render correctly with arbitrary props 1`] = `
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -743,10 +746,11 @@ exports[`BpkInfoBannerInner should render correctly with arbitrary props 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -762,13 +766,12 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-            role="presentation"
           >
             <button
+              aria-controls="children-container"
               aria-expanded="false"
-              aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
             >
               <span
@@ -804,7 +807,6 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
               >
                 <div
                   class="bpk-info-banner__toggle-button"
-                  title="View more"
                 >
                   <span
                     style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
@@ -821,6 +823,11 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
                       />
                     </svg>
                   </span>
+                  <span
+                    class="visually-hidden"
+                  >
+                    View more
+                  </span>
                 </div>
               </span>
             </button>
@@ -832,12 +839,13 @@ exports[`BpkInfoBannerInner should render correctly with child nodes 1`] = `
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 >
                   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
                 </div>
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -853,9 +861,8 @@ exports[`BpkInfoBannerInner should render correctly with dismissable option 1`] 
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--warning bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -923,10 +930,11 @@ exports[`BpkInfoBannerInner should render correctly with dismissable option 1`] 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
@@ -101,7 +101,9 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
             role="presentation"
           >
-            <div
+            <button
+              aria-expanded="false"
+              aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
               role="button"
             >
@@ -136,35 +138,28 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
               <span
                 class="bpk-info-banner__toggle"
               >
-                <button
-                  aria-expanded="false"
-                  aria-label="View more"
+                <div
                   class="bpk-info-banner__toggle-button"
                   title="View more"
-                  type="button"
                 >
-                  <div
-                    class="bpk-info-banner__expand-icon"
+                  <span
+                    style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
                   >
-                    <span
-                      style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
+                    <svg
+                      aria-hidden="true"
+                      height="1rem"
+                      viewBox="0 0 24 24"
+                      width="1rem"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-hidden="true"
-                        height="1rem"
-                        viewBox="0 0 24 24"
-                        width="1rem"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M19.113 8.095a1.496 1.496 0 0 1 0 2.008l-6.397 5.948a1 1 0 0 1-1.358.003l-6.532-6.01a1.427 1.427 0 0 1 .138-1.949 1.57 1.57 0 0 1 1.997-.103l5.078 4.638 4.97-4.535a1.72 1.72 0 0 1 2.104 0"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
+                      <path
+                        d="M19.113 8.095a1.496 1.496 0 0 1 0 2.008l-6.397 5.948a1 1 0 0 1-1.358.003l-6.532-6.01a1.427 1.427 0 0 1 .138-1.949 1.57 1.57 0 0 1 1.997-.103l5.078 4.638 4.97-4.535a1.72 1.72 0 0 1 2.104 0"
+                      />
+                    </svg>
+                  </span>
+                </div>
               </span>
-            </div>
+            </button>
             <div
               style="height: 0px; overflow: hidden; transition: height 200ms ease;"
             >
@@ -203,7 +198,9 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
             role="presentation"
           >
-            <div
+            <button
+              aria-expanded="true"
+              aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
               role="button"
             >
@@ -238,35 +235,28 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
               <span
                 class="bpk-info-banner__toggle"
               >
-                <button
-                  aria-expanded="true"
-                  aria-label="View more"
+                <div
                   class="bpk-info-banner__toggle-button"
                   title="View more"
-                  type="button"
                 >
-                  <div
-                    class="bpk-info-banner__expand-icon"
+                  <span
+                    style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
                   >
-                    <span
-                      style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
+                    <svg
+                      aria-hidden="true"
+                      height="1rem"
+                      viewBox="0 0 24 24"
+                      width="1rem"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-hidden="true"
-                        height="1rem"
-                        viewBox="0 0 24 24"
-                        width="1rem"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M4.887 15.905a1.496 1.496 0 0 1 0-2.008l6.397-5.948a1 1 0 0 1 1.358-.004l6.532 6.012a1.427 1.427 0 0 1-.138 1.948 1.57 1.57 0 0 1-1.997.103L11.96 11.37l-4.97 4.535a1.72 1.72 0 0 1-2.104 0z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
+                      <path
+                        d="M4.887 15.905a1.496 1.496 0 0 1 0-2.008l6.397-5.948a1 1 0 0 1 1.358-.004l6.532 6.012a1.427 1.427 0 0 1-.138 1.948 1.57 1.57 0 0 1-1.997.103L11.96 11.37l-4.97 4.535a1.72 1.72 0 0 1-2.104 0z"
+                      />
+                    </svg>
+                  </span>
+                </div>
               </span>
-            </div>
+            </button>
             <div
               style="height: auto; overflow: visible; transition: height 200ms ease;"
             >

--- a/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
@@ -77,7 +77,6 @@ exports[`withBannerAlertState(BpkInfoBannerDismissable) should render correctly 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 />
               </div>
             </div>
@@ -101,9 +100,9 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
           >
             <button
-              aria-controls="children-container"
               aria-expanded="false"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
+              type="button"
             >
               <span
                 class="bpk-info-banner__icon"
@@ -170,7 +169,6 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 >
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id
 blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis
@@ -201,9 +199,9 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
           >
             <button
-              aria-controls="children-container"
               aria-expanded="true"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
+              type="button"
             >
               <span
                 class="bpk-info-banner__icon"
@@ -268,7 +266,6 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
               <div>
                 <div
                   class="bpk-info-banner__children-container--no-action"
-                  id="children-container"
                 >
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id
 blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis

--- a/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
@@ -8,9 +8,8 @@ exports[`withBannerAlertState(BpkInfoBannerDismissable) should render correctly 
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-            role="presentation"
           >
             <div
               class="bpk-info-banner__header"
@@ -78,10 +77,11 @@ exports[`withBannerAlertState(BpkInfoBannerDismissable) should render correctly 
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 />
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -97,13 +97,12 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-            role="presentation"
           >
             <button
+              aria-controls="children-container"
               aria-expanded="false"
-              aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
             >
               <span
@@ -139,7 +138,6 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
               >
                 <div
                   class="bpk-info-banner__toggle-button"
-                  title="View more"
                 >
                   <span
                     style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
@@ -156,6 +154,11 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
                       />
                     </svg>
                   </span>
+                  <span
+                    class="visually-hidden"
+                  >
+                    View more
+                  </span>
                 </div>
               </span>
             </button>
@@ -167,6 +170,7 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
               >
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 >
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id
 blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis
@@ -177,7 +181,7 @@ ante in, vestibulum nulla.
                 </div>
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>
@@ -193,13 +197,12 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
     >
       <div>
         <div>
-          <section
+          <div
             class="bpk-info-banner bpk-info-banner--success bpk-info-banner--style-default"
-            role="presentation"
           >
             <button
+              aria-controls="children-container"
               aria-expanded="true"
-              aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
             >
               <span
@@ -235,7 +238,6 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
               >
                 <div
                   class="bpk-info-banner__toggle-button"
-                  title="View more"
                 >
                   <span
                     style="line-height: 1rem; display: inline-block; margin-top: 0.25rem; vertical-align: top;"
@@ -252,6 +254,11 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
                       />
                     </svg>
                   </span>
+                  <span
+                    class="visually-hidden"
+                  >
+                    View more
+                  </span>
                 </div>
               </span>
             </button>
@@ -261,6 +268,7 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
               <div>
                 <div
                   class="bpk-info-banner__children-container--no-action"
+                  id="children-container"
                 >
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id
 blandit ipsum. Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis
@@ -271,7 +279,7 @@ ante in, vestibulum nulla.
                 </div>
               </div>
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
+++ b/packages/bpk-component-info-banner/src/__snapshots__/withBannerAlertState-test.tsx.snap
@@ -105,7 +105,6 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly c
               aria-expanded="false"
               aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
-              role="button"
             >
               <span
                 class="bpk-info-banner__icon"
@@ -202,7 +201,6 @@ exports[`withBannerAlertState(BpkInfoBannerExpandable) should render correctly e
               aria-expanded="true"
               aria-label="View more"
               class="bpk-info-banner__header bpk-info-banner__header--expandable"
-              role="button"
             >
               <span
                 class="bpk-info-banner__icon"

--- a/packages/bpk-component-info-banner/src/withBannerAlertState-test.tsx
+++ b/packages/bpk-component-info-banner/src/withBannerAlertState-test.tsx
@@ -134,9 +134,7 @@ describe('withBannerAlertState(BpkInfoBannerExpandable)', () => {
       </BpkInfoBannerExpandableState>,
     );
 
-    const expandButton = screen.getByRole('button', { name: 'View more' });
-
-    await userEvent.click(expandButton);
+    await userEvent.click(screen.getByText(message));
     expect(onExpandMock).toHaveBeenCalled();
   });
 });

--- a/packages/bpk-component-info-banner/src/withBannerAlertState-test.tsx
+++ b/packages/bpk-component-info-banner/src/withBannerAlertState-test.tsx
@@ -133,8 +133,7 @@ describe('withBannerAlertState(BpkInfoBannerExpandable)', () => {
         {longMessage}
       </BpkInfoBannerExpandableState>,
     );
-
-    await userEvent.click(screen.getByText(message));
+    await userEvent.click(screen.getByRole('button'));
     expect(onExpandMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Context
Fix a11y issue - element with button role can not be operable via keyboard

We identified this issue in hotels day-view:

<img src="https://github.com/user-attachments/assets/13ddd869-0069-4490-aa93-ec655154a408" width=512/>


### Changes
1. Change the toggle button from `<button>` to `<div>` and not clickable.
2. Change the expendable header to a `<button>`.
3. Style adjustments to maintain the original appearance.


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here