### PR TITLE
[QUAR-801][BpkOverlay] Update video overlay to align with heavy overlay design

### DIFF
--- a/examples/bpk-component-overlay/examples.js
+++ b/examples/bpk-component-overlay/examples.js
@@ -29,7 +29,7 @@ import STYLES from './examples.module.scss';
 
 const IMAGE_SRC =
   'https://content.skyscnr.com/m/1c8c6338a92a7a94/original/matt-hardy-6ArTTluciuA-unsplash.jpg';
-const VIDEO_IMG_SRC =
+const HEAVY_IMG_SRC =
   'https://content.skyscnr.com/m/2af45124245b6759/original/SOCIAL9.png';
 
 const getClassName = cssModules(STYLES);
@@ -200,16 +200,16 @@ const VignetteExample = () => {
   );
 };
 
-const VideoOverlayExamples = () => {
-  const overlayTypeTop = OVERLAY_TYPES.videoTop;
-  const overlayTypeBottom = OVERLAY_TYPES.videoBottom;
+const HeavyOverlayExamples = () => {
+  const overlayTypeTop = OVERLAY_TYPES.heavyTop;
+  const overlayTypeBottom = OVERLAY_TYPES.heavyBottom;
   return (
     <div className={getClassName('bpk-overlay-stories')}>
       {[overlayTypeTop, overlayTypeBottom].map((overlayType) => (
         <div className={getClassName('bpk-overlay-stories__overlay-story')}>
           <BpkOverlay overlayType={overlayType}>
             <BpkImage
-              src={VIDEO_IMG_SRC}
+              src={HEAVY_IMG_SRC}
               altText="Sail boat"
               aspectRatio={360 / 640}
             />
@@ -225,7 +225,7 @@ const VideoOverlayExamples = () => {
         <BpkOverlay overlayType={overlayTypeTop}>
           <BpkOverlay overlayType={overlayTypeBottom}>
             <BpkImage
-              src={VIDEO_IMG_SRC}
+              src={HEAVY_IMG_SRC}
               altText="Sail boat"
               aspectRatio={360 / 640}
             />
@@ -283,7 +283,7 @@ export {
   LeftExamples,
   RightExamples,
   VignetteExample,
-  VideoOverlayExamples,
+  HeavyOverlayExamples,
   WithForegroundContentExample,
   MixedExample,
 };

--- a/examples/bpk-component-overlay/stories.tsx
+++ b/examples/bpk-component-overlay/stories.tsx
@@ -24,7 +24,7 @@ import {
   BottomExamples,
   LeftExamples,
   RightExamples,
-  VideoOverlayExamples,
+  HeavyOverlayExamples,
   VignetteExample,
   WithForegroundContentExample,
   MixedExample,
@@ -42,7 +42,7 @@ export const Bottom = BottomExamples;
 export const Left = LeftExamples;
 export const Right = RightExamples;
 export const Vignette = VignetteExample;
-export const VideoOverlays = VideoOverlayExamples;
+export const HeavyOverlays = HeavyOverlayExamples;
 
 export const WithForegroundContent = WithForegroundContentExample;
 

--- a/packages/bpk-component-overlay/src/BpkOverlay.module.scss
+++ b/packages/bpk-component-overlay/src/BpkOverlay.module.scss
@@ -160,12 +160,13 @@
       box-shadow: inset 0 0 50px rgba(tokens.$bpk-text-primary-day, 0.12);
     }
 
-    &--video {
+    &--heavy {
       &-top {
         background: linear-gradient(
           180deg,
           rgba(tokens.$bpk-text-primary-day, 0.45) 0%,
-          rgba(tokens.$bpk-text-primary-day, 0) 40%,
+          rgba(tokens.$bpk-text-primary-day, 0.15) 60%,
+          rgba(tokens.$bpk-text-primary-day, 0.05) 80%,
           rgba(tokens.$bpk-text-primary-day, 0) 100%
         );
       }
@@ -174,7 +175,6 @@
         background: linear-gradient(
           180deg,
           rgba(tokens.$bpk-text-primary-day, 0) 0%,
-          rgba(tokens.$bpk-text-primary-day, 0) 60%,
           rgba(tokens.$bpk-text-primary-day, 0.9) 100%
         );
       }

--- a/packages/bpk-component-overlay/src/BpkOverlay.tsx
+++ b/packages/bpk-component-overlay/src/BpkOverlay.tsx
@@ -41,8 +41,8 @@ export const OVERLAY_TYPES = {
   rightMedium: 'rightMedium',
   rightHigh: 'rightHigh',
   vignette: 'vignette',
-  videoTop: 'videoTop',
-  videoBottom: 'videoBottom',
+  heavyTop: 'heavyTop',
+  heavyBottom: 'heavyBottom',
   off: 'off',
 } as const;
 
@@ -63,8 +63,8 @@ const overlayTypeClassSuffixes = {
   [OVERLAY_TYPES.rightMedium]: 'right-medium',
   [OVERLAY_TYPES.rightHigh]: 'right-high',
   [OVERLAY_TYPES.vignette]: 'vignette',
-  [OVERLAY_TYPES.videoTop]: 'video-top',
-  [OVERLAY_TYPES.videoBottom]: 'video-bottom',
+  [OVERLAY_TYPES.heavyTop]: 'heavy-top',
+  [OVERLAY_TYPES.heavyBottom]: 'heavy-bottom',
   [OVERLAY_TYPES.off]: 'off',
 } as const;
 

--- a/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
+++ b/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
@@ -304,36 +304,6 @@ exports[`BpkOverlay should render correctly with overlayType={topMedium} 1`] = `
 </DocumentFragment>
 `;
 
-exports[`BpkOverlay should render correctly with overlayType={videoBottom} 1`] = `
-<DocumentFragment>
-  <div
-    class="bpk-overlay__wrapper"
-  >
-    <span>
-      Backpack
-    </span>
-    <div
-      class="bpk-overlay__overlay bpk-overlay__overlay--video-bottom"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`BpkOverlay should render correctly with overlayType={videoTop} 1`] = `
-<DocumentFragment>
-  <div
-    class="bpk-overlay__wrapper"
-  >
-    <span>
-      Backpack
-    </span>
-    <div
-      class="bpk-overlay__overlay bpk-overlay__overlay--video-top"
-    />
-  </div>
-</DocumentFragment>
-`;
-
 exports[`BpkOverlay should render correctly with overlayType={vignette} 1`] = `
 <DocumentFragment>
   <div

--- a/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
+++ b/packages/bpk-component-overlay/src/__snapshots__/BpkOverlay-test.tsx.snap
@@ -79,6 +79,36 @@ exports[`BpkOverlay should render correctly with overlayType={bottomMedium} 1`] 
 </DocumentFragment>
 `;
 
+exports[`BpkOverlay should render correctly with overlayType={heavyBottom} 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-overlay__wrapper"
+  >
+    <span>
+      Backpack
+    </span>
+    <div
+      class="bpk-overlay__overlay bpk-overlay__overlay--heavy-bottom"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BpkOverlay should render correctly with overlayType={heavyTop} 1`] = `
+<DocumentFragment>
+  <div
+    class="bpk-overlay__wrapper"
+  >
+    <span>
+      Backpack
+    </span>
+    <div
+      class="bpk-overlay__overlay bpk-overlay__overlay--heavy-top"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`BpkOverlay should render correctly with overlayType={leftHigh} 1`] = `
 <DocumentFragment>
   <div


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
Jira: https://skyscanner.atlassian.net/browse/QUAR-801

In January we added the video overlay style for the BpkOverlay component in https://github.com/Skyscanner/backpack/pull/3717 to be used in the homepage video advert POC. In the next version of the ad we have to align the video overlay with the [backpack heavy overlay design](https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=11552-10364&t=DpBVMfaxOntH0kNp-11). 
- Slack thread in #backpack-design-chat for context: https://skyscanner.slack.com/archives/CUQ587E5D/p1743775241236679
- Video homepage ad design: https://www.figma.com/design/o7vYhyVecpNyC92vTDPNTf/Video-Moments?node-id=2622-16895&t=ugMReV4E1xVklJKZ-0

We're renaming the overlay type from `video` to `heavy`, which would normally be a breaking change release, but since it's only used in [one place](https://github.skyscannertools.net/skyscanner/banana/blob/a2a9b588a220565bb727b935519567a56c1e812c/packages/webapp/src/components/HomepageHero/HomepageHeroVideo.tsx#L311-L315), we can make sure to update the overlay name there after doing the next Backpack release.

| Before | After |
| --- | --- |
| <img width="800" alt="Screenshot 2025-04-08 at 22 15 01" src="https://github.com/user-attachments/assets/5176a7b3-73b1-4a5b-a8d6-c3ec6f2f9f48" /> | <img width="800" alt="Screenshot 2025-04-08 at 22 25 25" src="https://github.com/user-attachments/assets/4dd2f17b-4030-4a72-87b3-80dda408ccf8" /> |


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
