### PR TITLE
[NOJIRA][BpkModal]fix closeText style of BpkModal in dark mode

### DIFF
--- a/examples/bpk-component-modal/examples.tsx
+++ b/examples/bpk-component-modal/examples.tsx
@@ -143,7 +143,7 @@ const ModalContainer = (props: ContainerProps) => {
 };
 
 const DefaultExample = (isOpen: boolean) => (
-  <ModalContainer title="Modal title" closeLabel="Close modal" isOpen={isOpen} >
+  <ModalContainer title="Modal title" closeLabel="Close modal" isOpen={isOpen}>
     This is a default modal. You can put anything you want in here.
   </ModalContainer>
 );
@@ -160,7 +160,12 @@ const ContrastExample = (isOpen: boolean) => (
 );
 
 const WideExample = (isOpen: boolean) => (
-  <ModalContainer title="Modal title" closeLabel="Close modal" isOpen={isOpen} wide>
+  <ModalContainer
+    title="Modal title"
+    closeLabel="Close modal"
+    isOpen={isOpen}
+    wide
+  >
     This is a wide modal.
   </ModalContainer>
 );
@@ -174,6 +179,17 @@ const OverflowingExample = (isOpen: boolean) => (
 const CloseButtonTextExample = (isOpen: boolean) => (
   <ModalContainer title="Modal title" closeText="Done" isOpen={isOpen}>
     This is a default modal. You can put anything you want in here.
+  </ModalContainer>
+);
+
+const ContrastWithCloseButtonTextExample = (isOpen: boolean) => (
+  <ModalContainer
+    title="Modal title"
+    modalStyle={MODAL_STYLING.surfaceContrast}
+    isOpen={isOpen}
+    closeText="Done"
+  >
+    This is a contrast modal. You can put anything you want in here.
   </ModalContainer>
 );
 
@@ -199,19 +215,34 @@ const NotFullScreenOnMobileExample = (isOpen: boolean) => (
 );
 
 const FullScreenExample = (isOpen: boolean) => (
-  <ModalContainer title="Modal title" closeLabel="Close modal" fullScreen isOpen={isOpen}>
+  <ModalContainer
+    title="Modal title"
+    closeLabel="Close modal"
+    fullScreen
+    isOpen={isOpen}
+  >
     This is a default modal. You can put anything you want in here.
   </ModalContainer>
 );
 
 const FullScreenOverflowingExample = (isOpen: boolean) => (
-  <ModalContainer title="Modal title" closeLabel="Close modal" fullScreen isOpen={isOpen}>
+  <ModalContainer
+    title="Modal title"
+    closeLabel="Close modal"
+    fullScreen
+    isOpen={isOpen}
+  >
     {Children.toArray(content)}
   </ModalContainer>
 );
 
 const NestedExample = (isOpen: boolean) => (
-  <ModalContainer title="Modal title" closeLabel="Close modal" fullScreen isOpen={isOpen}>
+  <ModalContainer
+    title="Modal title"
+    closeLabel="Close modal"
+    fullScreen
+    isOpen={isOpen}
+  >
     This is a full-screen modal. You can put anything you want in here,
     including other modals!
     <ModalContainer
@@ -229,17 +260,18 @@ const NestedExample = (isOpen: boolean) => (
 );
 
 const NoHeaderExample = (isOpen: boolean) => (
-  <ModalContainer
-    ariaLabel="Modal title"
-    showHeader={false}
-    isOpen={isOpen}
-  >
+  <ModalContainer ariaLabel="Modal title" showHeader={false} isOpen={isOpen}>
     This is a default modal. You can put anything you want in here.
   </ModalContainer>
 );
 
 const NoPaddingExample = (isOpen: boolean) => (
-  <ModalContainer title="Modal title" closeLabel="Close modal" padded={false} isOpen={isOpen}>
+  <ModalContainer
+    title="Modal title"
+    closeLabel="Close modal"
+    padded={false}
+    isOpen={isOpen}
+  >
     This is a default modal. You can put anything you want in here.
   </ModalContainer>
 );
@@ -251,7 +283,7 @@ const WithAccessoryViewExample = (isOpen: boolean) => (
     accessoryView={
       <BpkNavigationBarButtonLink
         label="Close"
-        onClick={() => { }}
+        onClick={() => {}}
         className={getClassName('bpk-modal__leading-button')}
       >
         <div>
@@ -282,4 +314,5 @@ export {
   NoPaddingExample,
   WithAccessoryViewExample,
   ContrastExample,
+  ContrastWithCloseButtonTextExample,
 };

--- a/examples/bpk-component-modal/stories.tsx
+++ b/examples/bpk-component-modal/stories.tsx
@@ -31,6 +31,7 @@ import {
   NoPaddingExample,
   WithAccessoryViewExample,
   ContrastExample,
+  ContrastWithCloseButtonTextExample,
 } from './examples';
 
 export default {
@@ -58,6 +59,7 @@ export const NoPadding = NoPaddingExample;
 
 export const WithAccessoryView = WithAccessoryViewExample;
 export const Contrast = ContrastExample;
+export const ContrastWithCloseButtonText = ContrastWithCloseButtonTextExample;
 
 // Due to how iframes work we can pass a local url to load the stories above.
 // Attempted to use a Custom Iframe component with a react portal and ref to

--- a/packages/bpk-component-modal/src/BpkModalInner.tsx
+++ b/packages/bpk-component-modal/src/BpkModalInner.tsx
@@ -154,7 +154,7 @@ const BpkModalInner = ({
                 closeText ? (
                   <BpkButtonLink
                     onClick={onClose}
-                    onDark={modalStyle === MODAL_STYLING.surfaceContrast}
+                    alternate={modalStyle === MODAL_STYLING.surfaceContrast}
                   >
                     {closeText}
                   </BpkButtonLink>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
When we wrongly set the `onDark` prop to `BpkButtonLink` before([original PR](https://github.com/Skyscanner/backpack/pull/3447/files#diff-df999835b1d554fe1ab9384a45253714a087966c76a54f3e00e1869ca698430dR154 )), but actually, we don't have `onDark` in  `BpkButtonLink`, but `alternate` instead https://github.com/Skyscanner/backpack/blob/9d698eaf7e0ddbb14d8f87c613f957167b58cc08/packages/bpk-component-link/src/BpkButtonLink.js#L36

this would also cause an warning  in dev  when comsumer uses BpkModal
<img width="922" height="77" alt="image" src="https://github.com/user-attachments/assets/ea092c65-b4a6-44ab-a1d9-8f89d1b91da3" />


## Screenshot

|before| after|
|---|---|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/6d1c3735-13f8-4cea-91a8-f270e4bcfbe2" />|<img width="300" height="458" alt="image" src="https://github.com/user-attachments/assets/ed6080b7-46bd-45ff-a48a-de5df569de6e" />|

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
