### PR TITLE
[CAPY-1253][BpkNavigationTabGroup]: Prevent NavigationTabGroup selection when tab opens a new browser tab

### DIFF
--- a/examples/bpk-component-navigation-tab-group/examples.tsx
+++ b/examples/bpk-component-navigation-tab-group/examples.tsx
@@ -67,6 +67,13 @@ const tabsOnlyText: BpkNavigationTabGroupProps['tabs'] = [
   { id: 'explore', text: 'Explore'},
 ];
 
+const tabsWithBlankTarget: BpkNavigationTabGroupProps['tabs'] = [
+  { id: 'air', text: 'Flights', href: '/', target: '_blank' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', target: '_blank' },
+  { id: 'car', text: 'Car hire', href: '/carhire', target: '_blank' },
+  { id: 'explore', text: 'Explore', href: '/Explore', target: '_blank' },
+];
+
 // Simple Navigation Tab Group
 const SimpleSurfaceContrast = () => (
   <div className={getClassNames('bpk-navigation-tab-group-story')}>
@@ -180,6 +187,20 @@ const TabsOnlyTextCanvasDefaultForExample = () => (
   </div>
 );
 
+// Tabs with Blank Target Navigation Tab Group
+const TabsWithBlankTarget = () => (
+  <div className={getClassNames('bpk-navigation-tab-group-story')}>
+    <BpkNavigationTabGroup
+      id="navExample"
+      tabs={tabsWithBlankTarget}
+      onItemClick={() => {}}
+      selectedIndex={2}
+      type={NAVIGATION_TAB_GROUP_TYPES.SurfaceContrast}
+      ariaLabel="Navigation tabs"
+    />
+  </div>
+);
+
 const VisualTestExample = () => (
   <div className={getClassNames('bpk-navigation-tab-group-story__mixed-container')}>
     <BpkText textStyle={TEXT_STYLES.heading3} tagName="h3">
@@ -227,5 +248,6 @@ export {
   TabsNoHrefCanvasDefaultForExample,
   TabsOnlyTextSurfaceContrastForExample,
   TabsOnlyTextCanvasDefaultForExample,
+  TabsWithBlankTarget,
   VisualTestExample,
 };

--- a/examples/bpk-component-navigation-tab-group/stories.tsx
+++ b/examples/bpk-component-navigation-tab-group/stories.tsx
@@ -27,6 +27,7 @@ import {
   TabsNoHrefCanvasDefaultForExample,
   TabsOnlyTextSurfaceContrastForExample,
   TabsOnlyTextCanvasDefaultForExample,
+  TabsWithBlankTarget,
   VisualTestExample,
 } from './examples';
 
@@ -50,6 +51,8 @@ export const WithIconCanvasDefault = WithIconCanvasDefaultForExample;
 export const OnlyTextSurfaceContrast = TabsOnlyTextSurfaceContrastForExample;
 
 export const OnlyTextCanvasDefault = TabsOnlyTextCanvasDefaultForExample;
+
+export const WithBlankTarget = TabsWithBlankTarget;
 
 export const VisualTest = VisualTestExample;
 

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
@@ -26,7 +26,7 @@ import type { Props } from './BpkNavigationTabGroup';
 const tabs: Props['tabs'] = [
   { id: 'air', text: 'Flights', href: '/' },
   { id: 'hotel', text: 'Hotels', href: '/hotel' },
-  { id: 'car', text: 'Car hire', href: '/carhire' },
+  { id: 'car', text: 'Car hire', href: '/carhire', target: '_blank' },
 ];
 
 const tabsWithAnalytics: Props['tabs'] = [
@@ -102,6 +102,32 @@ describe('BpkNavigationTabGroup', () => {
       expect.any(Object),
       { id:'hotel', text: 'Hotels', href: '/hotel' },
       1,
+    );
+  });
+
+  it('should ignore tab selection when link opens in new tab', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BpkNavigationTabGroup
+        id="navTest"
+        tabs={tabs}
+        onItemClick={() => {}}
+        selectedIndex={0}
+        ariaLabel="Navigation tabs"
+      />,
+    );
+
+    await user.click(screen.getByText('Car hire'));
+
+    const flightsTab = screen.getByRole('tab', { name: 'Flights' });
+    const carHireTab = screen.getByRole('tab', { name: 'Car hire' });
+
+    expect(flightsTab).toHaveClass(
+      'bpk-navigation-tab-wrap--surface-contrast-selected',
+    );
+    expect(carHireTab).not.toHaveClass(
+      'bpk-navigation-tab-wrap--surface-contrast-selected',
     );
   });
 

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup-test.tsx
@@ -26,6 +26,12 @@ import type { Props } from './BpkNavigationTabGroup';
 const tabs: Props['tabs'] = [
   { id: 'air', text: 'Flights', href: '/' },
   { id: 'hotel', text: 'Hotels', href: '/hotel' },
+  { id: 'car', text: 'Car hire', href: '/carhire' },
+];
+
+const tabsWithBlankTarget: Props['tabs'] = [
+  { id: 'air', text: 'Flights', href: '/' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', target: '_blank' },
   { id: 'car', text: 'Car hire', href: '/carhire', target: '_blank' },
 ];
 
@@ -111,7 +117,7 @@ describe('BpkNavigationTabGroup', () => {
     render(
       <BpkNavigationTabGroup
         id="navTest"
-        tabs={tabs}
+        tabs={tabsWithBlankTarget}
         onItemClick={() => {}}
         selectedIndex={0}
         ariaLabel="Navigation tabs"

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
@@ -107,7 +107,7 @@ const BpkNavigationTabGroup = ({
 }: Props) => {
   const [selectedTab, setSelectedTab] = useState(selectedIndex);
   const handleButtonClick = (e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>, tab: TabItem, index: number) => {
-    if (index !== selectedTab) {
+    if (index !== selectedTab && tab.target !== '_blank') {
       setSelectedTab(index);
     }
     onItemClick(e, tab, index);


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

We would like to prevent the tab selection in case the tab is an anchor supposed to open links in a new browser tab.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
