### PR TITLE
[Clov-970] Add xs spacing token for backpack layout component

### DIFF
--- a/packages/bpk-component-layout/README.md
+++ b/packages/bpk-component-layout/README.md
@@ -62,7 +62,7 @@ export default function Example() {
 The layout API is intentionally limited and strongly typed. The main groups are:
 
 - **Spacing** – `padding`, `margin`, logical props (`marginStart`, `marginEnd`, `paddingInline`), `gap`:
-  - Values: `BpkSpacing` tokens (`BpkSpacing.SM`, `BpkSpacing.MD`, …) or percentages (e.g. `'50%'`).
+  - Values: `BpkSpacing` tokens (`BpkSpacing.XS`, `BpkSpacing.SM`, `BpkSpacing.MD`, …) or percentages (e.g. `'50%'`).
 - **Size** – `width`, `height`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight`:
   - Values: rem strings (e.g. `'6rem'`), percentages (e.g. `'50%'`) or semantic values (`'auto' | 'full' | 'fit-content'`).
 - **Position** – `top`, `right`, `bottom`, `left`:

--- a/packages/bpk-component-layout/src/theme.ts
+++ b/packages/bpk-component-layout/src/theme.ts
@@ -50,6 +50,7 @@ const bpkTokens = require('@skyscanner/bpk-foundations-web/tokens/base.es6');
 // - bpk-spacing-xxl() returns 2.5rem
 // - bpk-spacing-base() returns 1rem (standard base spacing)
 // TODO: CLOV-1021 - will add spacing tokens to Backpack Foundations package and use them here after we ship the PoC
+const spacingXs = '.125rem'; // 2px
 const spacingSm = '.25rem';
 const spacingBase = '1rem'; // Standard base spacing
 const spacingMd = '.5rem';
@@ -71,6 +72,9 @@ const spacingXxl = '2.5rem';
 // Spacing tokens - directly imported from foundations
 const spacingMap: Record<string, { value: string }> = {
   'bpk-spacing-none': { value: '0' },
+  // Temporary: Foundations does not yet export a 2px spacing token. This will be
+  // replaced with a foundations value once available.
+  'bpk-spacing-xs': { value: spacingXs },
   'bpk-spacing-sm': { value: spacingSm },
   'bpk-spacing-base': { value: spacingBase },
   'bpk-spacing-md': { value: spacingMd },

--- a/packages/bpk-component-layout/src/tokenUtils-test.ts
+++ b/packages/bpk-component-layout/src/tokenUtils-test.ts
@@ -32,6 +32,13 @@ describe('processBpkProps', () => {
     expect(result.padding).toBe('.5rem');
   });
 
+  it('supports the temporary 2px spacing token (bpk-spacing-xs)', () => {
+    const result = processBpkProps({ padding: BpkSpacing.XS });
+
+    // bpk-spacing-xs is mapped to .125rem (2px) in theme.ts
+    expect(result.padding).toBe('.125rem');
+  });
+
   it('passes through percentage spacing values unchanged', () => {
     const result = processBpkProps({ margin: '50%' });
 

--- a/packages/bpk-component-layout/src/tokens.ts
+++ b/packages/bpk-component-layout/src/tokens.ts
@@ -29,6 +29,7 @@
  */
 export const BpkSpacing = {
   None: 'bpk-spacing-none',
+  XS: 'bpk-spacing-xs',
   SM: 'bpk-spacing-sm',
   Base: 'bpk-spacing-base',
   MD: 'bpk-spacing-md',


### PR DESCRIPTION
After conducting some tests, we discovered that a spacing of `2px` is currently in use in our production. We need to create a spacing token for this value. I had a brief conversation with our backpack designer, and we confirmed that we will be adding a new spacing token in the future. This PR is to add this value to backpack layout for our PoC

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
