### PR TITLE
[NOJIRA]revert [LUNA-2972][BpkDialogWrapper]: Prevent background scroll on iOS

### DIFF
--- a/packages/bpk-react-utils/src/BpkDialogWrapper/BpkDialogWrapper.tsx
+++ b/packages/bpk-react-utils/src/BpkDialogWrapper/BpkDialogWrapper.tsx
@@ -64,8 +64,10 @@ const dialogSupported = typeof HTMLDialogElement === 'function';
 
 const setPageProperties = ({ isDialogOpen }: DialogProps) => {
   document.body.style.overflowY = isDialogOpen ? 'hidden' : 'visible';
-  document.body.style.position = isDialogOpen ? 'fixed' : 'relative';
-  document.body.style.width = isDialogOpen ? '100%' : 'auto';
+  if (!dialogSupported) {
+    document.body.style.position = isDialogOpen ? 'fixed' : 'relative';
+    document.body.style.width = isDialogOpen ? '100%' : 'auto';
+  }
 };
 
 export const BpkDialogWrapper = ({


### PR DESCRIPTION
# What was the problem
revert https://github.com/Skyscanner/backpack/pull/4002/files as we encounter two visual test fail while bumping Banana backpack to include the fix.
We want to revert the change to make sure we can bump the other fix like the removal of unsafe React API usage ASAP
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
