### PR TITLE
[CAPY-1388][BpkImage]: onError callback for bpk-background-image

### DIFF
--- a/packages/bpk-component-image/src/BpkBackgroundImage.tsx
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.tsx
@@ -73,6 +73,12 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
     }
   }
 
+  componentDidUpdate(prevProps: BpkBackgroundImageProps) {
+    if (prevProps.src !== this.props.src) {
+      this.startImageLoad();
+    }
+  }
+
   onBackgroundImageError = (): void => {
     if (this.props.onError) {
       this.props.onError();

--- a/packages/bpk-component-image/src/BpkBackgroundImage.tsx
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.tsx
@@ -37,6 +37,7 @@ export type BpkBackgroundImageProps = {
   loading?: boolean;
   src: string;
   className?: string;
+  onError?: (() => void) | null;
   onLoad?: (() => void) | null;
   style?: {};
   imageStyle?: CSSProperties;
@@ -50,6 +51,7 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
     inView: true,
     loading: false,
     onLoad: null,
+    onError: null,
     style: {},
     imageStyle: {},
   };
@@ -71,6 +73,12 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
     }
   }
 
+  onBackgroundImageError = (): void => {
+    if (this.props.onError) {
+      this.props.onError();
+    }
+  };
+
   onBackgroundImageLoad = (): void => {
     if (this.props.onLoad) {
       this.props.onLoad();
@@ -88,6 +96,7 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
   startImageLoad = (): void => {
     this.trackImg = new Image();
     this.trackImg.src = this.props.src;
+    this.trackImg.onerror = this.onBackgroundImageError;
     this.trackImg.onload = this.onBackgroundImageLoad;
   };
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This PR 

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
