### PR TITLE
[BpkInput][CLOV-740] Code connect to Figma

### DIFF
--- a/packages/bpk-component-input/src/BpkInput.figma.tsx
+++ b/packages/bpk-component-input/src/BpkInput.figma.tsx
@@ -42,8 +42,8 @@ figma.connect(
     example: ({ dockedFirst, dockedLast, dockedMiddle, large }) => (
       <BpkInput
         id="input-id"
-        name="input-name"
-        value="Enter"
+        name=""
+        value=""
         large={large}
         dockedFirst={dockedFirst}
         dockedMiddle={dockedMiddle}

--- a/packages/bpk-component-input/src/BpkInput.figma.tsx
+++ b/packages/bpk-component-input/src/BpkInput.figma.tsx
@@ -1,0 +1,57 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import figma from '@figma/code-connect';
+
+import BpkInput from './BpkInput';
+
+figma.connect(
+  BpkInput,
+  'https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=30459%3A44636',
+  {
+    props: {
+      large: figma.enum('Size', {
+        Large: true,
+      }),
+      docked: figma.enum('Docking', {
+        None: true,
+      }),
+      dockedFirst: figma.enum('Docking', {
+        Left: true,
+      }),
+      dockedMiddle: figma.enum('Docking', {
+        Centre: true,
+      }),
+      dockedLast: figma.enum('Docking', {
+        Right: true,
+      }),
+    },
+    example: ({ docked, dockedFirst, dockedLast, dockedMiddle, large }) => (
+      <BpkInput
+        id="input-id"
+        name="input-name"
+        value="Enter"
+        large={large}
+        docked={docked}
+        dockedFirst={dockedFirst}
+        dockedMiddle={dockedMiddle}
+        dockedLast={dockedLast}
+      />
+    ),
+  },
+);

--- a/packages/bpk-component-input/src/BpkInput.figma.tsx
+++ b/packages/bpk-component-input/src/BpkInput.figma.tsx
@@ -26,6 +26,7 @@ figma.connect(
   {
     props: {
       large: figma.enum('Size', {
+        Default: false,
         Large: true,
       }),
       docked: figma.enum('Docking', {

--- a/packages/bpk-component-input/src/BpkInput.figma.tsx
+++ b/packages/bpk-component-input/src/BpkInput.figma.tsx
@@ -29,9 +29,6 @@ figma.connect(
         Default: false,
         Large: true,
       }),
-      docked: figma.enum('Docking', {
-        None: true,
-      }),
       dockedFirst: figma.enum('Docking', {
         Left: true,
       }),
@@ -42,13 +39,12 @@ figma.connect(
         Right: true,
       }),
     },
-    example: ({ docked, dockedFirst, dockedLast, dockedMiddle, large }) => (
+    example: ({ dockedFirst, dockedLast, dockedMiddle, large }) => (
       <BpkInput
         id="input-id"
         name="input-name"
         value="Enter"
         large={large}
-        docked={docked}
         dockedFirst={dockedFirst}
         dockedMiddle={dockedMiddle}
         dockedLast={dockedLast}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This pull request introduces a new integration file to connect the `BpkInput ` component with Figma using Code Connect. This enables designers and developers to preview and configure the component directly in Figma with mapped props.

Figma integration:

* Added a new file `BpkInput.figma.tsx` that connects the `BpkInput` component to Figma using the Code Connect API, mapping component props to Figma controls and providing a usage example for visualisation.


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
