### PR TITLE
[CAPY-1169][BpkChipGroup]: Set Chip Group Nudgers edge threshold

### DIFF
--- a/packages/bpk-component-chip-group/src/Nudger.tsx
+++ b/packages/bpk-component-chip-group/src/Nudger.tsx
@@ -56,6 +56,9 @@ const AlignedRightArrowIcon = withButtonAlignment(ArrowRight);
 // Chosen based on feeling good with the example stories
 const SCROLL_DISTANCE = 150;
 
+// Threshold to account for minor scroll rounding errors near edges
+const SCROLL_MARGIN = 2;
+
 const Nudger = ({
   ariaLabel,
   chipStyle = CHIP_TYPES.default,
@@ -77,8 +80,9 @@ const Nudger = ({
 
       const { offsetWidth, scrollLeft, scrollWidth } = scrollContainerRef.current;
       const scrollValue = rtl ? -Math.floor(scrollLeft) : Math.ceil(scrollLeft);
-      const showLeading = scrollValue > 0;
-      const showTrailing = scrollValue < scrollWidth - offsetWidth;
+      const maxScrollValue = scrollWidth - offsetWidth;
+      const showLeading = scrollValue > SCROLL_MARGIN;
+      const showTrailing = scrollValue < maxScrollValue - SCROLL_MARGIN;
 
       setShow(showLeading || showTrailing);
       setEnabled((leading && showLeading) || (!leading && showTrailing))


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

There is an intermittent edge case where the right hand nudger is never disabled due to `1px` calculation error, which may occurs depending on a combination of parents width and screen width. Unfortunately, I was not able to find the pattern that causes the issue, but looking for some external references the suggestion is to introduce a threshold of 2 pixels before evaluating nudgers conditions.

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/d6576307-632e-4a56-a54b-019d981a9bac" /> | <video src="https://github.com/user-attachments/assets/aa44c51c-dcb1-41db-8d06-bd0481bd9956" /> |

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
