### PR TITLE
[ACC-632][BpkCalendarGrid]: Fix accessibility issue - grid has no accessible name

### DIFF
--- a/examples/bpk-component-calendar/examples.js
+++ b/examples/bpk-component-calendar/examples.js
@@ -70,6 +70,7 @@ const CalendarGridExample = () => (
     weekStartsOn={1}
     onDateClick={action('Clicked day')}
     formatDateFull={formatDateFull}
+    formatMonth={formatMonth}
     DateComponent={BpkCalendarDate}
     preventKeyboardFocus
   />

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid-test.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid-test.tsx
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { addMonths, isWeekend } from 'date-fns';
+import { addMonths, isWeekend, format } from 'date-fns';
 
 import {
   colorMonteverde,
@@ -32,12 +32,15 @@ import { formatDateFull } from '../test-utils';
 import BpkCalendarDate from './BpkCalendarDate';
 import BpkCalendarGrid from './BpkCalendarGrid';
 
+const formatMonth = (date: Date) => format(date, 'MMMM yyyy');
+
 describe('BpkCalendarGrid', () => {
   it('should render correctly with a different "weekStartsOn" attribute', () => {
     const { asFragment } = render(
       <BpkCalendarGrid
         month={new Date('2016-10')}
         formatDateFull={formatDateFull}
+        formatMonth={formatMonth}
         DateComponent={BpkCalendarDate}
         weekStartsOn={3}
         minDate={new Date('2016-01')}
@@ -55,6 +58,7 @@ describe('BpkCalendarGrid', () => {
       <BpkCalendarGrid
         month={new Date('2016-10')}
         formatDateFull={formatDateFull}
+        formatMonth={formatMonth}
         DateComponent={BpkCalendarDate}
         weekStartsOn={1}
         dateModifiers={modifiers}
@@ -68,7 +72,7 @@ describe('BpkCalendarGrid', () => {
   it('should render correctly with a custom date component', () => {
     const MyCustomDate = (props: any) => {
       const cx = {
-        backgroundColor: (colorPanjin as string),
+        backgroundColor: colorPanjin as string,
         width: '50%',
         height: '50%',
         borderRadius: '5rem',
@@ -86,6 +90,7 @@ describe('BpkCalendarGrid', () => {
       <BpkCalendarGrid
         month={new Date('2016-10')}
         formatDateFull={formatDateFull}
+        formatMonth={formatMonth}
         DateComponent={MyCustomDate}
         weekStartsOn={1}
         minDate={new Date('2016-01')}
@@ -102,6 +107,7 @@ describe('BpkCalendarGrid', () => {
       <BpkCalendarGrid
         month={new Date('2016-10')}
         formatDateFull={formatDateFull}
+        formatMonth={formatMonth}
         DateComponent={BpkCalendarDate}
         weekStartsOn={0}
         onDateClick={onDateClick}
@@ -125,6 +131,7 @@ describe('BpkCalendarGrid', () => {
       <BpkCalendarGrid
         month={new Date('2016-10')}
         formatDateFull={formatDateFull}
+        formatMonth={formatMonth}
         DateComponent={BpkCalendarDate}
         weekStartsOn={0}
         minDate={new Date('2016-01')}

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
@@ -107,6 +107,7 @@ class BpkCalendarGrid extends Component<Props, State> {
     minDate: new Date(),
     onDateClick: () => {},
     onDateKeyDown: () => {},
+    formatMonth: () => {},
     preventKeyboardFocus: false,
     selectionConfiguration: {
       type: CALENDAR_SELECTION_TYPE.single,

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
@@ -29,6 +29,7 @@ import {
   getCalendar,
   getCalendarNoCustomLabel,
   isSameMonth,
+  format,
 } from './date-utils';
 
 import type { DateModifiers, SelectionConfiguration } from './custom-proptypes';
@@ -107,7 +108,7 @@ class BpkCalendarGrid extends Component<Props, State> {
     minDate: new Date(),
     onDateClick: () => {},
     onDateKeyDown: () => {},
-    formatMonth: () => {},
+    formatMonth: (month: Date) => format(month, 'MMMM yyyy'),
     preventKeyboardFocus: false,
     selectionConfiguration: {
       type: CALENDAR_SELECTION_TYPE.single,

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
@@ -56,6 +56,11 @@ type DefaultProps = {
   minDate: Date;
   onDateClick: () => void;
   onDateKeyDown: () => void;
+  /**
+   * A function to format a human-readable month, for example: "January 2018":
+   * If you just need to quickly prototype, use the following from [`date-fns`](https://date-fns.org/docs/format#usage)
+   */
+  formatMonth: (month: Date) => string;
   preventKeyboardFocus: boolean;
   /**
    * An object to indicate which configuration of the calendar is being used. Choices are `single` date selection or `range` date selection.
@@ -158,6 +163,7 @@ class BpkCalendarGrid extends Component<Props, State> {
       dateModifiers,
       dateProps,
       focusedDate,
+      formatMonth,
       ignoreOutsideDate,
       isKeyboardFocusable,
       markOutsideDays,
@@ -177,7 +183,12 @@ class BpkCalendarGrid extends Component<Props, State> {
     const classNames = getClassName('bpk-calendar-grid', className);
 
     return (
-      <div className={classNames} aria-hidden={!isKeyboardFocusable} role="grid" >
+      <div
+        className={classNames}
+        aria-hidden={!isKeyboardFocusable}
+        role="grid"
+        aria-label={formatMonth(month)}
+      >
         <div role="rowgroup">
           {calendarMonthWeeks.map((dates) => (
             <BpkCalendarWeek

--- a/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarContainer-test.tsx.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarContainer-test.tsx.snap
@@ -180,6 +180,7 @@ exports[`BpkCalendarContainer should focus the correct date when \`initiallyFocu
         />
         <div
           aria-hidden="false"
+          aria-label="February 2010"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
           role="grid"
         >
@@ -1032,6 +1033,7 @@ exports[`BpkCalendarContainer should focus the correct date when \`initiallyFocu
         </div>
         <div
           aria-hidden="true"
+          aria-label="March 2010"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
           role="grid"
         >
@@ -2081,6 +2083,7 @@ exports[`BpkCalendarContainer should render correctly 1`] = `
         />
         <div
           aria-hidden="false"
+          aria-label="February 2010"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
           role="grid"
         >
@@ -2933,6 +2936,7 @@ exports[`BpkCalendarContainer should render correctly 1`] = `
         </div>
         <div
           aria-hidden="true"
+          aria-label="March 2010"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
           role="grid"
         >
@@ -3982,6 +3986,7 @@ exports[`BpkCalendarContainer should render correctly in range mode 1`] = `
         />
         <div
           aria-hidden="false"
+          aria-label="February 2010"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
           role="grid"
         >
@@ -4834,6 +4839,7 @@ exports[`BpkCalendarContainer should render correctly in range mode 1`] = `
         </div>
         <div
           aria-hidden="true"
+          aria-label="March 2010"
           class="bpk-calendar-grid bpk-calendar-grid-transition__grid"
           role="grid"
         >

--- a/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarGrid-test.tsx.snap
+++ b/packages/bpk-component-calendar/src/__snapshots__/BpkCalendarGrid-test.tsx.snap
@@ -4,6 +4,7 @@ exports[`BpkCalendarGrid should render correctly with "weekDayKey" attribute set
 <DocumentFragment>
   <div
     aria-hidden="false"
+    aria-label="October 2016"
     class="bpk-calendar-grid"
     role="grid"
   >
@@ -847,6 +848,7 @@ exports[`BpkCalendarGrid should render correctly with a "dateModifiers" attribut
 <DocumentFragment>
   <div
     aria-hidden="false"
+    aria-label="October 2016"
     class="bpk-calendar-grid"
     role="grid"
   >
@@ -1690,6 +1692,7 @@ exports[`BpkCalendarGrid should render correctly with a custom date component 1`
 <DocumentFragment>
   <div
     aria-hidden="false"
+    aria-label="October 2016"
     class="bpk-calendar-grid"
     role="grid"
   >
@@ -2113,6 +2116,7 @@ exports[`BpkCalendarGrid should render correctly with a different "weekStartsOn"
 <DocumentFragment>
   <div
     aria-hidden="false"
+    aria-label="October 2016"
     class="bpk-calendar-grid"
     role="grid"
   >

--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGrid.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGrid.tsx
@@ -47,14 +47,16 @@ const BpkScrollableCalendarGrid = ({
   return (
     <div className={classNames}>
       <span className={getClassName('bpk-scrollable-calendar-grid__title')}>
-        <BpkText
-          tagName="h1"
-          textStyle={TEXT_STYLES.heading4}
-        >    
+        <BpkText tagName="h1" textStyle={TEXT_STYLES.heading4}>
           {formatMonth(month)}
         </BpkText>
       </span>
-      <BpkCalendarGrid month={month} ignoreOutsideDate {...rest} />
+      <BpkCalendarGrid
+        month={month}
+        ignoreOutsideDate
+        formatMonth={formatMonth}
+        {...rest}
+      />
     </div>
   );
 };

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.tsx.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.tsx.snap
@@ -99,6 +99,7 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
                 </span>
                 <div
                   aria-hidden="false"
+                  aria-label="February 2010"
                   class="bpk-calendar-grid"
                   role="grid"
                 >
@@ -691,6 +692,7 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
                 </span>
                 <div
                   aria-hidden="false"
+                  aria-label="March 2010"
                   class="bpk-calendar-grid"
                   role="grid"
                 >
@@ -1456,6 +1458,7 @@ exports[`BpkScrollableCalendar should render ranges correctly 1`] = `
                 </span>
                 <div
                   aria-hidden="false"
+                  aria-label="February 2010"
                   class="bpk-calendar-grid"
                   role="grid"
                 >
@@ -2048,6 +2051,7 @@ exports[`BpkScrollableCalendar should render ranges correctly 1`] = `
                 </span>
                 <div
                   aria-hidden="false"
+                  aria-label="March 2010"
                   class="bpk-calendar-grid"
                   role="grid"
                 >
@@ -2813,6 +2817,7 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
                 </span>
                 <div
                   aria-hidden="false"
+                  aria-label="February 2010"
                   class="bpk-calendar-grid"
                   role="grid"
                 >
@@ -3405,6 +3410,7 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
                 </span>
                 <div
                   aria-hidden="false"
+                  aria-label="March 2010"
                   class="bpk-calendar-grid"
                   role="grid"
                 >
@@ -4170,6 +4176,7 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
                 </span>
                 <div
                   aria-hidden="false"
+                  aria-label="February 2010"
                   class="bpk-calendar-grid"
                   role="grid"
                 >
@@ -4762,6 +4769,7 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
                 </span>
                 <div
                   aria-hidden="false"
+                  aria-label="March 2010"
                   class="bpk-calendar-grid"
                   role="grid"
                 >

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGrid-test.tsx.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGrid-test.tsx.snap
@@ -16,6 +16,7 @@ exports[`BpkCalendarScrollGrid should render correctly with a "dateModifiers" at
     </span>
     <div
       aria-hidden="false"
+      aria-label="October 2016"
       class="bpk-calendar-grid"
       role="grid"
     >
@@ -718,6 +719,7 @@ exports[`BpkCalendarScrollGrid should render correctly with a custom date compon
     </span>
     <div
       aria-hidden="false"
+      aria-label="October 2016"
       class="bpk-calendar-grid"
       role="grid"
     >
@@ -1154,6 +1156,7 @@ exports[`BpkCalendarScrollGrid should render correctly with a different "weekSta
     </span>
     <div
       aria-hidden="false"
+      aria-label="October 2016"
       class="bpk-calendar-grid"
       role="grid"
     >
@@ -1816,6 +1819,7 @@ exports[`BpkCalendarScrollGrid should render correctly with no optional props se
     </span>
     <div
       aria-hidden="false"
+      aria-label="October 2016"
       class="bpk-calendar-grid"
       role="grid"
     >

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
@@ -31,6 +31,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
               </span>
               <div
                 aria-hidden="false"
+                aria-label="February 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >
@@ -623,6 +624,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
               </span>
               <div
                 aria-hidden="false"
+                aria-label="March 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >
@@ -1319,6 +1321,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom "custom
               </span>
               <div
                 aria-hidden="false"
+                aria-label="February 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >
@@ -1951,6 +1954,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom "custom
               </span>
               <div
                 aria-hidden="false"
+                aria-label="March 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >
@@ -2647,6 +2651,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
               </span>
               <div
                 aria-hidden="false"
+                aria-label="February 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >
@@ -2946,6 +2951,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
               </span>
               <div
                 aria-hidden="false"
+                aria-label="March 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >
@@ -3348,6 +3354,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a different "wee
               </span>
               <div
                 aria-hidden="false"
+                aria-label="February 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >
@@ -3980,6 +3987,7 @@ exports[`BpkCalendarScrollGridList should render correctly with a different "wee
               </span>
               <div
                 aria-hidden="false"
+                aria-label="March 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >
@@ -4716,6 +4724,7 @@ exports[`BpkCalendarScrollGridList should render correctly with no optional prop
               </span>
               <div
                 aria-hidden="false"
+                aria-label="February 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >
@@ -5348,6 +5357,7 @@ exports[`BpkCalendarScrollGridList should render correctly with no optional prop
               </span>
               <div
                 aria-hidden="false"
+                aria-label="March 2010"
                 class="bpk-calendar-grid"
                 role="grid"
               >


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

 ## Context
The BpkCalendarGrid have some accessibility issues. This causes some high severity issues on the [Opex report](https://skyscanner.atlassian.net/wiki/spaces/RIRP/pages/1308246211/2025-02-17+-+UX+Platform#id-2025-02-17-UXPlatform-Accessibility) in [AQA](https://aqa.usablenet.com/#/audit/skyscanner/suites/TS11196/a11yMonitors/A159802-1739509200009/T163052/step1/details/view/AI5/info).

- WAI-ARIA grid role doesn't have an accessible name
- User interface component doesn't have an accessible name


## Snapshots

> Test in storybook for BpkCalendarGrid changes

|  Before   |   After      |   
| ----------------------- | ------------------------ | 
| <img src="https://github.com/user-attachments/assets/6b093bc2-bf20-48c8-99a3-a2c826a81016" width=300/> | <img src="https://github.com/user-attachments/assets/b2bff8b5-8126-4f41-829f-7b41265f21c3" width=300 /> | 


> Test in consumer [month view page](https://www.tianxun.com/transport/flights/lond/rome/?previousCultureSource=COOKIE&redirectedFrom=www.skyscanner.net), the issues decreased

|  Before   |   After      |   
| ----------------------- | ------------------------ | 
| <img src="https://github.com/user-attachments/assets/076487a9-c23c-45ba-96c2-deee1c98d60d" width=300/> | <img src="https://github.com/user-attachments/assets/2fb70c74-49b9-452d-980d-59b1bab4e6c9" width=300 /> | 



## Change description
- Add `aria-label` with `formatMonth(month)` to `BpkCalendarGrid`
- Pass through `formatMonth` to `BpkCalendarGrid` and `BpkScrollableCalendarGrid`

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here