### PR TITLE
[CLOVER-399][BpkText] Add color prop to improve overrides

### DIFF
--- a/examples/bpk-component-text/examples.js
+++ b/examples/bpk-component-text/examples.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import { textColors } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
+
 import BpkText, { TEXT_STYLES } from '../../packages/bpk-component-text';
 import { withDefaultProps } from '../../packages/bpk-react-utils';
 
@@ -179,6 +181,23 @@ const LarkenFallbackStylesExample = () => (
   </div>
 );
 
+const ColorPropExample = () => (
+  <div>
+    <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p" color={textColors.textPrimaryDay}>
+      Text with color token textPrimaryDay
+    </BpkText>
+    <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p" color="rgb(0, 98, 227)">
+      Text with color RGB rgb(0, 98, 227)
+    </BpkText>
+    <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p" color="#0c838a">
+      Text with color HEX #0c838a
+    </BpkText>
+    <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p" color="purple">
+      Text with color named purple
+    </BpkText>
+  </div>
+);
+
 const MixedExample = () => (
   <div>
     <HeroStylesExample />
@@ -187,6 +206,7 @@ const MixedExample = () => (
     <LabelStylesExample />
     <LarkenStylesExample />
     <LarkenFallbackStylesExample />
+    <ColorPropExample />
   </div>
 );
 
@@ -201,5 +221,6 @@ export {
   LabelStylesExample,
   LarkenStylesExample,
   LarkenFallbackStylesExample,
+  ColorPropExample,
   MixedExample,
 };

--- a/examples/bpk-component-text/stories.js
+++ b/examples/bpk-component-text/stories.js
@@ -29,6 +29,7 @@ import {
   LabelStylesExample,
   LarkenStylesExample,
   LarkenFallbackStylesExample,
+  ColorPropExample,
   MixedExample,
 } from './examples';
 
@@ -49,6 +50,8 @@ export const BodyStyles = BodyStylesExample;
 export const LabelStyles = LabelStylesExample;
 export const LarkenStyles = LarkenStylesExample;
 export const LarkenFallbackStyles = LarkenFallbackStylesExample;
+
+export const ColorProp = ColorPropExample;
 
 export const VisualTest = MixedExample;
 export const VisualTestWithZoom = VisualTest.bind({});

--- a/packages/bpk-component-text/README.md
+++ b/packages/bpk-component-text/README.md
@@ -80,7 +80,40 @@ export default () => (
 );
 ```
 
-For certain langauges/characters that are not supported by Larken, the fonts will use the Noto Sans/Serif fonts defined [here](https://www.skyscanner.design/latest/foundations/product-typography/fallback-fonts-Fx8gulTr)
+### Color Prop
+
+The color prop allows you to customize the text color of the BpkText component rather override by className. It supports a variety of color formats, including CSS named colors, HEX values, RGB/RGBA values, HSL/HSLA values and CSS global values. If no color is provided, the text color defaults to 'inherit', meaning it will inherit the color from its parent element. It's recommended to use predefined tokens from [bpk-foundations-web](https://github.com/Skyscanner/backpack-foundations/tree/7f2a6358ddb288a2c8372f3ffef3d39fa97a40cf/packages/bpk-foundations-web/tokens) for consistency.
+
+```javascript
+import BpkText, { TEXT_STYLES } from '@skyscanner/backpack-web/bpk-component-text';
+import { textColors } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
+
+export default () => (
+  <div>
+    {/* Using Backpack Token */}
+    <BpkText textStyle={TEXT_STYLES.bodyDefault} color={textColors.textPrimaryDay}>
+      Text with token textPrimaryDay
+    </BpkText>
+
+    {/* Using RGB Value */}
+      <BpkText textStyle={TEXT_STYLES.bodyDefault} color="rgb(0, 98, 227)">
+      Text with RGB color rgb(0, 98, 227)
+    </BpkText>
+
+    {/* Using HEX Value */}
+    <BpkText textStyle={TEXT_STYLES.bodyDefault} color="#0c838a">
+      Text with HEX color #0c838a
+    </BpkText>
+
+    {/* Using Named Color */}
+    <BpkText textStyle={TEXT_STYLES.bodyDefault} color="purple">
+      Text with named color purple
+    </BpkText>
+  </div>
+);
+```
+
+
 
 ## Props
 

--- a/packages/bpk-component-text/src/BpkText-test.tsx
+++ b/packages/bpk-component-text/src/BpkText-test.tsx
@@ -65,6 +65,13 @@ describe('BpkText', () => {
     expect(getByText(text)).toBeInstanceOf(HTMLParagraphElement);
   });
 
+  it('should render correctly with color prop', () => {
+    const { getByText } = render(<BpkText color="#0c838a">{text}</BpkText>);
+
+    expect(getByText(text)).toHaveClass('bpk-text bpk-text--body-default');
+    expect(getByText(text)).toHaveAttribute('style', '--text-color: #0c838a;');
+  });
+
   it('should pass down unknown props', () => {
     const { getByText } = render(
       // eslint-disable-next-line backpack/use-tokens

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -19,6 +19,8 @@
 @use '../../unstable__bpk-mixins/typography';
 
 .bpk-text {
+  color: var(--text-color, inherit);
+
   @include typography.bpk-text;
 
   &--xs {

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 import { cssModules } from '../../bpk-react-utils';
 
@@ -76,12 +76,14 @@ type Props = {
   tagName?: Tag;
   className?: string | null;
   id?: string;
+  color?: string;
   [rest: string]: any;
 };
 
 const BpkText = ({
   children,
   className = null,
+  color = 'inherit',
   tagName: TagName = 'span',
   textStyle = TEXT_STYLES.bodyDefault,
   ...rest
@@ -92,10 +94,14 @@ const BpkText = ({
     className,
   );
 
+  const style = {
+    '--text-color': color,
+  } as CSSProperties;
+
   return (
     // Allowed, TagName is always a dom element.
     // eslint-disable-next-line @skyscanner/rules/forbid-component-props
-    <TagName className={classNames} {...rest}>
+    <TagName className={classNames} style={style} {...rest}>
       {children}
     </TagName>
   );


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

BpkText’s lack of default or token-based color support leads to widespread manual style overrides (average 14.88% per major page), undermining VDL consistency and reducing design system reliability and maintainability across Skyscanner products.

We want to add color prop so that consumer can change BpkText color by config but not override.

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
