### PR TITLE
[BD-9759] Add close button beside BpkPopover body

### DIFF
--- a/examples/bpk-component-popover/examples.js
+++ b/examples/bpk-component-popover/examples.js
@@ -84,8 +84,7 @@ class PopoverContainer extends Component<Props, State> {
   };
 
   render() {
-    const { displayArrow, id, inputTrigger, ...rest } =
-      this.props;
+    const { displayArrow, id, inputTrigger, ...rest } = this.props;
     let target = null;
 
     const openButton = (
@@ -147,7 +146,10 @@ const DefaultExample = () => (
 const WithCustomRenderTargetExample = () => (
   <Spacer>
     <div id="my-target" />
-    <PopoverContainer id="my-popover-1" renderTarget={() => document.getElementById('my-target')} />
+    <PopoverContainer
+      id="my-popover-1"
+      renderTarget={() => document.getElementById('my-target')}
+    />
   </Spacer>
 );
 
@@ -175,6 +177,12 @@ const WithNoCloseButtonIconExample = () => (
   </Spacer>
 );
 
+const WithNoTitleExample = () => (
+  <Spacer>
+    <PopoverContainer id="my-popover" labelAsTitle={undefined} />
+  </Spacer>
+);
+
 const OnTheSideExample = () => (
   <Spacer>
     <PopoverContainer id="my-popover" placement="right" />
@@ -189,7 +197,7 @@ const InputTriggerExample = () => (
 
 const WithActionButtonExample = () => (
   <Spacer>
-    <PopoverContainer id="my-popover" actionText="Action" onAction={() => { }} />
+    <PopoverContainer id="my-popover" actionText="Action" onAction={() => {}} />
   </Spacer>
 );
 
@@ -204,10 +212,11 @@ export {
   WithCustomRenderTargetExample,
   HoverExample,
   WithoutArrowExample,
+  WithNoTitleExample,
   WithLabelAsTitleExample,
   WithNoCloseButtonIconExample,
   OnTheSideExample,
   InputTriggerExample,
   WithActionButtonExample,
-  VisualExample
+  VisualExample,
 };

--- a/examples/bpk-component-popover/stories.js
+++ b/examples/bpk-component-popover/stories.js
@@ -29,6 +29,7 @@ import {
   InputTriggerExample,
   WithActionButtonExample,
   WithNoCloseButtonIconExample,
+  WithNoTitleExample,
   VisualExample
 } from './examples';
 
@@ -44,6 +45,7 @@ export const WithoutArrow = WithoutArrowExample;
 export const WithLabelAsTitle = WithLabelAsTitleExample;
 export const WithNoCloseButtonIcon =
 WithNoCloseButtonIconExample;
+export const WithNoTitle = WithNoTitleExample;
 export const OnTheSide = OnTheSideExample;
 export const TriggeredByInput = InputTriggerExample;
 export const WithActionButton = WithActionButtonExample;

--- a/packages/bpk-component-popover/src/BpkPopover-test.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover-test.tsx
@@ -26,10 +26,10 @@ describe('BpkPopover', () => {
 
   beforeEach(() => {
     onCloseSpy = jest.fn();
-  })
+  });
 
   it('should render correctly', () => {
-    const target = (<button type="button">My target</button>);
+    const target = <button type="button">My target</button>;
     render(
       <BpkPopover
         id="my-popover"
@@ -66,12 +66,12 @@ describe('BpkPopover', () => {
           My popover content
         </BpkPopover>,
       );
-    })
+    });
     expect(screen.queryByRole('My popover content')).not.toBeInTheDocument();
   });
 
   it('should render without an arrow', async () => {
-    const target = (<button type="button">My target</button>);
+    const target = <button type="button">My target</button>;
     render(
       <BpkPopover
         id="my-popover"
@@ -87,7 +87,7 @@ describe('BpkPopover', () => {
     );
     await waitFor(async () => {
       expect(screen.getByText('My popover content')).toBeVisible();
-    })
+    });
   });
 
   it('should render correctly with "closeButtonProps" provided', () => {
@@ -107,7 +107,30 @@ describe('BpkPopover', () => {
       </BpkPopover>,
     );
 
-    expect(screen.getByRole('button', { name: /Close/i, })).toHaveAttribute('tabindex');
+    expect(screen.getByRole('button', { name: /Close/i })).toHaveAttribute(
+      'tabindex',
+    );
+  });
+
+  it('should render correctly with "closeButtonIcon" but without "labelAsTitle" attribute', () => {
+    render(
+      <BpkPopover
+        id="my-popover"
+        onClose={() => null}
+        label="My popover"
+        closeButtonLabel="Close"
+        closeButtonIcon
+        target={<button type="button">My target</button>}
+        closeButtonProps={{ tabIndex: 0 }}
+        isOpen
+      >
+        My popover content
+      </BpkPopover>,
+    );
+
+    expect(screen.getByRole('button', { name: /Close/i })).toHaveAttribute(
+      'tabindex',
+    );
   });
 
   it('should render correctly with "padded" attribute equal to false', () => {
@@ -164,7 +187,9 @@ describe('BpkPopover', () => {
       </BpkPopover>,
     );
 
-    const actionButton = container.getElementsByClassName('.bpk-popover__action');
+    const actionButton = container.getElementsByClassName(
+      '.bpk-popover__action',
+    );
     expect(actionButton).toBeTruthy();
     expect(screen.getByText('Action')).toBeVisible();
   });
@@ -209,7 +234,11 @@ describe('BpkPopover', () => {
         closeButtonLabel="Close"
         labelAsTitle
         closeButtonIcon
-        target={<button onClick={handleClick} type="button">My target</button>}
+        target={
+          <button onClick={handleClick} type="button">
+            My target
+          </button>
+        }
       >
         My popover content
       </BpkPopover>,
@@ -228,5 +257,4 @@ describe('BpkPopover', () => {
       expect(screen.getByText('My popover content')).toBeVisible();
     });
   });
-
 });

--- a/packages/bpk-component-popover/src/BpkPopover.module.scss
+++ b/packages/bpk-component-popover/src/BpkPopover.module.scss
@@ -58,6 +58,11 @@ $arrow-size: tokens.bpk-spacing-lg();
   }
 
   &__body {
+    display: flex;
+    column-gap: tokens.bpk-spacing-base();
+    justify-content: space-between;
+    align-items: flex-start;
+
     &--padded {
       padding: tokens.bpk-spacing-base();
 

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -204,7 +204,10 @@ const BpkPopover = ({
   );
 
   const classNames = getClassName('bpk-popover', className);
-  const bodyClassNames = getClassName(padded && 'bpk-popover__body--padded');
+  const bodyClassNames = getClassName(
+    'bpk-popover__body',
+    padded && 'bpk-popover__body--padded',
+  );
 
   const labelId = `bpk-popover-label-${id}`;
   const renderElement = typeof renderTarget === 'function' ? renderTarget() : renderTarget;
@@ -300,7 +303,23 @@ const BpkPopover = ({
                       {label}
                     </span>
                   )}
-                  <div className={bodyClassNames}>{children}</div>
+                  <div className={bodyClassNames}>
+                    <div>{children}</div>
+                    {!labelAsTitle && closeButtonIcon && (
+                      <BpkCloseButton
+                        label={closeButtonText || closeButtonLabel}
+                        onClick={(event: SyntheticEvent<HTMLButtonElement>) => {
+                          bindEventSource(
+                            EVENT_SOURCES.CLOSE_BUTTON,
+                            onClose,
+                            event,
+                          );
+                          setIsOpenState(false);
+                        }}
+                        {...closeButtonProps}
+                      />
+                    )}
+                  </div>
                   {actionText && onAction && (
                     <div className={getClassName('bpk-popover__action')}>
                       <BpkButtonLink onClick={onAction}>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
