### PR TITLE
[BD-9759][BpkPopover] Add close button beside body

### DIFF
--- a/examples/bpk-component-popover/examples.js
+++ b/examples/bpk-component-popover/examples.js
@@ -84,8 +84,7 @@ class PopoverContainer extends Component<Props, State> {
   };
 
   render() {
-    const { displayArrow, id, inputTrigger, ...rest } =
-      this.props;
+    const { displayArrow, id, inputTrigger, ...rest } = this.props;
     let target = null;
 
     const openButton = (
@@ -147,7 +146,10 @@ const DefaultExample = () => (
 const WithCustomRenderTargetExample = () => (
   <Spacer>
     <div id="my-target" />
-    <PopoverContainer id="my-popover-1" renderTarget={() => document.getElementById('my-target')} />
+    <PopoverContainer
+      id="my-popover-1"
+      renderTarget={() => document.getElementById('my-target')}
+    />
   </Spacer>
 );
 
@@ -175,6 +177,12 @@ const WithNoCloseButtonIconExample = () => (
   </Spacer>
 );
 
+const WithNoTitleExample = () => (
+  <Spacer>
+    <PopoverContainer id="my-popover" labelAsTitle={false} />
+  </Spacer>
+);
+
 const OnTheSideExample = () => (
   <Spacer>
     <PopoverContainer id="my-popover" placement="right" />
@@ -189,7 +197,7 @@ const InputTriggerExample = () => (
 
 const WithActionButtonExample = () => (
   <Spacer>
-    <PopoverContainer id="my-popover" actionText="Action" onAction={() => { }} />
+    <PopoverContainer id="my-popover" actionText="Action" onAction={() => {}} />
   </Spacer>
 );
 
@@ -204,10 +212,11 @@ export {
   WithCustomRenderTargetExample,
   HoverExample,
   WithoutArrowExample,
+  WithNoTitleExample,
   WithLabelAsTitleExample,
   WithNoCloseButtonIconExample,
   OnTheSideExample,
   InputTriggerExample,
   WithActionButtonExample,
-  VisualExample
+  VisualExample,
 };

--- a/examples/bpk-component-popover/stories.js
+++ b/examples/bpk-component-popover/stories.js
@@ -29,6 +29,7 @@ import {
   InputTriggerExample,
   WithActionButtonExample,
   WithNoCloseButtonIconExample,
+  WithNoTitleExample,
   VisualExample
 } from './examples';
 
@@ -44,6 +45,7 @@ export const WithoutArrow = WithoutArrowExample;
 export const WithLabelAsTitle = WithLabelAsTitleExample;
 export const WithNoCloseButtonIcon =
 WithNoCloseButtonIconExample;
+export const WithNoTitle = WithNoTitleExample;
 export const OnTheSide = OnTheSideExample;
 export const TriggeredByInput = InputTriggerExample;
 export const WithActionButton = WithActionButtonExample;

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.tsx
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.tsx
@@ -387,6 +387,7 @@ class BpkDatepicker extends Component<Props, State> {
               isOpen={this.state.isOpen}
               label={title}
               closeButtonText={closeButtonText}
+              closeButtonIcon={false}
               {...rest}
             >
               <Calendar {...calendarProps} fixedWidth={fixedWidth} />

--- a/packages/bpk-component-input/README.md
+++ b/packages/bpk-component-input/README.md
@@ -9,7 +9,10 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 ## Usage
 
 ```js
-import BpkInput, { INPUT_TYPES, CLEAR_BUTTON_MODES } from '@skyscanner/backpack-web/bpk-component-input';
+import BpkInput, {
+  INPUT_TYPES,
+  CLEAR_BUTTON_MODES,
+} from '@skyscanner/backpack-web/bpk-component-input';
 
 export default () => (
   <BpkInput
@@ -68,6 +71,7 @@ export default () => {
         isOpen={this.state.isOpen}
         label="Popover"
         closeButtonText="Close"
+        closeButtonIcon={false}
       >
         A popover!
       </BpkPopover>

--- a/packages/bpk-component-popover/README.md
+++ b/packages/bpk-component-popover/README.md
@@ -59,6 +59,7 @@ class App extends Component {
           closeButtonProps={{
             tabIndex: 0,
           }}
+          closeButtonIcon={false}
         >
           <BpkText>My popover content</BpkText>
         </BpkPopover>

--- a/packages/bpk-component-popover/src/BpkPopover-test.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover-test.tsx
@@ -38,6 +38,7 @@ describe('BpkPopover', () => {
         closeButtonLabel="Close"
         target={target}
         isOpen
+        closeButtonIcon={false}
       >
         My popover content
       </BpkPopover>,
@@ -53,6 +54,7 @@ describe('BpkPopover', () => {
       label: 'My popover',
       closeButtonLabel: 'Close',
       target: <button type="button">My target</button>,
+      closeButtonIcon: false,
     };
     const { rerender } = render(
       <BpkPopover {...props} isOpen>
@@ -81,6 +83,7 @@ describe('BpkPopover', () => {
         target={target}
         isOpen
         showArrow={false}
+        closeButtonIcon={false}
       >
         My popover content
       </BpkPopover>,
@@ -142,6 +145,7 @@ describe('BpkPopover', () => {
         closeButtonLabel="Close"
         padded={false}
         target={<button type="button">My target</button>}
+        closeButtonIcon={false}
         isOpen
       >
         My popover content
@@ -181,6 +185,7 @@ describe('BpkPopover', () => {
         actionText="Action"
         onAction={() => null}
         target={<button type="button">My target</button>}
+        closeButtonIcon={false}
         isOpen
       >
         My popover content

--- a/packages/bpk-component-popover/src/BpkPopover-test.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover-test.tsx
@@ -26,10 +26,10 @@ describe('BpkPopover', () => {
 
   beforeEach(() => {
     onCloseSpy = jest.fn();
-  })
+  });
 
   it('should render correctly', () => {
-    const target = (<button type="button">My target</button>);
+    const target = <button type="button">My target</button>;
     render(
       <BpkPopover
         id="my-popover"
@@ -66,12 +66,12 @@ describe('BpkPopover', () => {
           My popover content
         </BpkPopover>,
       );
-    })
+    });
     expect(screen.queryByRole('My popover content')).not.toBeInTheDocument();
   });
 
   it('should render without an arrow', async () => {
-    const target = (<button type="button">My target</button>);
+    const target = <button type="button">My target</button>;
     render(
       <BpkPopover
         id="my-popover"
@@ -87,7 +87,7 @@ describe('BpkPopover', () => {
     );
     await waitFor(async () => {
       expect(screen.getByText('My popover content')).toBeVisible();
-    })
+    });
   });
 
   it('should render correctly with "closeButtonProps" provided', () => {
@@ -107,7 +107,30 @@ describe('BpkPopover', () => {
       </BpkPopover>,
     );
 
-    expect(screen.getByRole('button', { name: /Close/i, })).toHaveAttribute('tabindex');
+    expect(screen.getByRole('button', { name: /Close/i })).toHaveAttribute(
+      'tabindex',
+    );
+  });
+
+  it('should render correctly with "closeButtonIcon" but without "labelAsTitle" attribute', () => {
+    render(
+      <BpkPopover
+        id="my-popover"
+        onClose={() => null}
+        label="My popover"
+        closeButtonLabel="Close"
+        closeButtonIcon
+        target={<button type="button">My target</button>}
+        closeButtonProps={{ tabIndex: 0 }}
+        isOpen
+      >
+        My popover content
+      </BpkPopover>,
+    );
+
+    expect(screen.getByRole('button', { name: /Close/i })).toHaveAttribute(
+      'tabindex',
+    );
   });
 
   it('should render correctly with "padded" attribute equal to false', () => {
@@ -164,7 +187,9 @@ describe('BpkPopover', () => {
       </BpkPopover>,
     );
 
-    const actionButton = container.getElementsByClassName('.bpk-popover__action');
+    const actionButton = container.getElementsByClassName(
+      '.bpk-popover__action',
+    );
     expect(actionButton).toBeTruthy();
     expect(screen.getByText('Action')).toBeVisible();
   });
@@ -209,7 +234,11 @@ describe('BpkPopover', () => {
         closeButtonLabel="Close"
         labelAsTitle
         closeButtonIcon
-        target={<button onClick={handleClick} type="button">My target</button>}
+        target={
+          <button onClick={handleClick} type="button">
+            My target
+          </button>
+        }
       >
         My popover content
       </BpkPopover>,
@@ -228,5 +257,4 @@ describe('BpkPopover', () => {
       expect(screen.getByText('My popover content')).toBeVisible();
     });
   });
-
 });

--- a/packages/bpk-component-popover/src/BpkPopover.module.scss
+++ b/packages/bpk-component-popover/src/BpkPopover.module.scss
@@ -58,6 +58,11 @@ $arrow-size: tokens.bpk-spacing-lg();
   }
 
   &__body {
+    display: flex;
+    column-gap: tokens.bpk-spacing-base();
+    justify-content: space-between;
+    align-items: flex-start;
+
     &--padded {
       padding: tokens.bpk-spacing-base();
 

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -204,10 +204,36 @@ const BpkPopover = ({
   );
 
   const classNames = getClassName('bpk-popover', className);
-  const bodyClassNames = getClassName(padded && 'bpk-popover__body--padded');
+  const bodyClassNames = getClassName(
+    'bpk-popover__body',
+    padded && 'bpk-popover__body--padded',
+  );
 
   const labelId = `bpk-popover-label-${id}`;
   const renderElement = typeof renderTarget === 'function' ? renderTarget() : renderTarget;
+
+  const closeButtonIconElement = (
+    <BpkCloseButton
+      label={closeButtonText || closeButtonLabel}
+      onClick={(event: SyntheticEvent<HTMLButtonElement>) => {
+        bindEventSource(EVENT_SOURCES.CLOSE_BUTTON, onClose, event);
+        setIsOpenState(false);
+      }}
+      {...closeButtonProps}
+    />
+  );
+  
+  const closeButtonTextElement = (
+    <BpkButtonLink
+      onClick={(event: SyntheticEvent<HTMLButtonElement>) => {
+        bindEventSource(EVENT_SOURCES.CLOSE_LINK, onClose, event);
+        setIsOpenState(false);
+      }}
+      {...closeButtonProps}
+    >
+      {closeButtonText}
+    </BpkButtonLink>
+  );
 
   return (
     <>
@@ -257,40 +283,9 @@ const BpkPopover = ({
                         {label}
                       </BpkText>
                       &nbsp;
-                      {closeButtonIcon ? (
-                        <BpkCloseButton
-                          label={closeButtonText || closeButtonLabel}
-                          onClick={(
-                            event: SyntheticEvent<HTMLButtonElement>,
-                          ) => {
-                            bindEventSource(
-                              EVENT_SOURCES.CLOSE_BUTTON,
-                              onClose,
-                              event,
-                            );
-                            setIsOpenState(false);
-                          }}
-                          {...closeButtonProps}
-                        />
-                      ) : (
-                        closeButtonText && (
-                          <BpkButtonLink
-                            onClick={(
-                              event: SyntheticEvent<HTMLButtonElement>,
-                            ) => {
-                              bindEventSource(
-                                EVENT_SOURCES.CLOSE_LINK,
-                                onClose,
-                                event,
-                              );
-                              setIsOpenState(false);
-                            }}
-                            {...closeButtonProps}
-                          >
-                            {closeButtonText}
-                          </BpkButtonLink>
-                        )
-                      )}
+                      {closeButtonIcon
+                        ? closeButtonIconElement
+                        : !!closeButtonText && closeButtonTextElement}
                     </header>
                   ) : (
                     <span
@@ -300,7 +295,10 @@ const BpkPopover = ({
                       {label}
                     </span>
                   )}
-                  <div className={bodyClassNames}>{children}</div>
+                  <div className={bodyClassNames}>
+                    <div>{children}</div>
+                    {!labelAsTitle && closeButtonIcon && closeButtonIconElement}
+                  </div>
                   {actionText && onAction && (
                     <div className={getClassName('bpk-popover__action')}>
                       <BpkButtonLink onClick={onAction}>
@@ -310,19 +308,7 @@ const BpkPopover = ({
                   )}
                   {!labelAsTitle && closeButtonText && (
                     <footer className={getClassName('bpk-popover__footer')}>
-                      <BpkButtonLink
-                        onClick={(event: SyntheticEvent<HTMLButtonElement>) => {
-                          bindEventSource(
-                            EVENT_SOURCES.CLOSE_LINK,
-                            onClose,
-                            event,
-                          );
-                          setIsOpenState(false);
-                        }}
-                        {...closeButtonProps}
-                      >
-                        {closeButtonText}
-                      </BpkButtonLink>
+                      {closeButtonTextElement}
                     </footer>
                   )}
                 </section>

--- a/packages/bpk-component-popover/src/accessibility-test.tsx
+++ b/packages/bpk-component-popover/src/accessibility-test.tsx
@@ -30,6 +30,7 @@ describe('BpkPopover accessibility tests', () => {
         onClose={() => null}
         label="My popover"
         closeButtonText="Close"
+        closeButtonIcon={false}
         target={target}
         isOpen
         showArrow


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

### Description
This PR adds the close icon button by default when no title in BpkPopover. This change makes the BpkPopover closable when customer components doesn't pass labelAsTitle but wanna close icon button.
### Breaking: This change would affect the default UI of all BpkPopover with `labelAsTitle = false`




| Before                        | After                         |
| ----------------------------- | ----------------------------- |
| <img width="452" height="228" alt="image" src="https://github.com/user-attachments/assets/e5972d0f-b081-4405-9694-bf73c070f655" /> | <img width="415" height="245" alt="image" src="https://github.com/user-attachments/assets/2dc61d3d-cfd7-4f3c-94bc-cfbfb368a650" /> |


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [ ] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
