### PR TITLE
[BpkHorizontalNav][CLOV-729] Code connect to Figma

### DIFF
--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.figma.tsx
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.figma.tsx
@@ -18,7 +18,7 @@
 
 import figma from '@figma/code-connect';
 
-import BpkHorizontalNav from './BpkHorizontalNav';
+import BpkHorizontalNav, { HORIZONTAL_NAV_TYPES } from './BpkHorizontalNav';
 import BpkHorizontalNavItem from './BpkHorizontalNavItem';
 
 figma.connect(
@@ -26,14 +26,14 @@ figma.connect(
   'https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=27880%3A31440',
   {
     props: {
-      autoScrollToSelected: figma.boolean('Line'),
+      showUnderline: figma.boolean('Line'),
       type: figma.enum('Style', {
-        Default: 'default',
-        'On Contrast': 'light',
+        Default: HORIZONTAL_NAV_TYPES.default,
+        'On Contrast': HORIZONTAL_NAV_TYPES.light,
       }),
     },
-    example: (props) => (
-      <BpkHorizontalNav {...props}>
+    example: ({ showUnderline, type }) => (
+      <BpkHorizontalNav showUnderline={showUnderline} type={type}>
         <BpkHorizontalNavItem>One</BpkHorizontalNavItem>
         <BpkHorizontalNavItem>Two</BpkHorizontalNavItem>
         <BpkHorizontalNavItem>Three</BpkHorizontalNavItem>

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.figma.tsx
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.figma.tsx
@@ -18,6 +18,7 @@
 
 import figma from '@figma/code-connect';
 
+import { HORIZONTAL_NAV_TYPES } from './BpkHorizontalNav';
 import BpkHorizontalNavItem from './BpkHorizontalNavItem';
 
 figma.connect(
@@ -27,13 +28,10 @@ figma.connect(
     props: {
       selected: figma.enum('State', {
         Active: true,
-        Pressed: true,
-        Hover: true,
-        'Not Selected': false,
       }),
       type: figma.enum('Style', {
-        Default: 'default',
-        Light: 'light',
+        Default: HORIZONTAL_NAV_TYPES.default,
+        Light: HORIZONTAL_NAV_TYPES.light,
       }),
       children: figma.textContent('Label'),
     },


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This pull request introduces a new integration file to connect the `BpkHorizontalNav` component with Figma using Code Connect. This enables designers and developers to preview and configure the component directly in Figma with mapped props.

Figma integration:

* Added a new file `BpkHorizontalNav.figma.tsx` and `BpkHorizontalNavItem.figma.tsx`  that connects the `BpkHorizontalNav` and `BpkHorizontalNavItem` component to Figma using the Code Connect API, mapping component props to Figma controls and providing a usage example for visualisation.


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
