### PR TITLE
[BpkStarRating] Add Figma Code connect to star rating

### DIFF
--- a/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.figma.tsx
+++ b/packages/bpk-component-star-rating/src/BpkInteractiveStarRating.figma.tsx
@@ -1,0 +1,35 @@
+import figma from "@figma/code-connect"
+
+import BpkInteractiveStarRating from "./BpkInteractiveStarRating"
+
+figma.connect(
+  BpkInteractiveStarRating,
+  "https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=51587%3A777",
+  {
+    props: {
+      large: figma.enum("Size", {
+        "Large": true,
+      }),
+      extraLarge: figma.enum("Size", {
+        "Extra-large": true,
+      }),
+      initialRating: figma.enum('Rating', {
+        "1 star": 1,
+        "2 stars": 2,
+        "3 stars": 3,
+        "4 stars": 4,
+        "5 stars": 5
+      })
+    },
+    example: ({  extraLarge, initialRating, large }) => (
+      <BpkInteractiveStarRating
+        getStarLabel={(rating: number, maxRating: number) => `${rating} out of ${maxRating} stars`}
+        id="uniqueId"
+        onRatingSelect={(rating: number) => console.log(rating)}
+        large={large}
+        extraLarge={extraLarge}
+        rating={initialRating}
+      />
+    ),
+  },
+)

--- a/packages/bpk-component-star-rating/src/BpkStarRating.figma.tsx
+++ b/packages/bpk-component-star-rating/src/BpkStarRating.figma.tsx
@@ -1,0 +1,80 @@
+import figma from '@figma/code-connect';
+
+import BpkStarRating from './BpkStarRating';
+
+
+/**
+ * Star rating
+ */
+figma.connect(
+  BpkStarRating,
+  'https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=4405%3A2',
+  {
+    props: {
+      large: figma.enum('Size', {
+        Large: true,
+      }),
+      rating: figma.enum('Rating', {
+        '1 star': 1,
+        '2 stars': 2,
+        '3 stars': 3,
+        '3.5 stars': 3.5,
+        '4 stars': 4,
+        '5 stars': 5,
+      }),
+      ratingLabel: figma.enum('Rating', {
+        '1 star': 'Rated 1 star out of 5',
+        '2 stars': 'Rated 2 stars out of 5',
+        '3 stars': 'Rated 3 stars out of 5',
+        '3.5 stars': 'Rated 3.5 stars out of 5',
+        '4 stars': 'Rated 4 stars out of 5',
+        '5 stars': 'Rated 5 stars out of 5',
+      }),
+    },
+    example: ({ large, rating, ratingLabel }) => (
+      <BpkStarRating
+        ratingLabel={ratingLabel}
+        large={large}
+        rating={rating}
+      />
+    ),
+  },
+);
+
+
+/**
+ * Hotel star rating
+ */
+figma.connect(
+  BpkStarRating,
+  'https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=12346%3A12561',
+  {
+    props: {
+      large: figma.enum('Size', {
+        Large: true,
+      }),
+      hotelRating: figma.enum('Rating', {
+        '1 star': 1,
+        '2 star': 2,
+        '3 star': 3,
+        '4 star': 4,
+        '5 star': 5,
+      }),
+      hotelRatingLabel: figma.enum('Rating', {
+        '1 star': '1 star hotel',
+        '2 star': '2 star hotel',
+        '3 star': '3 star hotel',
+        '4 star': '4 star hotel',
+        '5 star': '5 star hotel',
+      }),
+    },
+    example: ({ hotelRating, hotelRatingLabel, large }) => (
+      <BpkStarRating
+        ratingLabel={hotelRatingLabel}
+        large={large}
+        rating={hotelRating}
+        maxRating={hotelRating}
+      />
+    ),
+  },
+);


### PR DESCRIPTION
This pull request adds Figma integration files for the `BpkStarRating` and `BpkInteractiveStarRating` components, enabling live component previews and property controls directly from Figma. The integration defines how these components can be configured and previewed within the Figma design environment, supporting various sizes and rating values.

**Figma integration for star rating components:**

* Added `BpkStarRating.figma.tsx` to connect `BpkStarRating` to Figma, supporting both standard and hotel star rating variants with configurable props for size, rating value, and rating label, and linking to the appropriate Figma nodes.
* Added `BpkInteractiveStarRating.figma.tsx` to connect `BpkInteractiveStarRating` to Figma, allowing configuration of size and initial rating, and providing an example usage for interactive previews.