### PR TITLE
[Clov-727][BpkCheckbox] Connect checkbox to figma

### DIFF
--- a/packages/bpk-component-checkbox/src/BpkCheckbox.figma.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckbox.figma.tsx
@@ -25,19 +25,23 @@ figma.connect(
   'https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=30442%3A60450',
   {
     props: {
+      state: figma.enum('State', {
+        Disabled: true,
+      }),
       style: figma.enum('Style', {
         Default: false,
         'On dark': true,
       }),
+      label: figma.textContent('Option'),
       onChange: () => {},
     },
-    example: ({ label, name, onChange, style }) => (
+    example: ({ label, onChange, state, style }) => (
       <BpkCheckbox
-        name="name"
-        label="label"
+        name={label}
+        label={label}
         onChange={onChange}
         white={style}
-        checked
+        disabled={state}
       />
     ),
   },


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Connect BpkCheckbox to Figma.

| Checked and default style | Disabled and on dark style|
|:-----------|:------------:|
| <img width="926" height="626" alt="image" src="https://github.com/user-attachments/assets/964dbfc8-37ad-44af-92a8-9ce7175e592b" /> | <img width="932" height="638" alt="image" src="https://github.com/user-attachments/assets/51d6e618-b649-4953-b2c3-c843d55e9ad3" /> |


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
