### PR TITLE
[STAR-161] Replace DOM-based virtualization with content-visibility

### DIFF
--- a/examples/bpk-component-card-list/examples.tsx
+++ b/examples/bpk-component-card-list/examples.tsx
@@ -204,7 +204,7 @@ type ExampleCard = typeof DestinationCard | typeof Snippet;
 
 const makeList = (
   cardType: ExampleCard,
-  number: number = 15,
+  number: number = 100,
   vertical: boolean = false,
 ) => {
   const cardList = [];

--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel-test.tsx
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel-test.tsx
@@ -2,7 +2,7 @@
  * Backpack - Skyscanner's Design System
  *
  * Copyright 2016 Skyscanner Ltd
- *
+ *z
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,19 +16,26 @@
  * limitations under the License.
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
+
+
+import { render, screen, act, waitFor } from '@testing-library/react';
 
 import '@testing-library/jest-dom';
 import mockCards from '../../testMocks';
 import { LAYOUTS } from '../common-types';
 
 import BpkCardListCarousel from './BpkCardListCarousel';
+import { useIntersectionObserver } from './utils';
 
-jest.mock('./utils', () => ({
-  setA11yTabIndex: jest.fn(),
-  useScrollToCard: jest.fn(),
-  useIntersectionObserver: jest.fn(() => jest.fn()),
-}));
+jest.mock('./utils', () => {
+  const actual = jest.requireActual('./utils');
+  return {
+    ...actual,
+    setA11yTabIndex: jest.fn(),
+    useScrollToCard: jest.fn(),
+    useIntersectionObserver: jest.fn(),
+  };
+});
 
 describe('BpkCardListCarousel', () => {
   const mockSetCurrentIndex = jest.fn();
@@ -68,5 +75,144 @@ describe('BpkCardListCarousel', () => {
     const cards = screen.getAllByRole('group');
     expect(cards).toHaveLength(1);
     expect(cards[0]).toHaveTextContent('Card 1');
+  });
+
+  describe('virtualization', () => {
+    const mockUseIntersectionObserver = jest.mocked(useIntersectionObserver);
+
+    beforeAll(() => {
+      // Mock IntersectionObserver only for virtualization tests
+      global.IntersectionObserver = class IntersectionObserver {
+        root = null;
+
+        rootMargin = '';
+
+        thresholds = [];
+
+        observe = jest.fn();
+
+        unobserve = jest.fn();
+
+        disconnect = jest.fn();
+
+        takeRecords() {
+          return [];
+        }
+      };
+    });
+
+    // afterAll(() => {
+    //   delete (global as typeof globalThis & {
+    //     IntersectionObserver?: typeof IntersectionObserver;
+    //   }).IntersectionObserver;
+    // });
+
+    beforeEach(() => {
+      mockUseIntersectionObserver.mockImplementation(
+        (_observerOptions, setVisibilityList) =>
+          (element, index) => {
+            if (!element) return;
+            element.setAttribute('data-index', index.toString());
+
+            setTimeout(() => {
+              act(() => {
+                setVisibilityList(prev => {
+                  const target = index < 6 ? 1 : 0;
+                  if (prev[index] === target) return prev;
+                  const next = [...prev];
+                  next[index] = target;
+                  return next;
+                });
+              });
+            }, 0);
+
+          },
+      );
+    });
+
+
+    it('should render correctly with content-visibility virtualization', () => {
+      const { asFragment } = render(
+        <BpkCardListCarousel
+          currentIndex={0}
+          initiallyShownCards={3}
+          layout={LAYOUTS.rail}
+          setCurrentIndex={() => { }}
+        >
+          {Array.from({ length: 10 }, (_, i) => (
+            <div key={i}>Card {i + 1}</div>
+          ))}
+        </BpkCardListCarousel>
+      );
+      expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render correctly with many cards (virtualization scenario)', () => {
+      const { asFragment } = render(
+        <BpkCardListCarousel
+          currentIndex={0}
+          initiallyShownCards={3}
+          layout={LAYOUTS.rail}
+          setCurrentIndex={() => { }}
+        >
+          {Array.from({ length: 100 }, (_, i) => (
+            <div key={i}>Card {i + 1}</div>
+          ))}
+        </BpkCardListCarousel>
+      );
+      expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should apply content-visibility to cards outside viewport', async () => {
+      act(() => {
+        render(
+          <BpkCardListCarousel
+            currentIndex={0}
+            initiallyShownCards={3}
+            layout={LAYOUTS.rail}
+            setCurrentIndex={() => { }}
+          >
+            {Array.from({ length: 20 }, (_, i) => (
+              <div key={i}>
+                Card {i + 1}
+              </div>
+            ))}
+          </BpkCardListCarousel>
+        );
+      })
+
+      // Cards outside the initial viewport + buffer should have content-visibility
+
+      // expect(hiddenCardWrapper).toHaveStyle('content-visibility: auto');
+      await waitFor(() => {
+        const hiddenCardWrapper = screen.getByTestId('carousel-card-15');
+        expect(hiddenCardWrapper).toHaveStyle('content-visibility: auto');
+      })
+
+    });
+
+    it('should not apply content-visibility to cards in viewport', async () => {
+      render(
+        <BpkCardListCarousel
+          currentIndex={0}
+          initiallyShownCards={3}
+          layout={LAYOUTS.rail}
+          setCurrentIndex={() => { }}
+        >
+          {Array.from({ length: 10 }, (_, i) => (
+            <div key={i} data-testid={`card-${i}`}>Card {i + 1}</div>
+          ))}
+        </BpkCardListCarousel>
+      );
+
+      // Wait for intersection observer to set visibility state
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 200));
+      });
+
+      // Cards in viewport should not have content-visibility
+      const visibleCardWrapper = screen.getByTestId('card-0').parentElement as HTMLElement;
+      expect(visibleCardWrapper).not.toHaveStyle('content-visibility: auto');
+    });
   });
 });

--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
@@ -199,7 +199,7 @@ const BpkCardListCarousel = (props: CardListCarouselProps) => {
   ): boolean => {
     const isInViewport = index >= firstVisibleIndex - dynamicRenderBufferSize &&
                             index <= firstVisibleIndex + initiallyShownCards - 1 + dynamicRenderBufferSize;
-        const hasBeenVisible = hasBeenVisibleRef.current.has(index);
+    const hasBeenVisible = hasBeenVisibleRef.current.has(index);
 
     return isInViewport || hasBeenVisible
   }

--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
@@ -209,14 +209,16 @@ const BpkCardListCarousel = (props: CardListCarouselProps) => {
         }
 
         // Card virtualization optimization styles
-        const cardVirtualizationStyle: CSSProperties = {
-          contentVisibility: 'auto' // Use content-visibility for browser-native virtualization
-        };
+        const cardVirtualizationStyle: CSSProperties = {};
 
 
         const shouldBeVisible = shouldCardBeVisible(index);
-        if (!shouldBeVisible && cardDimensionStyle.width && cardDimensionStyle.height) {
-          cardVirtualizationStyle.containIntrinsicSize = `${cardDimensionStyle.width} ${cardDimensionStyle.height}`;
+        if (!shouldBeVisible) {
+          cardDimensionStyle.contentVisibility = 'auto'; // Use content-visibility for browser-native virtualization
+
+          if (cardDimensionStyle.width && cardDimensionStyle.height) {
+            cardVirtualizationStyle.containIntrinsicSize = `${cardDimensionStyle.width} ${cardDimensionStyle.height}`;
+          }
         }
 
         return (

--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.tsx
@@ -29,7 +29,6 @@ import throttle from 'lodash/throttle';
 
 import { cssModules } from '../../../bpk-react-utils';
 
-import { RENDER_BUFFER_SIZE } from './constants';
 import {
   lockScroll,
   setA11yTabIndex,
@@ -42,8 +41,6 @@ import type { CardListCarouselProps } from '../common-types';
 import STYLES from './BpkCardListCarousel.module.scss';
 
 const getClassName = cssModules(STYLES);
-
-const PAGINATION_INDICATOR_MAX_SHOWN_COUNT = 5;
 
 const BpkCardListCarousel = (props: CardListCarouselProps) => {
   const {
@@ -92,23 +89,6 @@ const BpkCardListCarousel = (props: CardListCarouselProps) => {
     cardRefs,
     stateScrollingLockRef,
   );
-
-  // Similar to Virtual Scrolling to improve performance
-  const firstVisibleIndex = Math.max(0, visibilityList.indexOf(1));
-  const lastVisibleIndex = firstVisibleIndex + initiallyShownCards - 1;
-
-  const dynamicRenderBufferSize = useMemo(() => {
-    if (childrenLength === 0 || initiallyShownCards === 0 || isMobile) return RENDER_BUFFER_SIZE;
-
-    // Calculate how many cards to render based on the number of initially shown cards and total children
-    const totalPages = Math.ceil(childrenLength / initiallyShownCards);
-    const shownIndicatorCount = Math.min(totalPages, PAGINATION_INDICATOR_MAX_SHOWN_COUNT);
-    return Math.max(
-      RENDER_BUFFER_SIZE,
-      (shownIndicatorCount - 1) * initiallyShownCards,
-    );
-  }, [childrenLength, initiallyShownCards, isMobile]);
-
   const cardRefFns = useMemo(
     () =>
       Array(childrenLength)
@@ -178,12 +158,7 @@ const BpkCardListCarousel = (props: CardListCarouselProps) => {
   }, []);
 
 
-  const shouldCardBeVisible = (index: number) => {
-    const isInViewport = index >= firstVisibleIndex - dynamicRenderBufferSize &&
-      index <= lastVisibleIndex + dynamicRenderBufferSize;
-
-    return isInViewport;
-  }
+  const shouldCardBeVisible = (index: number) => visibilityList[index] === 1;
 
   return (
     <div
@@ -210,12 +185,10 @@ const BpkCardListCarousel = (props: CardListCarouselProps) => {
 
         // Card virtualization optimization styles
         const cardVirtualizationStyle: CSSProperties = {};
+        const isCardVisible = shouldCardBeVisible(index);
 
-
-        const shouldBeVisible = shouldCardBeVisible(index);
-        if (!shouldBeVisible) {
-          cardDimensionStyle.contentVisibility = 'auto'; // Use content-visibility for browser-native virtualization
-
+        if (!isCardVisible) {
+          cardVirtualizationStyle.contentVisibility = 'auto';
           if (cardDimensionStyle.width && cardDimensionStyle.height) {
             cardVirtualizationStyle.containIntrinsicSize = `${cardDimensionStyle.width} ${cardDimensionStyle.height}`;
           }


### PR DESCRIPTION
## Context

Safari exhibits a UX issue where pagination buttons cause visual teleporting/jumping during smooth scrolling on `BpkCardListCarousel`. This happens when navigating rails with man cards (it was detected with 100 cards). The issue was reproduced on Safari 18.6 [(see example)](https://www.skyscanner.net/transport/flights-from/bcn/?adultsv2=1&cabinclass=economy&childrenv2=&ref=home&rtn=1&preferdirects=false&outboundaltsenabled=false&inboundaltsenabled=false&oym=2510&iym=2510&OverrideFeatureTest=ce_e2e_prototype_dev:B), though other versions may also be affected.

Root cause analysis showed that the carousel's virtualization logic swaps placeholder elements with real cards mid-animation. Combined with Safari's scroll-snap handling, this leads to recalculated landing points during scroll. The main detected factors are:

- Native smooth scrolling (`behavior: smooth`)
- CSS scroll-snap (`scroll-snap-type: x mandatory`)
- DOM mutations during scroll (from placeholder to real cards)

## Solution
We are replacing JS-based virtualization with CSS `content-visibility` to eliminate DOM mutations during scroll. Which ensures:

- Stability on DOM structure: All cards remain in the DOM throughout the scroll animation
- Browser-native virtualization: off-screen cards are efficiently managed by the browser

Additionally, CSS `containIntrinsicSize` is used to preserve dimensions for off-screen cards. Both properties are fully supported per Skyscanner's [browserlist](https://github.com/Skyscanner/browserslist-config-skyscanner/blob/main/index.js)

### What has changed?
- Remove programmatic scroll detection logic
- Remove JS virtual scroll logic
- Use `content-vivibility: auto` for off-screen cards
- Use `contain-intrinsic-size` to match actual card dimensions

### Visual changes

**Safari 18.6 with JS Virtual Scroll**

https://github.com/user-attachments/assets/b6a0abec-8609-46f2-a3cf-0d7682006d1c

**Safari 18.6 with CSS `content-visibility`**

https://github.com/user-attachments/assets/16988288-a824-4a5f-bb8f-f803db3f53e7

**Chrome with CSS `content-visibility`**

https://github.com/user-attachments/assets/ea0648fe-9427-4e52-a0bd-a472aad0e4b5


**Firefox with CSS `content-visibility`**

https://github.com/user-attachments/assets/462eba00-4ed5-4d4b-9a4b-ce273b370990



Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
