### PR TITLE
[BD-9736] [BpkPrice] Append data attribute to Price Element

### DIFF
--- a/examples/bpk-component-price/examples.js
+++ b/examples/bpk-component-price/examples.js
@@ -106,7 +106,7 @@ const SmallWithPreviousPriceLeadingAndTrailingTextAndDataAttributeExample =
       leadingText="Web only deal"
       price="£1,830"
       trailingText="per day"
-      dataAttributes={{ 'data-price-your-pick': true }}
+      dataAttributes={{ 'data-price-your-pick': 'true' }}
     />
   );
 
@@ -121,7 +121,10 @@ const SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample = () => (
 );
 
 const SmallWithDataAttributeExample = () => (
-  <BpkPrice price="£1,830" dataAttributes={{ 'data-price-your-pick': true }} />
+  <BpkPrice
+    price="£1,830"
+    dataAttributes={{ 'data-price-your-pick': 'true' }}
+  />
 );
 
 const SmallRightExample = () => (

--- a/examples/bpk-component-price/examples.js
+++ b/examples/bpk-component-price/examples.js
@@ -99,15 +99,16 @@ const SmallWithPreviousPriceLeadingTextExample = () => (
   />
 );
 
-const SmallWithPreviousPriceAndDataAttributeExample = () => (
-  <BpkPrice
-    previousPrice="£2,033"
-    leadingText="Web only deal"
-    price="£1,830"
-    trailingText="per day"
-    dataPriceYourPick
-  />
-);
+const SmallWithPreviousPriceLeadingAndTrailingTextAndDataAttributeExample =
+  () => (
+    <BpkPrice
+      previousPrice="£2,033"
+      leadingText="Web only deal"
+      price="£1,830"
+      trailingText="per day"
+      dataPriceYourPick
+    />
+  );
 
 const SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample = () => (
   <BpkPrice
@@ -119,7 +120,7 @@ const SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample = () => (
   />
 );
 
-const SmallWithDataAttrbuteExample = () => (
+const SmallWithDataAttributeExample = () => (
   <BpkPrice price="£1,830" dataPriceYourPick />
 );
 
@@ -241,8 +242,8 @@ const MixedExample = () => (
     <SmallWithPreviousPriceExample />
     <SmallWithPreviousPriceLeadingTextExample />
     <SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample />
-    <SmallWithDataAttrbuteExample />
-    <SmallWithPreviousPriceAndDataAttributeExample />
+    <SmallWithDataAttributeExample />
+    <SmallWithPreviousPriceLeadingAndTrailingTextAndDataAttributeExample />
     <SmallRightExample />
     <SmallRightWithTrailingTextExample />
     <SmallRightWithLeadingandTrailingTextExample />
@@ -273,8 +274,8 @@ export {
   SmallWithPreviousPriceExample,
   SmallWithPreviousPriceLeadingTextExample,
   SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample,
-  SmallWithDataAttrbuteExample,
-  SmallWithPreviousPriceAndDataAttributeExample,
+  SmallWithDataAttributeExample,
+  SmallWithPreviousPriceLeadingAndTrailingTextAndDataAttributeExample,
   SmallRightExample,
   SmallRightWithTrailingTextExample,
   SmallRightWithLeadingandTrailingTextExample,

--- a/examples/bpk-component-price/examples.js
+++ b/examples/bpk-component-price/examples.js
@@ -99,6 +99,16 @@ const SmallWithPreviousPriceLeadingTextExample = () => (
   />
 );
 
+const SmallWithPreviousPriceAndDataAttributeExample = () => (
+  <BpkPrice
+    previousPrice="£2,033"
+    leadingText="Web only deal"
+    price="£1,830"
+    trailingText="per day"
+    dataPriceYourPick
+  />
+);
+
 const SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample = () => (
   <BpkPrice
     previousPrice="£2,033"
@@ -107,6 +117,10 @@ const SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample = () => (
     trailingText="per day"
     icon={<NewWindowIcon />}
   />
+);
+
+const SmallWithDataAttrbuteExample = () => (
+  <BpkPrice price="£1,830" dataPriceYourPick />
 );
 
 const SmallRightExample = () => (
@@ -227,6 +241,8 @@ const MixedExample = () => (
     <SmallWithPreviousPriceExample />
     <SmallWithPreviousPriceLeadingTextExample />
     <SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample />
+    <SmallWithDataAttrbuteExample />
+    <SmallWithPreviousPriceAndDataAttributeExample />
     <SmallRightExample />
     <SmallRightWithTrailingTextExample />
     <SmallRightWithLeadingandTrailingTextExample />
@@ -257,6 +273,8 @@ export {
   SmallWithPreviousPriceExample,
   SmallWithPreviousPriceLeadingTextExample,
   SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample,
+  SmallWithDataAttrbuteExample,
+  SmallWithPreviousPriceAndDataAttributeExample,
   SmallRightExample,
   SmallRightWithTrailingTextExample,
   SmallRightWithLeadingandTrailingTextExample,

--- a/examples/bpk-component-price/examples.js
+++ b/examples/bpk-component-price/examples.js
@@ -106,7 +106,7 @@ const SmallWithPreviousPriceLeadingAndTrailingTextAndDataAttributeExample =
       leadingText="Web only deal"
       price="£1,830"
       trailingText="per day"
-      dataPriceYourPick
+      dataAttributes={{ 'data-price-your-pick': true }}
     />
   );
 
@@ -121,7 +121,7 @@ const SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample = () => (
 );
 
 const SmallWithDataAttributeExample = () => (
-  <BpkPrice price="£1,830" dataPriceYourPick />
+  <BpkPrice price="£1,830" dataAttributes={{ 'data-price-your-pick': true }} />
 );
 
 const SmallRightExample = () => (

--- a/examples/bpk-component-price/stories.js
+++ b/examples/bpk-component-price/stories.js
@@ -33,8 +33,8 @@ import {
   SmallWithPreviousPriceExample,
   SmallWithPreviousPriceLeadingTextExample,
   SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample,
-  SmallWithDataAttrbuteExample,
-  SmallWithPreviousPriceAndDataAttributeExample,
+  SmallWithDataAttributeExample,
+  SmallWithPreviousPriceLeadingAndTrailingTextAndDataAttributeExample,
   SmallRightExample,
   SmallRightWithTrailingTextExample,
   SmallRightWithLeadingandTrailingTextExample,
@@ -75,9 +75,9 @@ export const SmallWithPreviousPriceLeadingText =
   SmallWithPreviousPriceLeadingTextExample;
 export const SmallWithPreviousPriceLeadingAndTrailingTextAndIcon =
   SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample;
-export const SmallWithDataAttrbute = SmallWithDataAttrbuteExample;
-export const SmallWithPreviousPriceAndDataAttribute =
-  SmallWithPreviousPriceAndDataAttributeExample;
+export const SmallWithDataAttribute = SmallWithDataAttributeExample;
+export const SmallWithPreviousPriceLeadingAndTrailingTextAndDataAttribute =
+  SmallWithPreviousPriceLeadingAndTrailingTextAndDataAttributeExample;
 export const SmallRight = SmallRightExample;
 export const SmallRightWithTrailingText = SmallRightWithTrailingTextExample;
 export const SmallRightWithLeadingandTrailingText =

--- a/examples/bpk-component-price/stories.js
+++ b/examples/bpk-component-price/stories.js
@@ -33,6 +33,8 @@ import {
   SmallWithPreviousPriceExample,
   SmallWithPreviousPriceLeadingTextExample,
   SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample,
+  SmallWithDataAttrbuteExample,
+  SmallWithPreviousPriceAndDataAttributeExample,
   SmallRightExample,
   SmallRightWithTrailingTextExample,
   SmallRightWithLeadingandTrailingTextExample,
@@ -73,6 +75,9 @@ export const SmallWithPreviousPriceLeadingText =
   SmallWithPreviousPriceLeadingTextExample;
 export const SmallWithPreviousPriceLeadingAndTrailingTextAndIcon =
   SmallWithPreviousPriceLeadingAndTrailingTextAndIconExample;
+export const SmallWithDataAttrbute = SmallWithDataAttrbuteExample;
+export const SmallWithPreviousPriceAndDataAttribute =
+  SmallWithPreviousPriceAndDataAttributeExample;
 export const SmallRight = SmallRightExample;
 export const SmallRightWithTrailingText = SmallRightWithTrailingTextExample;
 export const SmallRightWithLeadingandTrailingText =

--- a/packages/bpk-component-price/src/BpkPrice-test.js
+++ b/packages/bpk-component-price/src/BpkPrice-test.js
@@ -97,7 +97,7 @@ describe.each([
         dataPriceYourPick
       />,
     );
-    expect(screen.getbyText(price)).toHaveAttribute(
+    expect(screen.getByText(price)).toHaveAttribute(
       'data-price-your-pick',
       'true',
     );

--- a/packages/bpk-component-price/src/BpkPrice-test.js
+++ b/packages/bpk-component-price/src/BpkPrice-test.js
@@ -94,7 +94,7 @@ describe.each([
         previousPrice={previousPrice}
         leadingText={leadingText}
         trailingText={trailingText}
-        dataAttributes={{ 'data-price-your-pick': true }}
+        dataAttributes={{ 'data-price-your-pick': 'true' }}
       />,
     );
     expect(screen.getByText(price)).toHaveAttribute(

--- a/packages/bpk-component-price/src/BpkPrice-test.js
+++ b/packages/bpk-component-price/src/BpkPrice-test.js
@@ -87,14 +87,14 @@ describe.each([
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should append data-price-your-pick to price element when dataPriceYourPick is true', () => {
+  it('should append data-price-your-pick to price element when pass dataAttributes', () => {
     render(
       <BpkPrice
         {...props}
         previousPrice={previousPrice}
         leadingText={leadingText}
         trailingText={trailingText}
-        dataPriceYourPick
+        dataAttributes={{ 'data-price-your-pick': true }}
       />,
     );
     expect(screen.getByText(price)).toHaveAttribute(

--- a/packages/bpk-component-price/src/BpkPrice-test.js
+++ b/packages/bpk-component-price/src/BpkPrice-test.js
@@ -17,13 +17,12 @@
  */
 /* @flow strict */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import NewWindowIcon from '../../bpk-component-icon/sm/new-window';
 
 import BpkPrice from './BpkPrice';
 import { ALIGNS, SIZES } from './common-types';
-
 
 const price = '£1,830';
 const previousPrice = '£2,000';
@@ -86,6 +85,22 @@ describe.each([
       />,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should append data-price-your-pick to price element when dataPriceYourPick is true', () => {
+    render(
+      <BpkPrice
+        {...props}
+        previousPrice={previousPrice}
+        leadingText={leadingText}
+        trailingText={trailingText}
+        dataPriceYourPick
+      />,
+    );
+    expect(screen.getbyText(price)).toHaveAttribute(
+      'data-price-your-pick',
+      'true',
+    );
   });
 
   it('should support previous price with leading text and icon attribute', () => {

--- a/packages/bpk-component-price/src/BpkPrice.js
+++ b/packages/bpk-component-price/src/BpkPrice.js
@@ -41,7 +41,7 @@ type Props = {
   trailingText: ?string,
   previousPrice: ?string,
   icon?: Node,
-  dataPriceYourPick?: boolean,
+  dataAttributes?: Record<string, string>,
 };
 
 const getClassName = cssModules(STYLES);
@@ -70,7 +70,7 @@ const BpkPrice = (props: Props) => {
   const {
     align,
     className,
-    dataPriceYourPick,
+    dataAttributes,
     icon,
     leadingClassName,
     leadingText,
@@ -152,7 +152,7 @@ const BpkPrice = (props: Props) => {
           <BpkText
             textStyle={priceTextStyle}
             tagName="span"
-            data-price-your-pick={dataPriceYourPick ? 'true' : undefined}
+            {...dataAttributes}
           >
             {price}
           </BpkText>
@@ -183,7 +183,7 @@ BpkPrice.propTypes = {
   trailingText: PropTypes.string,
   previousPrice: PropTypes.string,
   leadingClassName: PropTypes.string,
-  dataPriceYourPick: PropTypes.bool,
+  dataPriceYourPick: PropTypes.objectOf(PropTypes.string),
 };
 
 BpkPrice.defaultProps = {
@@ -194,7 +194,7 @@ BpkPrice.defaultProps = {
   trailingText: null,
   previousPrice: null,
   leadingClassName: null,
-  dataPriceYourPick: false,
+  dataPriceYourPick: {},
 };
 
 export default BpkPrice;

--- a/packages/bpk-component-price/src/BpkPrice.js
+++ b/packages/bpk-component-price/src/BpkPrice.js
@@ -41,6 +41,7 @@ type Props = {
   trailingText: ?string,
   previousPrice: ?string,
   icon?: Node,
+  dataPriceYourPick?: boolean,
 };
 
 const getClassName = cssModules(STYLES);
@@ -69,6 +70,7 @@ const BpkPrice = (props: Props) => {
   const {
     align,
     className,
+    dataPriceYourPick,
     icon,
     leadingClassName,
     leadingText,
@@ -147,7 +149,11 @@ const BpkPrice = (props: Props) => {
             !isAlignRight && 'bpk-price__spacing',
           )}
         >
-          <BpkText textStyle={priceTextStyle} tagName="span">
+          <BpkText
+            textStyle={priceTextStyle}
+            tagName="span"
+            data-price-your-pick={dataPriceYourPick ? 'true' : undefined}
+          >
             {price}
           </BpkText>
         </span>
@@ -177,6 +183,7 @@ BpkPrice.propTypes = {
   trailingText: PropTypes.string,
   previousPrice: PropTypes.string,
   leadingClassName: PropTypes.string,
+  dataPriceYourPick: PropTypes.bool,
 };
 
 BpkPrice.defaultProps = {
@@ -187,6 +194,7 @@ BpkPrice.defaultProps = {
   trailingText: null,
   previousPrice: null,
   leadingClassName: null,
+  dataPriceYourPick: false,
 };
 
 export default BpkPrice;

--- a/packages/bpk-component-price/src/BpkPrice.js
+++ b/packages/bpk-component-price/src/BpkPrice.js
@@ -183,7 +183,7 @@ BpkPrice.propTypes = {
   trailingText: PropTypes.string,
   previousPrice: PropTypes.string,
   leadingClassName: PropTypes.string,
-  dataPriceYourPick: PropTypes.objectOf(PropTypes.string),
+  dataAttributes: PropTypes.objectOf(PropTypes.string),
 };
 
 BpkPrice.defaultProps = {
@@ -194,7 +194,7 @@ BpkPrice.defaultProps = {
   trailingText: null,
   previousPrice: null,
   leadingClassName: null,
-  dataPriceYourPick: {},
+  dataAttributes: {},
 };
 
 export default BpkPrice;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

[BD-9736](https://skyscanner.atlassian.net/browse/BD-9736)

In some user case, some crawlers need to inspect the real price(not the previous price). So it will be convenient that we provide a data attribute to the price element(not the whole BpkPrice Component). This pr will add a prop: `dataPriceYourPick`. if set it true, then it will append a data attribute: `data-price-your-pick="true"` to the price element.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here


[BD-9736]: https://skyscanner.atlassian.net/browse/BD-9736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ