### PR TITLE
[NO JIRA][BpkButton] Fix BpkButton large size style

### DIFF
--- a/packages/bpk-component-button/src/BpkButtonV2/BpkButton.module.scss
+++ b/packages/bpk-component-button/src/BpkButtonV2/BpkButton.module.scss
@@ -54,6 +54,7 @@
 
     // override SVG display for link buttons
     --bpk-button-svg-display: inline-block;
+    --bpk-button-svg-vertical-align: middle;
 
     &--implicit {
       @include typography.bpk-link--implicit;
@@ -67,6 +68,10 @@
   &--link-on-dark {
     @include buttons.bpk-button--link-on-dark;
     @include typography.bpk-link--alternate;
+
+    // override SVG display for link buttons
+    --bpk-button-svg-display: inline-block;
+    --bpk-button-svg-vertical-align: middle;
 
     &--implicit {
       @include typography.bpk-link--implicit;
@@ -112,6 +117,7 @@
   /* stylelint-disable selector-max-compound-selectors */
   span > svg {
     display: var(--bpk-button-svg-display, block);
+    vertical-align: var(--bpk-button-svg-vertical-align, baseline);
   }
 
   svg {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Context
This PR fixes the vertical alignment of SVG icons within `BpkButton` components that use the `linkOnDark` variant by applying consistent alignment styles, which indirectly fix `BpkLoadingButton` when size is large.


Key changes
- Added CSS custom property for controlling SVG vertical alignment in link-style buttons
- Applied the same alignment fix to both `link` and `linkOnDark` button variants


| Before          | After |
| ----------------------------- | ----------------------------- |
| <img src="https://github.com/user-attachments/assets/2022ad1d-8288-405c-97bc-6cba4b9bfe08" width=400/> | <img src="https://github.com/user-attachments/assets/168881e4-3f97-4996-8a44-7a2de7bdbc94" width=400 /> |


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
