### PR TITLE
[GOOSE-559][BpkSwapButton] Override padding alignment set by Safari User Agent

### DIFF
--- a/packages/bpk-component-swap-button/src/BpkSwapButton.module.scss
+++ b/packages/bpk-component-swap-button/src/BpkSwapButton.module.scss
@@ -37,14 +37,13 @@
     display: flex;
     width: tokens.bpk-spacing-xxl();
     height: tokens.bpk-spacing-xxl();
+    padding: 0;
     justify-content: center;
     align-items: center;
     transition: transform tokens.$bpk-duration-base;
     border: tokens.$bpk-border-size-xl solid tokens.$bpk-core-primary-day;
     border-radius: 50%;
     background-color: tokens.$bpk-surface-default-day;
-    padding-block: 0;
-    padding-inline: 0;
 
     @include breakpoints.bpk-breakpoint-small-tablet {
       border: tokens.$bpk-border-size-lg solid tokens.$bpk-core-primary-day;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Ref: https://skyscanner.atlassian.net/browse/GOOSE-559

Safari ships its own user-agent styles, and our unstyled button ends up inheriting a few defaults we don’t actually want:

```css
padding-inline-start: 6px;
padding-block-start: 2px;
padding-block-end: 3px;
```

These extra paddings throw off the visual alignment compared to other browsers. This PR zeroes them out so the component isn’t relying on Safari’s quirks. Flexbox already handles centering, so resetting the padding brings consistent cross-browser rendering without changing layout logic.

### Before
<img width="206" height="173" alt="image" src="https://github.com/user-attachments/assets/796972fe-1139-460d-84a4-f94122e02bb5" />


### After (1px diff)
<img width="206" height="173" alt="image" src="https://github.com/user-attachments/assets/44170591-a5a9-44cb-b537-8bb8dd5ca113" />


> No changes noticed in Firefox and Chrome

---

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
