### PR TITLE
[CLOV-951][BpkButton] Mark BpkButton v1 as deprecated

### DIFF
--- a/packages/bpk-component-button/BpkButtonDestructive.tsx
+++ b/packages/bpk-component-button/BpkButtonDestructive.tsx
@@ -18,5 +18,10 @@
 
 import BpkButton, {type Props} from './src/BpkButton';
 
+/**
+ * @deprecated BpkButtonDestructive is deprecated and will be removed in a future major version. Please use BpkButtonV2 with type={BUTTON_TYPES.destructive} instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Destructive button component
+ */
 const BpkButtonDestructive = (props: Props) => <BpkButton {...props} destructive />
 export default BpkButtonDestructive;

--- a/packages/bpk-component-button/BpkButtonFeatured.tsx
+++ b/packages/bpk-component-button/BpkButtonFeatured.tsx
@@ -18,5 +18,10 @@
 
 import BpkButton, {type Props} from './src/BpkButton';
 
+/**
+ * @deprecated BpkButtonFeatured is deprecated and will be removed in a future major version. Please use BpkButtonV2 with type={BUTTON_TYPES.featured} instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Featured button component
+ */
 const BpkButtonFeatured = (props: Props) => <BpkButton {...props} featured />
 export default BpkButtonFeatured;

--- a/packages/bpk-component-button/BpkButtonLink.tsx
+++ b/packages/bpk-component-button/BpkButtonLink.tsx
@@ -18,5 +18,10 @@
 
 import BpkButton, {type Props} from './src/BpkButton';
 
+/**
+ * @deprecated BpkButtonLink is deprecated and will be removed in a future major version. Please use BpkButtonV2 with type={BUTTON_TYPES.link} instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Link button component
+ */
 const BpkButtonLink = (props: Props) => <BpkButton {...props} link />
 export default BpkButtonLink;

--- a/packages/bpk-component-button/BpkButtonLinkOnDark.tsx
+++ b/packages/bpk-component-button/BpkButtonLinkOnDark.tsx
@@ -17,5 +17,10 @@
  */
 import BpkButton, {type Props} from './src/BpkButton';
 
+/**
+ * @deprecated BpkButtonLinkOnDark is deprecated and will be removed in a future major version. Please use BpkButtonV2 with type={BUTTON_TYPES.linkOnDark} instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Link on dark button component
+ */
 const BpkButtonLinkOnDark = (props: Props) => <BpkButton {...props} linkOnDark />
 export default BpkButtonLinkOnDark;

--- a/packages/bpk-component-button/BpkButtonPrimary.tsx
+++ b/packages/bpk-component-button/BpkButtonPrimary.tsx
@@ -18,5 +18,10 @@
 
 import BpkButton, {type Props} from './src/BpkButton';
 
+/**
+ * @deprecated BpkButtonPrimary is deprecated and will be removed in a future major version. Please use BpkButtonV2 with type={BUTTON_TYPES.primary} instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Primary button component
+ */
 const BpkButtonPrimary = (props: Props) => <BpkButton {...props} />
 export default BpkButtonPrimary;

--- a/packages/bpk-component-button/BpkButtonPrimaryOnDark.tsx
+++ b/packages/bpk-component-button/BpkButtonPrimaryOnDark.tsx
@@ -18,5 +18,10 @@
 
 import BpkButton, {type Props} from './src/BpkButton';
 
+/**
+ * @deprecated BpkButtonPrimaryOnDark is deprecated and will be removed in a future major version. Please use BpkButtonV2 with type={BUTTON_TYPES.primaryOnDark} instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Primary on dark button component
+ */
 const BpkButtonPrimaryOnDark = (props: Props) => <BpkButton {...props} primaryOnDark />
 export default BpkButtonPrimaryOnDark;

--- a/packages/bpk-component-button/BpkButtonPrimaryOnLight.tsx
+++ b/packages/bpk-component-button/BpkButtonPrimaryOnLight.tsx
@@ -18,5 +18,10 @@
 
 import BpkButton, {type Props} from './src/BpkButton';
 
+/**
+ * @deprecated BpkButtonPrimaryOnLight is deprecated and will be removed in a future major version. Please use BpkButtonV2 with type={BUTTON_TYPES.primaryOnLight} instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Primary on light button component
+ */
 const BpkButtonPrimaryOnLight = (props: Props) => <BpkButton {...props} primaryOnLight />
 export default BpkButtonPrimaryOnLight;

--- a/packages/bpk-component-button/BpkButtonSecondary.tsx
+++ b/packages/bpk-component-button/BpkButtonSecondary.tsx
@@ -18,5 +18,10 @@
 
 import BpkButton, {type Props} from './src/BpkButton';
 
+/**
+ * @deprecated BpkButtonSecondary is deprecated and will be removed in a future major version. Please use BpkButtonV2 with type={BUTTON_TYPES.secondary} instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Secondary button component
+ */
 const BpkButtonSecondary = (props: Props) => <BpkButton {...props} secondary />
 export default BpkButtonSecondary;

--- a/packages/bpk-component-button/BpkButtonSecondaryOnDark.tsx
+++ b/packages/bpk-component-button/BpkButtonSecondaryOnDark.tsx
@@ -18,5 +18,10 @@
 
 import BpkButton, {type Props} from './src/BpkButton';
 
+/**
+ * @deprecated BpkButtonSecondaryOnDark is deprecated and will be removed in a future major version. Please use BpkButtonV2 with type={BUTTON_TYPES.secondaryOnDark} instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Secondary on dark button component
+ */
 const BpkButtonSecondaryOnDark = (props: Props) => <BpkButton {...props} secondaryOnDark />
 export default BpkButtonSecondaryOnDark;

--- a/packages/bpk-component-button/README.md
+++ b/packages/bpk-component-button/README.md
@@ -2,6 +2,10 @@
 
 > Backpack button component.
 
+# 👻 BpkButton (V1) has been deprecated, and usages should be replaced with BpkButtonV2
+
+The legacy `BpkButton` component and all its variants (`BpkButtonPrimary`, `BpkButtonSecondary`, etc.) are deprecated and will be removed in a future major version. Please migrate to `BpkButtonV2` using the migration guide.
+
 ## Installation
 
 Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.

--- a/packages/bpk-component-button/src/BpkButton.tsx
+++ b/packages/bpk-component-button/src/BpkButton.tsx
@@ -34,6 +34,11 @@ export type Props = CommonProps & {
   linkOnDark?: boolean;
 };
 
+/**
+ * @deprecated BpkButton is deprecated and will be removed in a future major version. Please use BpkButtonV2 instead.
+ * @param {Props} props - Component props
+ * @returns {JSX.Element} Button component
+ */
 const BpkButton = ({
   destructive = false,
   featured = false,


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)

-->

**Context** 

As part of the Design System modernization effort, we are migrating all usages of `BpkButton` (V1) to `BpkButtonV2` (V2).  Before we replace all usage of `BpkButton` with `BpkButtonV2` in active codebases, we need to mark it as deprecated to avoid consumer using `BpkButton` and recommend to using `BpkButtonV2` instead.

**Description**

- Added JSDoc deprecation warnings to all BpkButton v1 components
- Updated README with prominent deprecation notice
- Provided migration guidance directing users to BpkButtonV2 with corresponding BUTTON_TYPES

<img width="568" height="112" alt="image" src="https://github.com/user-attachments/assets/f859161a-7407-4c3a-90ec-0f9e337c1ad4" />


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [x] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
