### PR TITLE
[WIP][BpkAccordion] Introduce new styles

### DIFF
--- a/examples/bpk-component-accordion/examples.tsx
+++ b/examples/bpk-component-accordion/examples.tsx
@@ -419,6 +419,7 @@ const VariantExample = () => (
         <StatefulAccordionItem
           id="stops"
           title={ <BpkText textStyle={TEXT_STYLES.heading4}>You found some <BpkText textStyle={TEXT_STYLES.heading4} color={TEXT_COLORS.textSuccess}>great prices</BpkText> - nice one!</BpkText> }
+          label="Show price data"
           icon={<AlignedTrendDownIcon />}>
           <StopsContent />
         </StatefulAccordionItem>
@@ -429,8 +430,7 @@ const VariantExample = () => (
       <BpkAccordion divider={false} type={ACCORDION_TYPES.surfaceLowContrast}>
         <StatefulAccordionItem
           id="stops"
-          title={ <BpkText textStyle={TEXT_STYLES.heading4}>You found some <BpkText textStyle={TEXT_STYLES.heading4} color={TEXT_COLORS.textSuccess}>great prices</BpkText> - nice one!</BpkText> }
-          icon={<AlignedTrendDownIcon />}>
+          label="Our lowest price £90">
           <StopsContent />
         </StatefulAccordionItem>
       </BpkAccordion>

--- a/examples/bpk-component-accordion/examples.tsx
+++ b/examples/bpk-component-accordion/examples.tsx
@@ -39,6 +39,7 @@ import StopsIcon from '../../packages/bpk-component-icon/sm/stops';
 import TimeIcon from '../../packages/bpk-component-icon/sm/time';
 import TrendDownIcon from '../../packages/bpk-component-icon/lg/trend--down';
 import BpkText, { TEXT_COLORS, TEXT_STYLES } from '../../packages/bpk-component-text';
+import { ACCORDION_TYPES } from '../../packages/bpk-component-accordion/src/common-types';
 
 const SingleItemAccordion = withSingleItemAccordionState(BpkAccordion);
 const StatefulAccordionItem = withAccordionItemState(BpkAccordionItem);
@@ -414,7 +415,7 @@ const VariantExample = () => (
   <div>
     <div style={{ backgroundColor: canvasContrastDay, padding: '2rem' }}>
 
-      <BpkAccordion divider={false}>
+      <BpkAccordion divider={false} type={ACCORDION_TYPES.surfaceDefault}>
         <StatefulAccordionItem
           id="stops"
           title={ <BpkText textStyle={TEXT_STYLES.heading4}>You found some <BpkText textStyle={TEXT_STYLES.heading4} color={TEXT_COLORS.textSuccess}>great prices</BpkText> - nice one!</BpkText> }
@@ -425,7 +426,7 @@ const VariantExample = () => (
     </div>
 
     <div style={{ backgroundColor: canvasDay, padding: '2rem' }}>
-      <BpkAccordion divider={false}>
+      <BpkAccordion divider={false} type={ACCORDION_TYPES.surfaceLowContrast}>
         <StatefulAccordionItem
           id="stops"
           title={ <BpkText textStyle={TEXT_STYLES.heading4}>You found some <BpkText textStyle={TEXT_STYLES.heading4} color={TEXT_COLORS.textSuccess}>great prices</BpkText> - nice one!</BpkText> }

--- a/examples/bpk-component-accordion/examples.tsx
+++ b/examples/bpk-component-accordion/examples.tsx
@@ -17,8 +17,10 @@
  */
 
 import {
+  canvasContrastDay,
+  canvasDay,
   colorMonteverde,
-  colorPanjin,
+  colorPanjin, iconSizeLg,
   iconSizeSm,
   lineHeightBase,
   surfaceContrastDay,
@@ -35,13 +37,16 @@ import BpkCheckbox from '../../packages/bpk-component-checkbox';
 import { withAlignment } from '../../packages/bpk-component-icon';
 import StopsIcon from '../../packages/bpk-component-icon/sm/stops';
 import TimeIcon from '../../packages/bpk-component-icon/sm/time';
-import BpkText from '../../packages/bpk-component-text';
+import TrendDownIcon from '../../packages/bpk-component-icon/lg/trend--down';
+import BpkText, { TEXT_COLORS, TEXT_STYLES } from '../../packages/bpk-component-text';
 
 const SingleItemAccordion = withSingleItemAccordionState(BpkAccordion);
 const StatefulAccordionItem = withAccordionItemState(BpkAccordionItem);
 
 const AlignedStopsIcon = withAlignment(StopsIcon, lineHeightBase, iconSizeSm);
 const AlignedTimeIcon = withAlignment(TimeIcon, lineHeightBase, iconSizeSm);
+
+const AlignedTrendDownIcon = withAlignment(TrendDownIcon, lineHeightBase, iconSizeLg);
 
 const CheckboxWrapper = (props: any) => (
   <div style={{ padding: `1rem 0` }} {...props} />
@@ -405,6 +410,33 @@ const SingleItemExampleWithoutDividerOnDark = () => (
   </div>
 );
 
+const VariantExample = () => (
+  <div>
+    <div style={{ backgroundColor: canvasContrastDay, padding: '2rem' }}>
+
+      <BpkAccordion divider={false}>
+        <StatefulAccordionItem
+          id="stops"
+          title={ <BpkText textStyle={TEXT_STYLES.heading4}>You found some <BpkText textStyle={TEXT_STYLES.heading4} color={TEXT_COLORS.textSuccess}>great prices</BpkText> - nice one!</BpkText> }
+          icon={<AlignedTrendDownIcon />}>
+          <StopsContent />
+        </StatefulAccordionItem>
+      </BpkAccordion>
+    </div>
+
+    <div style={{ backgroundColor: canvasDay, padding: '2rem' }}>
+      <BpkAccordion divider={false}>
+        <StatefulAccordionItem
+          id="stops"
+          title={ <BpkText textStyle={TEXT_STYLES.heading4}>You found some <BpkText textStyle={TEXT_STYLES.heading4} color={TEXT_COLORS.textSuccess}>great prices</BpkText> - nice one!</BpkText> }
+          icon={<AlignedTrendDownIcon />}>
+          <StopsContent />
+        </StatefulAccordionItem>
+      </BpkAccordion>
+    </div>
+  </div>
+)
+
 export {
   SingleItemExample,
   SingleItemExampleInitiallyExpandedExample,
@@ -419,4 +451,5 @@ export {
   WithSeoContentOnDarkExample,
   SingleItemExampleWithoutDivider,
   SingleItemExampleWithoutDividerOnDark,
+  VariantExample,
 };

--- a/examples/bpk-component-accordion/stories.tsx
+++ b/examples/bpk-component-accordion/stories.tsx
@@ -32,7 +32,7 @@ import {
   WithSeoContentExample,
   WithSeoContentOnDarkExample,
   SingleItemExampleWithoutDivider,
-  SingleItemExampleWithoutDividerOnDark,
+  SingleItemExampleWithoutDividerOnDark, VariantExample,
 } from './examples';
 import {
   WithSingleItemAccordionStateMock,
@@ -76,6 +76,8 @@ export const WithoutDividerOnDark = SingleItemExampleWithoutDividerOnDark;
 
 export const VisualTest = SingleItemExample;
 export const VisualTestOnDark = WithDarkBackgroundExample;
+
+export const Variant = VariantExample;
 
 export const VisualTestWithZoom = {
   render: VisualTest,

--- a/packages/bpk-component-accordion/src/BpkAccordion.module.scss
+++ b/packages/bpk-component-accordion/src/BpkAccordion.module.scss
@@ -24,4 +24,14 @@
   &--on-dark {
     color: tokens.$bpk-text-on-dark-day;
   }
+
+  &--surface-default {
+    background: tokens.$bpk-surface-default-day;
+    border-radius: tokens.$bpk-border-radius-md;
+  }
+
+  &--surface-low-contrast {
+    background: tokens.$bpk-surface-low-contrast-day;
+    border-radius: tokens.$bpk-border-radius-md;
+  }
 }

--- a/packages/bpk-component-accordion/src/BpkAccordion.tsx
+++ b/packages/bpk-component-accordion/src/BpkAccordion.tsx
@@ -22,11 +22,13 @@ import type { ReactNode } from 'react';
 import { cssModules } from '../../bpk-react-utils';
 
 import STYLES from './BpkAccordion.module.scss';
+import { ACCORDION_TYPES, AccordionType } from './common-types';
 
 const getClassName = cssModules(STYLES);
 
 export type BpkAccordionProps = {
   children: ReactNode;
+  type?: AccordionType;
   className?: string;
   divider?: boolean;
   onDark?: boolean;
@@ -35,11 +37,13 @@ export type BpkAccordionProps = {
 export const BpkAccordionContext = createContext({
   onDark: false,
   divider: true,
+  type: ACCORDION_TYPES.default as AccordionType,
 });
 
 const BpkAccordion = (props: BpkAccordionProps) => {
   const {
     children,
+    type = ACCORDION_TYPES.default,
     className,
     divider = true,
     onDark = false,
@@ -49,11 +53,12 @@ const BpkAccordion = (props: BpkAccordionProps) => {
   const classNames = getClassName(
     'bpk-accordion',
     onDark && 'bpk-accordion--on-dark',
+    `bpk-accordion--${type}`,
     className,
   );
 
   return (
-    <BpkAccordionContext.Provider value={{ onDark, divider }}>
+    <BpkAccordionContext.Provider value={{ onDark, divider, type }}>
       <div className={classNames} {...rest}>
         {children}
       </div>

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
@@ -47,6 +47,11 @@
     @include utils.bpk-rtl {
       text-align: right;
     }
+
+    &--background-variant-padding {
+      padding: 0 tokens.bpk-spacing-base();
+      border-radius: tokens.$bpk-border-radius-md;
+    }
   }
 
   &__flex-container {

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
@@ -72,6 +72,7 @@
   &__icon-wrapper {
     display: flex;
     align-items: center;
+    gap: tokens.bpk-spacing-md();
 
     @include margins.bpk-margin-leading(tokens.bpk-spacing-md());
   }

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.tsx
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.tsx
@@ -27,6 +27,7 @@ import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
 
 import { BpkAccordionContext } from './BpkAccordion';
+import { ACCORDION_TYPES } from './common-types';
 
 import STYLES from './BpkAccordionItem.module.scss';
 
@@ -48,7 +49,7 @@ export type BpkAccordionItemProps = {
 };
 
 const BpkAccordionItem = (props: BpkAccordionItemProps) => {
-  const { divider, onDark } = useContext(BpkAccordionContext);
+  const { divider, onDark, type } = useContext(BpkAccordionContext);
   const itemClassNames = [getClassName('bpk-accordion__item')];
   const iconClassNames = [getClassName('bpk-accordion__item-expand-icon')];
   const titleTextClassNames = [getClassName('bpk-accordion__title-text')];
@@ -57,6 +58,7 @@ const BpkAccordionItem = (props: BpkAccordionItemProps) => {
   const contentInnerClassNames = [
     getClassName('bpk-accordion__content-inner-container'),
   ];
+  const toggleButtonClassNames = [getClassName('bpk-accordion__toggle-button')];
 
   const {
     children,
@@ -121,6 +123,12 @@ const BpkAccordionItem = (props: BpkAccordionItemProps) => {
     );
   }
 
+  if (type === ACCORDION_TYPES.surfaceLowContrast || type === ACCORDION_TYPES.surfaceDefault) {
+    toggleButtonClassNames.push(
+      getClassName('bpk-accordion__toggle-button--background-variant-padding'),
+    );
+  }
+
   const contentId = `${id}_content`;
   const clonedIcon = icon
     ? cloneElement(icon, {
@@ -141,7 +149,7 @@ const BpkAccordionItem = (props: BpkAccordionItemProps) => {
           aria-expanded={expanded}
           aria-controls={contentId}
           onClick={onClick}
-          className={getClassName('bpk-accordion__toggle-button')}
+          className={toggleButtonClassNames.join(' ')}
         >
           <div className={`${getClassName('bpk-accordion__flex-container')}`}>
             <div className={titleTextClassNames.join(' ')}>

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.tsx
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.tsx
@@ -37,7 +37,7 @@ const ExpandIcon = withButtonAlignment(ChevronDownIcon);
 export type BpkAccordionItemProps = {
   children: ReactNode;
   id: string;
-  title: string;
+  title: string | ReactElement;
   className?: string;
   expanded?: boolean;
   initiallyExpanded?: boolean;
@@ -128,6 +128,10 @@ const BpkAccordionItem = (props: BpkAccordionItemProps) => {
       })
     : null;
 
+  const titleItem = typeof title === 'string'
+    ?  <BpkText textStyle={textStyle} tagName={tagName}>{clonedIcon} {title}</BpkText>
+    : <>{clonedIcon} {title}</>;
+
   return (
     // $FlowFixMe[cannot-spread-inexact] - inexact rest. See decisions/flowfixme.md
     <div id={id} className={itemClassNames.join(' ')} {...rest}>
@@ -141,10 +145,7 @@ const BpkAccordionItem = (props: BpkAccordionItemProps) => {
         >
           <div className={`${getClassName('bpk-accordion__flex-container')}`}>
             <div className={titleTextClassNames.join(' ')}>
-              <BpkText textStyle={textStyle} tagName={tagName}>
-                {clonedIcon}
-                {title}
-              </BpkText>
+              {titleItem}
             </div>
             <span
               className={`${getClassName(

--- a/packages/bpk-component-accordion/src/BpkAccordionItem.tsx
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.tsx
@@ -38,7 +38,8 @@ const ExpandIcon = withButtonAlignment(ChevronDownIcon);
 export type BpkAccordionItemProps = {
   children: ReactNode;
   id: string;
-  title: string | ReactElement;
+  title?: string | ReactElement | null;
+  label?: string | null;
   className?: string;
   expanded?: boolean;
   initiallyExpanded?: boolean;
@@ -69,6 +70,7 @@ const BpkAccordionItem = (props: BpkAccordionItemProps) => {
     tagName = 'h3',
     textStyle = TEXT_STYLES.bodyDefault,
     title,
+    label,
     ...rest
   } = props;
 
@@ -158,9 +160,12 @@ const BpkAccordionItem = (props: BpkAccordionItemProps) => {
             <span
               className={`${getClassName(
                 'bpk-accordion__icon-wrapper',
-              )} ${iconClassNames.join(' ')}`}
+              )}`}
             >
-              <ExpandIcon />
+              { label && ( <BpkText textStyle={TEXT_STYLES.label2}>{label}</BpkText> ) }
+              <span className={`${iconClassNames.join(' ')}`}>
+                <ExpandIcon />
+              </span>
             </span>
           </div>
         </button>

--- a/packages/bpk-component-accordion/src/common-types.ts
+++ b/packages/bpk-component-accordion/src/common-types.ts
@@ -1,0 +1,8 @@
+
+export const ACCORDION_TYPES = {
+  default: 'default',
+  surfaceDefault: 'surface-default',
+  surfaceLowContrast: 'surface-low-contrast',
+} as const;
+
+export type AccordionType = (typeof ACCORDION_TYPES)[keyof typeof ACCORDION_TYPES];


### PR DESCRIPTION
# BpkAccordion

This pull request introduces new visual variants to the `BpkAccordion` component, allowing for different background and padding styles, as well as improved flexibility for item titles and labels. The changes add new props and context values, update styles, and enhance example and storybook coverage to demonstrate the new features.

**Accordion Variants and Styling:**

* Added `type` prop to `BpkAccordion` and `AccordionType`/`ACCORDION_TYPES` to support new visual variants (`surfaceDefault`, `surfaceLowContrast`, and `default`). The context is updated to pass this type to child items. (`[[1]](diffhunk://#diff-ed9d30760e091edde18c411ef69503a1af9408af4bf011ff3b9e7cc10a787dbdR25-R31)`, `[[2]](diffhunk://#diff-ed9d30760e091edde18c411ef69503a1af9408af4bf011ff3b9e7cc10a787dbdR40-R46)`, `[[3]](diffhunk://#diff-ed9d30760e091edde18c411ef69503a1af9408af4bf011ff3b9e7cc10a787dbdR56-R61)`, `[[4]](diffhunk://#diff-879f87a7b59ab9c445328c625c81f2d27209f9279a49393aac0810fcc82a11caR1-R8)`)
* Updated SCSS files to add styles for the new background variants and padding, including border-radius and gap adjustments for icon wrappers. (`[[1]](diffhunk://#diff-89b9e2911a4c0e43b99078bb868b8e8d57b3f7f3522b07c7fcb415157cb3aa11R27-R36)`, `[[2]](diffhunk://#diff-5b1965da520f4d42beb4451d6dabd6724b1b130710c78ca5ced991e1709ce67aR50-R54)`, `[[3]](diffhunk://#diff-5b1965da520f4d42beb4451d6dabd6724b1b130710c78ca5ced991e1709ce67aR75)`)

**Accordion Item Flexibility:**

* Enhanced `BpkAccordionItem` to accept optional `title` (can be string, React element, or null) and a new `label` prop for additional context beside the expand icon. The rendering logic and class names were updated to support these props and variants. (`[[1]](diffhunk://#diff-c1633b5fe31577e70d135e5d5673fa0243b2685ebf884349517837cd54ada81fR30)`, `[[2]](diffhunk://#diff-c1633b5fe31577e70d135e5d5673fa0243b2685ebf884349517837cd54ada81fL40-R42)`, `[[3]](diffhunk://#diff-c1633b5fe31577e70d135e5d5673fa0243b2685ebf884349517837cd54ada81fL51-R53)`, `[[4]](diffhunk://#diff-c1633b5fe31577e70d135e5d5673fa0243b2685ebf884349517837cd54ada81fR62)`, `[[5]](diffhunk://#diff-c1633b5fe31577e70d135e5d5673fa0243b2685ebf884349517837cd54ada81fR73)`, `[[6]](diffhunk://#diff-c1633b5fe31577e70d135e5d5673fa0243b2685ebf884349517837cd54ada81fR128-R144)`, `[[7]](diffhunk://#diff-c1633b5fe31577e70d135e5d5673fa0243b2685ebf884349517837cd54ada81fL140-R169)`)

**Examples and Storybook:**

* Added a new `VariantExample` in the examples file to demonstrate the new accordion types, including usage of icons, styled titles, and labels. (`[[1]](diffhunk://#diff-f458dbe007897360556d3ca119c75b47363e6dd577f1d6ba3271eabca4087532R20-R23)`, `[[2]](diffhunk://#diff-f458dbe007897360556d3ca119c75b47363e6dd577f1d6ba3271eabca4087532L38-R51)`, `[[3]](diffhunk://#diff-f458dbe007897360556d3ca119c75b47363e6dd577f1d6ba3271eabca4087532R414-R440)`, `[[4]](diffhunk://#diff-f458dbe007897360556d3ca119c75b47363e6dd577f1d6ba3271eabca4087532R455)`)
* Integrated `VariantExample` into the storybook for visual testing and documentation. (`[[1]](diffhunk://#diff-1364df18559b369c7440abfb76306b9c95109f82810d5d3f4bc3db292b85f6faL35-R35)`, `[[2]](diffhunk://#diff-1364df18559b369c7440abfb76306b9c95109f82810d5d3f4bc3db292b85f6faR80-R81)`)

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
