### PR TITLE
[CLOV-737][BpkSectionHeader]connect BpkSectionHeader to figma

### DIFF
--- a/packages/bpk-component-section-header/src/BpkSectionHeader.figma.tsx
+++ b/packages/bpk-component-section-header/src/BpkSectionHeader.figma.tsx
@@ -27,25 +27,23 @@ figma.connect(
   'https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=31941%3A4068',
   {
     props: {
-      // These props were automatically mapped based on your linked code:
       title: figma.string('Title'),
-      description: figma.string('Title'),
-      // No matching props could be found for these Figma properties:
-      // "title": figma.string('Title'),
-      // "subheading": figma.string('Subheading'),
+      description: figma.string('Subheading'),
       button: figma.boolean('Button', {
-        true: <BpkButtonV2 onClick={() => null}> action</BpkButtonV2>,
-        false: null,
+        true: <BpkButtonV2 onClick={() => null}>action</BpkButtonV2>,
       }),
-      // "subheading": figma.boolean('Subheading?'),
-      // "info": figma.boolean('Info?'),
       style: figma.enum('Style', {
         Default: SECTION_TYPES.default,
         'On Dark': SECTION_TYPES.onDark,
       }),
     },
-    example: (props) => (
-      <BpkSectionHeader title={props.title} description={props.description} />
+    example: ({ button, description, style, title }) => (
+      <BpkSectionHeader
+        title={title}
+        description={description}
+        style={style}
+        button={button}
+      />
     ),
   },
 );


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
Connect BpkSectionHeader to figma
|default|dark mode|
|---|---|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/097649e8-c012-41df-8118-37830797f09d" />| <img width="300" alt="image" src="https://github.com/user-attachments/assets/099bd57e-4eab-4807-acc2-53609d1057f9" />|

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
