### PR TITLE
[BpkHorizontalNav] fix focus outline

### DIFF
--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.module.scss
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.module.scss
@@ -43,6 +43,11 @@
     cursor: pointer;
     fill: currentcolor;
 
+    &:focus-visible {
+      @include utils.bpk-focus-indicator;
+      outline-offset: -(tokens.$bpk-one-pixel-rem * 2);
+    }
+
     &--default {
       @include utils.bpk-themeable-property(
         color,


### PR DESCRIPTION
# BpkHorizontalNav

Adjust the focus outline to be inside so it doesn't get clipped by the surrounding container

| Before | After | 
| --- | --- |
| <img width="314" alt="image" src="https://github.com/user-attachments/assets/14af472e-bd28-4389-b495-295782bbb0fb" /> | 
<img width="299" alt="image" src="https://github.com/user-attachments/assets/fa77bc46-9d62-46ea-b873-3cccaf8386f0" /> |


Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
