### PR TITLE
[IRN-5693][BpkModal] Support dialog a11y label when no header

### DIFF
--- a/examples/bpk-component-modal/examples.tsx
+++ b/examples/bpk-component-modal/examples.tsx
@@ -106,13 +106,13 @@ const content = [
     pulvinar erat dignissim vitae.
   </Paragraph>,
 ];
-type ContainerProps =  {
+type ContainerProps = {
   title?: string;
   buttonLabel?: string;
   id?: string;
   wrapperProps?: Object;
   isOpen?: boolean;
-} & Omit<BpkModalProps, 'getApplicationElement'| 'id' | 'isOpen'>;
+} & Omit<BpkModalProps, 'getApplicationElement' | 'id' | 'isOpen'>;
 
 const ModalContainer = (props: ContainerProps) => {
   const [isOpen, setIsOpen] = useState(props.isOpen || false);
@@ -230,8 +230,7 @@ const NestedExample = (isOpen: boolean) => (
 
 const NoHeaderExample = (isOpen: boolean) => (
   <ModalContainer
-    title="Modal title"
-    closeLabel="Close modal"
+    ariaLabel="Modal title"
     showHeader={false}
     isOpen={isOpen}
   >
@@ -252,7 +251,7 @@ const WithAccessoryViewExample = (isOpen: boolean) => (
     accessoryView={
       <BpkNavigationBarButtonLink
         label="Close"
-        onClick={() => {}}
+        onClick={() => { }}
         className={getClassName('bpk-modal__leading-button')}
       >
         <div>

--- a/packages/bpk-component-modal/src/BpkModalInner.tsx
+++ b/packages/bpk-component-modal/src/BpkModalInner.tsx
@@ -52,6 +52,7 @@ export type Props = {
    * The accessory view allows for icons and actions to be placed in front of the main title inside the modal header. To be used with `BpkNavigationBarButtonLink`
    */
   accessoryView?: ReactNode;
+  ariaLabel?: string // optional aria label for scenario when header is disabled
 };
 
 export const MODAL_STYLING = {
@@ -62,6 +63,7 @@ export type ModalStyle = (typeof MODAL_STYLING)[keyof typeof MODAL_STYLING];
 
 const BpkModalInner = ({
   accessoryView = null,
+  ariaLabel,
   children,
   className = null,
   closeLabel = '',
@@ -125,6 +127,7 @@ const BpkModalInner = ({
         tabIndex={-1}
         role="dialog"
         aria-labelledby={showHeader ? headingId : undefined}
+        aria-label={!showHeader ? ariaLabel : undefined}
         className={classNames.join(' ')}
         ref={dialogRef}
       >


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here