### PR TITLE
[CLOV-402][BpkCardList] Fix cardlist initially shown cards change issue

### DIFF
--- a/examples/bpk-component-card-list/examples.tsx
+++ b/examples/bpk-component-card-list/examples.tsx
@@ -167,7 +167,7 @@ const DestinationCard = (i: number) => (
       <div className={STYLES['bpk-destination__bottom']}>
         <div className={STYLES['bpk-destination__name']}>
           <BpkText textStyle={TEXT_STYLES.heading4}>
-            {`Destination Name ${i}`}
+            {`Destination ${i}`}
           </BpkText>
         </div>
         <div className={STYLES['bpk-destination__row']}>

--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
@@ -43,6 +43,8 @@ import STYLES from './BpkCardListCarousel.module.scss';
 
 const getClassName = cssModules(STYLES);
 
+const PAGINATION_INDICATOR_MAX_SHOWN_COUNT = 5;
+
 const BpkCardListCarousel = (props: CardListCarouselProps) => {
   const {
     carouselLabel = (initiallyShownCards: number, childrenLength: number) =>
@@ -101,10 +103,10 @@ const BpkCardListCarousel = (props: CardListCarouselProps) => {
 
     // Calculate how many cards to render based on the number of initially shown cards and total children
     const totalPages = Math.ceil(childrenLength / initiallyShownCards);
-    const shownIdicatorAccount = Math.min(totalPages, 5);
+    const shownIndicatorCount = Math.min(totalPages, PAGINATION_INDICATOR_MAX_SHOWN_COUNT);
     return Math.max(
       RENDER_BUFFER_SIZE,
-      shownIdicatorAccount * initiallyShownCards - initiallyShownCards,
+      shownIndicatorCount * initiallyShownCards - initiallyShownCards,
     );
   }, [childrenLength, initiallyShownCards, isMobile]);
 

--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
@@ -106,7 +106,7 @@ const BpkCardListCarousel = (props: CardListCarouselProps) => {
     const shownIndicatorCount = Math.min(totalPages, PAGINATION_INDICATOR_MAX_SHOWN_COUNT);
     return Math.max(
       RENDER_BUFFER_SIZE,
-      shownIndicatorCount * initiallyShownCards - initiallyShownCards,
+      (shownIndicatorCount - 1) * initiallyShownCards,
     );
   }, [childrenLength, initiallyShownCards, isMobile]);
 
@@ -197,7 +197,6 @@ const BpkCardListCarousel = (props: CardListCarouselProps) => {
         setCurrentIndex(newIndex);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initiallyShownCards]);
 
   useEffect(() => {

--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListRowRailContainer.tsx
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListRowRailContainer.tsx
@@ -67,6 +67,7 @@ const BpkCardListRowRailContainer = (props: CardListRowRailProps) => {
       <BpkCardListCarousel
         initiallyShownCards={initiallyShownCards}
         layout={layout}
+        setCurrentIndex={setCurrentIndex}
         currentIndex={currentIndex}
         isMobile={isMobile}
         carouselLabel={accessibilityLabels?.carouselLabel}

--- a/packages/bpk-component-card-list/src/common-types.ts
+++ b/packages/bpk-component-card-list/src/common-types.ts
@@ -77,10 +77,10 @@ type CardListGridStackProps = {
   initiallyShownCards: number;
   layout: typeof LAYOUTS.grid | typeof LAYOUTS.stack;
   accessory?:
-    | typeof ACCESSORY_DESKTOP_TYPES.expand
-    | typeof ACCESSORY_DESKTOP_TYPES.button
-    | typeof ACCESSORY_MOBILE_TYPES.expand
-    | typeof ACCESSORY_MOBILE_TYPES.button;
+  | typeof ACCESSORY_DESKTOP_TYPES.expand
+  | typeof ACCESSORY_DESKTOP_TYPES.button
+  | typeof ACCESSORY_MOBILE_TYPES.expand
+  | typeof ACCESSORY_MOBILE_TYPES.button;
   expandText?: string;
   buttonContent?: React.ReactNode;
   onButtonClick?: () => void;
@@ -102,6 +102,7 @@ type CardListCarouselProps = {
   initiallyShownCards: number;
   layout: typeof LAYOUTS.row | typeof LAYOUTS.rail;
   currentIndex: number;
+  setCurrentIndex: Dispatch<SetStateAction<number>>;
   isMobile?: boolean;
   carouselLabel?: (initiallyShownCards: number, childrenLength: number) => string;
   slideLabel?: (index: number, childrenLength: number) => string;

--- a/packages/bpk-component-card-list/src/common-types.ts
+++ b/packages/bpk-component-card-list/src/common-types.ts
@@ -77,10 +77,10 @@ type CardListGridStackProps = {
   initiallyShownCards: number;
   layout: typeof LAYOUTS.grid | typeof LAYOUTS.stack;
   accessory?:
-  | typeof ACCESSORY_DESKTOP_TYPES.expand
-  | typeof ACCESSORY_DESKTOP_TYPES.button
-  | typeof ACCESSORY_MOBILE_TYPES.expand
-  | typeof ACCESSORY_MOBILE_TYPES.button;
+    | typeof ACCESSORY_DESKTOP_TYPES.expand
+    | typeof ACCESSORY_DESKTOP_TYPES.button
+    | typeof ACCESSORY_MOBILE_TYPES.expand
+    | typeof ACCESSORY_MOBILE_TYPES.button;
   expandText?: string;
   buttonContent?: React.ReactNode;
   onButtonClick?: () => void;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

1. When change `initiallyShownCards`, the `currentIndex` should be update
2. Update  buffer size dynamically to guarantee the last shown indicator corresponding card is rendered.

https://github.com/user-attachments/assets/c7abf56f-3c63-4f21-ae64-4f9f9f6b1669
https://github.com/user-attachments/assets/44c21363-48f9-40b8-a0d9-a1a7d12eac72


wing changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
