### PR TITLE
[QUAR-991] [BpkInsetBannerSponsored] Add closeOnScrimClick prop to BpkBottomSheet

### DIFF
--- a/packages/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
@@ -113,6 +113,7 @@ const BpkInsetBannerSponsored = ({
               closeLabel="Close bottom sheet"
               ariaLabel={callToAction?.bottomSheetA11yLabel || ''}
               closeOnScrimClick
+              closeOnEscPressed
             >
               {callToAction.bottomSheetContent.map((item, index) => (
                 <div

--- a/packages/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
+++ b/packages/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
@@ -112,6 +112,7 @@ const BpkInsetBannerSponsored = ({
               title={callToAction?.bottomSheetTitle || ''}
               closeLabel="Close bottom sheet"
               ariaLabel={callToAction?.bottomSheetA11yLabel || ''}
+              closeOnScrimClick
             >
               {callToAction.bottomSheetContent.map((item, index) => (
                 <div


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

### Description
This PR adds the `closeOnScrimClick` prop to the BpkBottomSheet component in BpkInsetBannerSponsored. This change makes the Bottom Sheet close when users click outside of it (on the background/scrim), bringing its behavior in line with the BpkPopover component used in the original BpkInsetBanner.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
