### PR TITLE
[BD-9545][BpkLink] Add bpk-link--explicit for the new bpk-link design.

### DIFF
--- a/examples/bpk-component-link/examples.js
+++ b/examples/bpk-component-link/examples.js
@@ -31,11 +31,23 @@ import {
 
 const LinkExample = () => (
   <div>
-    <BpkLink href="#" onClick={action('#1 clicked')} explicit>
+    <BpkLink href="#" onClick={action('#1 clicked')}>
       Link #1
     </BpkLink>
     <br />
     <BpkLink href="#" onClick={action('#2 clicked')}>
+      Link #2
+    </BpkLink>
+  </div>
+);
+
+const ExplicitLinkExample = () => (
+  <div>
+    <BpkLink href="#" onClick={action('#1 clicked')} explicit>
+      Link #1
+    </BpkLink>
+    <br />
+    <BpkLink href="#" onClick={action('#2 clicked')} explicit>
       Link #2
     </BpkLink>
   </div>
@@ -103,6 +115,7 @@ const MixedExample = () => (
 
 export {
   LinkExample,
+  ExplicitLinkExample,
   ButtonLinkExample,
   LinkAlternativeExample,
   ButtonLinkAlternativeExample,

--- a/examples/bpk-component-link/examples.js
+++ b/examples/bpk-component-link/examples.js
@@ -41,13 +41,13 @@ const LinkExample = () => (
   </div>
 );
 
-const ExplicitLinkExample = () => (
+const ImplicitLinkExample = () => (
   <div>
-    <BpkLink href="#" onClick={action('#1 clicked')} explicit>
+    <BpkLink href="#" onClick={action('#1 clicked')} implicit>
       Link #1
     </BpkLink>
     <br />
-    <BpkLink href="#" onClick={action('#2 clicked')} explicit>
+    <BpkLink href="#" onClick={action('#2 clicked')} implicit>
       Link #2
     </BpkLink>
   </div>
@@ -115,7 +115,7 @@ const MixedExample = () => (
 
 export {
   LinkExample,
-  ExplicitLinkExample,
+  ImplicitLinkExample,
   ButtonLinkExample,
   LinkAlternativeExample,
   ButtonLinkAlternativeExample,

--- a/examples/bpk-component-link/examples.js
+++ b/examples/bpk-component-link/examples.js
@@ -31,7 +31,7 @@ import {
 
 const LinkExample = () => (
   <div>
-    <BpkLink href="#" onClick={action('#1 clicked')}>
+    <BpkLink href="#" onClick={action('#1 clicked')} explicit>
       Link #1
     </BpkLink>
     <br />

--- a/examples/bpk-component-link/examples.js
+++ b/examples/bpk-component-link/examples.js
@@ -73,6 +73,18 @@ const LinkAlternativeExample = () => (
   </BpkDarkExampleWrapper>
 );
 
+const LinkAlternativeImplicitExample = () => (
+  <BpkDarkExampleWrapper>
+    <BpkLink href="#" onClick={action('#1 clicked')} alternate implicit>
+      Link #1
+    </BpkLink>
+    <br />
+    <BpkLink href="#" onClick={action('#2 clicked')} alternate implicit>
+      Link #2
+    </BpkLink>
+  </BpkDarkExampleWrapper>
+);
+
 const ButtonLinkAlternativeExample = () => (
   <BpkDarkExampleWrapper>
     <BpkButtonLink onClick={action('#1 clicked')} alternate>
@@ -118,6 +130,7 @@ export {
   ImplicitLinkExample,
   ButtonLinkExample,
   LinkAlternativeExample,
+  LinkAlternativeImplicitExample,
   ButtonLinkAlternativeExample,
   CombinedExample,
   CombinedAlternativeExample,

--- a/examples/bpk-component-link/stories.js
+++ b/examples/bpk-component-link/stories.js
@@ -22,6 +22,7 @@ import BpkLink from '../../packages/bpk-component-link/src/BpkLink';
 
 import {
   LinkExample,
+  ExplicitLinkExample,
   ButtonLinkExample,
   LinkAlternativeExample,
   ButtonLinkAlternativeExample,
@@ -39,6 +40,7 @@ export default {
 };
 
 export const Example = LinkExample;
+export const ExampleExplicit = ExplicitLinkExample;
 export const ExampleButtons = ButtonLinkExample;
 
 export const ExampleAlternate = LinkAlternativeExample;

--- a/examples/bpk-component-link/stories.js
+++ b/examples/bpk-component-link/stories.js
@@ -22,7 +22,7 @@ import BpkLink from '../../packages/bpk-component-link/src/BpkLink';
 
 import {
   LinkExample,
-  ExplicitLinkExample,
+  ImplicitLinkExample,
   ButtonLinkExample,
   LinkAlternativeExample,
   ButtonLinkAlternativeExample,
@@ -40,7 +40,7 @@ export default {
 };
 
 export const Example = LinkExample;
-export const ExampleExplicit = ExplicitLinkExample;
+export const ExampleImplicit = ImplicitLinkExample;
 export const ExampleButtons = ButtonLinkExample;
 
 export const ExampleAlternate = LinkAlternativeExample;

--- a/examples/bpk-component-link/stories.js
+++ b/examples/bpk-component-link/stories.js
@@ -25,6 +25,7 @@ import {
   ImplicitLinkExample,
   ButtonLinkExample,
   LinkAlternativeExample,
+  LinkAlternativeImplicitExample,
   ButtonLinkAlternativeExample,
   CombinedExample,
   CombinedAlternativeExample,
@@ -44,6 +45,7 @@ export const ExampleImplicit = ImplicitLinkExample;
 export const ExampleButtons = ButtonLinkExample;
 
 export const ExampleAlternate = LinkAlternativeExample;
+export const ExampleAlternateImplicit = LinkAlternativeImplicitExample;
 
 export const ExampleAlternateButtons = ButtonLinkAlternativeExample;
 

--- a/packages/bpk-component-link/src/BpkLink.js
+++ b/packages/bpk-component-link/src/BpkLink.js
@@ -39,7 +39,7 @@ type Props = {
   blank: boolean,
   rel: ?string,
   alternate: boolean,
-  explicit: Boolean,
+  implicit: boolean,
 };
 
 const BpkLink = forwardRef((props: Props, ref) => {
@@ -48,8 +48,8 @@ const BpkLink = forwardRef((props: Props, ref) => {
     blank,
     children,
     className,
-    explicit,
     href,
+    implicit,
     onClick,
     rel: propRel,
     ...rest
@@ -66,8 +66,8 @@ const BpkLink = forwardRef((props: Props, ref) => {
   if (className) {
     classNames.push(className);
   }
-  if (explicit) {
-    classNames.push(getClassName('bpk-link--explicit'));
+  if (implicit) {
+    classNames.push(getClassName('bpk-link--implicit'));
   }
 
   return (
@@ -97,6 +97,7 @@ BpkLink.propTypes = {
   blank: PropTypes.bool,
   rel: PropTypes.string,
   alternate: PropTypes.bool,
+  implicit: PropTypes.bool,
 };
 
 BpkLink.defaultProps = {
@@ -105,6 +106,7 @@ BpkLink.defaultProps = {
   blank: false,
   rel: null,
   alternate: false,
+  implicit: false,
 };
 
 export default BpkLink;

--- a/packages/bpk-component-link/src/BpkLink.js
+++ b/packages/bpk-component-link/src/BpkLink.js
@@ -39,6 +39,7 @@ type Props = {
   blank: boolean,
   rel: ?string,
   alternate: boolean,
+  explicit: Boolean,
 };
 
 const BpkLink = forwardRef((props: Props, ref) => {
@@ -47,6 +48,7 @@ const BpkLink = forwardRef((props: Props, ref) => {
     blank,
     children,
     className,
+    explicit,
     href,
     onClick,
     rel: propRel,
@@ -63,6 +65,9 @@ const BpkLink = forwardRef((props: Props, ref) => {
   }
   if (className) {
     classNames.push(className);
+  }
+  if (explicit) {
+    classNames.push(getClassName('bpk-link--explicit'));
   }
 
   return (

--- a/packages/bpk-component-link/src/BpkLink.js
+++ b/packages/bpk-component-link/src/BpkLink.js
@@ -60,14 +60,14 @@ const BpkLink = forwardRef((props: Props, ref) => {
   const target = blank ? '_blank' : null;
   const rel = blank ? propRel || 'noopener noreferrer' : propRel;
 
-  if (alternate) {
-    classNames.push(getClassName('bpk-link--alternate'));
-  }
   if (className) {
     classNames.push(className);
   }
   if (implicit) {
     classNames.push(getClassName('bpk-link--implicit'));
+  }
+  if (alternate) {
+    classNames.push(getClassName('bpk-link--alternate'));
   }
 
   return (

--- a/packages/bpk-component-link/src/BpkLink.module.scss
+++ b/packages/bpk-component-link/src/BpkLink.module.scss
@@ -29,7 +29,7 @@
     @include typography.bpk-link--alternate;
   }
 
-  &--explicit {
-    @include typography.bpk-link--explicit;
+  &--implicit {
+    @include typography.bpk-link--implicit;
   }
 }

--- a/packages/bpk-component-link/src/BpkLink.module.scss
+++ b/packages/bpk-component-link/src/BpkLink.module.scss
@@ -25,11 +25,11 @@
     @include typography.bpk-link--active;
   }
 
-  &--alternate {
-    @include typography.bpk-link--alternate;
-  }
-
   &--implicit {
     @include typography.bpk-link--implicit;
+  }
+
+  &--alternate {
+    @include typography.bpk-link--alternate;
   }
 }

--- a/packages/bpk-component-link/src/BpkLink.module.scss
+++ b/packages/bpk-component-link/src/BpkLink.module.scss
@@ -28,4 +28,8 @@
   &--alternate {
     @include typography.bpk-link--alternate;
   }
+
+  &--explicit {
+    @include typography.bpk-link--explicit;
+  }
 }

--- a/packages/bpk-mixins/_buttons.scss
+++ b/packages/bpk-mixins/_buttons.scss
@@ -395,7 +395,7 @@
   background: none; /* stylelint-disable-line order/order, order/properties-order */
   box-shadow: none;
 
-  @include bpk-link;
+  @include bpk-link--implicit;
 
   &::after {
     bottom: auto;

--- a/packages/bpk-mixins/_buttons.scss
+++ b/packages/bpk-mixins/_buttons.scss
@@ -397,6 +397,10 @@
 
   @include bpk-link;
 
+  &::after {
+    bottom: auto;
+  }
+
   padding: $vertical-padding 0; /* stylelint-disable-line order/order, order/properties-order */
   color: $bpk-private-button-link-normal-foreground-day;
 

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -791,7 +791,11 @@
   cursor: pointer;
   appearance: none;
 
-  @include bpk-themeable-property(color, --bpk-link-color, $bpk-text-link-day);
+  @include bpk-themeable-property(
+    color,
+    --bpk-link-color,
+    $bpk-text-primary-day
+  );
 
   @include bpk-hover {
     text-decoration: none;
@@ -799,7 +803,7 @@
     @include bpk-themeable-property(
       color,
       --bpk-link-hover-color,
-      $bpk-text-link-day
+      $bpk-text-primary-day
     );
 
     &::after {
@@ -811,7 +815,7 @@
     @include bpk-themeable-property(
       color,
       --bpk-link-visited-color,
-      $bpk-text-link-day
+      $bpk-text-primary-day
     );
   }
 
@@ -819,7 +823,7 @@
     @include bpk-themeable-property(
       color,
       --bpk-link-active-color,
-      $bpk-text-link-day
+      $bpk-text-primary-day
     );
 
     &::after {
@@ -841,7 +845,7 @@
     @include bpk-themeable-property(
       background,
       --bpk-link-color,
-      $bpk-text-link-day
+      $bpk-text-primary-day
     );
 
     @media (prefers-reduced-motion) {
@@ -863,8 +867,16 @@
 @mixin bpk-link--implicit {
   display: inline;
 
+  @include bpk-themeable-property(color, --bpk-link-color, $bpk-text-link-day);
+
   @include bpk-hover {
     text-decoration: underline;
+
+    @include bpk-themeable-property(
+      color,
+      --bpk-link-hover-color,
+      $bpk-text-link-day
+    );
   }
 
   &::after {
@@ -874,6 +886,12 @@
 
   &:active {
     text-decoration: underline;
+
+    @include bpk-themeable-property(
+      color,
+      --bpk-link-active-color,
+      $bpk-text-link-day
+    );
   }
 }
 
@@ -898,6 +916,14 @@
     @include bpk-themeable-property(
       color,
       --bpk-link-alternate-hover-color,
+      $bpk-text-on-dark-day
+    );
+  }
+
+  &::after {
+    @include bpk-themeable-property(
+      background,
+      --bpk-link-alternate-color,
       $bpk-text-on-dark-day
     );
   }
@@ -934,14 +960,14 @@
 ///   }
 
 @mixin bpk-link--active {
-  color: $bpk-text-link-day;
+  color: $bpk-text-primary-day;
 
   &:visited {
-    color: $bpk-text-link-day;
+    color: $bpk-text-primary-day;
   }
 
   &:active {
-    color: $bpk-text-link-day;
+    color: $bpk-text-primary-day;
   }
 }
 

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -865,23 +865,29 @@
 ///   }
 
 @mixin bpk-link--implicit {
-  display: inline;
-
-  @include bpk-themeable-property(color, --bpk-link-color, $bpk-text-link-day);
+  @include bpk-themeable-property(
+    color,
+    --bpk-link-color,
+    $bpk-text-primary-day
+  );
 
   @include bpk-hover {
-    text-decoration: underline;
-
     @include bpk-themeable-property(
       color,
       --bpk-link-hover-color,
-      $bpk-text-link-day
+      $bpk-text-primary-day
     );
+
+    &::after {
+      width: 100%;
+    }
   }
 
   &::after {
-    content: none;
-    display: none;
+    width: 0;
+    transition:
+      width 0.2s ease 0s,
+      left 0.2s ease 0s;
   }
 
   &:active {
@@ -890,8 +896,12 @@
     @include bpk-themeable-property(
       color,
       --bpk-link-active-color,
-      $bpk-text-link-day
+      $bpk-text-primary-day
     );
+
+    &::after {
+      width: 100%;
+    }
   }
 }
 

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -820,6 +820,50 @@
   }
 }
 
+/// Explicit inline link.
+///
+/// @example scss
+///   .selector {
+///     @include bpk-link();
+///     @include bpk-link--explicit();
+///   }
+
+@mixin bpk-link--explicit {
+  display: inline-block;
+
+  @include bpk-hover {
+    text-decoration: none;
+
+    &::after {
+      width: 0%;
+    }
+  }
+
+  &::after {
+    position: relative;
+    bottom: tokens.$bpk-border-size-sm;
+    content: '';
+    display: block;
+    width: 100%;
+    height: tokens.$bpk-border-size-sm;
+    transition:
+      width 0.2s ease 0s,
+      left 0.2s ease 0s;
+
+    @include bpk-themeable-property(
+      background,
+      --bpk-link-color,
+      $bpk-text-link-day
+    );
+
+    @media (prefers-reduced-motion) {
+      transition:
+        width 0s ease 0s,
+        left 0s ease 0s;
+    }
+  }
+}
+
 /// White link. Modifies the bpk-link mixin.
 ///
 /// @require {mixin} bpk-link

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -782,6 +782,8 @@
 ///   }
 
 @mixin bpk-link {
+  position: relative;
+  display: inline-block;
   padding: 0;
   border: 0;
   background-color: transparent;
@@ -792,13 +794,17 @@
   @include bpk-themeable-property(color, --bpk-link-color, $bpk-text-link-day);
 
   @include bpk-hover {
-    text-decoration: underline;
+    text-decoration: none;
 
     @include bpk-themeable-property(
       color,
       --bpk-link-hover-color,
       $bpk-text-link-day
     );
+
+    &::after {
+      width: 0%;
+    }
   }
 
   &:visited {
@@ -810,29 +816,11 @@
   }
 
   &:active {
-    text-decoration: underline;
-
     @include bpk-themeable-property(
       color,
       --bpk-link-active-color,
       $bpk-text-link-day
     );
-  }
-}
-
-/// Explicit inline link.
-///
-/// @example scss
-///   .selector {
-///     @include bpk-link();
-///     @include bpk-link--explicit();
-///   }
-
-@mixin bpk-link--explicit {
-  display: inline-block;
-
-  @include bpk-hover {
-    text-decoration: none;
 
     &::after {
       width: 0%;
@@ -840,8 +828,8 @@
   }
 
   &::after {
-    position: relative;
-    bottom: tokens.$bpk-border-size-sm;
+    position: absolute;
+    bottom: 0;
     content: '';
     display: block;
     width: 100%;
@@ -861,6 +849,31 @@
         width 0s ease 0s,
         left 0s ease 0s;
     }
+  }
+}
+
+/// Implicit inline link.
+///
+/// @example scss
+///   .selector {
+///     @include bpk-link();
+///     @include bpk-link--implicit();
+///   }
+
+@mixin bpk-link--implicit {
+  display: inline;
+
+  @include bpk-hover {
+    text-decoration: underline;
+  }
+
+  &::after {
+    content: none;
+    display: none;
+  }
+
+  &:active {
+    text-decoration: underline;
   }
 }
 


### PR DESCRIPTION
[Jira -- Explicit Link](https://skyscanner.atlassian.net/jira/polaris/projects/VDL2/ideas/view/6107461?issueViewLayout=sidebar&issueViewSection=overview&selectedIssue=VDL2-34)

<img width="500" alt="image" src="https://github.com/user-attachments/assets/78229ae5-d407-4435-8965-236492218ae2" />\

**Description**:
1. update the bpk-link to the new explicit bpk-link style;
2. add a new boolean prop "implicit" to bpk-link to enable using old design;
3. add a new "bpk-link--implicit" example and update the propTypes and defaultProps.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here