### PR TITLE
[IRN-6176][BpkCardList] use negative margin to remove bottom padding

### DIFF
--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.module.scss
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.module.scss
@@ -25,7 +25,8 @@
   &__rail {
     display: flex;
     padding-top: tokens.bpk-spacing-sm();
-    padding-bottom: tokens.bpk-spacing-lg();
+    padding-block-end: tokens.bpk-spacing-lg();
+    margin-block-end: -(tokens.bpk-spacing-lg());
     overflow-x: hidden;
     box-sizing: border-box;
     gap: tokens.bpk-spacing-sm();
@@ -34,7 +35,8 @@
     scrollbar-width: none;
 
     @include breakpoints.bpk-breakpoint-mobile {
-      padding-bottom: tokens.bpk-spacing-base();
+      padding-block-end: tokens.bpk-spacing-base();
+      margin-block-end: -(tokens.bpk-spacing-base());
       overflow-x: scroll;
     }
 

--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListRowRailContainer.module.scss
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListRowRailContainer.module.scss
@@ -16,11 +16,14 @@
  * limitations under the License.
  */
 
+@use '../../../unstable__bpk-mixins/tokens';
+
 .bpk-card-list-row-rail {
   display: flex;
   flex-direction: column;
 
   &__accessory {
     width: 100%;
+    margin-block-start: tokens.bpk-spacing-lg();
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
