### PR TITLE
[CLOVER-532][BpkText] Add BpkText color prop with leverage css classname

### DIFF
--- a/examples/bpk-component-text/examples.js
+++ b/examples/bpk-component-text/examples.js
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-import { textColors } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
-
-import BpkText, { TEXT_STYLES } from '../../packages/bpk-component-text';
+import BpkText, { TEXT_COLORS, TEXT_STYLES } from '../../packages/bpk-component-text';
 import { withDefaultProps } from '../../packages/bpk-react-utils';
 
 const Paragraph = withDefaultProps(BpkText, {
@@ -182,8 +180,8 @@ const LarkenFallbackStylesExample = () => (
 );
 
 const ColorPropExample = () => (
-  <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p" color={textColors.textPrimaryDay}>
-    Text with color token textPrimaryDay
+  <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p" color={TEXT_COLORS.textSecondary}>
+    Text with color token textSecondary
   </BpkText>
 );
 

--- a/examples/bpk-component-text/examples.js
+++ b/examples/bpk-component-text/examples.js
@@ -192,7 +192,7 @@ const ColorPropExample = () => (
 
     <div className={getClassName('bpk-stories-text_success')}>
       <BpkText tagName="p" color={TEXT_COLORS.textSecondary}>
-          Text with color prop textSecondary with parent color override
+          Text with color prop textSecondary with parent className override
       </BpkText>
     </div>
 

--- a/examples/bpk-component-text/examples.js
+++ b/examples/bpk-component-text/examples.js
@@ -17,7 +17,12 @@
  */
 
 import BpkText, { TEXT_COLORS, TEXT_STYLES } from '../../packages/bpk-component-text';
-import { withDefaultProps } from '../../packages/bpk-react-utils';
+import { withDefaultProps , cssModules } from '../../packages/bpk-react-utils';
+
+
+import STYLES from './examples.module.scss';
+
+const getClassName = cssModules(STYLES);
 
 const Paragraph = withDefaultProps(BpkText, {
   textStyle: TEXT_STYLES.bodyLongform,
@@ -180,9 +185,28 @@ const LarkenFallbackStylesExample = () => (
 );
 
 const ColorPropExample = () => (
-  <BpkText tagName="p" color={TEXT_COLORS.textSecondary}>
-    Text with color token textSecondary
-  </BpkText>
+  <div>
+    <BpkText tagName="p" color={TEXT_COLORS.textSecondary}>
+      Text with color prop textSecondary
+    </BpkText>
+
+    <div className={getClassName('bpk-stories-text_success')}>
+      <BpkText tagName="p" color={TEXT_COLORS.textSecondary}>
+          Text with color prop textSecondary with parent color override
+      </BpkText>
+    </div>
+
+    <div className={getClassName('bpk-stories-text_success')}>
+       <BpkText tagName="p">
+        Text without color prop with parent color override
+      </BpkText>
+    </div>
+
+    <BpkText tagName="p" className={getClassName('bpk-stories-text_success')} color={TEXT_COLORS.textSecondary} >
+      Text with color prop textSecondary with self className override
+    </BpkText>
+
+  </div>
 );
 
 const MixedExample = () => (

--- a/examples/bpk-component-text/examples.js
+++ b/examples/bpk-component-text/examples.js
@@ -180,7 +180,7 @@ const LarkenFallbackStylesExample = () => (
 );
 
 const ColorPropExample = () => (
-  <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p" color={TEXT_COLORS.textSecondary}>
+  <BpkText tagName="p" color={TEXT_COLORS.textSecondary}>
     Text with color token textSecondary
   </BpkText>
 );

--- a/examples/bpk-component-text/examples.module.scss
+++ b/examples/bpk-component-text/examples.module.scss
@@ -1,0 +1,25 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../packages/unstable__bpk-mixins/tokens';
+
+.bpk-stories-text {
+  &_success {
+    color: tokens.$bpk-text-success-day;
+  }
+}

--- a/packages/bpk-component-text/README.md
+++ b/packages/bpk-component-text/README.md
@@ -82,15 +82,14 @@ export default () => (
 
 ### Color Prop
 
-The color prop allows you to customize the text color of the BpkText component rather override by className. It's recommended to use predefined tokens from [bpk-foundations-web](https://github.com/Skyscanner/backpack-foundations/tree/7f2a6358ddb288a2c8372f3ffef3d39fa97a40cf/packages/bpk-foundations-web/tokens) for consistency.
+The `color` prop allows you to set the text color directly rather override by  `className`. It uses predefined `TEXT_COLORS` tokens to ensure ux consistency with the design system.
 
 ```javascript
-import BpkText, { TEXT_STYLES } from '@skyscanner/backpack-web/bpk-component-text';
-import { textColors } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
+import BpkText, { TEXT_COLORS } from '@skyscanner/backpack-web/bpk-component-text';
 
 export default () => (
-  <BpkText textStyle={TEXT_STYLES.bodyDefault} color={textColors.textPrimaryDay}>
-    Text with token textPrimaryDay
+  <BpkText color={TEXT_COLORS.textSecondary}>
+    Text with token textSecondary
   </BpkText>
 );
 ```

--- a/packages/bpk-component-text/index.ts
+++ b/packages/bpk-component-text/index.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import component, { TEXT_STYLES } from './src/BpkText';
+import component, { TEXT_COLORS, TEXT_STYLES } from './src/BpkText';
 
 export default component;
-export { TEXT_STYLES };
+export { TEXT_COLORS, TEXT_STYLES };

--- a/packages/bpk-component-text/src/BpkText-test.tsx
+++ b/packages/bpk-component-text/src/BpkText-test.tsx
@@ -115,7 +115,6 @@ describe('BpkText', () => {
     const { getByText } = render(<BpkText color="invalid">{text}</BpkText>);
 
     expect(getByText(text)).toHaveClass('bpk-text bpk-text--body-default');
-    expect(getByText(text)).not.toHaveAttribute('style');
   });
 
   it('should render correctly with prop color with className', () => {

--- a/packages/bpk-component-text/src/BpkText-test.tsx
+++ b/packages/bpk-component-text/src/BpkText-test.tsx
@@ -106,7 +106,7 @@ describe('BpkText', () => {
     );
 
     expect(getByText(text)).toHaveClass(
-      `bpk-text bpk-text--body-default bpk-text--textSecondaryDay`,
+      `bpk-text bpk-text--body-default bpk-text--textSecondary`,
     );
   });
 
@@ -116,5 +116,17 @@ describe('BpkText', () => {
 
     expect(getByText(text)).toHaveClass('bpk-text bpk-text--body-default');
     expect(getByText(text)).not.toHaveAttribute('style');
+  });
+
+  it('should render correctly with prop color with className', () => {
+    const { getByText } = render(
+      <BpkText color={TEXT_COLORS.textSecondary} className="test-classname">
+        {text}
+      </BpkText>,
+    );
+
+    expect(getByText(text)).toHaveClass(
+      `bpk-text bpk-text--body-default bpk-text--textSecondary test-classname`,
+    );
   });
 });

--- a/packages/bpk-component-text/src/BpkText-test.tsx
+++ b/packages/bpk-component-text/src/BpkText-test.tsx
@@ -18,10 +18,11 @@
 
 import { render } from '@testing-library/react';
 
-import { textColors } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 import '@testing-library/jest-dom';
 
-import BpkText from './BpkText';
+import { textSecondaryDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
+
+import BpkText, { TEXT_COLORS } from './BpkText';
 
 import type { Tag, TextStyle } from './BpkText';
 
@@ -99,24 +100,18 @@ describe('BpkText', () => {
     });
   });
 
-  [
-    { color: textColors.textSecondaryDay, expected: 'rgb(98, 105, 113)' },
-    // eslint-disable-next-line backpack/use-tokens
-    { color: 'rgb(0, 98, 227)', expected: 'rgb(0, 98, 227)' },
-    // eslint-disable-next-line backpack/use-tokens
-    { color: '#0c838a', expected: 'rgb(12, 131, 138)' },
-    // eslint-disable-next-line backpack/use-tokens
-    { color: 'purple', expected: 'purple' },
-  ].forEach(({ color, expected }) => {
-    it(`should render correctly with color="${color}"`, () => {
-      const { getByText } = render(<BpkText color={color}>{text}</BpkText>);
+  it('should render correctly with prop color is token textSecondary', () => {
+    const { getByText } = render(
+      <BpkText color={TEXT_COLORS.textSecondary}>{text}</BpkText>,
+    );
 
-      expect(getByText(text)).toHaveClass('bpk-text bpk-text--body-default');
-      expect(getByText(text)).toHaveAttribute('style', `color: ${expected};`);
-    });
+    expect(getByText(text)).toHaveClass(
+      `bpk-text bpk-text--body-default bpk-text--textSecondaryDay`,
+    );
   });
 
-  it('should render correctly with prop color=invalid', () => {
+  it('should render correctly with prop color is invalid', () => {
+    // @ts-expect-error Type '"invalid"' is not assignable to type 'TextColor | null | undefined'.
     const { getByText } = render(<BpkText color="invalid">{text}</BpkText>);
 
     expect(getByText(text)).toHaveClass('bpk-text bpk-text--body-default');

--- a/packages/bpk-component-text/src/BpkText-test.tsx
+++ b/packages/bpk-component-text/src/BpkText-test.tsx
@@ -20,7 +20,7 @@ import { render } from '@testing-library/react';
 
 import '@testing-library/jest-dom';
 
-import { textSecondaryDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
+import { textSuccessDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 import BpkText, { TEXT_COLORS } from './BpkText';
 
@@ -99,33 +99,57 @@ describe('BpkText', () => {
       expect(getByText(text)).toHaveClass(`bpk-text bpk-text--${textStyle}`);
     });
   });
+  describe('text color prop', () => {
+    it('should render correctly with prop color is token textSecondary', () => {
+      const { getByText } = render(
+        <BpkText color={TEXT_COLORS.textSecondary}>{text}</BpkText>,
+      );
 
-  it('should render correctly with prop color is token textSecondary', () => {
-    const { getByText } = render(
-      <BpkText color={TEXT_COLORS.textSecondary}>{text}</BpkText>,
-    );
+      expect(getByText(text)).toHaveClass(
+        `bpk-text bpk-text--body-default bpk-text--text-secondary`,
+      );
+    });
 
-    expect(getByText(text)).toHaveClass(
-      `bpk-text bpk-text--body-default bpk-text--text-secondary`,
-    );
-  });
+    it('should render correctly with prop color is invalid', () => {
+      // @ts-expect-error Type '"invalid"' is not assignable to type 'TextColor | null | undefined'.
+      const { getByText } = render(<BpkText color="invalid">{text}</BpkText>);
 
-  it('should render correctly with prop color is invalid', () => {
-    // @ts-expect-error Type '"invalid"' is not assignable to type 'TextColor | null | undefined'.
-    const { getByText } = render(<BpkText color="invalid">{text}</BpkText>);
+      expect(getByText(text)).toHaveClass('bpk-text bpk-text--body-default');
+    });
 
-    expect(getByText(text)).toHaveClass('bpk-text bpk-text--body-default');
-  });
+    it('should render correctly with prop color with className', () => {
+      const { getByText } = render(
+        <BpkText color={TEXT_COLORS.textSecondary} className="test-classname">
+          {text}
+        </BpkText>,
+      );
 
-  it('should render correctly with prop color with className', () => {
-    const { getByText } = render(
-      <BpkText color={TEXT_COLORS.textSecondary} className="test-classname">
-        {text}
-      </BpkText>,
-    );
+      expect(getByText(text)).toHaveClass(
+        `bpk-text bpk-text--body-default bpk-text--text-secondary test-classname`,
+      );
+    });
 
-    expect(getByText(text)).toHaveClass(
-      `bpk-text bpk-text--body-default bpk-text--text-secondary test-classname`,
-    );
+    it('should inherit parent color when no color prop is provided', () => {
+      const { getByText } = render(
+        <div style={{ color: textSuccessDay }}>
+          <BpkText>{text}</BpkText>
+        </div>,
+      );
+
+      expect(getByText(text)).not.toHaveClass('bpk-text--text-success');
+      expect(window.getComputedStyle(getByText(text)).color).toBe(
+        textSuccessDay,
+      );
+    });
+
+    it('should not inherit parent color when color prop is provided', () => {
+      const { getByText } = render(
+        <div style={{ color: textSuccessDay }}>
+          <BpkText color={TEXT_COLORS.textError}>{text}</BpkText>
+        </div>,
+      );
+
+      expect(getByText(text)).toHaveClass('bpk-text--text-error');
+    });
   });
 });

--- a/packages/bpk-component-text/src/BpkText-test.tsx
+++ b/packages/bpk-component-text/src/BpkText-test.tsx
@@ -106,7 +106,7 @@ describe('BpkText', () => {
     );
 
     expect(getByText(text)).toHaveClass(
-      `bpk-text bpk-text--body-default bpk-text--textSecondary`,
+      `bpk-text bpk-text--body-default bpk-text--text-secondary`,
     );
   });
 
@@ -126,7 +126,7 @@ describe('BpkText', () => {
     );
 
     expect(getByText(text)).toHaveClass(
-      `bpk-text bpk-text--body-default bpk-text--textSecondary test-classname`,
+      `bpk-text bpk-text--body-default bpk-text--text-secondary test-classname`,
     );
   });
 });

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -37,12 +37,6 @@ $text-colors: (
 );
 
 .bpk-text {
-  @each $color-name, $color-token in $text-colors {
-    &--#{$color-name} {
-      color: $color-token;
-    }
-  }
-
   @include typography.bpk-text;
 
   &--xs {
@@ -167,5 +161,11 @@ $text-colors: (
 
   &--editorial-3 {
     @include typography.bpk-editorial-3;
+  }
+
+  @each $color-name, $color-token in $text-colors {
+    &--#{$color-name} {
+      color: $color-token;
+    }
   }
 }

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -26,7 +26,7 @@ $text-colors: (
   'text-success': tokens.$bpk-text-success-day,
   'text-error': tokens.$bpk-text-error-day,
   'text-disabled': tokens.$bpk-text-disabled-day,
-  'text-disabled-on-dark': tokens.$bpk-text-disabled-on-dark-day,
+  'text-disabled-dark': tokens.$bpk-text-disabled-on-dark-day,
   'text-primary-dark': tokens.$bpk-text-primary-dark-color,
   'text-primary-light': tokens.$bpk-text-primary-light-color,
   'text-secondary-dark': tokens.$bpk-text-secondary-dark-color,

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+@use '../../unstable__bpk-mixins/tokens';
 @use '../../unstable__bpk-mixins/typography';
 
 .bpk-text {
@@ -143,5 +144,61 @@
 
   &--editorial-3 {
     @include typography.bpk-editorial-3;
+  }
+
+  &--textHeroDay {
+    color: tokens.$bpk-text-hero-day;
+  }
+
+  &--textPrimaryDay {
+    color: tokens.$bpk-text-primary-day;
+  }
+
+  &--textSecondaryDay {
+    color: tokens.$bpk-text-secondary-day;
+  }
+
+  &--textSuccessDay {
+    color: tokens.$bpk-text-success-day;
+  }
+
+  &--textErrorDay {
+    color: tokens.$bpk-text-error-day;
+  }
+
+  &--textDisabledDay {
+    color: tokens.$bpk-text-disabled-day;
+  }
+
+  &--textDisabledOnDarkDay {
+    color: tokens.$bpk-text-disabled-on-dark-day;
+  }
+
+  &--textOnDarkDay {
+    color: tokens.$bpk-text-on-dark-day;
+  }
+
+  &--textPrimaryDarkColor {
+    color: tokens.$bpk-text-primary-dark-color;
+  }
+
+  &--textPrimaryLightColor {
+    color: tokens.$bpk-text-primary-light-color;
+  }
+
+  &--textSecondaryDarkColor {
+    color: tokens.$bpk-text-secondary-dark-color;
+  }
+
+  &--textSecondaryLightColor {
+    color: tokens.$bpk-text-secondary-light-color;
+  }
+
+  &--textTertiaryDarkColor {
+    color: tokens.$bpk-text-tertiary-dark-color;
+  }
+
+  &--textTertiaryLightColor {
+    color: tokens.$bpk-text-tertiary-light-color;
   }
 }

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -26,7 +26,7 @@ $text-colors: (
   'text-success': tokens.$bpk-text-success-day,
   'text-error': tokens.$bpk-text-error-day,
   'text-disabled': tokens.$bpk-text-disabled-day,
-  'text-disabled-dark': tokens.$bpk-text-disabled-on-dark-day,
+  'text-disabled-on-dark': tokens.$bpk-text-disabled-on-dark-day,
   'text-primary-dark': tokens.$bpk-text-primary-dark-color,
   'text-primary-light': tokens.$bpk-text-primary-light-color,
   'text-secondary-dark': tokens.$bpk-text-secondary-dark-color,

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -20,20 +20,20 @@
 @use '../../unstable__bpk-mixins/typography';
 
 $text-colors: (
-  'textHero': tokens.$bpk-text-hero-day,
-  'textPrimary': tokens.$bpk-text-primary-day,
-  'textSecondary': tokens.$bpk-text-secondary-day,
-  'textSuccess': tokens.$bpk-text-success-day,
-  'textError': tokens.$bpk-text-error-day,
-  'textDisabled': tokens.$bpk-text-disabled-day,
-  'textDisabledOnDark': tokens.$bpk-text-disabled-on-dark-day,
-  'textOnDark': tokens.$bpk-text-on-dark-day,
-  'textPrimaryDark': tokens.$bpk-text-primary-dark-color,
-  'textPrimaryLight': tokens.$bpk-text-primary-light-color,
-  'textSecondaryDark': tokens.$bpk-text-secondary-dark-color,
-  'textSecondaryLight': tokens.$bpk-text-secondary-light-color,
-  'textTertiaryDark': tokens.$bpk-text-tertiary-dark-color,
-  'textTertiaryLight': tokens.$bpk-text-tertiary-light-color,
+  'text-hero': tokens.$bpk-text-hero-day,
+  'text-primary': tokens.$bpk-text-primary-day,
+  'text-secondary': tokens.$bpk-text-secondary-day,
+  'text-success': tokens.$bpk-text-success-day,
+  'text-error': tokens.$bpk-text-error-day,
+  'text-disabled': tokens.$bpk-text-disabled-day,
+  'text-disabled-on-dark': tokens.$bpk-text-disabled-on-dark-day,
+  'text-on-dark': tokens.$bpk-text-on-dark-day,
+  'text-primary-dark': tokens.$bpk-text-primary-dark-color,
+  'text-primary-light': tokens.$bpk-text-primary-light-color,
+  'text-secondary-dark': tokens.$bpk-text-secondary-dark-color,
+  'text-secondary-light': tokens.$bpk-text-secondary-light-color,
+  'text-tertiary-dark': tokens.$bpk-text-tertiary-dark-color,
+  'text-tertiary-light': tokens.$bpk-text-tertiary-light-color,
 );
 
 .bpk-text {

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -20,19 +20,17 @@
 @use '../../unstable__bpk-mixins/typography';
 
 $text-colors: (
-  'text-hero': tokens.$bpk-text-hero-day,
-  'text-primary': tokens.$bpk-text-primary-day,
-  'text-secondary': tokens.$bpk-text-secondary-day,
-  'text-success': tokens.$bpk-text-success-day,
-  'text-error': tokens.$bpk-text-error-day,
   'text-disabled': tokens.$bpk-text-disabled-day,
   'text-disabled-on-dark': tokens.$bpk-text-disabled-on-dark-day,
-  'text-primary-dark': tokens.$bpk-text-primary-dark-color,
-  'text-primary-light': tokens.$bpk-text-primary-light-color,
-  'text-secondary-dark': tokens.$bpk-text-secondary-dark-color,
-  'text-secondary-light': tokens.$bpk-text-secondary-light-color,
-  'text-tertiary-dark': tokens.$bpk-text-tertiary-dark-color,
-  'text-tertiary-light': tokens.$bpk-text-tertiary-light-color,
+  'text-error': tokens.$bpk-text-error-day,
+  'text-hero': tokens.$bpk-text-hero-day,
+  'text-link': tokens.$bpk-text-link-day,
+  'text-on-dark': tokens.$bpk-text-on-dark-day,
+  'text-on-light': tokens.$bpk-text-on-light-day,
+  'text-primary': tokens.$bpk-text-primary-day,
+  'text-primary-inverse': tokens.$bpk-text-primary-inverse-day,
+  'text-secondary': tokens.$bpk-text-secondary-day,
+  'text-success': tokens.$bpk-text-success-day,
 );
 
 .bpk-text {
@@ -162,9 +160,9 @@ $text-colors: (
     @include typography.bpk-editorial-3;
   }
 
-  @each $color-name, $color-token in $text-colors {
+  @each $color-name, $color-value in $text-colors {
     &--#{$color-name} {
-      color: $color-token;
+      color: $color-value;
     }
   }
 }

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -20,23 +20,29 @@
 @use '../../unstable__bpk-mixins/typography';
 
 $text-colors: (
-  'textHeroDay': tokens.$bpk-text-hero-day,
-  'textPrimaryDay': tokens.$bpk-text-primary-day,
-  'textSecondaryDay': tokens.$bpk-text-secondary-day,
-  'textSuccessDay': tokens.$bpk-text-success-day,
-  'textErrorDay': tokens.$bpk-text-error-day,
-  'textDisabledDay': tokens.$bpk-text-disabled-day,
-  'textDisabledOnDarkDay': tokens.$bpk-text-disabled-on-dark-day,
-  'textOnDarkDay': tokens.$bpk-text-on-dark-day,
-  'textPrimaryDarkColor': tokens.$bpk-text-primary-dark-color,
-  'textPrimaryLightColor': tokens.$bpk-text-primary-light-color,
-  'textSecondaryDarkColor': tokens.$bpk-text-secondary-dark-color,
-  'textSecondaryLightColor': tokens.$bpk-text-secondary-light-color,
-  'textTertiaryDarkColor': tokens.$bpk-text-tertiary-dark-color,
-  'textTertiaryLightColor': tokens.$bpk-text-tertiary-light-color,
+  'textHero': tokens.$bpk-text-hero-day,
+  'textPrimary': tokens.$bpk-text-primary-day,
+  'textSecondary': tokens.$bpk-text-secondary-day,
+  'textSuccess': tokens.$bpk-text-success-day,
+  'textError': tokens.$bpk-text-error-day,
+  'textDisabled': tokens.$bpk-text-disabled-day,
+  'textDisabledOnDark': tokens.$bpk-text-disabled-on-dark-day,
+  'textOnDark': tokens.$bpk-text-on-dark-day,
+  'textPrimaryDark': tokens.$bpk-text-primary-dark-color,
+  'textPrimaryLight': tokens.$bpk-text-primary-light-color,
+  'textSecondaryDark': tokens.$bpk-text-secondary-dark-color,
+  'textSecondaryLight': tokens.$bpk-text-secondary-light-color,
+  'textTertiaryDark': tokens.$bpk-text-tertiary-dark-color,
+  'textTertiaryLight': tokens.$bpk-text-tertiary-light-color,
 );
 
 .bpk-text {
+  @each $color-name, $color-token in $text-colors {
+    &--#{$color-name} {
+      color: $color-token;
+    }
+  }
+
   @include typography.bpk-text;
 
   &--xs {
@@ -161,11 +167,5 @@ $text-colors: (
 
   &--editorial-3 {
     @include typography.bpk-editorial-3;
-  }
-
-  @each $class-name, $color-token in $text-colors {
-    &--#{$class-name} {
-      color: $color-token;
-    }
   }
 }

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -19,6 +19,23 @@
 @use '../../unstable__bpk-mixins/tokens';
 @use '../../unstable__bpk-mixins/typography';
 
+$text-colors: (
+  'textHeroDay': tokens.$bpk-text-hero-day,
+  'textPrimaryDay': tokens.$bpk-text-primary-day,
+  'textSecondaryDay': tokens.$bpk-text-secondary-day,
+  'textSuccessDay': tokens.$bpk-text-success-day,
+  'textErrorDay': tokens.$bpk-text-error-day,
+  'textDisabledDay': tokens.$bpk-text-disabled-day,
+  'textDisabledOnDarkDay': tokens.$bpk-text-disabled-on-dark-day,
+  'textOnDarkDay': tokens.$bpk-text-on-dark-day,
+  'textPrimaryDarkColor': tokens.$bpk-text-primary-dark-color,
+  'textPrimaryLightColor': tokens.$bpk-text-primary-light-color,
+  'textSecondaryDarkColor': tokens.$bpk-text-secondary-dark-color,
+  'textSecondaryLightColor': tokens.$bpk-text-secondary-light-color,
+  'textTertiaryDarkColor': tokens.$bpk-text-tertiary-dark-color,
+  'textTertiaryLightColor': tokens.$bpk-text-tertiary-light-color,
+);
+
 .bpk-text {
   @include typography.bpk-text;
 
@@ -146,59 +163,9 @@
     @include typography.bpk-editorial-3;
   }
 
-  &--textHeroDay {
-    color: tokens.$bpk-text-hero-day;
-  }
-
-  &--textPrimaryDay {
-    color: tokens.$bpk-text-primary-day;
-  }
-
-  &--textSecondaryDay {
-    color: tokens.$bpk-text-secondary-day;
-  }
-
-  &--textSuccessDay {
-    color: tokens.$bpk-text-success-day;
-  }
-
-  &--textErrorDay {
-    color: tokens.$bpk-text-error-day;
-  }
-
-  &--textDisabledDay {
-    color: tokens.$bpk-text-disabled-day;
-  }
-
-  &--textDisabledOnDarkDay {
-    color: tokens.$bpk-text-disabled-on-dark-day;
-  }
-
-  &--textOnDarkDay {
-    color: tokens.$bpk-text-on-dark-day;
-  }
-
-  &--textPrimaryDarkColor {
-    color: tokens.$bpk-text-primary-dark-color;
-  }
-
-  &--textPrimaryLightColor {
-    color: tokens.$bpk-text-primary-light-color;
-  }
-
-  &--textSecondaryDarkColor {
-    color: tokens.$bpk-text-secondary-dark-color;
-  }
-
-  &--textSecondaryLightColor {
-    color: tokens.$bpk-text-secondary-light-color;
-  }
-
-  &--textTertiaryDarkColor {
-    color: tokens.$bpk-text-tertiary-dark-color;
-  }
-
-  &--textTertiaryLightColor {
-    color: tokens.$bpk-text-tertiary-light-color;
+  @each $class-name, $color-token in $text-colors {
+    &--#{$class-name} {
+      color: $color-token;
+    }
   }
 }

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -161,7 +161,7 @@ $text-colors: (
   }
 
   @each $color-name, $color-value in $text-colors {
-    &--#{$color-name} {
+    &.bpk-text--#{$color-name} {
       color: $color-value;
     }
   }

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -27,7 +27,6 @@ $text-colors: (
   'text-error': tokens.$bpk-text-error-day,
   'text-disabled': tokens.$bpk-text-disabled-day,
   'text-disabled-on-dark': tokens.$bpk-text-disabled-on-dark-day,
-  'text-on-dark': tokens.$bpk-text-on-dark-day,
   'text-primary-dark': tokens.$bpk-text-primary-dark-color,
   'text-primary-light': tokens.$bpk-text-primary-light-color,
   'text-secondary-dark': tokens.$bpk-text-secondary-dark-color,

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -59,19 +59,17 @@ export const TEXT_STYLES = {
 } as const;
 
 export const TEXT_COLORS = {
-  textHero: 'text-hero',
-  textPrimary: 'text-primary',
-  textSecondary: 'text-secondary',
-  textSuccess: 'text-success',
-  textError: 'text-error',
   textDisabled: 'text-disabled',
   textDisabledOnDark: 'text-disabled-on-dark',
-  textPrimaryDark: 'text-primary-dark',
-  textPrimaryLight: 'text-primary-light',
-  textSecondaryDark: 'text-secondary-dark',
-  textSecondaryLight: 'text-secondary-light',
-  textTertiaryDark: 'text-tertiary-dark',
-  textTertiaryLight: 'text-tertiary-light',
+  textError: 'text-error',
+  textHero: 'text-hero',
+  textLink: 'text-link',
+  textOnDark: 'text-on-dark',
+  textOnLight: 'text-on-light',
+  textPrimary: 'text-primary',
+  textPrimaryInverse: 'text-primary-inverse',
+  textSecondary: 'text-secondary',
+  textSuccess: 'text-success',
 } as const;
 
 export type TextColor = (typeof TEXT_COLORS)[keyof typeof TEXT_COLORS];

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -58,6 +58,24 @@ export const TEXT_STYLES = {
   editorial3: 'editorial-3',
 } as const;
 
+export const TEXT_COLORS = {
+  textHero: 'textHeroDay',
+  textPrimary: 'textPrimaryDay',
+  textSecondary: 'textSecondaryDay',
+  textSuccess: 'textSuccessDay',
+  textError: 'textErrorDay',
+  textDisabled: 'textDisabledDay',
+  textDisabledOnDark: 'textDisabledOnDarkDay',
+  textOnDark: 'textOnDarkDay',
+  textPrimaryDark: 'textPrimaryDarkColor',
+  textPrimaryLight: 'textPrimaryLightColor',
+  textSecondaryDark: 'textSecondaryDarkColor',
+  textSecondaryLight: 'textSecondaryLightColor',
+  textTertiaryDark: 'textTertiaryDarkColor',
+  textTertiaryLight: 'textTertiaryLightColor',
+} as const;
+
+export type TextColor = (typeof TEXT_COLORS)[keyof typeof TEXT_COLORS];
 export type TextStyle = (typeof TEXT_STYLES)[keyof typeof TEXT_STYLES];
 export type Tag =
   | 'span'
@@ -75,7 +93,7 @@ type Props = {
   textStyle?: TextStyle;
   tagName?: Tag;
   className?: string | null;
-  color?: string | null;
+  color?: TextColor | null;
   id?: string;
   [rest: string]: any;
 };
@@ -91,16 +109,14 @@ const BpkText = ({
   const classNames = getClassName(
     'bpk-text',
     `bpk-text--${textStyle}`,
+    color ? `bpk-text--${color}` : '',
     className,
   );
-
-  const { style, ...otherProps } = rest;
-  const computedStyles = { ...style, ...(color ? { color } : {}) };
 
   return (
     // Allowed, TagName is always a dom element.
     // eslint-disable-next-line @skyscanner/rules/forbid-component-props
-    <TagName className={classNames} style={computedStyles} {...otherProps}>
+    <TagName className={classNames} {...rest}>
       {children}
     </TagName>
   );

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -65,7 +65,7 @@ export const TEXT_COLORS = {
   textSuccess: 'text-success',
   textError: 'text-error',
   textDisabled: 'text-disabled',
-  textDisabledDark: 'text-disabled-dark',
+  textDisabledOnDark: 'text-disabled-on-dark',
   textPrimaryDark: 'text-primary-dark',
   textPrimaryLight: 'text-primary-light',
   textSecondaryDark: 'text-secondary-dark',

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -58,22 +58,22 @@ export const TEXT_STYLES = {
   editorial3: 'editorial-3',
 } as const;
 
-export const TEXT_COLORS = {
-  textHero: 'textHeroDay',
-  textPrimary: 'textPrimaryDay',
-  textSecondary: 'textSecondaryDay',
-  textSuccess: 'textSuccessDay',
-  textError: 'textErrorDay',
-  textDisabled: 'textDisabledDay',
-  textDisabledOnDark: 'textDisabledOnDarkDay',
-  textOnDark: 'textOnDarkDay',
-  textPrimaryDark: 'textPrimaryDarkColor',
-  textPrimaryLight: 'textPrimaryLightColor',
-  textSecondaryDark: 'textSecondaryDarkColor',
-  textSecondaryLight: 'textSecondaryLightColor',
-  textTertiaryDark: 'textTertiaryDarkColor',
-  textTertiaryLight: 'textTertiaryLightColor',
-} as const;
+export const TEXT_COLORS = [
+  'textHero',
+  'textPrimary',
+  'textSecondary',
+  'textSuccess',
+  'textError',
+  'textDisabled',
+  'textDisabledOnDark',
+  'textOnDark',
+  'textPrimaryDark',
+  'textPrimaryLight',
+  'textSecondaryDark',
+  'textSecondaryLight',
+  'textTertiaryDark',
+  'textTertiaryLight',
+] as const;
 
 export type TextColor = (typeof TEXT_COLORS)[keyof typeof TEXT_COLORS];
 export type TextStyle = (typeof TEXT_STYLES)[keyof typeof TEXT_STYLES];

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -66,7 +66,6 @@ export const TEXT_COLORS = {
   textError: 'text-error',
   textDisabled: 'text-disabled',
   textDisabledOnDark: 'text-disabled-on-dark',
-  textOnDark: 'text-on-dark',
   textPrimaryDark: 'text-primary-dark',
   textPrimaryLight: 'text-primary-light',
   textSecondaryDark: 'text-secondary-dark',

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -59,20 +59,20 @@ export const TEXT_STYLES = {
 } as const;
 
 export const TEXT_COLORS = {
-  textHero: 'textHero',
-  textPrimary: 'textPrimary',
-  textSecondary: 'textSecondary',
-  textSuccess: 'textSuccess',
-  textError: 'textError',
-  textDisabled: 'textDisabled',
-  textDisabledOnDark: 'textDisabledOnDark',
-  textOnDark: 'textOnDark',
-  textPrimaryDark: 'textPrimaryDark',
-  textPrimaryLight: 'textPrimaryLight',
-  textSecondaryDark: 'textSecondaryDark',
-  textSecondaryLight: 'textSecondaryLight',
-  textTertiaryDark: 'textTertiaryDark',
-  textTertiaryLight: 'textTertiaryLight',
+  textHero: 'text-hero',
+  textPrimary: 'text-primary',
+  textSecondary: 'text-secondary',
+  textSuccess: 'text-success',
+  textError: 'text-error',
+  textDisabled: 'text-disabled',
+  textDisabledOnDark: 'text-disabled-on-dark',
+  textOnDark: 'text-on-dark',
+  textPrimaryDark: 'text-primary-dark',
+  textPrimaryLight: 'text-primary-light',
+  textSecondaryDark: 'text-secondary-dark',
+  textSecondaryLight: 'text-secondary-light',
+  textTertiaryDark: 'text-tertiary-dark',
+  textTertiaryLight: 'text-tertiary-light',
 } as const;
 
 export type TextColor = (typeof TEXT_COLORS)[keyof typeof TEXT_COLORS];

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -65,7 +65,7 @@ export const TEXT_COLORS = {
   textSuccess: 'text-success',
   textError: 'text-error',
   textDisabled: 'text-disabled',
-  textDisabledOnDark: 'text-disabled-on-dark',
+  textDisabledDark: 'text-disabled-dark',
   textPrimaryDark: 'text-primary-dark',
   textPrimaryLight: 'text-primary-light',
   textSecondaryDark: 'text-secondary-dark',

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -58,22 +58,22 @@ export const TEXT_STYLES = {
   editorial3: 'editorial-3',
 } as const;
 
-export const TEXT_COLORS = [
-  'textHero',
-  'textPrimary',
-  'textSecondary',
-  'textSuccess',
-  'textError',
-  'textDisabled',
-  'textDisabledOnDark',
-  'textOnDark',
-  'textPrimaryDark',
-  'textPrimaryLight',
-  'textSecondaryDark',
-  'textSecondaryLight',
-  'textTertiaryDark',
-  'textTertiaryLight',
-] as const;
+export const TEXT_COLORS = {
+  textHero: 'textHero',
+  textPrimary: 'textPrimary',
+  textSecondary: 'textSecondary',
+  textSuccess: 'textSuccess',
+  textError: 'textError',
+  textDisabled: 'textDisabled',
+  textDisabledOnDark: 'textDisabledOnDark',
+  textOnDark: 'textOnDark',
+  textPrimaryDark: 'textPrimaryDark',
+  textPrimaryLight: 'textPrimaryLight',
+  textSecondaryDark: 'textSecondaryDark',
+  textSecondaryLight: 'textSecondaryLight',
+  textTertiaryDark: 'textTertiaryDark',
+  textTertiaryLight: 'textTertiaryLight',
+} as const;
 
 export type TextColor = (typeof TEXT_COLORS)[keyof typeof TEXT_COLORS];
 export type TextStyle = (typeof TEXT_STYLES)[keyof typeof TEXT_STYLES];


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

**Context**

BpkText’s lack of default or token-based color support leads to widespread manual style overrides (average 14.88% per major page), undermining VDL consistency and reducing design system reliability and maintainability across Skyscanner products.

We have added color prop so that consumer can change `BpkText` color by config but not override before, and want to constraint for `BpkText` color prop only allowed BPK text color tokens.

**Changes**
- Add `BpkText` color prop with leverage css classname, replaces inline style-based color prop with CSS class-based approach using predefined tokens
- Exports `TEXT_COLORS` constants and `TextColor` type for consumer use
- Updates tests and documentation to reflect the new color prop implementation

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
