### PR TITLE
[CLOV-795][BPKCardList]Fix not left align issue 

### DIFF
--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListRowRailContainer.module.scss
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListRowRailContainer.module.scss
@@ -15,10 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use '../../../unstable__bpk-mixins/tokens';
+@use '../../../unstable__bpk-mixins/utils';
 
 .bpk-card-list-row-rail {
   display: flex;
+  margin-left: -1 * tokens.bpk-spacing-md();
   flex-direction: column;
+
+  @include utils.bpk-rtl {
+    margin-right: -1 * tokens.bpk-spacing-md();
+    margin-left: 0;
+  }
 
   &__accessory {
     width: 100%;

--- a/packages/bpk-component-star-rating/src/BpkStar.js
+++ b/packages/bpk-component-star-rating/src/BpkStar.js
@@ -82,18 +82,18 @@ const BpkStar = ({
 
   let Icon = SmallIcon;
   let OutlineIcon = OutlineSmallIcon;
-  let HalfIcon = HalfSmallIcon;
+  let HalfIcon = withRtlSupport(HalfSmallIcon);
 
   if (large) {
     Icon = LargeIcon;
     OutlineIcon = OutlineLargeIcon;
-    HalfIcon = HalfLargeIcon;
+    HalfIcon = withRtlSupport(HalfLargeIcon);
   }
 
   if (extraLarge) {
     Icon = ExtraLargeIcon;
     OutlineIcon = OutlineExtraLargeIcon;
-    HalfIcon = HalfExtraLargeIcon;
+    HalfIcon = withRtlSupport(HalfExtraLargeIcon);
   }
 
   if (type === STAR_TYPES.HALF) {

--- a/packages/bpk-component-star-rating/src/__snapshots__/BpkStar-test.js.snap
+++ b/packages/bpk-component-star-rating/src/__snapshots__/BpkStar-test.js.snap
@@ -67,6 +67,7 @@ exports[`BpkStar should render correctly with a large half star 1`] = `
   >
     <svg
       aria-hidden="true"
+      class="bpk-icon--rtl-support"
       height="1.5rem"
       viewBox="0 0 24 24"
       width="1.5rem"
@@ -127,6 +128,7 @@ exports[`BpkStar should render correctly with half star 1`] = `
   >
     <svg
       aria-hidden="true"
+      class="bpk-icon--rtl-support"
       height="1rem"
       viewBox="0 0 24 24"
       width="1rem"

--- a/packages/bpk-component-star-rating/src/__snapshots__/BpkStarRating-test.js.snap
+++ b/packages/bpk-component-star-rating/src/__snapshots__/BpkStarRating-test.js.snap
@@ -360,6 +360,7 @@ exports[`BpkStarRating should render correctly with "rounding" attribute 1`] = `
     >
       <svg
         aria-hidden="true"
+        class="bpk-icon--rtl-support"
         height="1rem"
         viewBox="0 0 24 24"
         width="1rem"
@@ -618,6 +619,7 @@ exports[`BpkStarRating should render correctly with 3.5 stars 1`] = `
     >
       <svg
         aria-hidden="true"
+        class="bpk-icon--rtl-support"
         height="1rem"
         viewBox="0 0 24 24"
         width="1rem"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
We noticed that the cards(Rail card) are not left-aligned with the title, subtitle, and chips above them.
Before:
<img width="460" height="556" alt="image" src="https://github.com/user-attachments/assets/e89712b1-9a4e-4845-8010-275b08c9d956" />


After:
<img width="460" height="542" alt="image" src="https://github.com/user-attachments/assets/a6bff2fe-4799-4354-aa58-d5d200693ef4" />


Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
