### PR TITLE
[QUAR-864][BpkInsetBannerSponsored]-add new examples for sponsored banners with and without images

### DIFF
--- a/examples/bpk-component-inset-banner-v2/examples.tsx
+++ b/examples/bpk-component-inset-banner-v2/examples.tsx
@@ -26,7 +26,8 @@ const image =
 
 const imageWidth = 300;
 const imageHeight = 150;
-const logoUrl = 'https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png';
+const logoUrl =
+  'https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png';
 
 const WithCtaTextAndBottomSheetExampleLightV2 = () => (
   <div id="bottom-sheet-container">
@@ -49,7 +50,7 @@ const WithCtaTextAndBottomSheetExampleLightV2 = () => (
                 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
             },
           ],
-          bottomSheetTitle: "About this advert",
+          bottomSheetTitle: 'About this advert',
           closeBtnIcon: true,
           labelTitle: true,
           bottomSheetLabel: 'Info',
@@ -83,7 +84,7 @@ const WithCustomBottomSheetWidthAndMarginsExampleV2 = () => (
             'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
         },
       ],
-      bottomSheetTitle: "About this advert",
+      bottomSheetTitle: 'About this advert',
       closeBtnIcon: true,
       labelTitle: true,
       bottomSheetLabel: 'Info',
@@ -118,7 +119,7 @@ const WithImageAndBottomSheetExampleV2 = () => (
             'Experience the beauty of the Canadian Rockies with our exclusive travel packages.',
         },
       ],
-      bottomSheetTitle: "About this advert",
+      bottomSheetTitle: 'About this advert',
       closeBtnIcon: true,
       labelTitle: true,
       bottomSheetLabel: 'Info',
@@ -130,8 +131,69 @@ const WithImageAndBottomSheetExampleV2 = () => (
   />
 );
 
+const WithoutImageOnDarkExampleV2 = () => (
+  <BpkInsetBannerSponsored
+    title="Summer Travel Deals"
+    subheadline="Exclusive offers on flights and hotels"
+    logo={logoUrl}
+    callToAction={{
+      text: 'Sponsored',
+      bottomSheetContent: [
+        {
+          title: 'Limited Time Offers',
+          description:
+            'Take advantage of our summer travel deals with discounts on flights, hotels, and vacation packages.',
+        },
+      ],
+      bottomSheetTitle: 'About this advert',
+      closeBtnIcon: true,
+      labelTitle: true,
+      bottomSheetLabel: 'Info',
+      buttonCloseLabel: 'Close',
+      buttonA11yLabel: 'More info',
+    }}
+    backgroundColor="#0770E3"
+    variant={VARIANT.onDark}
+    accessibilityLabel="Sponsored by Skyscanner"
+  />
+);
+
+const WithImageOnLightExampleV2 = () => (
+  <BpkInsetBannerSponsored
+    title="Visit Santorini"
+    subheadline="Experience the beauty of Greek islands"
+    logo={logoUrl}
+    image={{
+      src: image,
+      altText: 'Santorini landscape',
+      aspectRatio: imageWidth / imageHeight,
+    }}
+    callToAction={{
+      text: 'Sponsored',
+      bottomSheetContent: [
+        {
+          title: 'Greece Getaways',
+          description:
+            'Explore the stunning views and unique architecture of Santorini with our curated travel guides.',
+        },
+      ],
+      bottomSheetTitle: 'About this advert',
+      closeBtnIcon: true,
+      labelTitle: true,
+      bottomSheetLabel: 'Info',
+      buttonCloseLabel: 'Close',
+      buttonA11yLabel: 'More info',
+    }}
+    backgroundColor="#FFE300"
+    variant={VARIANT.onLight}
+    accessibilityLabel="Sponsored by Skyscanner"
+  />
+);
+
 export {
   WithCtaTextAndBottomSheetExampleLightV2,
   WithCustomBottomSheetWidthAndMarginsExampleV2,
-  WithImageAndBottomSheetExampleV2
+  WithImageAndBottomSheetExampleV2,
+  WithoutImageOnDarkExampleV2,
+  WithImageOnLightExampleV2,
 };

--- a/examples/bpk-component-inset-banner-v2/examples.tsx
+++ b/examples/bpk-component-inset-banner-v2/examples.tsx
@@ -26,16 +26,19 @@ const image =
 
 const imageWidth = 300;
 const imageHeight = 150;
-const logoUrl =
+const logoDarkUrl =
   'https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png';
 
-const WithCtaTextAndBottomSheetExampleLightV2 = () => (
+const logoWhiteUrl =
+  'https://js.skyscnr.com/sttc/bpk-content/skyland-a76916b4.png';
+
+const WithCtaTextAndBottomSheetExampleV2Light = () => (
   <div id="bottom-sheet-container">
     <div id="pagewrap">
       <BpkInsetBannerSponsored
         title="Lorem ipsum"
         subheadline="Lorem ipsum dolor sit amet"
-        logo={logoUrl}
+        logo={logoDarkUrl}
         callToAction={{
           text: 'Sponsored',
           bottomSheetContent: [
@@ -65,11 +68,11 @@ const WithCtaTextAndBottomSheetExampleLightV2 = () => (
   </div>
 );
 
-const WithCustomBottomSheetWidthAndMarginsExampleV2 = () => (
+const WithCustomBottomSheetWidthAndMarginsExampleV2Light = () => (
   <BpkInsetBannerSponsored
     title="Lorem ipsum"
     subheadline="Lorem ipsum dolor sit amet"
-    logo={logoUrl}
+    logo={logoDarkUrl}
     callToAction={{
       text: 'Sponsored',
       bottomSheetContent: [
@@ -100,11 +103,11 @@ const WithCustomBottomSheetWidthAndMarginsExampleV2 = () => (
   />
 );
 
-const WithImageAndBottomSheetExampleV2 = () => (
+const WithImageAndBottomSheetExampleV2Dark = () => (
   <BpkInsetBannerSponsored
     title="Explore the Canadian Rockies"
     subheadline="Discover breathtaking landscapes and outdoor adventures"
-    logo={logoUrl}
+    logo={logoWhiteUrl}
     image={{
       src: image,
       altText: 'Canadian Rockies',
@@ -131,11 +134,11 @@ const WithImageAndBottomSheetExampleV2 = () => (
   />
 );
 
-const WithoutImageOnDarkExampleV2 = () => (
+const WithCtaTextAndBottomSheetExampleV2Dark = () => (
   <BpkInsetBannerSponsored
     title="Summer Travel Deals"
     subheadline="Exclusive offers on flights and hotels"
-    logo={logoUrl}
+    logo={logoWhiteUrl}
     callToAction={{
       text: 'Sponsored',
       bottomSheetContent: [
@@ -158,11 +161,11 @@ const WithoutImageOnDarkExampleV2 = () => (
   />
 );
 
-const WithImageOnLightExampleV2 = () => (
+const WithImageAndBottomSheetExampleV2Light = () => (
   <BpkInsetBannerSponsored
     title="Visit Santorini"
     subheadline="Experience the beauty of Greek islands"
-    logo={logoUrl}
+    logo={logoDarkUrl}
     image={{
       src: image,
       altText: 'Santorini landscape',
@@ -191,9 +194,9 @@ const WithImageOnLightExampleV2 = () => (
 );
 
 export {
-  WithCtaTextAndBottomSheetExampleLightV2,
-  WithCustomBottomSheetWidthAndMarginsExampleV2,
-  WithImageAndBottomSheetExampleV2,
-  WithoutImageOnDarkExampleV2,
-  WithImageOnLightExampleV2,
+  WithCtaTextAndBottomSheetExampleV2Light,
+  WithCustomBottomSheetWidthAndMarginsExampleV2Light,
+  WithImageAndBottomSheetExampleV2Dark,
+  WithCtaTextAndBottomSheetExampleV2Dark,
+  WithImageAndBottomSheetExampleV2Light,
 };

--- a/examples/bpk-component-inset-banner-v2/stories.ts
+++ b/examples/bpk-component-inset-banner-v2/stories.ts
@@ -21,7 +21,9 @@ import { BpkInsetBannerSponsored } from '../../packages/bpk-component-inset-bann
 import {
   WithCtaTextAndBottomSheetExampleLightV2,
   WithCustomBottomSheetWidthAndMarginsExampleV2,
-  WithImageAndBottomSheetExampleV2
+  WithImageAndBottomSheetExampleV2,
+  WithoutImageOnDarkExampleV2,
+  WithImageOnLightExampleV2,
 } from './examples';
 
 export default {
@@ -29,6 +31,11 @@ export default {
   component: BpkInsetBannerSponsored,
 };
 
-export const SponsoredBannerWithCtaTextAndPopoverLight = WithCtaTextAndBottomSheetExampleLightV2;
-export const SponsoredBannerWithCustomPopoverWidthAndMargins = WithCustomBottomSheetWidthAndMarginsExampleV2;
-export const SponsoredBannerWithImageAndBottomSheet = WithImageAndBottomSheetExampleV2;
+export const SponsoredBannerWithCtaTextAndPopoverLight =
+  WithCtaTextAndBottomSheetExampleLightV2;
+export const SponsoredBannerWithCustomPopoverWidthAndMargins =
+  WithCustomBottomSheetWidthAndMarginsExampleV2;
+export const SponsoredBannerWithImageAndBottomSheet =
+  WithImageAndBottomSheetExampleV2;
+export const SponsoredBannerWithoutImageOnDark = WithoutImageOnDarkExampleV2;
+export const SponsoredBannerWithImageOnLight = WithImageOnLightExampleV2;

--- a/examples/bpk-component-inset-banner-v2/stories.ts
+++ b/examples/bpk-component-inset-banner-v2/stories.ts
@@ -19,11 +19,11 @@
 import { BpkInsetBannerSponsored } from '../../packages/bpk-component-inset-banner/src/bpk-component-inset-banner-v2/src/BpkInsetBannerSponsored';
 
 import {
-  WithCtaTextAndBottomSheetExampleLightV2,
-  WithCustomBottomSheetWidthAndMarginsExampleV2,
-  WithImageAndBottomSheetExampleV2,
-  WithoutImageOnDarkExampleV2,
-  WithImageOnLightExampleV2,
+  WithCtaTextAndBottomSheetExampleV2Light,
+  WithCustomBottomSheetWidthAndMarginsExampleV2Light,
+  WithImageAndBottomSheetExampleV2Dark,
+  WithCtaTextAndBottomSheetExampleV2Dark,
+  WithImageAndBottomSheetExampleV2Light,
 } from './examples';
 
 export default {
@@ -32,10 +32,12 @@ export default {
 };
 
 export const SponsoredBannerWithCtaTextAndPopoverLight =
-  WithCtaTextAndBottomSheetExampleLightV2;
+  WithCtaTextAndBottomSheetExampleV2Light;
+export const SponsoredBannerWithCtaTextAndPopoverDark =
+  WithCtaTextAndBottomSheetExampleV2Dark;
+export const SponsoredBannerWithImageAndBottomSheetDark =
+  WithImageAndBottomSheetExampleV2Dark;
+export const SponsoredBannerWithImageAndBottomSheetLight =
+  WithImageAndBottomSheetExampleV2Light;
 export const SponsoredBannerWithCustomPopoverWidthAndMargins =
-  WithCustomBottomSheetWidthAndMarginsExampleV2;
-export const SponsoredBannerWithImageAndBottomSheet =
-  WithImageAndBottomSheetExampleV2;
-export const SponsoredBannerWithoutImageOnDark = WithoutImageOnDarkExampleV2;
-export const SponsoredBannerWithImageOnLight = WithImageOnLightExampleV2;
+  WithCustomBottomSheetWidthAndMarginsExampleV2Light;


### PR DESCRIPTION
# Add Missing Variants for bpk-component-inset-banner-v2

## Description
This PR adds the missing variant combinations for the BpkInsetBannerSponsored component to ensure coverage of both `onLight` and `onDark` themes with and without images.

### Problem
Our examples only demonstrated:
- `onLight` variant without an image
- `onDark` variant with an image

### Solution
Added the following examples:
1. `WithCtaTextAndBottomSheetExampleV2Dark` - Shows the inset banner in `onDark` variant without an image
2. `WithImageAndBottomSheetExampleV2Light` - Shows the inset banner in `onLight` variant with an image

Now the component has coverage for all combinations:
- onLight + no image ✅
- onLight + image ✅
- onDark + no image ✅
- onDark + image ✅

## Implementation Details
- Created two new component examples in examples.tsx
- Added corresponding story exports in stories.ts
- Maintained consistent styling and conventions with existing examples


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
