### PR TITLE
Update dependabot.yml to include the packages deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directory: "/"
+  directories: 
+    - "/"
+    - "/packages"
   schedule:
     interval: weekly
     time: "10:00"


### PR DESCRIPTION
I noticed that when dependabot raises PRs it ignores those in the packages directory which is what is used by the consumers of Backpack.

An example here is #3780 where its only bumping bpk-svgs in the root and not in the packages so consumers wouldn't get that version setting naturally!

So this PR changes the config to switch from `directory` to `directories` which allows us to specify multiple locations for manifest files for dependabot to check. This follows the docs here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files

This will now mean when say `bpk-svgs` or `bpk-foundations-web` gets an automated PR this will happen in both the root and `packages` json files!