### PR TITLE
[CLOVER-701][BpkBackgroundImage] Remove UNSAFE_componentWillReceiveProps usage

### DIFF
--- a/packages/bpk-component-image/src/BpkBackgroundImage-test.tsx
+++ b/packages/bpk-component-image/src/BpkBackgroundImage-test.tsx
@@ -171,4 +171,41 @@ describe('BpkBackgroundImage', () => {
 
     expect(mockOnError).toHaveBeenCalled();
   });
+
+  it('loads image when inView flips or src changes', () => {
+    const loaded: string[] = [];
+    Object.defineProperty(window, 'Image', {
+      writable: true,
+      configurable: true,
+      value: class {
+        set src(url: string) {
+          loaded.push(url);
+        }
+
+        onloadHandler?: () => void;
+
+        onerrorHandler?: () => void;
+
+        set onload(cb: () => void) {
+          this.onloadHandler = cb;
+        }
+
+        set onerror(cb: () => void) {
+          this.onerrorHandler = cb;
+        }
+      },
+    });
+
+    const { rerender } = render(
+      <BpkBackgroundImage aspectRatio={1} src="one.jpg" inView={false} />,
+    );
+    expect(loaded).toEqual([]);
+
+    rerender(<BpkBackgroundImage aspectRatio={1} src="one.jpg" inView />);
+    expect(loaded).toEqual(['one.jpg']);
+
+    loaded.length = 0;
+    rerender(<BpkBackgroundImage aspectRatio={1} src="two.jpg" inView />);
+    expect(loaded).toEqual(['two.jpg']);
+  });
 });

--- a/packages/bpk-component-image/src/BpkBackgroundImage.tsx
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.tsx
@@ -67,14 +67,10 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
     }
   }
 
-  UNSAFE_componentWillReceiveProps(newProps: BpkBackgroundImageProps) {
-    if (!this.props.inView && newProps.inView) {
-      this.startImageLoad();
-    }
-  }
-
   componentDidUpdate(prevProps: BpkBackgroundImageProps) {
-    if (prevProps.src !== this.props.src) {
+    const { inView, src } = this.props;
+
+    if (prevProps.src !== src || (inView && !prevProps.inView)) {
       this.startImageLoad();
     }
   }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Using `UNSAFE_componentWillReceiveProps` in strict mode is not recommended and may indicate bugs in your code. See https://reactjs.org/link/unsafe-component-lifecycles for details.

Remove UNSAFE_componentWillReceiveProps usage


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
