### PR TITLE
[NO JIRA][BpkBottomSheet] Export PADDING_TYPE

### DIFF
--- a/examples/bpk-component-bottom-sheet/examples.tsx
+++ b/examples/bpk-component-bottom-sheet/examples.tsx
@@ -19,8 +19,9 @@
 import { Component, Children } from 'react';
 import type { ReactNode } from 'react';
 
-import BpkBottomSheet from '../../packages/bpk-component-bottom-sheet';
-import { PADDING_TYPE } from '../../packages/bpk-component-bottom-sheet/src/BpkBottomSheet';
+import BpkBottomSheet, {
+  PADDING_TYPE,
+} from '../../packages/bpk-component-bottom-sheet';
 import { BpkButtonV2 } from '../../packages/bpk-component-button';
 import BpkText, { TEXT_STYLES } from '../../packages/bpk-component-text';
 import { cssModules, withDefaultProps } from '../../packages/bpk-react-utils';

--- a/packages/bpk-component-bottom-sheet/README.md
+++ b/packages/bpk-component-bottom-sheet/README.md
@@ -10,7 +10,7 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 
 ```js
 import { Component } from 'react';
-import BpkBottomSheet from '@skyscanner/backpack-web/bpk-component-bottom-sheet';
+import BpkBottomSheet, { PADDING_TYPE } from '@skyscanner/backpack-web/bpk-component-bottom-sheet';
 import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
 
 class App extends Component {

--- a/packages/bpk-component-bottom-sheet/index.ts
+++ b/packages/bpk-component-bottom-sheet/index.ts
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-import BpkBottomSheet from './src/BpkBottomSheet';
+import BpkBottomSheet, { PADDING_TYPE } from './src/BpkBottomSheet';
 
 import type { Props } from './src/BpkBottomSheet';
 
 export type BpkBottomSheetProps = Props;
 
+export { PADDING_TYPE };
 export default BpkBottomSheet;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Export `PADDING_TYPE` in `BpkBottomSheet`

before
```
import BpkBottomSheet from '@skyscanner/backpack-web/bpk-component-bottom-sheet';
import { PADDING_TYPE } from '@skyscanner/backpack-web/bpk-component-bottom-sheet/src/BpkBottomSheet';
```
after
```
import BpkBottomSheet, { PADDING_TYPE } from '@skyscanner/backpack-web/bpk-component-bottom-sheet';
```

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
