### PR TITLE
[QUAR-706][BpkPopover & BpkInsetBanner] Add custom z-index value

### DIFF
--- a/packages/bpk-component-inset-banner/README.md
+++ b/packages/bpk-component-inset-banner/README.md
@@ -30,6 +30,7 @@ export default () => (
       popoverId: 'popover',
       labelTitle: true,
       closeBtnIcon: false,
+      zIndexCustom: 1200;
     }}
     logo="logo.png"
     subheadline="My subheadline"

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner-test.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner-test.tsx
@@ -67,7 +67,7 @@ describe('BpkInsetBanner', () => {
       />,
     );
 
-    const ctaButton = screen.getByTestId('adInfoBtn');
+    const ctaButton = screen.getByTestId('ctaBtn');
 
     fireEvent.click(ctaButton);
 

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
@@ -51,6 +51,7 @@ export type Props = {
     popoverId?: string;
     labelTitle?: boolean;
     closeBtnIcon?: boolean;
+    zIndexCustom?: number;
   };
   logo?: string;
   subheadline?: string;
@@ -121,11 +122,12 @@ const BpkInsetBanner = ({
               closeButtonText={callToAction?.buttonCloseLabel}
               closeButtonIcon={callToAction?.closeBtnIcon}
               labelAsTitle={callToAction?.labelTitle}
+              zIndexValue={callToAction?.zIndexCustom}
               target={
                 <button
                   aria-label={callToAction?.buttonA11yLabel}
                   className={getClassName('bpk-inset-banner--cta-button')}
-                  data-testid="adInfoBtn"
+                  data-testid="ctaBtn"
                   aria-hidden="false"
                   type="button"
                 >

--- a/packages/bpk-component-popover/src/BpkPopover.module.scss
+++ b/packages/bpk-component-popover/src/BpkPopover.module.scss
@@ -25,10 +25,6 @@
 
 $arrow-size: tokens.bpk-spacing-lg();
 
-.bpk-popover--container {
-  z-index: tokens.$bpk-zindex-popover;
-}
-
 .bpk-popover {
   transition: opacity tokens.$bpk-duration-sm ease-in-out;
   outline: 0;

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -109,6 +109,7 @@ export type Props = CloseButtonProps & {
   target: ReactElement<any>;
   closeButtonLabel?: string;
   actionText?: string;
+  zIndexValue?: number;
   onAction?: () => void;
   renderTarget?: () => HTMLElement | HTMLElement | undefined;
   [rest: string]: any;
@@ -134,6 +135,7 @@ const BpkPopover = ({
   renderTarget = () => undefined,
   showArrow = true,
   target,
+  zIndexValue = 900,
   ...rest
 }: Props) => {
   const [isOpenState, setIsOpenState] = useState(isOpen);
@@ -208,8 +210,8 @@ const BpkPopover = ({
             <div
               className={getClassName('bpk-popover--container')}
               ref={refs.setFloating}
-              style={floatingStyles}
               {...getFloatingProps()}
+              style={{ ...floatingStyles, zIndex: zIndexValue }}
             >
               <TransitionInitialMount
                 appearClassName={getClassName('bpk-popover--appear')}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

JIRA: https://skyscanner.atlassian.net/browse/QUAR-706
Thread with context: https://skyscanner.slack.com/archives/C0JHPDSSU/p1740574285075669

When trying to use the `BpkInsetBanner` with CTA popover in the Banana booking panel page, there were 2 other backpack components on the page with higher z-index taking priority and preventing the popover of the inset banner from showing. To fix this we decided to add a custom z-index prop (`zIndexCustom `) to the inset banner component that gets passed to the popover component (via `zIndexValue` prop). If a z-index value is provided then that can be used for the popover, otherwise the default z-index of `900` is used.

| Before (default `z-index: 900`) | After (custom `z-index: 1100`) |
| --- | --- |
| <img width="400" alt="Screenshot 2025-03-04 at 14 13 07" src="https://github.com/user-attachments/assets/6601758e-a361-44c4-a05d-1c49d2b213bb" /> | <img width="400" alt="Screenshot 2025-03-04 at 14 14 08" src="https://github.com/user-attachments/assets/7cb38bb5-aa69-4522-bd7f-1a7c5d2c4eef" /> |


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here