### PR TITLE
[BpkAutosuggest] Fix autosuggestion title not breaking words when title doesn't include spaces

### DIFF
--- a/packages/bpk-component-autosuggest/src/BpkAutosuggest.module.scss
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggest.module.scss
@@ -135,6 +135,7 @@ $arrow-size: tokens.bpk-spacing-sm() * 3;
 
     &-value {
       display: block;
+      overflow-wrap: anywhere;
     }
 
     &-sub-heading {


### PR DESCRIPTION
# BpkAutosuggest

This pull request makes a small improvement to the styling of the autosuggest component. The change ensures that long values in the component will wrap anywhere, preventing layout issues or overflow.

- Added the `overflow-wrap: anywhere;` CSS property to the `.bpk-autosuggest__value` class in `BpkAutosuggest.module.scss` to improve text wrapping for long values.

Title value of an autosuggest item was already allowed to be multi line, this change just adds extra behaviour when there's no 'soft' (spaces, commas) way of breaking the word.

| Before | After |
| --- | --- |
| <img width="318" height="202" alt="image" src="https://github.com/user-attachments/assets/50f4c6cd-22f6-45b7-99cc-b2b853577ed3" /> | <img width="324" height="264" alt="Edinburgh_Edinburgh_Edinburgh_E" src="https://github.com/user-attachments/assets/2107687d-92e0-41b1-b8cc-26f82728df56" /> |

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
