### PR TITLE
[Clover GF][BpkTooltip]The max-width of BpkTooltip can be Customized

### DIFF
--- a/packages/bpk-component-tooltip/src/BpkTooltip.tsx
+++ b/packages/bpk-component-tooltip/src/BpkTooltip.tsx
@@ -70,6 +70,7 @@ export type Props = {
   hideOnTouchDevices?: boolean;
   placement?: Placement;
   isOpen?: boolean;
+  maxWidth?: string;
 };
 
 // This function is to ensure the arrow alignment when used on the top and bottom
@@ -97,6 +98,7 @@ const BpkTooltip = ({
   hideOnTouchDevices = true,
   id,
   isOpen = false,
+  maxWidth,
   padded = true,
   placement = 'bottom',
   target,
@@ -150,6 +152,8 @@ const BpkTooltip = ({
     type === TOOLTIP_TYPES.dark && 'bpk-tooltip__arrow--dark',
   );
 
+  const innerStyles = maxWidth ? { maxWidth } : undefined;
+
   return (
     <>
       {targetWithAccessibilityProps}
@@ -183,7 +187,9 @@ const BpkTooltip = ({
                   strokeWidth={strokeWidth}
                   style={getArrowAlignment(context.placement)}
                 />
-                <div className={innerClassNames}>{children}</div>
+                <div className={innerClassNames} style={innerStyles}>
+                  {children}
+                </div>
               </section>
             </TransitionInitialMount>
           </div>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
