### PR TITLE
[CLOV-402][BpkCardList] optimize cardlist spacing 

### DIFF
--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.module.scss
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.module.scss
@@ -25,7 +25,7 @@
   &__rail {
     display: flex;
     padding-top: tokens.bpk-spacing-sm();
-    padding-bottom: tokens.bpk-spacing-sm();
+    padding-bottom: tokens.bpk-spacing-lg();
     overflow-x: hidden;
     box-sizing: border-box;
     gap: tokens.bpk-spacing-sm();
@@ -34,6 +34,7 @@
     scrollbar-width: none;
 
     @include breakpoints.bpk-breakpoint-mobile {
+      padding-bottom: tokens.bpk-spacing-base();
       overflow-x: scroll;
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

The spacing between cards and pagination for different with UI, update to keep implementation and UI are same.

Before:
<img width="1110" height="479" alt="image" src="https://github.com/user-attachments/assets/617cb1ef-77fd-44c6-aedc-01ea81dc3894" />

After:
<img width="1108" height="469" alt="image" src="https://github.com/user-attachments/assets/9d8ccfa0-ef66-44b0-8e1f-ba7eea7246c3" />

Design:
<img width="1331" height="681" alt="image" src="https://github.com/user-attachments/assets/3d096966-99a4-40dd-a816-6c10d6b18a0f" />
<img width="1329" height="562" alt="image" src="https://github.com/user-attachments/assets/677a990e-fb4f-4fe2-b9f1-4c38f1063cad" />

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
