### PR TITLE
[CAPY-1583][BpkNavigationTabGroup] Package experiment visual change implementation - hidden behind feature flags

### DIFF
--- a/examples/bpk-component-navigation-tab-group/examples.tsx
+++ b/examples/bpk-component-navigation-tab-group/examples.tsx
@@ -214,6 +214,22 @@ const TabsWithBlankTarget = () => (
   </div>
 );
 
+// Tabs with Packages Experiment Tab
+const TabsWithPackagesVisualChangeExample = () => (
+  <div className={getClassNames('bpk-navigation-tab-group-story')}>
+    <BpkNavigationTabGroup
+      id="navExample"
+      tabs={tabsWithPackagesAndIcons}
+      onItemClick={() => {}}
+      selectedIndex={2}
+      type={NAVIGATION_TAB_GROUP_TYPES.SurfaceContrast}
+      ariaLabel="Navigation tabs"
+      packagesExperimentEnabled
+      packagesExperimentVersion={PackageExperimentVersions.VISUAL_CHANGE_ONLY}
+    />
+  </div>
+);
+
 const VisualTestExample = () => (
   <div className={getClassNames('bpk-navigation-tab-group-story__mixed-container')}>
     <BpkText textStyle={TEXT_STYLES.heading3} tagName="h3">
@@ -248,23 +264,11 @@ const VisualTestExample = () => (
       No Href CanvasDefault
     </BpkText>
     <TabsNoHrefCanvasDefaultForExample />
+    <BpkText textStyle={TEXT_STYLES.heading3} tagName="h3">
+      Header Tab With Packages Experiment - Visual Change Only
+    </BpkText>
+    <TabsWithPackagesVisualChangeExample />
     <br />
-  </div>
-);
-
-// Tabs with Packages Experiment Tab
-const TabsWithPackagesVisualChangeExample = () => (
-  <div className={getClassNames('bpk-navigation-tab-group-story')}>
-    <BpkNavigationTabGroup
-      id="navExample"
-      tabs={tabsWithPackagesAndIcons}
-      onItemClick={() => {}}
-      selectedIndex={2}
-      type={NAVIGATION_TAB_GROUP_TYPES.SurfaceContrast}
-      ariaLabel="Navigation tabs"
-      packagesExperimentEnabled
-      packagesExperimentVersion={PackageExperimentVersions.VISUAL_CHANGE_ONLY}
-    />
   </div>
 );
 

--- a/examples/bpk-component-navigation-tab-group/examples.tsx
+++ b/examples/bpk-component-navigation-tab-group/examples.tsx
@@ -16,12 +16,16 @@
  * limitations under the License.
  */
 import { withRtlSupport } from '../../packages/bpk-component-icon';
+import Beach from '../../packages/bpk-component-icon/sm/beach';
 import Car from '../../packages/bpk-component-icon/sm/cars';
 import Explore from '../../packages/bpk-component-icon/sm/explore';
 import Flight from '../../packages/bpk-component-icon/sm/flight';
 import Hotel from '../../packages/bpk-component-icon/sm/hotels';
 import BpkNavigationTabGroup from '../../packages/bpk-component-navigation-tab-group';
-import { NAVIGATION_TAB_GROUP_TYPES } from '../../packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup';
+import {
+  NAVIGATION_TAB_GROUP_TYPES,
+  PackageExperimentVersions,
+} from '../../packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup';
 import BpkText, { TEXT_STYLES } from '../../packages/bpk-component-text';
 import { cssModules } from '../../packages/bpk-react-utils';
 
@@ -39,6 +43,8 @@ const carIcons = withRtlSupport(Car);
 
 const flightIcons = withRtlSupport(Flight);
 
+const packageIcons = withRtlSupport(Beach);
+
 const tabs: BpkNavigationTabGroupProps['tabs'] = [
   { id: 'air', text: 'Flights', href: '/' },
   { id: 'hotel', text: 'Hotels', href: '/hotel' },
@@ -51,6 +57,13 @@ const tabsWithIcon: BpkNavigationTabGroupProps['tabs'] = [
   { id: 'hotel', text: 'Hotels', href: '/hotel', icon: hotelIcons, 'data-cy':'hotel-feature', 'data-analytics':'hotels' },
   { id: 'car', text: 'Car hire', href: '/carhire', icon: carIcons, 'data-cy':'carhire-feature', 'data-analytics':'car hire' },
   { id: 'explore', text: 'Explore', href: '/Explore', icon: exploreIcons, 'data-cy':'explore-feature', 'data-analytics':'explore' },
+];
+
+const tabsWithPackagesAndIcons: BpkNavigationTabGroupProps['tabs'] = [
+  { id: 'air', text: 'Flights', href: '/', icon: flightIcons, 'data-cy':'flight-feature', 'data-analytics':'flights' },
+  { id: 'hotel', text: 'Hotels', href: '/hotel', icon: hotelIcons, 'data-cy':'hotel-feature', 'data-analytics':'hotels' },
+  { id: 'car', text: 'Car hire', href: '/carhire', icon: carIcons, 'data-cy':'carhire-feature', 'data-analytics':'car hire' },
+  { id: 'packages', text: 'Packages', href: '/destinations/packages-holidays', icon: packageIcons, 'data-cy':'packages', 'data-analytics':'packages' },
 ];
 
 const tabsNoHref: BpkNavigationTabGroupProps['tabs'] = [
@@ -239,6 +252,22 @@ const VisualTestExample = () => (
   </div>
 );
 
+// Tabs with Packages Experiment Tab
+const TabsWithPackagesVisualChangeExample = () => (
+  <div className={getClassNames('bpk-navigation-tab-group-story')}>
+    <BpkNavigationTabGroup
+      id="navExample"
+      tabs={tabsWithPackagesAndIcons}
+      onItemClick={() => {}}
+      selectedIndex={2}
+      type={NAVIGATION_TAB_GROUP_TYPES.SurfaceContrast}
+      ariaLabel="Navigation tabs"
+      packagesExperimentEnabled
+      packagesExperimentVersion={PackageExperimentVersions.VISUAL_CHANGE_ONLY}
+    />
+  </div>
+);
+
 export {
   SimpleSurfaceContrast,
   SimpleCanvasDefault,
@@ -250,4 +279,5 @@ export {
   TabsOnlyTextCanvasDefaultForExample,
   TabsWithBlankTarget,
   VisualTestExample,
+  TabsWithPackagesVisualChangeExample,
 };

--- a/examples/bpk-component-navigation-tab-group/stories.tsx
+++ b/examples/bpk-component-navigation-tab-group/stories.tsx
@@ -29,6 +29,7 @@ import {
   TabsOnlyTextCanvasDefaultForExample,
   TabsWithBlankTarget,
   VisualTestExample,
+  TabsWithPackagesVisualChangeExample,
 } from './examples';
 
 export default {
@@ -55,6 +56,8 @@ export const OnlyTextCanvasDefault = TabsOnlyTextCanvasDefaultForExample;
 export const WithBlankTarget = TabsWithBlankTarget;
 
 export const VisualTest = VisualTestExample;
+
+export const PackagesExperimentVisualChange = TabsWithPackagesVisualChangeExample;
 
 export const VisualTestWithZoom = {
   render: VisualTest,

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.module.scss
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.module.scss
@@ -26,6 +26,9 @@
   white-space: nowrap;
 }
 
+$bpk-navigation-tab-min-width-visual-change-only: tokens.bpk-spacing-xxxl() +
+  tokens.bpk-spacing-md() + tokens.bpk-spacing-sm();
+
 .bpk-navigation-tab-group {
   display: flex;
 
@@ -72,9 +75,7 @@
     }
 
     &--visual-change-only {
-      display: flex;
-      min-width: tokens.bpk-spacing-xxxl() + tokens.bpk-spacing-md() +
-        tokens.bpk-spacing-sm();
+      min-width: $bpk-navigation-tab-min-width-visual-change-only;
       min-height: tokens.bpk-spacing-xxl() + tokens.bpk-spacing-base();
       padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
       flex-direction: column;
@@ -82,6 +83,8 @@
       align-items: center;
       border-radius: tokens.$bpk-border-radius-nav-tabs;
       text-align: center;
+
+      @include borders.bpk-border-sm(tokens.$bpk-text-disabled-night);
     }
 
     &--canvas-default {

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.module.scss
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.module.scss
@@ -71,6 +71,19 @@
       }
     }
 
+    &--visual-change-only {
+      display: flex;
+      min-width: tokens.bpk-spacing-xxxl() + tokens.bpk-spacing-md() +
+        tokens.bpk-spacing-sm();
+      min-height: tokens.bpk-spacing-xxl() + tokens.bpk-spacing-base();
+      padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      border-radius: tokens.$bpk-border-radius-nav-tabs;
+      text-align: center;
+    }
+
     &--canvas-default {
       background-color: transparent;
       color: tokens.$bpk-text-primary-day;
@@ -113,6 +126,10 @@
       &-selected {
         fill: tokens.$bpk-text-on-dark-day;
       }
+    }
+
+    &--visual-change-only-experiment {
+      margin-inline-end: 0;
     }
   }
 }

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.module.scss
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.module.scss
@@ -74,9 +74,9 @@ $bpk-navigation-tab-min-width-visual-change-only: tokens.bpk-spacing-xxxl() +
       }
     }
 
-    &--visual-change-only {
+    &--visual-change-only-packages-experiment {
       min-width: $bpk-navigation-tab-min-width-visual-change-only;
-      min-height: tokens.bpk-spacing-xxl() + tokens.bpk-spacing-base();
+      min-height: tokens.bpk-spacing-xxl() + tokens.bpk-spacing-md();
       padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
       flex-direction: column;
       justify-content: center;

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
@@ -83,7 +83,7 @@ const TabWrap = ({ children, onClick, packagesExperimentEnabled, packagesExperim
     'bpk-navigation-tab-wrap',
     `bpk-navigation-tab-wrap--${type}`,
     selected && `bpk-navigation-tab-wrap--${type}-selected`,
-    (isVisualChangeExperimentEnabled(packagesExperimentEnabled, packagesExperimentVersion)) && 'bpk-navigation-tab-wrap--visual-change-only',
+    (isVisualChangeExperimentEnabled(packagesExperimentEnabled, packagesExperimentVersion)) && 'bpk-navigation-tab-wrap--visual-change-only-packages-experiment',
   );
 
   return tab.href ? (

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
@@ -73,12 +73,17 @@ type TabWrapProps = {
   packagesExperimentVersion?: string;
 };
 
+const isVisualChangeExperimentEnabled = (
+  packagesExperimentEnabled?: boolean,
+  packagesExperimentVersion?: string,
+): boolean | undefined => packagesExperimentEnabled && packagesExperimentVersion === PackageExperimentVersions.VISUAL_CHANGE_ONLY
+
 const TabWrap = ({ children, onClick, packagesExperimentEnabled, packagesExperimentVersion, selected, tab, type }: TabWrapProps) => {
   const tabStyling = getClassName(
     'bpk-navigation-tab-wrap',
     `bpk-navigation-tab-wrap--${type}`,
     selected && `bpk-navigation-tab-wrap--${type}-selected`,
-    (packagesExperimentEnabled && packagesExperimentVersion === PackageExperimentVersions.VISUAL_CHANGE_ONLY) && 'bpk-navigation-tab-wrap--visual-change-only',
+    (isVisualChangeExperimentEnabled(packagesExperimentEnabled, packagesExperimentVersion)) && 'bpk-navigation-tab-wrap--visual-change-only',
   );
 
   return tab.href ? (
@@ -126,8 +131,7 @@ const BpkNavigationTabGroup = ({
     onItemClick(e, tab, index);
   };
 
-  const visualChangeExperimentPackagesTabEnabled =
-    packagesExperimentEnabled && packagesExperimentVersion === PackageExperimentVersions.VISUAL_CHANGE_ONLY;
+  const visualChangeExperimentPackagesTabEnabled = isVisualChangeExperimentEnabled(packagesExperimentEnabled, packagesExperimentVersion);
 
   const containerStyling = getClassName('bpk-navigation-tab-group');
 

--- a/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+++ b/packages/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
@@ -39,6 +39,12 @@ type TabWrapItem = {
   [rest: string]: any;
 };
 
+export const PackageExperimentVersions = {
+  NO_VISUAL_CHANGES_WITH_NEW_BUBBLE: 'NO_VISUAL_CHANGES_WITH_NEW_BUBBLE',
+  VISUAL_CHANGE_ONLY: 'VISUAL_CHANGE_ONLY',
+  VISUAL_CHANGE_AND_NEW_BUBBLE: 'VISUAL_CHANGE_AND_NEW_BUBBLE',
+};
+
 type TabItem = TabWrapItem & {
   text: string;
   icon?: FunctionComponent<any> | null;
@@ -53,6 +59,8 @@ export type Props = {
   onItemClick: (e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>,tab: TabItem, index: number) => void;
   selectedIndex: number;
   ariaLabel: string;
+  packagesExperimentEnabled?: boolean;
+  packagesExperimentVersion?: string;
 };
 
 type TabWrapProps = {
@@ -61,13 +69,16 @@ type TabWrapProps = {
   selected: boolean;
   children: ReactElement;
   onClick: (e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+  packagesExperimentEnabled?: boolean;
+  packagesExperimentVersion?: string;
 };
 
-const TabWrap = ({ children, onClick, selected, tab, type }: TabWrapProps) => {
+const TabWrap = ({ children, onClick, packagesExperimentEnabled, packagesExperimentVersion, selected, tab, type }: TabWrapProps) => {
   const tabStyling = getClassName(
     'bpk-navigation-tab-wrap',
     `bpk-navigation-tab-wrap--${type}`,
     selected && `bpk-navigation-tab-wrap--${type}-selected`,
+    (packagesExperimentEnabled && packagesExperimentVersion === PackageExperimentVersions.VISUAL_CHANGE_ONLY) && 'bpk-navigation-tab-wrap--visual-change-only',
   );
 
   return tab.href ? (
@@ -101,6 +112,8 @@ const BpkNavigationTabGroup = ({
   ariaLabel,
   id,
   onItemClick,
+  packagesExperimentEnabled = false,
+  packagesExperimentVersion = '',
   selectedIndex,
   tabs,
   type = NAVIGATION_TAB_GROUP_TYPES.SurfaceContrast,
@@ -112,6 +125,9 @@ const BpkNavigationTabGroup = ({
     }
     onItemClick(e, tab, index);
   };
+
+  const visualChangeExperimentPackagesTabEnabled =
+    packagesExperimentEnabled && packagesExperimentVersion === PackageExperimentVersions.VISUAL_CHANGE_ONLY;
 
   const containerStyling = getClassName('bpk-navigation-tab-group');
 
@@ -134,6 +150,8 @@ const BpkNavigationTabGroup = ({
             selected={selected}
             onClick={(e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => handleButtonClick(e, tab, index)}
             type={type}
+            packagesExperimentEnabled={packagesExperimentEnabled}
+            packagesExperimentVersion={packagesExperimentVersion}
           >
             <>
               {Icon && (
@@ -141,6 +159,7 @@ const BpkNavigationTabGroup = ({
                   className={getClassName(
                     'bpk-navigation-tab-icon',
                     `bpk-navigation-tab-icon--${type}`,
+                    visualChangeExperimentPackagesTabEnabled && 'bpk-navigation-tab-icon--visual-change-only-experiment',
                     selected && `bpk-navigation-tab-icon--${type}-selected`,
                   )}
                 >


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
The PR does not introduce breaking changes as it is hiding new functionality behind feature flags.


Before:
<img width="425" height="136" alt="image" src="https://github.com/user-attachments/assets/f97c3c4c-3cec-4783-8d18-ce6a461c3f5c" />


After:
RTL OFF:
<img width="425" height="136" alt="image" src="https://github.com/user-attachments/assets/86902164-1d03-47bf-a79f-2deb243cac28" />

RTL ON:
<img width="879" height="132" alt="image" src="https://github.com/user-attachments/assets/e957b0ac-b49b-40a1-b4c0-920ddc6816ee" />


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
