### PR TITLE
[maintainence] SPIK: uninstall d3-path

### DIFF
--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -18,7 +18,6 @@
         "@skyscanner/bpk-svgs": "^20.6.0",
         "a11y-focus-scope": "^1.1.3",
         "a11y-focus-store": "^1.0.0",
-        "d3-path": "^2.0.0",
         "d3-scale": "^4.0.2",
         "intersection-observer": "^0.7.0",
         "lodash": "^4.17.20",
@@ -622,11 +621,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/d3-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
-      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",

--- a/packages/package.json
+++ b/packages/package.json
@@ -31,7 +31,6 @@
     "@skyscanner/bpk-svgs": "^20.6.0",
     "a11y-focus-scope": "^1.1.3",
     "a11y-focus-store": "^1.0.0",
-    "d3-path": "^2.0.0",
     "d3-scale": "^4.0.2",
     "intersection-observer": "^0.7.0",
     "lodash": "^4.17.20",


### PR DESCRIPTION
The `d3-path` is not used in 

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
