### PR TITLE
[NO-JIRA][BpkRating] Fixed the issue where some BpkRating attributes were required

### DIFF
--- a/packages/bpk-component-rating/src/BpkRating-test.tsx
+++ b/packages/bpk-component-rating/src/BpkRating-test.tsx
@@ -21,15 +21,10 @@ import { render, screen } from '@testing-library/react';
 import BpkRating, { RATING_SIZES, RATING_SCALES } from '../index';
 
 describe('BpkRating', () => {
-  const defaultProps = {
-    ratingScale: RATING_SCALES.zeroToFive,
-    size: RATING_SIZES.base,
-  };
 
   it('should render correctly', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="4.6 Excellent 672 reviews"
         value={4.6}
         title="Excellent"
@@ -44,7 +39,6 @@ describe('BpkRating', () => {
   it('should render large size correctly', () => {
      render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="4.6 Excellent 2,420 reviews"
         value={4.6}
         title="Excellent"
@@ -60,7 +54,6 @@ describe('BpkRating', () => {
   it('should render showScale rating correctly', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="6.7 Average might recommend"
         title="Average"
         subtitle="Might recommend"
@@ -76,7 +69,6 @@ describe('BpkRating', () => {
   it('should not show scale with showScale=false correctly', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="4.9 Awesome It is a fantanstic place"
         title="Awesome"
         subtitle="It is a fantanstic place"
@@ -91,7 +83,6 @@ describe('BpkRating', () => {
   it('should render title only correctly', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="6.7 Average might recommend"
         title="Average"
         value={6.7}
@@ -106,7 +97,6 @@ describe('BpkRating', () => {
   it('should render large title only correctly', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="6.7 Average might recommend"
         title="Average"
         value={6.7}
@@ -121,7 +111,6 @@ describe('BpkRating', () => {
   it('should render zero to ten scale rating correctly', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="8.2 Excellent 2,420 reviews"
         value={8.2}
         title="Excellent"
@@ -139,7 +128,6 @@ describe('BpkRating', () => {
   it('should correctly handling values lower than 0', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="-1.3 Low bad option"
         title="Low"
         subtitle="Bad option"
@@ -157,7 +145,6 @@ describe('BpkRating', () => {
   it('should correctly handling values higher than 5 when rating scale is zero to five', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="10 Super, smashing, great"
         title="Smashing"
         subtitle="Doubleplusgood"
@@ -175,7 +162,6 @@ describe('BpkRating', () => {
   it('should correctly handling values higher than 10 when rating scale is zero to ten', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="15 Amazing brilliant"
         title="Amazing"
         subtitle="Brilliant"
@@ -194,7 +180,6 @@ describe('BpkRating', () => {
   it('should correctly when value is string type', () => {
     render(
       <BpkRating
-        {...defaultProps}
         ariaLabel="4,6 Wonderful Wise choice"
         title="Wonderful"
         subtitle="Wise choice"

--- a/packages/bpk-component-rating/src/BpkRating.tsx
+++ b/packages/bpk-component-rating/src/BpkRating.tsx
@@ -48,9 +48,9 @@ const getMaxValue = (ratingScale: ValueOf<typeof RATING_SCALES>) => {
 type Props = {
   ariaLabel: string,
   className?: string,
-  ratingScale: ValueOf<typeof RATING_SCALES>,
+  ratingScale?: ValueOf<typeof RATING_SCALES>,
   showScale?: boolean,
-  size: ValueOf<typeof RATING_SIZES>,
+  size?: ValueOf<typeof RATING_SIZES>,
   subtitle?: string,
   title?: string | ReactNode,
   value: string | number,


### PR DESCRIPTION
The BpkRating only has two required props. However, the previous changes(#2184 and #3872) made two props required by mistake. This PR is to fix this issue.
**Props explanation**: https://backpack.github.io/storybook/iframe.html?args=&id=bpk-component-rating--documentation&viewMode=docs
<img width="848" height="526" alt="Screenshot 2025-07-16 at 19 17 10" src="https://github.com/user-attachments/assets/0801399a-098c-4949-a99b-ef8485409d7b" />


Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
