### PR TITLE
LUNA-2972: BpkDialogWrapper: Prevent background scroll on iOS

### DIFF
--- a/packages/bpk-react-utils/src/BpkDialogWrapper/BpkDialogWrapper.tsx
+++ b/packages/bpk-react-utils/src/BpkDialogWrapper/BpkDialogWrapper.tsx
@@ -46,7 +46,7 @@ interface CommonProps {
     exit?: string
   };
   timeout?: { appear?: number, exit?: number };
-};
+}
 
 export type Props = CommonProps & ({ ariaLabelledby: string } | { ariaLabel: string; });
 
@@ -59,11 +59,8 @@ const dialogSupported = typeof HTMLDialogElement === 'function';
 
 const setPageProperties = ({ isDialogOpen }: DialogProps) => {
   document.body.style.overflowY = isDialogOpen ? 'hidden' : 'visible';
-
-  if (!dialogSupported) {
-    document.body.style.position = isDialogOpen ? 'fixed' : 'relative';
-    document.body.style.width = isDialogOpen ? '100%' : 'auto';
-  }
+  document.body.style.position = isDialogOpen ? 'fixed' : 'relative';
+  document.body.style.width = isDialogOpen ? '100%' : 'auto';
 };
 
 export const BpkDialogWrapper = ({
@@ -79,7 +76,6 @@ export const BpkDialogWrapper = ({
   transitionClassNames = {},
   ...ariaProps
 }: Props) => {
-
   const ref = useRef<HTMLDialogElement>(null);
   const [dialogTarget, setDialogTarget] = useState<HTMLElement | null>(null);
 
@@ -129,7 +125,7 @@ export const BpkDialogWrapper = ({
 
     setPageProperties({ isDialogOpen: isOpen });
     return () => {
-      setPageProperties({ isDialogOpen: false })
+      setPageProperties({ isDialogOpen: false });
       window.removeEventListener('keydown', handleKeyDown);
     };
   }, [id, isOpen, onClose, closeOnEscPressed, closeOnScrimClick]);
@@ -166,7 +162,10 @@ export const BpkDialogWrapper = ({
           className={getClassName('bpk-dialog-wrapper--container', dialogClassName)}
           onCancel={(e) => {
             e.preventDefault();
-            if (closeOnEscPressed && (!dialogTarget || e.target === dialogTarget)) {
+            if (
+              closeOnEscPressed &&
+              (!dialogTarget || e.target === dialogTarget)
+            ) {
               onClose(e, { source: 'ESCAPE' })
             }
           }}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

# What was the problem
When using iOS, the traveler is able to touch scroll on the parent screen behind the BpkDialogWrapper (see video below)

https://github.com/user-attachments/assets/a76529e4-e7f8-45e8-9d41-94d402d0c53f

# What's the fix?
We need to apply `position: fixed` to the parent document body to prevent the document being scrolled by touch. In below video we have applied this fix.

https://github.com/user-attachments/assets/ef3ee644-c1d9-4cfc-b735-aed16b2f84cd


Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
