### PR TITLE
[NO-JIRA][BpkInsetBanner] Fix UI issues

### DIFF
--- a/examples/bpk-component-inset-banner/examples.tsx
+++ b/examples/bpk-component-inset-banner/examples.tsx
@@ -92,13 +92,37 @@ const WithCtaTextAndPopoverExampleLight = () => (
     logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
     callToAction={{
       text: 'Sponsored',
-      popoverMessage: 'This is a popover message',
+      popoverMessage:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+      closeBtnIcon: true,
+      labelTitle: true,
+      popverLabel: 'Info',
+      buttonCloseLabel: 'Close',
+      buttonA11yLabel: 'More info',
+    }}
+    backgroundColor="#FFE300"
+    variant={VARIANT.onLight}
+    accessibilityLabel="Sponsored by Skyscanner"
+  />
+);
+
+const WithCustomPopoverWidthAndMarginsExample = () => (
+  <BpkInsetBanner
+    title="Lorem ipsum"
+    subheadline="Lorem ipsum dolor sit amet"
+    logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
+    callToAction={{
+      text: 'Sponsored',
+      popoverMessage:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
       closeBtnIcon: true,
       labelTitle: true,
       popverLabel: 'Info',
       buttonCloseLabel: 'Close',
       buttonA11yLabel: 'More info',
       popoverWidth: '15rem',
+      popoverMarginStart: '1rem',
+      popoverMarginEnd: '1rem',
     }}
     backgroundColor="#FFE300"
     variant={VARIANT.onLight}
@@ -113,4 +137,5 @@ export {
   WithBodyTextExampleLight,
   WithBodyTextAndLinkExampleDark,
   WithCtaTextAndPopoverExampleLight,
+  WithCustomPopoverWidthAndMarginsExample,
 };

--- a/examples/bpk-component-inset-banner/examples.tsx
+++ b/examples/bpk-component-inset-banner/examples.tsx
@@ -98,6 +98,7 @@ const WithCtaTextAndPopoverExampleLight = () => (
       popverLabel: 'Info',
       buttonCloseLabel: 'Close',
       buttonA11yLabel: 'More info',
+      popoverWidth: '15rem',
     }}
     backgroundColor="#FFE300"
     variant={VARIANT.onLight}

--- a/examples/bpk-component-inset-banner/stories.ts
+++ b/examples/bpk-component-inset-banner/stories.ts
@@ -25,6 +25,7 @@ import {
   WithBodyTextExampleLight,
   WithBodyTextAndLinkExampleDark,
   WithCtaTextAndPopoverExampleLight,
+  WithCustomPopoverWidthAndMarginsExample,
 } from './examples';
 
 export default {
@@ -40,3 +41,4 @@ export const WithBodyTextAndLinkDark = WithBodyTextAndLinkExampleDark;
 export const VisualTestDark = WithBodyTextAndLinkExampleDark;
 export const VisualTestLight = WithLogoAndCtaTextExampleLight;
 export const WithCtaTextAndPopoverLight = WithCtaTextAndPopoverExampleLight;
+export const WithCustomPopoverWidthAndMargins = WithCustomPopoverWidthAndMarginsExample;

--- a/packages/bpk-component-inset-banner/README.md
+++ b/packages/bpk-component-inset-banner/README.md
@@ -28,6 +28,7 @@ export default () => (
       buttonA11yLabel: 'More info',
       popverLabel: 'More info',
       popoverId: 'popover',
+      popoverWidth: '15rem',
       labelTitle: true,
       closeBtnIcon: false,
       zIndexCustom: 1200;

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
@@ -51,6 +51,7 @@
     padding-inline-end: tokens.bpk-spacing-base();
 
     @include breakpoints.bpk-breakpoint-mobile {
+      max-width: 120 * tokens.$bpk-one-pixel-rem;
       max-height: tokens.bpk-spacing-lg();
     }
   }

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.module.scss
@@ -51,7 +51,7 @@
     padding-inline-end: tokens.bpk-spacing-base();
 
     @include breakpoints.bpk-breakpoint-mobile {
-      max-width: 120 * tokens.$bpk-one-pixel-rem;
+      max-width: 3 * tokens.bpk-spacing-xxl();
       max-height: tokens.bpk-spacing-lg();
     }
   }

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
@@ -50,6 +50,8 @@ export type Props = {
     popverLabel?: string;
     popoverId?: string;
     popoverWidth?: string;
+    popoverMarginStart?: string;
+    popoverMarginEnd?: string;
     labelTitle?: boolean;
     closeBtnIcon?: boolean;
     zIndexCustom?: number;
@@ -77,6 +79,8 @@ const BpkInsetBanner = ({
   );
 
   const popoverWidth = callToAction?.popoverWidth || 'auto';
+  const popoverMarginStart = callToAction?.popoverMarginStart || 'auto';
+  const popoverMarginEnd = callToAction?.popoverMarginEnd || 'auto';
 
   return (
     <div>
@@ -112,7 +116,11 @@ const BpkInsetBanner = ({
             }}
           >
             <BpkPopover
-              style={{ width: popoverWidth, marginInlineEnd: '1rem' }}
+              style={{
+                width: popoverWidth,
+                marginInlineEnd: popoverMarginEnd,
+                marginInlineStart: popoverMarginStart,
+              }}
               id={callToAction?.popoverId || ''}
               label={callToAction?.popverLabel || ''}
               placement={callToAction?.popoverPlacement || 'bottom'}

--- a/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBanner.tsx
@@ -49,6 +49,7 @@ export type Props = {
     buttonA11yLabel?: string;
     popverLabel?: string;
     popoverId?: string;
+    popoverWidth?: string;
     labelTitle?: boolean;
     closeBtnIcon?: boolean;
     zIndexCustom?: number;
@@ -74,6 +75,8 @@ const BpkInsetBanner = ({
     `bpk-inset-banner--${variant}`,
     body && 'bpk-inset-banner--with-body',
   );
+
+  const popoverWidth = callToAction?.popoverWidth || 'auto';
 
   return (
     <div>
@@ -109,6 +112,7 @@ const BpkInsetBanner = ({
             }}
           >
             <BpkPopover
+              style={{ width: popoverWidth, marginInlineEnd: '1rem' }}
               id={callToAction?.popoverId || ''}
               label={callToAction?.popverLabel || ''}
               placement={callToAction?.popoverPlacement || 'bottom'}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
### Context
We noticed that in our sponsored booking panel ad that uses the bpk inset banner, on iPhones the popover is cutoff at the end due to the width of the popover being too large. There's also an issue with the width of certain partner logos being too big and pushing content out of the banner.
| Popover UI issue on iPhone |
| --- |
| <img width="200" alt="Screenshot 2025-04-22 at 13 10 58" src="https://github.com/user-attachments/assets/7915cbb4-92fa-4e6a-b45d-4cf353f13e34" /> |


### Suggested solution
- Added a `popoverWidth` prop to pass a string width value (so that either pixel or rem values can be passed) to the popover
- Added a max width of 120px for logos in mobile screen sizes
- Added 1rem margin to the right of the popover so it isn't stuck to the right side of the screen like it currently is.

### Screenshots

| Before | After |
| --- | --- |
| <img width="175" alt="Screenshot 2025-04-22 at 16 47 01" src="https://github.com/user-attachments/assets/fc2ee9ee-0e31-4325-812b-58ce12ce923d" /> <img width="175" alt="Screenshot 2025-04-22 at 16 47 05" src="https://github.com/user-attachments/assets/a752d5c1-6803-43c6-bb20-c2648742cba8" /> | <img width="175" alt="Screenshot 2025-04-22 at 16 48 35" src="https://github.com/user-attachments/assets/2389459f-628b-4411-b770-50b461be816c" /> <img width="175" alt="Screenshot 2025-04-22 at 16 48 52" src="https://github.com/user-attachments/assets/0396cd3a-26ff-47e7-a443-10a2ea4ff362" /> |

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
