### PR TITLE
[NO-JIRA][BpkChipGroup] Align nudger margins in rail chip group with design

### DIFF
--- a/packages/bpk-component-chip-group/src/Nudger.module.scss
+++ b/packages/bpk-component-chip-group/src/Nudger.module.scss
@@ -19,13 +19,5 @@
 @use '../../unstable__bpk-mixins/tokens';
 
 .bpk-chip-group-nudger {
-  &--leading {
-    margin-inline-end: tokens.bpk-spacing-md();
-    margin-inline-start: tokens.bpk-spacing-sm();
-  }
-
-  &--trailing {
-    margin-inline-end: tokens.bpk-spacing-sm();
-    margin-inline-start: tokens.bpk-spacing-md();
-  }
+  margin-inline: tokens.bpk-spacing-sm();
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
> We noticed that the spacing between the nudgers and the chips is 12px (8px+4p) while it [should be 8px](https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=30119-41685&t=PwBcT7Q8ucoRaEw2-0).  Potentially the easiest (but maybe not the best?) fix would be to reduce the margin-inline-end  to 4px (bpk-spacing-sm).

[Slack thread](https://skyscanner.slack.com/archives/C0JHPDSSU/p1740996283806069)

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here