### PR TITLE
[CAPY-1378][BpkImage]: Fixing bpk-background-image loading spinner position

### DIFF
--- a/packages/bpk-component-image/src/BpkBackgroundImage.tsx
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.tsx
@@ -125,12 +125,14 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
           {loading && (
             <CSSTransition
               classNames={{
-                exit: getClassName('bpk-image__spinner--shown'),
-                exitActive: getClassName('bpk-image__spinner--hidden'),
+                exit: getClassName('bpk-background-image__spinner--shown'),
+                exitActive: getClassName(
+                  'bpk-background-image__spinner--hidden',
+                ),
               }}
               timeout={parseInt(animations.durationBase, 10)}
             >
-              <div className={getClassName('bpk-image__spinner')}>
+              <div className={getClassName('bpk-background-image__spinner')}>
                 <BpkSpinner />
               </div>
             </CSSTransition>

--- a/packages/bpk-component-image/src/__snapshots__/BpkBackgroundImage-test.tsx.snap
+++ b/packages/bpk-component-image/src/__snapshots__/BpkBackgroundImage-test.tsx.snap
@@ -59,7 +59,7 @@ exports[`BpkBackgroundImage should have loading behavior 1`] = `
         style="width: 100%; height: 100%; background-repeat: no-repeat; background-size: cover; background-position: 50% 50%;"
       />
       <div
-        class="bpk-image__spinner"
+        class="bpk-background-image__spinner"
       >
         <span
           class="bpk-spinner bpk-spinner--dark"

--- a/packages/bpk-component-image/src/withLoadingBehavior.tsx
+++ b/packages/bpk-component-image/src/withLoadingBehavior.tsx
@@ -55,11 +55,7 @@ export default function withLoadingBehavior<P extends object>(
 
     render() {
       return (
-        <WrappedComponent
-          onLoad={this.onLoad}
-          loading={this.state.loading}
-          {...(this.props as P)}
-        />
+        <WrappedComponent onLoad={this.onLoad} loading {...(this.props as P)} />
       );
     }
   }

--- a/packages/bpk-component-image/src/withLoadingBehavior.tsx
+++ b/packages/bpk-component-image/src/withLoadingBehavior.tsx
@@ -55,7 +55,11 @@ export default function withLoadingBehavior<P extends object>(
 
     render() {
       return (
-        <WrappedComponent onLoad={this.onLoad} loading {...(this.props as P)} />
+        <WrappedComponent
+          onLoad={this.onLoad}
+          loading={this.state.loading}
+          {...(this.props as P)}
+        />
       );
     }
   }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR fixes the position of the loading spinner for `bpk-background-image` by fixing the class names from `bpk-image-*` to `bpk-background-image-*`.

| Before | After |
| - | - |
| ![Screenshot 2025-05-07 at 13 00 17](https://github.com/user-attachments/assets/9a799224-69e9-4c2e-909d-af11412e7f56) | ![Screenshot 2025-05-07 at 12 59 59](https://github.com/user-attachments/assets/2d041d0d-8d3c-4ae3-88ef-54575444a908) |

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
