### PR TITLE
[MAT-2306][BpkDrawer] Update BpkDrawer by allowing dynamic width and animation

### DIFF
--- a/packages/bpk-component-drawer/src/BpkDrawer.tsx
+++ b/packages/bpk-component-drawer/src/BpkDrawer.tsx
@@ -21,15 +21,12 @@
 import type { ReactNode } from 'react';
 import { useState, useEffect } from 'react';
 
-import type { animations } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
-
 import { Portal, isDeviceIpad, isDeviceIphone } from '../../bpk-react-utils';
 import { withScrim } from '../../bpk-scrim-utils';
 
 import BpkDrawerContent from './BpkDrawerContent';
 
 const BpkScrimDrawerContent = withScrim(BpkDrawerContent);
-type ValueOf<T> = T[keyof T];
 
 export type Props = {
   id: string,
@@ -44,7 +41,6 @@ export type Props = {
   title: string,
   getApplicationElement: () => HTMLElement | null,
   width?: string,
-  transitionDuration?: ValueOf<typeof animations>,
   renderTarget?: null | HTMLElement | (() => null | HTMLElement),
   dialogRef?: (ref: HTMLElement | null | undefined) => void,
   className?: string,
@@ -76,7 +72,6 @@ const BpkDrawer = ({
   padded = true,
   renderTarget = null,
   title,
-  transitionDuration,
   width,
 }: Props) =>  {
 
@@ -106,7 +101,6 @@ const BpkDrawer = ({
           closeLabel={closeLabel || ""}
           closeText={closeText}
           width={width}
-          transitionDuration={transitionDuration}
           // eslint-disable-next-line @skyscanner/rules/forbid-component-props
           className={className}
           contentClassName={contentClassName}

--- a/packages/bpk-component-drawer/src/BpkDrawer.tsx
+++ b/packages/bpk-component-drawer/src/BpkDrawer.tsx
@@ -21,12 +21,15 @@
 import type { ReactNode } from 'react';
 import { useState, useEffect } from 'react';
 
+import type { animations } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
+
 import { Portal, isDeviceIpad, isDeviceIphone } from '../../bpk-react-utils';
 import { withScrim } from '../../bpk-scrim-utils';
 
 import BpkDrawerContent from './BpkDrawerContent';
 
 const BpkScrimDrawerContent = withScrim(BpkDrawerContent);
+type ValueOf<T> = T[keyof T];
 
 export type Props = {
   id: string,
@@ -40,6 +43,8 @@ export type Props = {
   ) => void;
   title: string,
   getApplicationElement: () => HTMLElement | null,
+  width?: string,
+  transitionDuration?: ValueOf<typeof animations>,
   renderTarget?: null | HTMLElement | (() => null | HTMLElement),
   dialogRef?: (ref: HTMLElement | null | undefined) => void,
   className?: string,
@@ -71,6 +76,8 @@ const BpkDrawer = ({
   padded = true,
   renderTarget = null,
   title,
+  transitionDuration,
+  width,
 }: Props) =>  {
 
   const [isDrawerShown, setIsDrawerShown] = useState(true);
@@ -98,6 +105,8 @@ const BpkDrawer = ({
           dialogRef={dialogRef}
           closeLabel={closeLabel || ""}
           closeText={closeText}
+          width={width}
+          transitionDuration={transitionDuration}
           // eslint-disable-next-line @skyscanner/rules/forbid-component-props
           className={className}
           contentClassName={contentClassName}

--- a/packages/bpk-component-drawer/src/BpkDrawer.tsx
+++ b/packages/bpk-component-drawer/src/BpkDrawer.tsx
@@ -72,7 +72,7 @@ const BpkDrawer = ({
   padded = true,
   renderTarget = null,
   title,
-  width,
+  width = '90%',
 }: Props) =>  {
 
   const [isDrawerShown, setIsDrawerShown] = useState(true);

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.module.scss
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.module.scss
@@ -32,7 +32,7 @@
   height: 100%;
   flex-direction: column;
   transform: translate(100%);
-  transition: transform var(--duration, tokens.$bpk-duration-sm) ease;
+  transition: transform tokens.$bpk-duration-base ease;
   outline: 0;
   background: tokens.$bpk-surface-default-day;
   overflow-y: scroll;
@@ -60,7 +60,7 @@
   }
 
   &--exiting {
-    transition: transform tokens.$bpk-duration-xs ease;
+    transition: transform tokens.$bpk-duration-base ease;
   }
 
   &--exiting,
@@ -112,8 +112,8 @@
     @include breakpoints.bpk-breakpoint-mobile {
       transform: scale(0.9);
       transition:
-        opacity tokens.$bpk-duration-sm ease-in-out,
-        transform var(--duration, tokens.$bpk-duration-sm) ease-in-out;
+        opacity tokens.$bpk-duration-base ease-in-out,
+        transform tokens.$bpk-duration-base ease-in-out;
       opacity: tokens.$bpk-modal-initial-opacity;
 
       &--entering,

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.module.scss
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.module.scss
@@ -28,7 +28,7 @@
   right: 0;
   display: flex;
   z-index: tokens.$bpk-zindex-drawer;
-  width: var(--dynamic-width, 90%);
+  width: var(--dynamic-width);
   height: 100%;
   flex-direction: column;
   transform: translate(100%);

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.module.scss
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.module.scss
@@ -28,12 +28,11 @@
   right: 0;
   display: flex;
   z-index: tokens.$bpk-zindex-drawer;
-  width: 90%;
-  max-width: 50 * tokens.bpk-spacing-md();
+  width: var(--dynamic-width, 90%);
   height: 100%;
   flex-direction: column;
   transform: translate(100%);
-  transition: transform tokens.$bpk-duration-sm ease;
+  transition: transform var(--duration, tokens.$bpk-duration-sm) ease;
   outline: 0;
   background: tokens.$bpk-surface-default-day;
   overflow-y: scroll;
@@ -114,7 +113,7 @@
       transform: scale(0.9);
       transition:
         opacity tokens.$bpk-duration-sm ease-in-out,
-        transform tokens.$bpk-duration-sm ease-in-out;
+        transform var(--duration, tokens.$bpk-duration-sm) ease-in-out;
       opacity: tokens.$bpk-modal-initial-opacity;
 
       &--entering,

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
@@ -31,6 +31,7 @@ import { cssModules } from '../../bpk-react-utils';
 import STYLES from './BpkDrawerContent.module.scss';
 
 const getClassName = cssModules(STYLES);
+type ValueOf<T> = T[keyof T];
 
 type Props = {
   children: ReactNode,
@@ -39,6 +40,8 @@ type Props = {
   onClose: () => void
   id: string,
   title: string,
+  width?: string,
+  transitionDuration?: ValueOf<typeof animations>,
   className?: string | null,
   contentClassName?: string,
   closeLabel?: string,
@@ -70,6 +73,8 @@ const BpkDrawerContent = ({
   onCloseAnimationComplete,
   padded,
   title,
+  transitionDuration,
+  width,
   ...rest
 }: Props) => {
 
@@ -114,6 +119,11 @@ const BpkDrawerContent = ({
           role="dialog"
           key="dialog"
           aria-labelledby={headingId}
+          style={{
+            // @ts-expect-error TS is reporting this incorrectly as styles are valid
+            '--dynamic-width': width,
+            '--duration': transitionDuration,
+          }}
           className={[
             drawerClassNames.join(' '),
             getClassName(`bpk-drawer--${status}`, mobileModalDisplay ? `bpk-drawer__modal-mobile-view--${status}` : undefined),

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
@@ -31,7 +31,6 @@ import { cssModules } from '../../bpk-react-utils';
 import STYLES from './BpkDrawerContent.module.scss';
 
 const getClassName = cssModules(STYLES);
-type ValueOf<T> = T[keyof T];
 
 type Props = {
   children: ReactNode,
@@ -41,7 +40,6 @@ type Props = {
   id: string,
   title: string,
   width?: string,
-  transitionDuration?: ValueOf<typeof animations>,
   className?: string | null,
   contentClassName?: string,
   closeLabel?: string,
@@ -73,7 +71,6 @@ const BpkDrawerContent = ({
   onCloseAnimationComplete,
   padded,
   title,
-  transitionDuration,
   width,
   ...rest
 }: Props) => {
@@ -122,7 +119,6 @@ const BpkDrawerContent = ({
           style={{
             // @ts-expect-error TS is reporting this incorrectly as styles are valid
             '--dynamic-width': width,
-            '--duration': transitionDuration,
           }}
           className={[
             drawerClassNames.join(' '),

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode, RefObject } from 'react';
+import type { CSSProperties, ReactNode, RefObject } from 'react';
 
 import { Transition } from 'react-transition-group';
 
@@ -116,10 +116,11 @@ const BpkDrawerContent = ({
           role="dialog"
           key="dialog"
           aria-labelledby={headingId}
-          style={{
-            // @ts-expect-error TS is reporting this incorrectly as styles are valid
-            '--dynamic-width': width,
-          }}
+          style={
+            {
+              '--dynamic-width': width,
+            } as CSSProperties
+          }
           className={[
             drawerClassNames.join(' '),
             getClassName(`bpk-drawer--${status}`, mobileModalDisplay ? `bpk-drawer__modal-mobile-view--${status}` : undefined),

--- a/packages/bpk-component-drawer/src/__snapshots__/BpkDrawer-test.tsx.snap
+++ b/packages/bpk-component-drawer/src/__snapshots__/BpkDrawer-test.tsx.snap
@@ -21,6 +21,7 @@ exports[`BpkDrawer should render correctly in the given target if renderTarget i
           class="bpk-drawer bpk-drawer--entering"
           id="my-drawer"
           role="dialog"
+          style="--dynamic-width: 90%;"
           tabindex="-1"
         >
           <header


### PR DESCRIPTION
[[MAT-2306]](https://skyscanner.atlassian.net/browse/MAT-2306)
[BpkDrawer](https://www.skyscanner.design/latest/components/drawer/web-QAxL5e0N) needs a code contribution:
- Any width can be applied by consumers. This essentially means removing the 400px max-width and allowing any width.
- Update transition into duration-base for both entering and exiting

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[KOA-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here

[MAT-2306]: https://skyscanner.atlassian.net/browse/MAT-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ