### PR TITLE
[IRN-6177] [BpkCardList] Fix issue with carousel alignment

### DIFF
--- a/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.module.scss
+++ b/packages/bpk-component-card-list/src/BpkCardListRowRail/BpkCardListCarousel.module.scss
@@ -62,17 +62,16 @@
 
       @include breakpoints.bpk-breakpoint-mobile {
         // On mobile, if there is more than one card in the viewport, the last card only shows partially, so subtract 0.8 when do the calculation
-        flex: 0 0
-          calc(
-            (
-                100% -
-                  (
-                    tokens.bpk-spacing-md() *
-                      (var(--initially-shown-cards, 3) - 1)
-                  )
-              ) /
-              max(1, (var(--initially-shown-cards, 3) - 0.8))
-          );
+        flex-basis: calc(
+          (
+              100% -
+                (
+                  tokens.bpk-spacing-md() *
+                    (var(--initially-shown-cards, 3) - 1)
+                )
+            ) /
+            max(1, (var(--initially-shown-cards, 3) - 0.8))
+        );
 
         &:first-child {
           padding-left: tokens.bpk-spacing-sm();
@@ -83,6 +82,20 @@
           }
         }
       }
+    }
+  }
+
+  &__row {
+    margin-inline: -1 * tokens.bpk-spacing-md();
+
+    &__card {
+      flex-basis: calc(
+        (
+            100% -
+              (tokens.bpk-spacing-sm() * (var(--initially-shown-cards, 3) - 1))
+          ) /
+          var(--initially-shown-cards, 3)
+      );
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
This change is to address the issues with alignment when using row to rail. 

There are a few concerns:
- Drop shadows on cards getting cut off
- Ensuring the width of the cards is correct
- Where is the edge of the container

This change fixes is by when we are in the row state, we can have negative margin equal to the padding on the cards, and adjust the flex basis of the cards to fill the space correctly.

<img width="1074" height="437" alt="image" src="https://github.com/user-attachments/assets/88e86f8a-3790-4180-bd9b-db2d8d0f6356" />

Because of the peaking on the cards, we don't apply this to rail mode, so it only fixes the issue on desktop.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
