### PR TITLE
[BpkScrollableCalendarGrid] Adjust month heading from H1 to H2

### DIFF
--- a/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGrid.tsx
+++ b/packages/bpk-component-scrollable-calendar/src/BpkScrollableCalendarGrid.tsx
@@ -47,7 +47,7 @@ const BpkScrollableCalendarGrid = ({
   return (
     <div className={classNames}>
       <span className={getClassName('bpk-scrollable-calendar-grid__title')}>
-        <BpkText tagName="h1" textStyle={TEXT_STYLES.heading4}>
+        <BpkText tagName="h2" textStyle={TEXT_STYLES.heading4}>
           {formatMonth(month)}
         </BpkText>
       </span>

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.tsx.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendar-test.tsx.snap
@@ -91,11 +91,11 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
                 <span
                   class="bpk-scrollable-calendar-grid__title"
                 >
-                  <h1
+                  <h2
                     class="bpk-text bpk-text--heading-4"
                   >
                     February 2010
-                  </h1>
+                  </h2>
                 </span>
                 <div
                   aria-hidden="false"
@@ -684,11 +684,11 @@ exports[`BpkScrollableCalendar should render correctly 1`] = `
                 <span
                   class="bpk-scrollable-calendar-grid__title"
                 >
-                  <h1
+                  <h2
                     class="bpk-text bpk-text--heading-4"
                   >
                     March 2010
-                  </h1>
+                  </h2>
                 </span>
                 <div
                   aria-hidden="false"
@@ -1450,11 +1450,11 @@ exports[`BpkScrollableCalendar should render ranges correctly 1`] = `
                 <span
                   class="bpk-scrollable-calendar-grid__title"
                 >
-                  <h1
+                  <h2
                     class="bpk-text bpk-text--heading-4"
                   >
                     February 2010
-                  </h1>
+                  </h2>
                 </span>
                 <div
                   aria-hidden="false"
@@ -2043,11 +2043,11 @@ exports[`BpkScrollableCalendar should render ranges correctly 1`] = `
                 <span
                   class="bpk-scrollable-calendar-grid__title"
                 >
-                  <h1
+                  <h2
                     class="bpk-text bpk-text--heading-4"
                   >
                     March 2010
-                  </h1>
+                  </h2>
                 </span>
                 <div
                   aria-hidden="false"
@@ -2809,11 +2809,11 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
                 <span
                   class="bpk-scrollable-calendar-grid__title"
                 >
-                  <h1
+                  <h2
                     class="bpk-text bpk-text--heading-4"
                   >
                     February 2010
-                  </h1>
+                  </h2>
                 </span>
                 <div
                   aria-hidden="false"
@@ -3402,11 +3402,11 @@ exports[`BpkScrollableCalendar should support arbitrary props 1`] = `
                 <span
                   class="bpk-scrollable-calendar-grid__title"
                 >
-                  <h1
+                  <h2
                     class="bpk-text bpk-text--heading-4"
                   >
                     March 2010
-                  </h1>
+                  </h2>
                 </span>
                 <div
                   aria-hidden="false"
@@ -4168,11 +4168,11 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
                 <span
                   class="bpk-scrollable-calendar-grid__title"
                 >
-                  <h1
+                  <h2
                     class="bpk-text bpk-text--heading-4"
                   >
                     February 2010
-                  </h1>
+                  </h2>
                 </span>
                 <div
                   aria-hidden="false"
@@ -4761,11 +4761,11 @@ exports[`BpkScrollableCalendar should support custom class names 1`] = `
                 <span
                   class="bpk-scrollable-calendar-grid__title"
                 >
-                  <h1
+                  <h2
                     class="bpk-text bpk-text--heading-4"
                   >
                     March 2010
-                  </h1>
+                  </h2>
                 </span>
                 <div
                   aria-hidden="false"

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGrid-test.tsx.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGrid-test.tsx.snap
@@ -8,11 +8,11 @@ exports[`BpkCalendarScrollGrid should render correctly with a "dateModifiers" at
     <span
       class="bpk-scrollable-calendar-grid__title"
     >
-      <h1
+      <h2
         class="bpk-text bpk-text--heading-4"
       >
         October 2016
-      </h1>
+      </h2>
     </span>
     <div
       aria-hidden="false"
@@ -711,11 +711,11 @@ exports[`BpkCalendarScrollGrid should render correctly with a custom date compon
     <span
       class="bpk-scrollable-calendar-grid__title"
     >
-      <h1
+      <h2
         class="bpk-text bpk-text--heading-4"
       >
         October 2016
-      </h1>
+      </h2>
     </span>
     <div
       aria-hidden="false"
@@ -1148,11 +1148,11 @@ exports[`BpkCalendarScrollGrid should render correctly with a different "weekSta
     <span
       class="bpk-scrollable-calendar-grid__title"
     >
-      <h1
+      <h2
         class="bpk-text bpk-text--heading-4"
       >
         October 2016
-      </h1>
+      </h2>
     </span>
     <div
       aria-hidden="false"
@@ -1811,11 +1811,11 @@ exports[`BpkCalendarScrollGrid should render correctly with no optional props se
     <span
       class="bpk-scrollable-calendar-grid__title"
     >
-      <h1
+      <h2
         class="bpk-text bpk-text--heading-4"
       >
         October 2016
-      </h1>
+      </h2>
     </span>
     <div
       aria-hidden="false"

--- a/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
+++ b/packages/bpk-component-scrollable-calendar/src/__snapshots__/BpkScrollableCalendarGridList-test.tsx.snap
@@ -23,11 +23,11 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   February 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"
@@ -616,11 +616,11 @@ exports[`BpkCalendarScrollGridList should render correctly with a "dateModifiers
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   March 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"
@@ -1313,11 +1313,11 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom "custom
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   February 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"
@@ -1946,11 +1946,11 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom "custom
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   March 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"
@@ -2643,11 +2643,11 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   February 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"
@@ -2943,11 +2943,11 @@ exports[`BpkCalendarScrollGridList should render correctly with a custom date co
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   March 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"
@@ -3346,11 +3346,11 @@ exports[`BpkCalendarScrollGridList should render correctly with a different "wee
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   February 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"
@@ -3979,11 +3979,11 @@ exports[`BpkCalendarScrollGridList should render correctly with a different "wee
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   March 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"
@@ -4716,11 +4716,11 @@ exports[`BpkCalendarScrollGridList should render correctly with no optional prop
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   February 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"
@@ -5349,11 +5349,11 @@ exports[`BpkCalendarScrollGridList should render correctly with no optional prop
               <span
                 class="bpk-scrollable-calendar-grid__title"
               >
-                <h1
+                <h2
                   class="bpk-text bpk-text--heading-4"
                 >
                   March 2010
-                </h1>
+                </h2>
               </span>
               <div
                 aria-hidden="false"


### PR DESCRIPTION
# BpkScrollableCalendarGrid

The month labels were all set to be H1. For accessibility, there can only be a single H1 per page. We assume that the page that includes this calendar will always have an H1 as page title and the calendar should be at least H2. 

In the future we can consider to let the consumer pass the appropriate heading level for the calendar grid.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
