### PR TITLE
[BpkSegmentedControl] adjust role and add label prop

### DIFF
--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl-test.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl-test.tsx
@@ -100,4 +100,21 @@ describe('BpkSegmentedControl', () => {
 
     expect(selectedButton).toBeInTheDocument();
   });
+
+  it('should render with role="group" on the outer div', () => {
+    render(<BpkSegmentedControl {...defaultProps} />);
+    const group = screen.getByRole('group');
+    expect(group).toBeInTheDocument();
+  });
+
+  it('should set the accessible label on the group when label prop is provided', () => {
+    render(
+      <BpkSegmentedControl
+        {...defaultProps}
+        label="Segmented control label"
+      />,
+    );
+    const group = screen.getByRole('group');
+    expect(group).toHaveAttribute('aria-label', 'Segmented control label');
+  });
 });

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl-test.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl-test.tsx
@@ -117,4 +117,10 @@ describe('BpkSegmentedControl', () => {
     const group = screen.getByRole('group');
     expect(group).toHaveAttribute('aria-label', 'Segmented control label');
   });
+
+  it('should not set aria-label when label prop is not provided', () => {
+    render(<BpkSegmentedControl {...defaultProps} label={undefined} />);
+    const group = screen.getByRole('group');
+    expect(group).not.toHaveAttribute('aria-label');
+  });
 });

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
@@ -72,7 +72,7 @@ const BpkSegmentedControl = ({
     <div
       className={containerStyling}
       role="group"
-      aria-label={label}
+      {...(label ? { 'aria-label': label } : {})}
     >
       {buttonContents.map((content, index) => {
         const isSelected = index === selectedButton;

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
@@ -42,6 +42,10 @@ export type Props = {
   onItemClick: (id: number) => void;
   selectedIndex: number;
   shadow?: boolean;
+  /**
+   * Accessible label for the segmented control group.
+   */
+  label?: string;
 };
 
 const BpkSegmentedControl = ({
@@ -50,6 +54,7 @@ const BpkSegmentedControl = ({
   selectedIndex,
   shadow = false,
   type = SEGMENT_TYPES.CanvasDefault,
+  label,
 }: Props) => {
   const [selectedButton, setSelectedButton] = useState(selectedIndex);
   const handleButtonClick = (id: number) => {
@@ -64,7 +69,11 @@ const BpkSegmentedControl = ({
   );
 
   return (
-    <div className={containerStyling}>
+    <div
+      className={containerStyling}
+      role="group"
+      aria-label={label}
+    >
       {buttonContents.map((content, index) => {
         const isSelected = index === selectedButton;
         const rightOfOption = index === selectedButton + 1;

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
@@ -35,6 +35,10 @@ export type SegmentTypes = (typeof SEGMENT_TYPES)[keyof typeof SEGMENT_TYPES];
 
 export type Props = {
   buttonContents: string[] | ReactNode[];
+  /**
+   * Accessible label for the segmented control group.
+   */
+  label?: string;
   type?: SegmentTypes;
   /*
    * Index parameter to track which is clicked
@@ -42,10 +46,6 @@ export type Props = {
   onItemClick: (id: number) => void;
   selectedIndex: number;
   shadow?: boolean;
-  /**
-   * Accessible label for the segmented control group.
-   */
-  label?: string;
 };
 
 const BpkSegmentedControl = ({

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
@@ -50,11 +50,11 @@ export type Props = {
 
 const BpkSegmentedControl = ({
   buttonContents,
+  label,
   onItemClick,
   selectedIndex,
   shadow = false,
   type = SEGMENT_TYPES.CanvasDefault,
-  label,
 }: Props) => {
   const [selectedButton, setSelectedButton] = useState(selectedIndex);
   const handleButtonClick = (id: number) => {


### PR DESCRIPTION
CLOV-252, adjust segmented control

To ensure we make the segmented control more accessible we're setting a group role and adding an aria-label that is settable using the label prop.

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
