### PR TITLE
[LUNA-2516][BPKSegmentedControls] Updates the implemenation to support arrow navigation

### DIFF
--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl-test.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl-test.tsx
@@ -100,4 +100,26 @@ describe('BpkSegmentedControl', () => {
 
     expect(selectedButton).toBeInTheDocument();
   });
+
+  it('should move selection with arrow keys', () => {
+    render(<BpkSegmentedControl {...defaultProps} />);
+
+    const radios = screen.getAllByRole('radio');
+
+    radios[0].focus();
+    expect(radios[0]).toHaveFocus();
+
+    // Press left arrow key
+    fireEvent.keyDown(radios[1], { key: 'ArrowLeft', code: 'ArrowLeft' });
+
+    // Should move to previous radio (index 0 = 'one')
+    expect(radios[0]).toHaveFocus();
+
+    // Press right arrow key
+    fireEvent.keyDown(radios[0], { key: 'ArrowRight', code: 'ArrowRight' });
+
+    // Should move back to 'two'
+    expect(radios[1]).toHaveFocus();
+  });
+
 });

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
@@ -35,6 +35,7 @@
 }
 
 .bpk-segmented-control {
+  position: relative;
   min-height: tokens.bpk-spacing-xl();
   padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
   border: none;
@@ -88,6 +89,20 @@
       color: tokens.$bpk-text-on-dark-day;
     }
   }
+}
+
+.bpk-segmented-control-label {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  padding: tokens.bpk-spacing-md();
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  cursor: pointer;
 }
 
 // Handle border lines between buttons

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.module.scss
@@ -89,20 +89,10 @@
       color: tokens.$bpk-text-on-dark-day;
     }
   }
-}
 
-.bpk-segmented-control-label {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: flex;
-  padding: tokens.bpk-spacing-md();
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  cursor: pointer;
+  &-label {
+    cursor: pointer;
+  }
 }
 
 // Handle border lines between buttons

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
@@ -64,7 +64,7 @@ const BpkSegmentedControl = ({
   );
 
   return (
-    <div className={containerStyling}>
+    <div className={containerStyling} role="radiogroup">
       {buttonContents.map((content, index) => {
         const isSelected = index === selectedButton;
         const rightOfOption = index === selectedButton + 1;
@@ -78,17 +78,24 @@ const BpkSegmentedControl = ({
             `bpk-segmented-control--${type}-selected-shadow`,
         );
 
+        const radioId = `segmented-control-${index}`;
         return (
-          <button
-            key={`index-${index.toString()}`}
-            id={index.toString()}
-            type="button"
-            onClick={() => handleButtonClick(index)}
-            className={buttonStyling}
-            aria-pressed={!!isSelected}
-          >
-            {content}
-          </button>
+          <div key={radioId} className={buttonStyling}>
+            <input
+              id={radioId}
+              type="radio"
+              name="bpk-segmented-control"
+              checked={isSelected}
+              onChange={() => handleButtonClick(index)}
+              className="visually-hidden"
+            />
+            <label
+              htmlFor={radioId}
+              className={getClassName('bpk-segmented-control-label')}
+            >
+              {content}
+            </label>
+          </div>
         );
       })}
     </div>


### PR DESCRIPTION
# BPKSegmentedControls

As part of the web audit, we identifed that the Segmented Controls component does not allow arrow navigation. This was the case because all the control panels were buttons. To allow the panels to be navigable using arrow keys, we need to replace the buttons with input filed of type `radio`.

The solution preserves the previous styles and behaviour. The only change is the aforementioned keyboard navigation.



<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
