### PR TITLE
[BpkButton][BD-9548] BpkButton - type=link new default style update

### DIFF
--- a/packages/bpk-component-button/src/BpkButtonV2/BpkButton.tsx
+++ b/packages/bpk-component-button/src/BpkButtonV2/BpkButton.tsx
@@ -15,6 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Children } from 'react';
+
 import { cssModules } from '../../../bpk-react-utils';
 
 import { BUTTON_TYPES, SIZE_TYPES } from './common-types';
@@ -53,6 +55,17 @@ export const BpkButtonV2 = ({
 
   const target = blank ? '_blank' : '';
   const rel = blank ? propRel || 'noopener noreferrer' : propRel;
+  let processedChildren;
+  if (!disabled && (type === BUTTON_TYPES.link || type === BUTTON_TYPES.linkOnDark)) {
+    processedChildren = Children.map(children, (child) => {
+      if (typeof child === 'string') {
+        return <span className={getCommonClassName(`bpk-button--${type}__text`)}>{child}</span>;
+      }
+      return child;
+    });
+  } else {
+    processedChildren = children;
+  }
 
   if (!disabled && href) {
     return (
@@ -64,7 +77,7 @@ export const BpkButtonV2 = ({
         rel={rel}
         {...rest}
       >
-        {children}
+        {processedChildren}
       </a>
     );
   }
@@ -77,7 +90,7 @@ export const BpkButtonV2 = ({
       onClick={onClick}
       {...rest}
     >
-      {children}
+      {processedChildren}
     </button>
   );
 };

--- a/packages/bpk-component-button/src/BpkButtonV2/__snapshots__/BpkButton-test.tsx.snap
+++ b/packages/bpk-component-button/src/BpkButtonV2/__snapshots__/BpkButton-test.tsx.snap
@@ -147,7 +147,16 @@ exports[`BpkButtonV2 should render correctly with type="link" 1`] = `
     class="bpk-button bpk-button--link"
     type="button"
   >
-    link button
+    <span
+      class="bpk-button--link__text"
+    >
+      link
+    </span>
+    <span
+      class="bpk-button--link__text"
+    >
+       button
+    </span>
   </button>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.tsx.snap
+++ b/packages/bpk-component-floating-notification/src/__snapshots__/BpkFloatingNotification-test.tsx.snap
@@ -53,7 +53,11 @@ exports[`BpkFloatingNotification should render correctly with CTA text 1`] = `
         class="bpk-button bpk-button--link-on-dark"
         type="button"
       >
-        View
+        <span
+          class="bpk-button--link-on-dark__text"
+        >
+          View
+        </span>
       </button>
     </div>
   </div>

--- a/packages/bpk-mixins/_buttons.scss
+++ b/packages/bpk-mixins/_buttons.scss
@@ -395,24 +395,34 @@
   background: none; /* stylelint-disable-line order/order, order/properties-order */
   box-shadow: none;
 
-  @include bpk-link--implicit;
+  @include bpk-link;
 
   &::after {
-    bottom: auto;
+    content: none;
+  }
+
+  &__text {
+    display: inline-block;
+
+    @include bpk-link-underline-explicit;
+
+    &::after {
+      position: relative;
+    }
   }
 
   padding: $vertical-padding 0; /* stylelint-disable-line order/order, order/properties-order */
-  color: $bpk-private-button-link-normal-foreground-day;
+  color: $bpk-text-primary-day;
 
   @include bpk-hover {
     background: none;
-    color: $bpk-private-button-link-pressed-foreground-day;
+    color: $bpk-text-primary-day;
     text-decoration: none;
   }
 
   &:active {
     background: none;
-    color: $bpk-private-button-link-pressed-foreground-day;
+    color: $bpk-text-primary-day;
     text-decoration: none;
   }
 
@@ -469,6 +479,16 @@
     );
   }
 
+  &__text {
+    &::after {
+      @include bpk-themeable-property(
+        background,
+        --bpk-button-link-on-dark-hover-text-color,
+        $bpk-private-button-link-on-dark-pressed-foreground-day
+      );
+    }
+  }
+
   &:disabled {
     @include bpk-themeable-property(
       color,
@@ -494,6 +514,10 @@
   padding-right: $horizontal-padding;
   padding-left: $horizontal-padding;
   border-radius: $bpk-button-border-radius;
+
+  &::after {
+    display: none;
+  }
 }
 
 /// Large icon-only button. Modifies the bpk-button & bpk-button--large lib.
@@ -514,6 +538,10 @@
   padding-right: $horizontal-padding;
   padding-left: $horizontal-padding;
   border-radius: $bpk-button-border-radius;
+
+  &::after {
+    display: none;
+  }
 }
 
 /// Featured button. Modifies the bpk-button

--- a/packages/bpk-mixins/_buttons.scss
+++ b/packages/bpk-mixins/_buttons.scss
@@ -395,12 +395,6 @@
   background: none; /* stylelint-disable-line order/order, order/properties-order */
   box-shadow: none;
 
-  @include bpk-link;
-
-  &::after {
-    content: none;
-  }
-
   &__text {
     display: inline-block;
 
@@ -412,24 +406,36 @@
   }
 
   padding: $vertical-padding 0; /* stylelint-disable-line order/order, order/properties-order */
-  color: $bpk-text-primary-day;
+
+  @include bpk-themeable-property(
+    color,
+    --bpk-button-link-text-color,
+    $bpk-text-primary-day
+  );
 
   @include bpk-hover {
     background: none;
-    color: $bpk-text-primary-day;
-    text-decoration: none;
+
+    @include bpk-themeable-property(
+      color,
+      --bpk-button-link-text-hover-color,
+      $bpk-text-primary-day
+    );
   }
 
   &:active {
     background: none;
-    color: $bpk-text-primary-day;
-    text-decoration: none;
+
+    @include bpk-themeable-property(
+      color,
+      --bpk-button-link-text-active-color,
+      $bpk-text-primary-day
+    );
   }
 
   &:disabled {
     background: none;
     color: $bpk-text-disabled-day;
-    text-decoration: none;
   }
 
   &-large {

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -837,8 +837,6 @@
   @include bpk-link-underline-explicit;
 
   @include bpk-hover {
-    text-decoration: none;
-
     @include bpk-themeable-property(
       color,
       --bpk-link-hover-color,
@@ -898,7 +896,7 @@
   }
 
   &:active {
-    text-decoration: underline;
+    text-decoration: none;
 
     @include bpk-themeable-property(
       color,

--- a/packages/bpk-mixins/_typography.scss
+++ b/packages/bpk-mixins/_typography.scss
@@ -781,51 +781,8 @@
 ///     @include bpk-link();
 ///   }
 
-@mixin bpk-link {
-  position: relative;
-  display: inline-block;
-  padding: 0;
-  border: 0;
-  background-color: transparent;
-  text-decoration: none;
-  cursor: pointer;
-  appearance: none;
-
-  @include bpk-themeable-property(
-    color,
-    --bpk-link-color,
-    $bpk-text-primary-day
-  );
-
+@mixin bpk-link-underline-explicit {
   @include bpk-hover {
-    text-decoration: none;
-
-    @include bpk-themeable-property(
-      color,
-      --bpk-link-hover-color,
-      $bpk-text-primary-day
-    );
-
-    &::after {
-      width: 0%;
-    }
-  }
-
-  &:visited {
-    @include bpk-themeable-property(
-      color,
-      --bpk-link-visited-color,
-      $bpk-text-primary-day
-    );
-  }
-
-  &:active {
-    @include bpk-themeable-property(
-      color,
-      --bpk-link-active-color,
-      $bpk-text-primary-day
-    );
-
     &::after {
       width: 0%;
     }
@@ -853,6 +810,56 @@
         width 0s ease 0s,
         left 0s ease 0s;
     }
+  }
+
+  &:active {
+    &::after {
+      width: 0%;
+    }
+  }
+}
+
+@mixin bpk-link {
+  position: relative;
+  display: inline-block;
+  padding: 0;
+  border: 0;
+  background-color: transparent;
+  text-decoration: none;
+  cursor: pointer;
+  appearance: none;
+
+  @include bpk-themeable-property(
+    color,
+    --bpk-link-color,
+    $bpk-text-primary-day
+  );
+  @include bpk-link-underline-explicit;
+
+  @include bpk-hover {
+    text-decoration: none;
+
+    @include bpk-themeable-property(
+      color,
+      --bpk-link-hover-color,
+      $bpk-text-primary-day
+    );
+  }
+
+  &:visited {
+    @include bpk-themeable-property(
+      color,
+      --bpk-link-visited-color,
+      $bpk-text-primary-day
+    );
+  }
+
+  &:active {
+    @include bpk-themeable-property(
+      color,
+      --bpk-link-active-color,
+      $bpk-text-primary-day
+    );
   }
 }
 


### PR DESCRIPTION
[Jira Link](https://skyscanner.atlassian.net/browse/BD-9548)
### Description:
update the `BpkButton - type=link` to the new explicit bpk-link style;

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
