### PR TITLE
Revert "Bump @floating-ui/react from 0.26.12 to 0.27.8 in /packages"

### DIFF
--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -9,7 +9,7 @@
       "version": "21.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@floating-ui/react": "^0.27.8",
+        "@floating-ui/react": "^0.26.12",
         "@popperjs/core": "^2.11.8",
         "@radix-ui/react-compose-refs": "^1.1.1",
         "@radix-ui/react-slider": "1.1.2",
@@ -66,44 +66,40 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "license": "MIT",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.5.tgz",
+      "integrity": "sha512-8GrTWmoFhm5BsMZOTHeGD2/0FLKLQQHvO/ZmQga4tKempYRLz8aqJGqXVuQgisnMObq2YZ2SgkwctN1LOOxcqA==",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.5"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.8.tgz",
+      "integrity": "sha512-kx62rP19VZ767Q653wsP1XZCGIirkE09E0QUGNYTM/ttbbQHqcGPdSfWFxUyyNLc/W6aoJRBajOSXhP6GXjC0Q==",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.5"
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.8.tgz",
-      "integrity": "sha512-EQJ4Th328y2wyHR3KzOUOoTW2UKjFk53fmyahfwExnFQ8vnsMYqKc+fFPOkeYtj5tcp1DUMiNJ7BFhed7e9ONw==",
-      "license": "MIT",
+      "version": "0.26.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.12.tgz",
+      "integrity": "sha512-D09o62HrWdIkstF2kGekIKAC0/N/Dl6wo3CQsnLcOmO3LkW6Ik8uIb3kw8JYkwxNCcg+uJ2bpWUiIijTBep05w==",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.9",
+        "@floating-ui/react-dom": "^2.0.0",
+        "@floating-ui/utils": "^0.2.0",
         "tabbable": "^6.0.0"
       },
       "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
-      "license": "MIT",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+      "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -118,10 +114,9 @@
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT"
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.5.tgz",
+      "integrity": "sha512-sTcG+QZ6fdEUObICavU+aB3Mp8HY4n14wYHdxK4fXjPmv3PXZZeY5RaguJmGyeH/CJQhX3fqKUtS4qc1LoHwhQ=="
     },
     "node_modules/@googlemaps/js-api-loader": {
       "version": "1.16.2",

--- a/packages/package.json
+++ b/packages/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@floating-ui/react": "^0.27.8",
+    "@floating-ui/react": "^0.26.12",
     "@popperjs/core": "^2.11.8",
     "@radix-ui/react-compose-refs": "^1.1.1",
     "@radix-ui/react-slider": "1.1.2",


### PR DESCRIPTION
Reverts Skyscanner/backpack#3812 for a quick fix. We found an adoption issue in v37.9.0 . The consumer microsite, built with React 17.x, encounters dependency errors when attempting to adopt Backpack v37.9.0 due to the 'react/jsx-runtime' alias.
To remove the blocker of new version adoption for some cases, we decided to revert @floating-ui/react  0.26.12  for a while and **will use a new PR to solve the related issues**.