### PR TITLE
[CLOV-145][BpkNavigationTabGroup] Adjust Accessibility behaviour

### DIFF
--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
@@ -77,8 +77,7 @@ const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
       className={tabStyling}
       href={tab.href}
       onClick={(e: MouseEvent<HTMLAnchorElement>) => onClick(e)}
-      role="tab"
-      aria-selected={selected}
+      aria-current={selected ? 'page' : false}
     >
       {children}
     </a>
@@ -114,6 +113,7 @@ const BpkNavigationTabGroup = ({
   };
 
   const containerStyling = getClassName('bpk-navigation-tab-group');
+  const isTabList = !tabs.some(item => item.href !== undefined && item.href !== null);
 
   return (
     <nav
@@ -122,7 +122,7 @@ const BpkNavigationTabGroup = ({
       role="navigation"
       aria-label={ariaLabel}
     >
-    <div role="tablist" className={getClassName('bpk-navigation-tab-list')}>
+    <div role={isTabList ? "tablist" : undefined} className={getClassName('bpk-navigation-tab-list')}>
       {tabs.map((tab, index) => {
         const selected = index === selectedTab;
         const {icon,text,...tabWrapItem} = tab;


### PR DESCRIPTION
# BpkNavigationTabGroup

After reviewing this component's behaviour, we have concluded that when using href on items in the list, we should not mark them as tablist/tab. When a traveller activates one of the links in the component, navigation will take place, which does not match the behaviour we signpost when using the tablist role. 

This PR addresses this concern and makes the component more compliant.

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
