### PR TITLE
[GOOSE-148][BpkSegmentedControl] Refactor for use by Flights Search Controls

### DIFF
--- a/examples/bpk-component-segmented-control/examples.module.scss
+++ b/examples/bpk-component-segmented-control/examples.module.scss
@@ -1,0 +1,5 @@
+.bpk-component-segmented-control-stories__custom-button {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/examples/bpk-component-segmented-control/examples.module.scss
+++ b/examples/bpk-component-segmented-control/examples.module.scss
@@ -17,6 +17,7 @@
  */
 
 .bpk-component-segmented-control-stories__custom-button {
+  display: block;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/examples/bpk-component-segmented-control/examples.module.scss
+++ b/examples/bpk-component-segmented-control/examples.module.scss
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .bpk-component-segmented-control-stories__custom-button {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/examples/bpk-component-segmented-control/examples.tsx
+++ b/examples/bpk-component-segmented-control/examples.tsx
@@ -91,23 +91,23 @@ const SimpleSurfaceContrast = () => (
 
 //  Custom Button Segmented Control
 const customButtonContentDatesFixed = [
-  <div
+  <span
     className={getClassName(
       'bpk-component-segmented-control-stories__custom-button',
     )}
   >
     Specific dates
-  </div>,
+  </span>,
 ];
 
 const customButtonContentDatesFlexible = [
-  <div
+  <span
     className={getClassName(
       'bpk-component-segmented-control-stories__custom-button',
     )}
   >
     Flexible dates
-  </div>,
+  </span>,
 ];
 
 const allCustomButtonContent = [

--- a/examples/bpk-component-segmented-control/examples.tsx
+++ b/examples/bpk-component-segmented-control/examples.tsx
@@ -18,13 +18,18 @@
 
 import {
   canvasContrastDay,
-  surfaceContrastDay
+  surfaceContrastDay,
 } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 import BpkSegmentedControl from '../../packages/bpk-component-segmented-control';
 import { SEGMENT_TYPES } from '../../packages/bpk-component-segmented-control/src/BpkSegmentedControl';
+import { cssModules } from '../../packages/bpk-react-utils';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import { BpkDarkExampleWrapper } from '../bpk-storybook-utils';
+
+import STYLES from './examples.module.scss';
+
+const getClassName = cssModules(STYLES);
 
 const canvasDefaultWrapperStyle = {
   backgroundColor: canvasContrastDay,
@@ -84,7 +89,86 @@ const SimpleSurfaceContrast = () => (
   </BpkDarkExampleWrapper>
 );
 
-// // Complex Segmented Control
+//  Custom Button Segmented Control
+const customButtonContentDatesFixed = [
+  <div
+    className={getClassName(
+      'bpk-component-segmented-control-stories__custom-button',
+    )}
+  >
+    Specific dates
+  </div>,
+];
+
+const customButtonContentDatesFlexible = [
+  <div
+    className={getClassName(
+      'bpk-component-segmented-control-stories__custom-button',
+    )}
+  >
+    Flexible dates
+  </div>,
+];
+
+const allCustomButtonContent = [
+  customButtonContentDatesFixed,
+  customButtonContentDatesFlexible,
+];
+
+const CustomSurfaceContrast = () => (
+  <BpkDarkExampleWrapper padded>
+    <BpkSegmentedControl
+      buttonContents={allCustomButtonContent}
+      onItemClick={() => {}}
+      selectedIndex={1}
+      type={SEGMENT_TYPES.SurfaceContrast}
+      shadow
+    />
+  </BpkDarkExampleWrapper>
+);
+
+const CustomSurfaceDefault = () => (
+  <BpkSegmentedControl
+    buttonContents={allCustomButtonContent}
+    onItemClick={() => {}}
+    selectedIndex={1}
+    type={SEGMENT_TYPES.SurfaceDefault}
+    shadow
+  />
+);
+
+const CustomCanvasContrast = () => (
+  <BpkDarkExampleWrapper padded style={{ backgroundColor: canvasContrastDay }}>
+    <BpkSegmentedControl
+      buttonContents={allCustomButtonContent}
+      onItemClick={() => {}}
+      selectedIndex={1}
+      type={SEGMENT_TYPES.CanvasContrast}
+      shadow
+    />
+  </BpkDarkExampleWrapper>
+);
+
+const CustomCanvasDefault = () => (
+  <BpkSegmentedControl
+    buttonContents={allCustomButtonContent}
+    onItemClick={() => {}}
+    selectedIndex={1}
+    type={SEGMENT_TYPES.CanvasDefault}
+    shadow
+  />
+);
+
+const CustomSurfaceDefaultNoShadow = () => (
+  <BpkSegmentedControl
+    buttonContents={allCustomButtonContent}
+    onItemClick={() => {}}
+    selectedIndex={1}
+    type={SEGMENT_TYPES.SurfaceDefault}
+  />
+);
+
+// Complex Segmented Control
 const complexButtonContentBest = [
   <>
     <div>Best</div>
@@ -107,7 +191,7 @@ const complexButtonContentFastest = [
   </>,
 ];
 
-const allButtonContent = [
+const allComplexButtonContent = [
   complexButtonContentBest,
   complexButtonContentCheapest,
   complexButtonContentFastest,
@@ -116,7 +200,7 @@ const allButtonContent = [
 const ComplexSurfaceContrast = () => (
   <BpkDarkExampleWrapper padded>
     <BpkSegmentedControl
-      buttonContents={allButtonContent}
+      buttonContents={allComplexButtonContent}
       onItemClick={() => {}}
       selectedIndex={1}
       type={SEGMENT_TYPES.SurfaceContrast}
@@ -127,7 +211,7 @@ const ComplexSurfaceContrast = () => (
 
 const ComplexSurfaceDefault = () => (
   <BpkSegmentedControl
-    buttonContents={allButtonContent}
+    buttonContents={allComplexButtonContent}
     onItemClick={() => {}}
     selectedIndex={1}
     type={SEGMENT_TYPES.SurfaceDefault}
@@ -136,12 +220,9 @@ const ComplexSurfaceDefault = () => (
 );
 
 const ComplexCanvasContrast = () => (
-  <BpkDarkExampleWrapper
-    padded
-    style={{ backgroundColor: canvasContrastDay }}
-  >
+  <BpkDarkExampleWrapper padded style={{ backgroundColor: canvasContrastDay }}>
     <BpkSegmentedControl
-      buttonContents={allButtonContent}
+      buttonContents={allComplexButtonContent}
       onItemClick={() => {}}
       selectedIndex={1}
       type={SEGMENT_TYPES.CanvasContrast}
@@ -152,7 +233,7 @@ const ComplexCanvasContrast = () => (
 
 const ComplexCanvasDefault = () => (
   <BpkSegmentedControl
-    buttonContents={allButtonContent}
+    buttonContents={allComplexButtonContent}
     onItemClick={() => {}}
     selectedIndex={1}
     type={SEGMENT_TYPES.CanvasDefault}
@@ -162,7 +243,7 @@ const ComplexCanvasDefault = () => (
 
 const ComplexSurfaceDefaultNoShadow = () => (
   <BpkSegmentedControl
-    buttonContents={allButtonContent}
+    buttonContents={allComplexButtonContent}
     onItemClick={() => {}}
     selectedIndex={1}
     type={SEGMENT_TYPES.SurfaceDefault}
@@ -186,6 +267,11 @@ export {
   SimpleCanvasContrast,
   SimpleSurfaceDefault,
   SimpleSurfaceContrast,
+  CustomSurfaceContrast,
+  CustomSurfaceDefault,
+  CustomCanvasContrast,
+  CustomCanvasDefault,
+  CustomSurfaceDefaultNoShadow,
   ComplexSurfaceContrast,
   ComplexSurfaceDefault,
   ComplexCanvasContrast,

--- a/examples/bpk-component-segmented-control/stories.tsx
+++ b/examples/bpk-component-segmented-control/stories.tsx
@@ -23,12 +23,17 @@ import {
   SimpleCanvasContrast,
   SimpleSurfaceDefault,
   SimpleSurfaceContrast,
+  CustomSurfaceContrast,
+  CustomSurfaceDefault,
+  CustomCanvasContrast,
+  CustomCanvasDefault,
+  CustomSurfaceDefaultNoShadow,
   ComplexSurfaceContrast,
   ComplexSurfaceDefault,
   ComplexCanvasContrast,
   ComplexCanvasDefault,
   ComplexSurfaceDefaultNoShadow,
-  VisualExample
+  VisualExample,
 } from './examples';
 
 export default {
@@ -40,6 +45,12 @@ export const SimpleTwoSegmentsCanvasDefault = SimpleDefault;
 export const SimpleThreeSegmentsCanvasContrast = SimpleCanvasContrast;
 export const SimpleFourSegmentsSurfaceDefault = SimpleSurfaceDefault;
 export const SimpleFourSegmentsSurfaceContrast = SimpleSurfaceContrast;
+export const CustomThreeSegmentsSurfaceContrast = CustomSurfaceContrast;
+export const CustomThreeSegmentsSurfaceDefault = CustomSurfaceDefault;
+export const CustomThreeSegmentsCanvasContrast = CustomCanvasContrast;
+export const CustomThreeSegmentsCanvasDefault = CustomCanvasDefault;
+export const CustomThreeSegmentsSurfaceDefaultNoShadow =
+  CustomSurfaceDefaultNoShadow;
 export const ComplexThreeSegmentsSurfaceContrast = ComplexSurfaceContrast;
 export const ComplexThreeSegmentsSurfaceDefault = ComplexSurfaceDefault;
 export const ComplexThreeSegmentsCanvasContrast = ComplexCanvasContrast;

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
@@ -38,8 +38,6 @@
   min-height: tokens.bpk-spacing-xl();
   padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
   border: none;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   cursor: pointer;
   overflow: hidden;
 

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
@@ -39,7 +39,6 @@
   min-height: tokens.bpk-spacing-xl();
   padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
   border: none;
-  text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
@@ -23,8 +23,9 @@
 @use '../../unstable__bpk-mixins/shadows';
 
 .bpk-segmented-control-group {
-  display: flex;
-  flex-wrap: nowrap;
+  display: grid;
+  grid-auto-columns: 1fr;
+  grid-auto-flow: column;
   overflow: hidden;
 
   @include radii.bpk-border-radius-sm;
@@ -37,9 +38,10 @@
 .bpk-segmented-control {
   min-height: tokens.bpk-spacing-xl();
   padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
-  flex: 1;
   border: none;
+  text-align: center;
   text-overflow: ellipsis;
+  white-space: nowrap;
   cursor: pointer;
   overflow: hidden;
 

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
@@ -27,8 +27,6 @@
   grid-auto-columns: 1fr;
   grid-auto-flow: column;
 
-  // overflow: hidden;
-
   @include radii.bpk-border-radius-sm;
 
   &-shadow {

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
@@ -26,7 +26,8 @@
   display: grid;
   grid-auto-columns: 1fr;
   grid-auto-flow: column;
-  overflow: hidden;
+
+  // overflow: hidden;
 
   @include radii.bpk-border-radius-sm;
 
@@ -45,6 +46,12 @@
   overflow: hidden;
 
   @include typography.bpk-label-2;
+
+  &:focus-visible {
+    z-index: 0; // Ensure the focus indicator is above the other buttons
+
+    @include utils.bpk-focus-indicator;
+  }
 
   &--canvas-default {
     background-color: tokens.$bpk-private-segmented-control-canvas-default-day;

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
@@ -64,7 +64,7 @@ const BpkSegmentedControl = ({
   );
 
   return (
-    <div role="radiogroup" className={containerStyling}>
+    <div className={containerStyling}>
       {buttonContents.map((content, index) => {
         const isSelected = index === selectedButton;
         const rightOfOption = index === selectedButton + 1;


### PR DESCRIPTION
[JIRA](https://skyscanner.atlassian.net/browse/GOOSE-148)

### What's changed

This PR contains changes required for the Segmented Control component to be used by the Flights Search Controls date switcher.

Specifically, this PR...

- Switches CSS Flex with CSS Grid so that the tab items maintain equal widths when used and centred within a flex container.
- Removes style `text-overflow` from control item, as it was agreed that consumers should be in charge of how the content is displayed within each item, and not enforce via this component.
- A11y fixes including ([context](https://skyscanner.slack.com/archives/C0JHPDSSU/p1742283184632619?thread_ts=1742227344.368179&cid=C0JHPDSSU)):
  - Removal of `radiogroup` role. This is because the component does not behave as would be expected for radio group so removing for now until it's decided on a better approach
  - Fix to show focus indicator when navigating the component via keyboard

# Screenshots / Recordings

### Before

#### Custom button story

N/A

#### Switch to grid

![Screenshot 2025-03-20 at 14 52 36](https://github.com/user-attachments/assets/32c2d19c-4cdd-4458-adee-6c4d797394d3)

### After

#### Custom button story (FSC use case)

https://github.com/user-attachments/assets/dcc7bf3b-eaab-4f2e-b104-30e8b9ee1452

#### Switch to grid

![Screenshot 2025-03-20 at 14 53 13](https://github.com/user-attachments/assets/42d145a1-97c8-487a-853b-83c5c011e5a6)

#### Focus indicator fix

https://github.com/user-attachments/assets/a1d17150-ecea-47c5-aec5-8c1fb7a585fa

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here