### PR TITLE
[WOODPECKER-3717]Remove defaultProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,13 +100,11 @@
     "verbose": true
   },
   "browserslist": [
-    "Android >= 96",
-    "Chrome >= 87",
-    "Edge >= 96",
-    "Firefox >= 95",
-    "Opera >= 82",
-    "Safari >= 12",
-    "Samsung >= 16"
+    "Chrome >= 109",
+    "Edge >= 129",
+    "Firefox >= 131",
+    "Safari >= 15",
+    "Samsung >= 26"
   ],
   "devDependencies": {
     "@babel/cli": "^7.28.3",

--- a/packages/bpk-component-button/src/BpkButton.tsx
+++ b/packages/bpk-component-button/src/BpkButton.tsx
@@ -21,7 +21,6 @@ import BpkButtonBase, { BUTTON_TYPES } from './BpkButtonBase';
 import {
   type Props as CommonProps,
   propTypes,
-  defaultProps,
 } from './common-types';
 
 export type Props = CommonProps & {
@@ -35,19 +34,17 @@ export type Props = CommonProps & {
   linkOnDark?: boolean;
 };
 
-const BpkButton = (props: Props) => {
-  const {
-    destructive,
-    featured,
-    link,
-    linkOnDark,
-    primaryOnDark,
-    primaryOnLight,
-    secondary,
-    secondaryOnDark,
-    ...rest
-  } = props;
-
+const BpkButton = ({
+  destructive = false,
+  featured = false,
+  link = false,
+  linkOnDark = false,
+  primaryOnDark = false,
+  primaryOnLight = false,
+  secondary = false,
+  secondaryOnDark = false,
+  ...rest
+}: Props) => {
   if (primaryOnDark) {
     return <BpkButtonBase type={BUTTON_TYPES.primaryOnDark} {...rest} />;
   }
@@ -75,18 +72,6 @@ const BpkButton = (props: Props) => {
     return <BpkButtonBase type={BUTTON_TYPES.linkOnDark} {...rest} />;
   }
   return <BpkButtonBase {...rest} />;
-};
-
-BpkButton.defaultProps = {
-  ...defaultProps,
-  primaryOnDark: false,
-  primaryOnLight: false,
-  secondary: false,
-  secondaryOnDark: false,
-  destructive: false,
-  featured: false,
-  link: false,
-  linkOnDark: false,
 };
 
 BpkButton.propTypes = {

--- a/packages/bpk-component-button/src/BpkButtonBase.tsx
+++ b/packages/bpk-component-button/src/BpkButtonBase.tsx
@@ -23,6 +23,7 @@ import COMMON_STYLES from './BpkButtonBase.module.scss';
 
 const getClassName = cssModules(COMMON_STYLES);
 
+const noop = () => null;
 // This is a duplicate of BpkButtonV2
 // Better to duplicate rather than prematurely align the abstraction between Button and ButtonV2
 export const BUTTON_TYPES = {
@@ -47,7 +48,7 @@ const BpkButtonBase = (
     href = '',
     iconOnly = false,
     large = false,
-    onClick = () => null,
+    onClick = noop,
     rel: propRel = undefined,
     submit = false,
     type,

--- a/packages/bpk-component-button/src/BpkButtonBase.tsx
+++ b/packages/bpk-component-button/src/BpkButtonBase.tsx
@@ -17,7 +17,7 @@
  */
 import { cssModules } from '../../bpk-react-utils';
 
-import { type Props, propTypes, defaultProps } from './common-types';
+import { type Props, propTypes } from './common-types';
 
 import COMMON_STYLES from './BpkButtonBase.module.scss';
 
@@ -39,22 +39,21 @@ export const BUTTON_TYPES = {
 
 type ValueOf<T> = T[keyof T];
 const BpkButtonBase = (
-  props: Props & { type?: ValueOf<typeof BUTTON_TYPES> },
-) => {
-  const {
-    blank,
+  {
+    blank = false,
     children,
-    className,
-    disabled,
-    href,
-    iconOnly,
-    large,
-    onClick,
-    rel: propRel,
-    submit,
+    className = '',
+    disabled = false,
+    href = '',
+    iconOnly = false,
+    large = false,
+    onClick = () => null,
+    rel: propRel  = '',
+    submit = false,
     type,
     ...rest
-  } = props;
+  }: Props & { type?: ValueOf<typeof BUTTON_TYPES> },
+) => {
 
   const classNames = [];
   if (type === undefined) {
@@ -135,6 +134,5 @@ const BpkButtonBase = (
 };
 
 BpkButtonBase.propTypes = { ...propTypes };
-BpkButtonBase.defaultProps = { ...defaultProps };
 
 export default BpkButtonBase;

--- a/packages/bpk-component-button/src/BpkButtonBase.tsx
+++ b/packages/bpk-component-button/src/BpkButtonBase.tsx
@@ -48,7 +48,7 @@ const BpkButtonBase = (
     iconOnly = false,
     large = false,
     onClick = () => null,
-    rel: propRel  = '',
+    rel: propRel = '',
     submit = false,
     type,
     ...rest

--- a/packages/bpk-component-button/src/BpkButtonBase.tsx
+++ b/packages/bpk-component-button/src/BpkButtonBase.tsx
@@ -48,7 +48,7 @@ const BpkButtonBase = (
     iconOnly = false,
     large = false,
     onClick = () => null,
-    rel: propRel = '',
+    rel: propRel = undefined,
     submit = false,
     type,
     ...rest

--- a/packages/bpk-component-button/src/common-types.ts
+++ b/packages/bpk-component-button/src/common-types.ts
@@ -23,12 +23,12 @@ export type Props = {
   children: ReactNode;
   href?: string;
   className?: string;
-  disabled: boolean;
+  disabled?: boolean;
   onClick?: (event: SyntheticEvent) => unknown;
-  submit: boolean;
-  large: boolean;
-  iconOnly: boolean;
-  blank: boolean;
+  submit?: boolean;
+  large?: boolean;
+  iconOnly?: boolean;
+  blank?: boolean;
   rel?: string;
 };
 

--- a/packages/bpk-component-button/src/common-types.ts
+++ b/packages/bpk-component-button/src/common-types.ts
@@ -32,18 +32,6 @@ export type Props = {
   rel?: string;
 };
 
-export const defaultProps = {
-  href: null,
-  className: null,
-  disabled: false,
-  onClick: null,
-  submit: false,
-  large: false,
-  iconOnly: false,
-  blank: false,
-  rel: null,
-};
-
 export const propTypes = {
   children: PropTypes.node.isRequired,
   href: PropTypes.string,

--- a/packages/bpk-component-checkbox/src/BpkCheckbox.js
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.js
@@ -43,21 +43,19 @@ type Props = {
   indeterminate: boolean,
 };
 
-const BpkCheckbox = (props: Props) => {
-  const {
-    checked,
-    className,
-    disabled,
-    indeterminate,
+const BpkCheckbox = ({
+  checked = false,
+    className = null,
+    disabled = false,
+    indeterminate = false,
     label,
     name,
-    required,
-    smallLabel,
-    valid,
-    white,
+    required = false,
+    smallLabel = false,
+    valid = null,
+    white = false,
     ...rest
-  } = props;
-
+}: Props) => {
   // Explicit check for false primitive value as undefined is
   // treated as neither valid nor invalid
   const isInvalid = valid === false;
@@ -123,15 +121,6 @@ BpkCheckbox.propTypes = {
   indeterminate: PropTypes.bool,
 };
 
-BpkCheckbox.defaultProps = {
-  required: false,
-  disabled: false,
-  white: false,
-  className: null,
-  smallLabel: false,
-  valid: null,
-  checked: false,
-  indeterminate: false,
-};
+
 
 export default BpkCheckbox;

--- a/packages/bpk-component-fieldset/src/BpkFieldset.js
+++ b/packages/bpk-component-fieldset/src/BpkFieldset.js
@@ -43,21 +43,19 @@ export type Props = {
   description: ?string,
 };
 
-const BpkFieldset = (props: Props) => {
-  const {
-    children,
-    className,
-    description,
-    disabled,
-    isCheckbox,
-    label,
-    required,
-    valid,
-    validationMessage,
-    validationProps,
-    ...rest
-  } = props;
-
+const BpkFieldset = ({
+  children,
+  className = null,
+  description = null,
+  disabled = false,
+  isCheckbox = false,
+  label = null,
+  required = false,
+  valid = null,
+  validationMessage = null,
+  validationProps = {},
+  ...rest
+}: Props) => {
   if (!children) {
     return null;
   }
@@ -181,19 +179,6 @@ export const propTypes = {
   description: PropTypes.string,
 };
 
-export const defaultProps = {
-  label: null,
-  disabled: false,
-  valid: null,
-  required: false,
-  className: null,
-  validationMessage: null,
-  isCheckbox: false,
-  validationProps: {},
-  description: null,
-};
-
 BpkFieldset.propTypes = { ...propTypes };
-BpkFieldset.defaultProps = { ...defaultProps };
 
 export default BpkFieldset;

--- a/packages/bpk-component-flare/src/BpkContentBubble.js
+++ b/packages/bpk-component-flare/src/BpkContentBubble.js
@@ -27,17 +27,15 @@ import STYLES from './bpk-content-bubble.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkContentBubble = (props) => {
-  const {
-    className,
-    content,
-    contentClassName,
-    flareProps,
-    rounded,
-    showPointer,
+  const BpkContentBubble = ({
+    className = null,
+    content = null,
+    contentClassName = null,
+    flareProps = null,
+    rounded = true,
+    showPointer = true,
     ...rest
-  } = props;
-
+  }) => {
   const wrapperClassNames = [getClassName('bpk-content-bubble__wrapper')];
   const contentClassNames = [
     getClassName('bpk-content-bubble__content-wrapper'),
@@ -112,15 +110,6 @@ BpkContentBubble.propTypes = {
   showPointer: PropTypes.bool,
   className: PropTypes.string,
   contentClassName: PropTypes.string,
-};
-
-BpkContentBubble.defaultProps = {
-  flareProps: null,
-  rounded: true,
-  content: null,
-  showPointer: true,
-  className: null,
-  contentClassName: null,
 };
 
 export default BpkContentBubble;

--- a/packages/bpk-component-flare/src/BpkContentBubble.js
+++ b/packages/bpk-component-flare/src/BpkContentBubble.js
@@ -93,7 +93,6 @@ const getClassName = cssModules(STYLES);
         {showPointer && (
           <div className={getClassName('bpk-content-bubble__pointer')}>
             <BpkFlareBar
-              rounded={rounded}
               {...flareProps}
             />
           </div>

--- a/packages/bpk-component-flare/src/BpkFlareBar.js
+++ b/packages/bpk-component-flare/src/BpkFlareBar.js
@@ -26,9 +26,11 @@ import STYLES from './bpk-flare-bar.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-const BpkFlareBar = (props) => {
-  const { className, rounded, svgClassName, ...rest } = props;
-
+const BpkFlareBar = ({
+  className = null,
+  svgClassName = null,
+  ...rest
+}) => {
   const classNames = [getClassName('bpk-flare-bar__container')];
   if (className) {
     classNames.push(className);
@@ -50,13 +52,6 @@ const BpkFlareBar = (props) => {
 BpkFlareBar.propTypes = {
   className: PropTypes.string,
   svgClassName: PropTypes.string,
-  rounded: PropTypes.bool,
-};
-
-BpkFlareBar.defaultProps = {
-  className: null,
-  svgClassName: null,
-  rounded: false,
 };
 
 export default BpkFlareBar;

--- a/packages/bpk-component-form-validation/src/BpkFormValidation.js
+++ b/packages/bpk-component-form-validation/src/BpkFormValidation.js
@@ -37,10 +37,14 @@ const AlignedExclamationIcon = withAlignment(
   iconSizeSm,
 );
 
-const BpkFormValidation = (props) => {
-  const { children, className, containerProps, expanded, isCheckbox, ...rest } =
-    props;
-
+const BpkFormValidation = ({
+  children,
+  className = null,
+  containerProps = {},
+  expanded,
+  isCheckbox = false,
+  ...rest
+}) => {
   const classNames = getClassName(
     'bpk-form-validation',
     expanded && 'bpk-form-validation--appear',
@@ -74,12 +78,6 @@ BpkFormValidation.propTypes = {
   isCheckbox: PropTypes.bool,
   className: PropTypes.string,
   containerProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-};
-
-BpkFormValidation.defaultProps = {
-  isCheckbox: false,
-  className: null,
-  containerProps: {},
 };
 
 export default BpkFormValidation;

--- a/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
@@ -213,6 +213,7 @@ const BpkInfoBannerInner = ({
           {isExpandable && action && (
             <BpkLink
               onClick={action.callback}
+              href={null}
             >
               {action.title}
             </BpkLink>

--- a/packages/bpk-component-label/src/BpkLabel.js
+++ b/packages/bpk-component-label/src/BpkLabel.js
@@ -35,9 +35,15 @@ export type Props = {
   white: boolean,
 };
 
-const BpkLabel = (props: Props) => {
-  const { children, className, disabled, required, valid, white, ...rest } =
-    props;
+const BpkLabel = ({
+  children,
+  className = null,
+  disabled = false,
+  required = false,
+  valid = null,
+  white = false,
+  ...rest
+}: Props) => {
   const invalid = valid === false;
 
   const classNames = getClassName(
@@ -69,12 +75,6 @@ BpkLabel.propTypes = {
   white: PropTypes.bool,
 };
 
-BpkLabel.defaultProps = {
-  className: null,
-  disabled: false,
-  valid: null,
-  required: false,
-  white: false,
-};
+
 
 export default BpkLabel;

--- a/packages/bpk-component-link/src/BpkButtonLink.js
+++ b/packages/bpk-component-link/src/BpkButtonLink.js
@@ -41,7 +41,7 @@ const BpkButtonLink = ({
   alternate = false,
   children,
   className = null,
-  implicit =false,
+  implicit = false,
   onClick,
   ...rest
 }: Props) => {

--- a/packages/bpk-component-link/src/BpkButtonLink.js
+++ b/packages/bpk-component-link/src/BpkButtonLink.js
@@ -37,8 +37,14 @@ type Props = {
   implicit?: boolean;
 };
 
-const BpkButtonLink = (props: Props) => {
-  const { alternate, children, className, implicit, onClick, ...rest } = props;
+const BpkButtonLink = ({
+  alternate = false,
+  children,
+  className = null,
+  implicit =false,
+  onClick,
+  ...rest
+}: Props) => {
   const classNames = [getClassName('bpk-link')];
   const underlinedClassNames = [getClassName('bpk-link-underlined')];
 
@@ -51,7 +57,7 @@ const BpkButtonLink = (props: Props) => {
   if (alternate) {
     classNames.push(getClassName('bpk-link--alternate'));
   }
-  
+
   if (implicit && !alternate) {
     underlinedClassNames.push(getClassName('bpk-link-underlined--implicit'));
   } else if (alternate && !implicit) {
@@ -79,12 +85,6 @@ BpkButtonLink.propTypes = {
   className: PropTypes.string,
   alternate: PropTypes.bool,
   implicit: PropTypes.bool,
-};
-
-BpkButtonLink.defaultProps = {
-  className: null,
-  alternate: false,
-  implicit: false,
 };
 
 export { themeAttributes };

--- a/packages/bpk-component-link/src/BpkLink.js
+++ b/packages/bpk-component-link/src/BpkLink.js
@@ -42,19 +42,17 @@ type Props = {
   implicit: boolean,
 };
 
-const BpkLink = forwardRef((props: Props, ref) => {
-  const {
-    alternate,
-    blank,
-    children,
-    className,
-    href,
-    implicit,
-    onClick,
-    rel: propRel,
-    ...rest
-  } = props;
-
+const BpkLink = forwardRef(({
+  alternate = false,
+  blank = false,
+  children,
+  className = null,
+  href,
+  implicit = false,
+  onClick = null,
+  rel: propRel = null,
+  ...rest
+}: Props, ref) => {
   const classNames = [getClassName('bpk-link')];
   const underlinedClassNames = [getClassName('bpk-link-underlined')];
 
@@ -70,7 +68,7 @@ const BpkLink = forwardRef((props: Props, ref) => {
   if (alternate) {
     classNames.push(getClassName('bpk-link--alternate'));
   }
-  
+
   if (implicit && !alternate) {
     underlinedClassNames.push(getClassName('bpk-link-underlined--implicit'));
   } else if (alternate && !implicit) {
@@ -107,15 +105,6 @@ BpkLink.propTypes = {
   rel: PropTypes.string,
   alternate: PropTypes.bool,
   implicit: PropTypes.bool,
-};
-
-BpkLink.defaultProps = {
-  className: null,
-  onClick: null,
-  blank: false,
-  rel: null,
-  alternate: false,
-  implicit: false,
 };
 
 export default BpkLink;

--- a/packages/bpk-component-list/src/BpkList.js
+++ b/packages/bpk-component-list/src/BpkList.js
@@ -36,10 +36,14 @@ type Props = {
   title: ?string,
 };
 
-const BpkList = (props: Props) => {
-  const { ariaLabel, ariaLabelledby, children, className, ordered, title } =
-    props;
-
+const BpkList = ({
+  ariaLabel = null,
+  ariaLabelledby = null,
+  children,
+  className = null,
+  ordered = false,
+  title = null
+}: Props) => {
   const ListElements: any = ordered ? 'ol' : 'ul';
   const classNames: string = getClassName('bpk-list', className);
 
@@ -67,12 +71,5 @@ BpkList.propTypes = {
   title: PropTypes.string,
 };
 
-BpkList.defaultProps = {
-  ordered: false,
-  className: null,
-  ariaLabel: null,
-  ariaLabelledby: null,
-  title: null,
-};
 
 export default BpkList;

--- a/packages/bpk-component-list/src/BpkListItem.js
+++ b/packages/bpk-component-list/src/BpkListItem.js
@@ -32,9 +32,7 @@ type Props = {
   className: ?string,
 };
 
-const BpkListItem = (props: Props) => {
-  const { children, className } = props;
-
+const BpkListItem = ({children, className = null}: Props) => {
   const classNames = getClassName('bpk-list__item', className);
 
   return <li className={classNames}>{children}</li>;
@@ -46,10 +44,6 @@ BpkListItem.propTypes = {
     PropTypes.node,
   ]).isRequired,
   className: PropTypes.string,
-};
-
-BpkListItem.defaultProps = {
-  className: null,
 };
 
 export default BpkListItem;

--- a/packages/bpk-component-price/src/BpkPrice.js
+++ b/packages/bpk-component-price/src/BpkPrice.js
@@ -66,21 +66,19 @@ const getDefaultTextStyle = (size: $Values<typeof SIZES>) => {
   return TEXT_STYLES.xs;
 };
 
-const BpkPrice = (props: Props) => {
-  const {
-    align,
-    className,
-    dataAttributes,
-    icon,
-    leadingClassName,
-    leadingText,
-    previousPrice,
-    price,
-    size,
-    trailingText,
-    ...rest
-  } = props;
-
+const BpkPrice = ({
+  align = ALIGNS.left,
+  className = null,
+  dataAttributes = {},
+  icon,
+  leadingClassName = null,
+  leadingText = null,
+  previousPrice = null,
+  price,
+  size = SIZES.small,
+  trailingText = null,
+  ...rest
+}: Props) => {
   const defaultTextStyle = getDefaultTextStyle(size);
   const priceTextStyle = getPriceTextStyle(size);
   const isAlignRight = align === ALIGNS.right;
@@ -184,17 +182,6 @@ BpkPrice.propTypes = {
   previousPrice: PropTypes.string,
   leadingClassName: PropTypes.string,
   dataAttributes: PropTypes.objectOf(PropTypes.string),
-};
-
-BpkPrice.defaultProps = {
-  size: SIZES.small,
-  align: ALIGNS.left,
-  className: null,
-  leadingText: null,
-  trailingText: null,
-  previousPrice: null,
-  leadingClassName: null,
-  dataAttributes: {},
 };
 
 export default BpkPrice;

--- a/packages/bpk-component-radio/src/BpkRadio.js
+++ b/packages/bpk-component-radio/src/BpkRadio.js
@@ -37,10 +37,16 @@ type Props = {
   valid: ?boolean,
 };
 
-const BpkRadio = (props: Props) => {
-  const { ariaLabel, className, disabled, label, name, valid, white, ...rest } =
-    props;
-
+const BpkRadio = ({
+  ariaLabel = null,
+  className = null,
+  disabled = false,
+  label,
+  name,
+  valid = null,
+  white = false,
+  ...rest
+}: Props) => {
   // Explicit check for false primitive value as undefined is
   // treated as neither valid nor invalid
   const isInvalid = valid === false;
@@ -84,14 +90,6 @@ BpkRadio.propTypes = {
   white: PropTypes.bool,
   className: PropTypes.string,
   valid: PropTypes.bool,
-};
-
-BpkRadio.defaultProps = {
-  ariaLabel: null,
-  disabled: false,
-  white: false,
-  className: null,
-  valid: null,
 };
 
 export default BpkRadio;

--- a/packages/bpk-component-select/src/BpkSelect.js
+++ b/packages/bpk-component-select/src/BpkSelect.js
@@ -43,21 +43,19 @@ export type Props = {
   wrapperClassName: ?string,
 };
 
-const BpkSelect = (props: Props) => {
-  const {
-    className,
-    disabled,
-    docked,
-    dockedFirst,
-    dockedLast,
-    dockedMiddle,
-    image,
-    large,
-    valid,
-    wrapperClassName,
-    ...rest
-  } = props;
-
+const BpkSelect = ({
+  className = null,
+  disabled = false,
+  docked = false,
+  dockedFirst = false,
+  dockedLast = false,
+  dockedMiddle = false,
+  image = null,
+  large = false,
+  valid = null,
+  wrapperClassName = null,
+  ...rest
+}: Props) => {
   // Explicit check for false primitive value as undefined is
   // treated as neither valid nor invalid
   const isInvalid = valid === false;
@@ -124,19 +122,6 @@ BpkSelect.propTypes = {
   large: PropTypes.bool,
   valid: PropTypes.bool,
   wrapperClassName: PropTypes.string,
-};
-
-BpkSelect.defaultProps = {
-  className: null,
-  docked: false,
-  dockedFirst: false,
-  dockedLast: false,
-  dockedMiddle: false,
-  disabled: false,
-  image: null,
-  large: false,
-  valid: null,
-  wrapperClassName: null,
 };
 
 export default BpkSelect;

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStar.js
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStar.js
@@ -38,10 +38,16 @@ type Props = {
   selected: boolean,
 };
 
-const BpkInteractiveStar = (props: Props) => {
-  const { label, name, onClick, onMouseEnter, selected, type, value, ...rest } =
-    props;
-
+const BpkInteractiveStar = ({
+  label,
+  name,
+  onClick,
+  onMouseEnter,
+  selected = false,
+  type,
+  value,
+  ...rest
+}: Props) => {
   const buttonClassNames = getClassName(
     'bpk-interactive-star',
     selected && 'bpk-interactive-star--selected',
@@ -66,9 +72,9 @@ const BpkInteractiveStar = (props: Props) => {
     >
       <div className={iconClassNames} >
         <BpkStarNonRtl
-          type={type} 
+          type={type}
           /* $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md */
-          {...rest} 
+          {...rest}
         />
       </div>
     </button>
@@ -83,10 +89,6 @@ BpkInteractiveStar.propTypes = {
   type: PropTypes.oneOf([STAR_TYPES.EMPTY, STAR_TYPES.FULL]).isRequired,
   value: PropTypes.number.isRequired,
   selected: PropTypes.bool,
-};
-
-BpkInteractiveStar.defaultProps = {
-  selected: false,
 };
 
 export default BpkInteractiveStar;

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.js
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.js
@@ -51,22 +51,20 @@ type Props = {
   rating: number,
 };
 
-const BpkInteractiveStarRating = (props: Props) => {
-  const {
-    className,
-    extraLarge,
-    getStarLabel,
-    hoverRating,
-    id,
-    large,
-    maxRating,
-    onMouseLeave,
-    onRatingHover,
-    onRatingSelect,
-    rating,
-    ...rest
-  } = props;
-
+const BpkInteractiveStarRating = ({
+  className = null,
+  extraLarge = false,
+  getStarLabel,
+  hoverRating = 0,
+  id,
+  large = false,
+  maxRating = 5,
+  onMouseLeave = () => null,
+  onRatingHover = () => null,
+  onRatingSelect = () => null,
+  rating = 0,
+  ...rest
+}: Props) => {
   const stars = [];
   const classNames = [getClassName('bpk-star-rating')];
   const displayRating = hoverRating || rating;
@@ -115,18 +113,6 @@ BpkInteractiveStarRating.propTypes = {
   onRatingHover: PropTypes.func,
   onRatingSelect: PropTypes.func,
   rating: PropTypes.number,
-};
-
-BpkInteractiveStarRating.defaultProps = {
-  className: null,
-  hoverRating: 0,
-  large: false,
-  extraLarge: false,
-  maxRating: 5,
-  onMouseLeave: () => null,
-  onRatingHover: () => null,
-  onRatingSelect: () => null,
-  rating: 0,
 };
 
 export default BpkInteractiveStarRating;

--- a/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.js
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.js
@@ -29,6 +29,8 @@ import STYLES from './BpkStarRating.module.scss';
 
 const getClassName = cssModules(STYLES);
 
+const noop = () => null;
+
 export const getTypeByRating = (starNumber: number, rating: number) => {
   if (starNumber > rating) {
     return STAR_TYPES.EMPTY;
@@ -59,9 +61,9 @@ const BpkInteractiveStarRating = ({
   id,
   large = false,
   maxRating = 5,
-  onMouseLeave = () => null,
-  onRatingHover = () => null,
-  onRatingSelect = () => null,
+  onMouseLeave = noop,
+  onRatingHover = noop,
+  onRatingSelect = noop,
   rating = 0,
   ...rest
 }: Props) => {

--- a/packages/bpk-component-star-rating/src/BpkStar.js
+++ b/packages/bpk-component-star-rating/src/BpkStar.js
@@ -51,8 +51,13 @@ type Props = {
   extraLarge: boolean,
 };
 
-const BpkStar = (props: Props) => {
-  const { className, extraLarge, large, type, ...rest } = props;
+const BpkStar = ({
+  className = null,
+  extraLarge = false,
+  large = false,
+  type,
+  ...rest
+}: Props) => {
   const iconClassNames = getClassName(
     'bpk-star',
     large && 'bpk-star--large',
@@ -102,14 +107,14 @@ const BpkStar = (props: Props) => {
 
   return type === STAR_TYPES.FULL ? (
     <span className={iconClassNames} >
-      <Icon 
+      <Icon
       // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
       {...rest} />
     </span>
 
   ) : (
     <span className={iconClassNames} >
-      <OutlineIcon 
+      <OutlineIcon
       // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
       {...rest} />
     </span>
@@ -123,12 +128,6 @@ BpkStar.propTypes = {
   className: PropTypes.string,
   large: PropTypes.bool,
   extraLarge: PropTypes.bool,
-};
-
-BpkStar.defaultProps = {
-  className: null,
-  large: false,
-  extraLarge: false,
 };
 
 export const BpkStarNonRtl = BpkStar;

--- a/packages/bpk-component-star-rating/src/BpkStarRating.js
+++ b/packages/bpk-component-star-rating/src/BpkStarRating.js
@@ -60,17 +60,16 @@ type Props = {
     | typeof ROUNDING_TYPES.nearest,
 };
 
-const BpkStarRating = (props: Props) => {
-  const {
-    className,
-    extraLarge,
-    large,
-    maxRating,
-    rating,
-    ratingLabel,
-    rounding,
-    ...rest
-  } = props;
+const BpkStarRating = ({
+  className = null,
+  extraLarge = false,
+  large = false,
+  maxRating = 5,
+  rating = 0,
+  ratingLabel,
+  rounding = ROUNDING_TYPES.down,
+  ...rest
+}: Props) => {
 
   const stars = [];
   const classNames = [getClassName('bpk-star-rating')];
@@ -119,15 +118,6 @@ BpkStarRating.propTypes = {
     ROUNDING_TYPES.up,
     ROUNDING_TYPES.nearest,
   ]),
-};
-
-BpkStarRating.defaultProps = {
-  className: null,
-  large: false,
-  extraLarge: false,
-  maxRating: 5,
-  rating: 0,
-  rounding: ROUNDING_TYPES.down,
 };
 
 export default BpkStarRating;

--- a/packages/bpk-component-table/src/BpkTable.js
+++ b/packages/bpk-component-table/src/BpkTable.js
@@ -32,8 +32,7 @@ type Props = {
   className: ?string,
 };
 
-const BpkTable = (props: Props) => {
-  const { children, className, ...rest } = props;
+const BpkTable = ({children, className = null, ...rest}: Props) => {
 
   const classNames = getClassName('bpk-table', className);
 
@@ -50,8 +49,5 @@ BpkTable.propTypes = {
   className: PropTypes.string,
 };
 
-BpkTable.defaultProps = {
-  className: null,
-};
 
 export default BpkTable;

--- a/packages/bpk-component-table/src/BpkTableCell.js
+++ b/packages/bpk-component-table/src/BpkTableCell.js
@@ -32,15 +32,13 @@ type Props = {
   className: ?string,
 };
 
-const BpkTableCell = (props: Props) => {
-  const { className, ...rest } = props;
-
+const BpkTableCell = ({children, className = null, ...rest}: Props) => {
   const classNames = getClassName('bpk-table__cell', className);
 
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
     <td className={classNames} {...rest}>
-      {props.children}
+      {children}
     </td>
   );
 };
@@ -48,10 +46,6 @@ const BpkTableCell = (props: Props) => {
 BpkTableCell.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
-};
-
-BpkTableCell.defaultProps = {
-  className: null,
 };
 
 export default BpkTableCell;

--- a/packages/bpk-component-table/src/BpkTableHeadCell.js
+++ b/packages/bpk-component-table/src/BpkTableHeadCell.js
@@ -29,7 +29,7 @@ const getClassName = cssModules(STYLES);
 
 type Props = { children: Node, className: ?string };
 
-const BpkTableHeadCell = ({ children, className = null, ...rest }: Props) => {
+const BpkTableHeadCell = ({ className = null, ...rest }: Props) => {
 
   const classNames = getClassName(
     'bpk-table__cell',

--- a/packages/bpk-component-table/src/BpkTableHeadCell.js
+++ b/packages/bpk-component-table/src/BpkTableHeadCell.js
@@ -29,8 +29,7 @@ const getClassName = cssModules(STYLES);
 
 type Props = { children: Node, className: ?string };
 
-const BpkTableHeadCell = (props: Props) => {
-  const { className, ...rest } = props;
+const BpkTableHeadCell = ({ children, className = null, ...rest }: Props) => {
 
   const classNames = getClassName(
     'bpk-table__cell',
@@ -44,10 +43,6 @@ const BpkTableHeadCell = (props: Props) => {
 BpkTableHeadCell.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-};
-
-BpkTableHeadCell.defaultProps = {
-  className: null,
 };
 
 export default BpkTableHeadCell;

--- a/packages/bpk-component-table/src/BpkTableHeadCell.js
+++ b/packages/bpk-component-table/src/BpkTableHeadCell.js
@@ -29,7 +29,7 @@ const getClassName = cssModules(STYLES);
 
 type Props = { children: Node, className: ?string };
 
-const BpkTableHeadCell = ({ className = null, ...rest }: Props) => {
+const BpkTableHeadCell = ({ children, className = null, ...rest }: Props) => {
 
   const classNames = getClassName(
     'bpk-table__cell',
@@ -37,7 +37,11 @@ const BpkTableHeadCell = ({ className = null, ...rest }: Props) => {
     className,
   );
 
-  return <th {...rest} className={classNames} />;
+    return (
+    <th className={classNames} {...rest}>
+      {children}
+    </th>
+  );
 };
 
 BpkTableHeadCell.propTypes = {

--- a/packages/bpk-component-table/src/BpkTableHeadCell.js
+++ b/packages/bpk-component-table/src/BpkTableHeadCell.js
@@ -37,7 +37,7 @@ const BpkTableHeadCell = ({ children, className = null, ...rest }: Props) => {
     className,
   );
 
-    return (
+  return (
     <th className={classNames} {...rest}>
       {children}
     </th>

--- a/packages/bpk-component-textarea/src/BpkTextarea.js
+++ b/packages/bpk-component-textarea/src/BpkTextarea.js
@@ -35,9 +35,12 @@ type Props = {
   large: ?boolean,
 };
 
-const BpkTextarea = (props: Props) => {
-  const { className, large, valid, ...rest } = props;
-
+const BpkTextarea = ({
+  className = null,
+  large = null,
+  valid = false,
+  ...rest
+}: Props) => {
   // Explicit check for false primitive value as undefined is
   // treated as neither valid nor invalid
   const isInvalid = valid === false;
@@ -64,12 +67,6 @@ BpkTextarea.propTypes = {
   className: PropTypes.string,
   valid: PropTypes.bool,
   large: PropTypes.bool,
-};
-
-BpkTextarea.defaultProps = {
-  className: null,
-  valid: null,
-  large: false,
 };
 
 export default BpkTextarea;

--- a/packages/bpk-component-textarea/src/BpkTextarea.js
+++ b/packages/bpk-component-textarea/src/BpkTextarea.js
@@ -37,8 +37,8 @@ type Props = {
 
 const BpkTextarea = ({
   className = null,
-  large = null,
-  valid = false,
+  large = false,
+  valid = null,
   ...rest
 }: Props) => {
   // Explicit check for false primitive value as undefined is


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
