### PR TITLE
[LUNA-3186]: Make marker prop optional in BpkPriceRange (breaking change option)

### DIFF
--- a/examples/bpk-component-price-range/examples.tsx
+++ b/examples/bpk-component-price-range/examples.tsx
@@ -18,9 +18,12 @@
 
 import type { ReactNode } from 'react';
 
-import BpkPriceRange from '../../packages/bpk-component-price-range';
+import BpkPriceRange, {
+  type BpkPriceRangeProps,
+  MARKER_DISPLAY_TYPES,
+} from '../../packages/bpk-component-price-range';
 
-const segments = {
+const segments: BpkPriceRangeProps['segments'] = {
   low: {
     price: '£100',
     percentage: 20,
@@ -31,7 +34,7 @@ const segments = {
   },
 };
 
-const veryLargeSegments = {
+const veryLargeSegments: BpkPriceRangeProps['segments'] = {
   low: {
     price: '35M ₫',
     percentage: 20,
@@ -50,207 +53,124 @@ const Wrapper = ({
   isLarge?: boolean;
 }) => <div style={{ width: isLarge ? '15rem' : '8.75rem' }}>{children}</div>;
 
-// Use case 3: Dot marker without boundaries
-const DotMarkerWithoutBoundariesLowExample = () => (
+// Use case 1: Dot marker (boundaries hidden)
+const DotMarkerLowExample = () => (
   <Wrapper>
     <BpkPriceRange
-      showPriceOnBoundaries={false}
-      marker={{ price: '£50', percentage: 10, type: 'dot' }}
+      marker={{ price: '£50', percentage: 10, type: MARKER_DISPLAY_TYPES.DOT }}
       segments={segments}
     />
   </Wrapper>
 );
 
-const DotMarkerWithoutBoundariesMediumExample = () => (
+const DotMarkerMediumExample = () => (
   <Wrapper>
     <BpkPriceRange
-      showPriceOnBoundaries={false}
-      marker={{ price: '£150', percentage: 50, type: 'dot' }}
+      marker={{ price: '£150', percentage: 50, type: MARKER_DISPLAY_TYPES.DOT }}
       segments={segments}
     />
   </Wrapper>
 );
 
-const DotMarkerWithoutBoundariesHighExample = () => (
+const DotMarkerHighExample = () => (
   <Wrapper>
     <BpkPriceRange
-      showPriceOnBoundaries={false}
-      marker={{ price: '£300', percentage: 90, type: 'dot' }}
+      marker={{ price: '£300', percentage: 90, type: MARKER_DISPLAY_TYPES.DOT }}
       segments={segments}
     />
   </Wrapper>
 );
 
-// Use case 1: Dot marker with boundaries
-const DotMarkerWithBoundariesLowExample = () => (
+// Use case 2: Bubble marker (boundaries shown)
+const BubbleMarkerLowExample = () => (
   <Wrapper isLarge>
     <BpkPriceRange
-      showPriceOnBoundaries
-      marker={{ price: '£50', percentage: 10, type: 'dot' }}
+      marker={{
+        price: '£50',
+        percentage: 10,
+        type: MARKER_DISPLAY_TYPES.BUBBLE,
+      }}
       segments={segments}
     />
   </Wrapper>
 );
 
-const DotMarkerWithBoundariesMediumExample = () => (
+const BubbleMarkerMediumExample = () => (
   <Wrapper isLarge>
     <BpkPriceRange
-      showPriceOnBoundaries
-      marker={{ price: '£150', percentage: 50, type: 'dot' }}
+      marker={{
+        price: '£150',
+        percentage: 50,
+        type: MARKER_DISPLAY_TYPES.BUBBLE,
+      }}
       segments={segments}
     />
   </Wrapper>
 );
 
-const DotMarkerWithBoundariesHighExample = () => (
+const BubbleMarkerHighExample = () => (
   <Wrapper isLarge>
     <BpkPriceRange
-      showPriceOnBoundaries
-      marker={{ price: '£300', percentage: 90, type: 'dot' }}
+      marker={{
+        price: '£300',
+        percentage: 90,
+        type: MARKER_DISPLAY_TYPES.BUBBLE,
+      }}
       segments={segments}
     />
   </Wrapper>
 );
 
-// Use case 2: Bubble marker with boundaries
-const BubbleMarkerWithBoundariesLowExample = () => (
+const BubbleMarkerVeryLargeExample = () => (
   <Wrapper isLarge>
     <BpkPriceRange
-      showPriceOnBoundaries
-      marker={{ price: '£50', percentage: 10, type: 'bubble' }}
-      segments={segments}
-    />
-  </Wrapper>
-);
-
-const BubbleMarkerWithBoundariesMediumExample = () => (
-  <Wrapper isLarge>
-    <BpkPriceRange
-      showPriceOnBoundaries
-      marker={{ price: '£150', percentage: 50, type: 'bubble' }}
-      segments={segments}
-    />
-  </Wrapper>
-);
-
-const BubbleMarkerWithBoundariesHighExample = () => (
-  <Wrapper isLarge>
-    <BpkPriceRange
-      showPriceOnBoundaries
-      marker={{ price: '£300', percentage: 90, type: 'bubble' }}
-      segments={segments}
-    />
-  </Wrapper>
-);
-
-const BubbleMarkerWithBoundariesVeryLargeExample = () => (
-  <Wrapper isLarge>
-    <BpkPriceRange
-      showPriceOnBoundaries
-      marker={{ price: '70M ₫', percentage: 90, type: 'bubble' }}
+      marker={{
+        price: '70M ₫',
+        percentage: 90,
+        type: MARKER_DISPLAY_TYPES.BUBBLE,
+      }}
       segments={veryLargeSegments}
     />
   </Wrapper>
 );
 
-// Use case 4: Bubble marker without boundaries
-const BubbleMarkerWithoutBoundariesLowExample = () => (
-  <Wrapper>
-    <BpkPriceRange
-      showPriceOnBoundaries={false}
-      marker={{ price: '£50', percentage: 10, type: 'bubble' }}
-      segments={segments}
-    />
-  </Wrapper>
-);
-
-const BubbleMarkerWithoutBoundariesMediumExample = () => (
-  <Wrapper>
-    <BpkPriceRange
-      showPriceOnBoundaries={false}
-      marker={{ price: '£150', percentage: 50, type: 'bubble' }}
-      segments={segments}
-    />
-  </Wrapper>
-);
-
-const BubbleMarkerWithoutBoundariesHighExample = () => (
-  <Wrapper>
-    <BpkPriceRange
-      showPriceOnBoundaries={false}
-      marker={{ price: '£300', percentage: 90, type: 'bubble' }}
-      segments={segments}
-    />
-  </Wrapper>
-);
-
-// Use case 5: No marker with boundaries
-const NoMarkerWithBoundariesExample = () => (
+// Use case 3: No marker (boundaries shown)
+const NoMarkerExample = () => (
   <Wrapper isLarge>
-    <BpkPriceRange showPriceOnBoundaries segments={segments} />
-  </Wrapper>
-);
-
-// Use case 6: No marker without boundaries
-const NoMarkerWithoutBoundariesExample = () => (
-  <Wrapper>
-    <BpkPriceRange showPriceOnBoundaries={false} segments={segments} />
+    <BpkPriceRange segments={segments} />
   </Wrapper>
 );
 
 const MixedExample = () => (
   <div>
-    <h4>Use case 1: Dot marker with boundaries</h4>
-    <DotMarkerWithBoundariesLowExample />
-    <DotMarkerWithBoundariesMediumExample />
-    <DotMarkerWithBoundariesHighExample />
+    <h4>Use case 1: Dot marker (boundaries hidden)</h4>
+    <DotMarkerLowExample />
+    <DotMarkerMediumExample />
+    <DotMarkerHighExample />
 
-    <h4>Use case 2: Bubble marker with boundaries</h4>
-    <BubbleMarkerWithBoundariesLowExample />
-    <BubbleMarkerWithBoundariesMediumExample />
-    <BubbleMarkerWithBoundariesHighExample />
-    <BubbleMarkerWithBoundariesVeryLargeExample />
+    <h4>Use case 2: Bubble marker (boundaries shown)</h4>
+    <BubbleMarkerLowExample />
+    <BubbleMarkerMediumExample />
+    <BubbleMarkerHighExample />
+    <BubbleMarkerVeryLargeExample />
 
-    <h4>Use case 3: Dot marker without boundaries</h4>
-    <DotMarkerWithoutBoundariesLowExample />
-    <DotMarkerWithoutBoundariesMediumExample />
-    <DotMarkerWithoutBoundariesHighExample />
-
-    <h4>Use case 4: Bubble marker without boundaries</h4>
-    <BubbleMarkerWithoutBoundariesLowExample />
-    <BubbleMarkerWithoutBoundariesMediumExample />
-    <BubbleMarkerWithoutBoundariesHighExample />
-
-    <h4>Use case 5: No marker with boundaries</h4>
-    <NoMarkerWithBoundariesExample />
-
-    <h4>Use case 6: No marker without boundaries</h4>
-    <NoMarkerWithoutBoundariesExample />
+    <h4>Use case 3: No marker (boundaries shown)</h4>
+    <NoMarkerExample />
   </div>
 );
 
 export {
-  // Use case 1: Dot marker with boundaries
-  DotMarkerWithBoundariesLowExample,
-  DotMarkerWithBoundariesMediumExample,
-  DotMarkerWithBoundariesHighExample,
-  // Use case 2: Bubble marker with boundaries
-  BubbleMarkerWithBoundariesLowExample,
-  BubbleMarkerWithBoundariesMediumExample,
-  BubbleMarkerWithBoundariesHighExample,
-  BubbleMarkerWithBoundariesVeryLargeExample,
-  // Use case 3: Dot marker without boundaries
-  DotMarkerWithoutBoundariesLowExample,
-  DotMarkerWithoutBoundariesMediumExample,
-  DotMarkerWithoutBoundariesHighExample,
-  // Use case 4: Bubble marker without boundaries
-  BubbleMarkerWithoutBoundariesLowExample,
-  BubbleMarkerWithoutBoundariesMediumExample,
-  BubbleMarkerWithoutBoundariesHighExample,
-  // Use case 5: No marker with boundaries
-  NoMarkerWithBoundariesExample,
-  // Use case 6: No marker without boundaries
-  NoMarkerWithoutBoundariesExample,
+  // Use case 1: Dot marker (boundaries hidden)
+  DotMarkerLowExample,
+  DotMarkerMediumExample,
+  DotMarkerHighExample,
+  // Use case 2: Bubble marker (boundaries shown)
+  BubbleMarkerLowExample,
+  BubbleMarkerMediumExample,
+  BubbleMarkerHighExample,
+  BubbleMarkerVeryLargeExample,
+  // Use case 3: No marker (boundaries shown)
+  NoMarkerExample,
   // Mixed
   MixedExample,
 };

--- a/examples/bpk-component-price-range/examples.tsx
+++ b/examples/bpk-component-price-range/examples.tsx
@@ -50,106 +50,207 @@ const Wrapper = ({
   isLarge?: boolean;
 }) => <div style={{ width: isLarge ? '15rem' : '8.75rem' }}>{children}</div>;
 
-const SmallerLowPriceRangeExample = () => (
+// Use case 3: Dot marker without boundaries
+const DotMarkerWithoutBoundariesLowExample = () => (
   <Wrapper>
     <BpkPriceRange
-      showPriceIndicator={false}
-      marker={{ price: '£50', percentage: 10 }}
+      showPriceOnBoundaries={false}
+      marker={{ price: '£50', percentage: 10, type: 'dot' }}
       segments={segments}
     />
   </Wrapper>
 );
-const SmallerMediumPriceRangeExample = () => (
+
+const DotMarkerWithoutBoundariesMediumExample = () => (
   <Wrapper>
     <BpkPriceRange
-      showPriceIndicator={false}
-      marker={{ price: '£150', percentage: 50 }}
+      showPriceOnBoundaries={false}
+      marker={{ price: '£150', percentage: 50, type: 'dot' }}
       segments={segments}
     />
   </Wrapper>
 );
 
-const SmallerHighPriceRangeExample = () => (
+const DotMarkerWithoutBoundariesHighExample = () => (
   <Wrapper>
     <BpkPriceRange
-      showPriceIndicator={false}
-      marker={{ price: '£300', percentage: 90 }}
+      showPriceOnBoundaries={false}
+      marker={{ price: '£300', percentage: 90, type: 'dot' }}
       segments={segments}
     />
   </Wrapper>
 );
 
-const LargeLowPriceRangeExample = () => (
+// Use case 1: Dot marker with boundaries
+const DotMarkerWithBoundariesLowExample = () => (
   <Wrapper isLarge>
     <BpkPriceRange
-      marker={{ price: '£50', percentage: 10 }}
+      showPriceOnBoundaries
+      marker={{ price: '£50', percentage: 10, type: 'dot' }}
       segments={segments}
     />
   </Wrapper>
 );
 
-const LargeMediumPriceRangeExample = () => (
+const DotMarkerWithBoundariesMediumExample = () => (
   <Wrapper isLarge>
     <BpkPriceRange
-      marker={{ price: '£150', percentage: 50 }}
+      showPriceOnBoundaries
+      marker={{ price: '£150', percentage: 50, type: 'dot' }}
       segments={segments}
     />
   </Wrapper>
 );
 
-const LargeHighPriceRangeExample = () => (
+const DotMarkerWithBoundariesHighExample = () => (
   <Wrapper isLarge>
     <BpkPriceRange
-      marker={{ price: '£300', percentage: 90 }}
+      showPriceOnBoundaries
+      marker={{ price: '£300', percentage: 90, type: 'dot' }}
       segments={segments}
     />
   </Wrapper>
 );
 
-const VeryLargeHighPriceRangeExample = () => (
+// Use case 2: Bubble marker with boundaries
+const BubbleMarkerWithBoundariesLowExample = () => (
   <Wrapper isLarge>
     <BpkPriceRange
-      marker={{ price: '70M ₫', percentage: 90 }}
+      showPriceOnBoundaries
+      marker={{ price: '£50', percentage: 10, type: 'bubble' }}
+      segments={segments}
+    />
+  </Wrapper>
+);
+
+const BubbleMarkerWithBoundariesMediumExample = () => (
+  <Wrapper isLarge>
+    <BpkPriceRange
+      showPriceOnBoundaries
+      marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+      segments={segments}
+    />
+  </Wrapper>
+);
+
+const BubbleMarkerWithBoundariesHighExample = () => (
+  <Wrapper isLarge>
+    <BpkPriceRange
+      showPriceOnBoundaries
+      marker={{ price: '£300', percentage: 90, type: 'bubble' }}
+      segments={segments}
+    />
+  </Wrapper>
+);
+
+const BubbleMarkerWithBoundariesVeryLargeExample = () => (
+  <Wrapper isLarge>
+    <BpkPriceRange
+      showPriceOnBoundaries
+      marker={{ price: '70M ₫', percentage: 90, type: 'bubble' }}
       segments={veryLargeSegments}
     />
   </Wrapper>
 );
 
-const NoMarkerWithLabelsExample = () => (
-  <Wrapper isLarge>
-    <BpkPriceRange segments={segments} />
+// Use case 4: Bubble marker without boundaries
+const BubbleMarkerWithoutBoundariesLowExample = () => (
+  <Wrapper>
+    <BpkPriceRange
+      showPriceOnBoundaries={false}
+      marker={{ price: '£50', percentage: 10, type: 'bubble' }}
+      segments={segments}
+    />
   </Wrapper>
 );
 
-const NoMarkerWithoutLabelsExample = () => (
+const BubbleMarkerWithoutBoundariesMediumExample = () => (
   <Wrapper>
-    <BpkPriceRange showPriceIndicator={false} segments={segments} />
+    <BpkPriceRange
+      showPriceOnBoundaries={false}
+      marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+      segments={segments}
+    />
+  </Wrapper>
+);
+
+const BubbleMarkerWithoutBoundariesHighExample = () => (
+  <Wrapper>
+    <BpkPriceRange
+      showPriceOnBoundaries={false}
+      marker={{ price: '£300', percentage: 90, type: 'bubble' }}
+      segments={segments}
+    />
+  </Wrapper>
+);
+
+// Use case 5: No marker with boundaries
+const NoMarkerWithBoundariesExample = () => (
+  <Wrapper isLarge>
+    <BpkPriceRange showPriceOnBoundaries segments={segments} />
+  </Wrapper>
+);
+
+// Use case 6: No marker without boundaries
+const NoMarkerWithoutBoundariesExample = () => (
+  <Wrapper>
+    <BpkPriceRange showPriceOnBoundaries={false} segments={segments} />
   </Wrapper>
 );
 
 const MixedExample = () => (
   <div>
-    <SmallerLowPriceRangeExample />
-    <SmallerMediumPriceRangeExample />
-    <SmallerHighPriceRangeExample />
-    <LargeLowPriceRangeExample />
-    <LargeMediumPriceRangeExample />
-    <LargeHighPriceRangeExample />
-    <VeryLargeHighPriceRangeExample />
-    <NoMarkerWithLabelsExample />
-    <NoMarkerWithoutLabelsExample />
+    <h4>Use case 1: Dot marker with boundaries</h4>
+    <DotMarkerWithBoundariesLowExample />
+    <DotMarkerWithBoundariesMediumExample />
+    <DotMarkerWithBoundariesHighExample />
+
+    <h4>Use case 2: Bubble marker with boundaries</h4>
+    <BubbleMarkerWithBoundariesLowExample />
+    <BubbleMarkerWithBoundariesMediumExample />
+    <BubbleMarkerWithBoundariesHighExample />
+    <BubbleMarkerWithBoundariesVeryLargeExample />
+
+    <h4>Use case 3: Dot marker without boundaries</h4>
+    <DotMarkerWithoutBoundariesLowExample />
+    <DotMarkerWithoutBoundariesMediumExample />
+    <DotMarkerWithoutBoundariesHighExample />
+
+    <h4>Use case 4: Bubble marker without boundaries</h4>
+    <BubbleMarkerWithoutBoundariesLowExample />
+    <BubbleMarkerWithoutBoundariesMediumExample />
+    <BubbleMarkerWithoutBoundariesHighExample />
+
+    <h4>Use case 5: No marker with boundaries</h4>
+    <NoMarkerWithBoundariesExample />
+
+    <h4>Use case 6: No marker without boundaries</h4>
+    <NoMarkerWithoutBoundariesExample />
   </div>
 );
 
 export {
-  SmallerLowPriceRangeExample,
-  SmallerHighPriceRangeExample,
-  SmallerMediumPriceRangeExample,
-  LargeLowPriceRangeExample,
-  LargeHighPriceRangeExample,
-  LargeMediumPriceRangeExample,
-  VeryLargeHighPriceRangeExample,
-  NoMarkerWithLabelsExample,
-  NoMarkerWithoutLabelsExample,
+  // Use case 1: Dot marker with boundaries
+  DotMarkerWithBoundariesLowExample,
+  DotMarkerWithBoundariesMediumExample,
+  DotMarkerWithBoundariesHighExample,
+  // Use case 2: Bubble marker with boundaries
+  BubbleMarkerWithBoundariesLowExample,
+  BubbleMarkerWithBoundariesMediumExample,
+  BubbleMarkerWithBoundariesHighExample,
+  BubbleMarkerWithBoundariesVeryLargeExample,
+  // Use case 3: Dot marker without boundaries
+  DotMarkerWithoutBoundariesLowExample,
+  DotMarkerWithoutBoundariesMediumExample,
+  DotMarkerWithoutBoundariesHighExample,
+  // Use case 4: Bubble marker without boundaries
+  BubbleMarkerWithoutBoundariesLowExample,
+  BubbleMarkerWithoutBoundariesMediumExample,
+  BubbleMarkerWithoutBoundariesHighExample,
+  // Use case 5: No marker with boundaries
+  NoMarkerWithBoundariesExample,
+  // Use case 6: No marker without boundaries
+  NoMarkerWithoutBoundariesExample,
+  // Mixed
   MixedExample,
 };

--- a/examples/bpk-component-price-range/examples.tsx
+++ b/examples/bpk-component-price-range/examples.tsx
@@ -82,6 +82,18 @@ const DotMarkerHighExample = () => (
 );
 
 // Use case 2: Bubble marker (boundaries shown)
+const BubbleMarkerDefaultTypeExample = () => (
+  <Wrapper isLarge>
+    <BpkPriceRange
+      marker={{
+        price: '£150',
+        percentage: 50,
+      }}
+      segments={segments}
+    />
+  </Wrapper>
+);
+
 const BubbleMarkerLowExample = () => (
   <Wrapper isLarge>
     <BpkPriceRange
@@ -149,6 +161,7 @@ const MixedExample = () => (
     <DotMarkerHighExample />
 
     <h4>Use case 2: Bubble marker (boundaries shown)</h4>
+    <BubbleMarkerDefaultTypeExample />
     <BubbleMarkerLowExample />
     <BubbleMarkerMediumExample />
     <BubbleMarkerHighExample />
@@ -165,6 +178,7 @@ export {
   DotMarkerMediumExample,
   DotMarkerHighExample,
   // Use case 2: Bubble marker (boundaries shown)
+  BubbleMarkerDefaultTypeExample,
   BubbleMarkerLowExample,
   BubbleMarkerMediumExample,
   BubbleMarkerHighExample,

--- a/examples/bpk-component-price-range/examples.tsx
+++ b/examples/bpk-component-price-range/examples.tsx
@@ -115,6 +115,18 @@ const VeryLargeHighPriceRangeExample = () => (
   </Wrapper>
 );
 
+const NoMarkerWithLabelsExample = () => (
+  <Wrapper isLarge>
+    <BpkPriceRange segments={segments} />
+  </Wrapper>
+);
+
+const NoMarkerWithoutLabelsExample = () => (
+  <Wrapper>
+    <BpkPriceRange showPriceIndicator={false} segments={segments} />
+  </Wrapper>
+);
+
 const MixedExample = () => (
   <div>
     <SmallerLowPriceRangeExample />
@@ -124,6 +136,8 @@ const MixedExample = () => (
     <LargeMediumPriceRangeExample />
     <LargeHighPriceRangeExample />
     <VeryLargeHighPriceRangeExample />
+    <NoMarkerWithLabelsExample />
+    <NoMarkerWithoutLabelsExample />
   </div>
 );
 
@@ -135,5 +149,7 @@ export {
   LargeHighPriceRangeExample,
   LargeMediumPriceRangeExample,
   VeryLargeHighPriceRangeExample,
+  NoMarkerWithLabelsExample,
+  NoMarkerWithoutLabelsExample,
   MixedExample,
 };

--- a/examples/bpk-component-price-range/stories.tsx
+++ b/examples/bpk-component-price-range/stories.tsx
@@ -26,6 +26,8 @@ import {
   LargeHighPriceRangeExample,
   LargeMediumPriceRangeExample,
   VeryLargeHighPriceRangeExample,
+  NoMarkerWithLabelsExample,
+  NoMarkerWithoutLabelsExample,
   MixedExample,
 } from './examples';
 
@@ -41,6 +43,8 @@ export const LargeLowPriceRange = LargeLowPriceRangeExample;
 export const LargeMediumPriceRange = LargeMediumPriceRangeExample;
 export const LargeHighPriceRange = LargeHighPriceRangeExample;
 export const VeryLargeHighPriceRange = VeryLargeHighPriceRangeExample;
+export const NoMarkerWithLabels = NoMarkerWithLabelsExample;
+export const NoMarkerWithoutLabels = NoMarkerWithoutLabelsExample;
 
 export const VisualTest = MixedExample;
 export const VisualTestWithZoom = {

--- a/examples/bpk-component-price-range/stories.tsx
+++ b/examples/bpk-component-price-range/stories.tsx
@@ -19,27 +19,17 @@
 import BpkPriceRange from '../../packages/bpk-component-price-range';
 
 import {
-  // Use case 1: Dot marker with boundaries
-  DotMarkerWithBoundariesLowExample,
-  DotMarkerWithBoundariesMediumExample,
-  DotMarkerWithBoundariesHighExample,
-  // Use case 2: Bubble marker with boundaries
-  BubbleMarkerWithBoundariesLowExample,
-  BubbleMarkerWithBoundariesMediumExample,
-  BubbleMarkerWithBoundariesHighExample,
-  BubbleMarkerWithBoundariesVeryLargeExample,
-  // Use case 3: Dot marker without boundaries
-  DotMarkerWithoutBoundariesLowExample,
-  DotMarkerWithoutBoundariesMediumExample,
-  DotMarkerWithoutBoundariesHighExample,
-  // Use case 4: Bubble marker without boundaries
-  BubbleMarkerWithoutBoundariesLowExample,
-  BubbleMarkerWithoutBoundariesMediumExample,
-  BubbleMarkerWithoutBoundariesHighExample,
-  // Use case 5: No marker with boundaries
-  NoMarkerWithBoundariesExample,
-  // Use case 6: No marker without boundaries
-  NoMarkerWithoutBoundariesExample,
+  // Use case 1: Dot marker (boundaries hidden)
+  DotMarkerLowExample,
+  DotMarkerMediumExample,
+  DotMarkerHighExample,
+  // Use case 2: Bubble marker (boundaries shown)
+  BubbleMarkerLowExample,
+  BubbleMarkerMediumExample,
+  BubbleMarkerHighExample,
+  BubbleMarkerVeryLargeExample,
+  // Use case 3: No marker (boundaries shown)
+  NoMarkerExample,
   // Mixed
   MixedExample,
 } from './examples';
@@ -49,43 +39,19 @@ export default {
   component: BpkPriceRange,
 };
 
-// Use case 1: Dot marker with boundaries
-export const DotMarkerWithBoundariesLow = DotMarkerWithBoundariesLowExample;
-export const DotMarkerWithBoundariesMedium =
-  DotMarkerWithBoundariesMediumExample;
-export const DotMarkerWithBoundariesHigh = DotMarkerWithBoundariesHighExample;
+// Use case 1: Dot marker (boundaries hidden)
+export const DotMarkerLow = DotMarkerLowExample;
+export const DotMarkerMedium = DotMarkerMediumExample;
+export const DotMarkerHigh = DotMarkerHighExample;
 
-// Use case 2: Bubble marker with boundaries
-export const BubbleMarkerWithBoundariesLow =
-  BubbleMarkerWithBoundariesLowExample;
-export const BubbleMarkerWithBoundariesMedium =
-  BubbleMarkerWithBoundariesMediumExample;
-export const BubbleMarkerWithBoundariesHigh =
-  BubbleMarkerWithBoundariesHighExample;
-export const BubbleMarkerWithBoundariesVeryLarge =
-  BubbleMarkerWithBoundariesVeryLargeExample;
+// Use case 2: Bubble marker (boundaries shown)
+export const BubbleMarkerLow = BubbleMarkerLowExample;
+export const BubbleMarkerMedium = BubbleMarkerMediumExample;
+export const BubbleMarkerHigh = BubbleMarkerHighExample;
+export const BubbleMarkerVeryLarge = BubbleMarkerVeryLargeExample;
 
-// Use case 3: Dot marker without boundaries
-export const DotMarkerWithoutBoundariesLow =
-  DotMarkerWithoutBoundariesLowExample;
-export const DotMarkerWithoutBoundariesMedium =
-  DotMarkerWithoutBoundariesMediumExample;
-export const DotMarkerWithoutBoundariesHigh =
-  DotMarkerWithoutBoundariesHighExample;
-
-// Use case 4: Bubble marker without boundaries
-export const BubbleMarkerWithoutBoundariesLow =
-  BubbleMarkerWithoutBoundariesLowExample;
-export const BubbleMarkerWithoutBoundariesMedium =
-  BubbleMarkerWithoutBoundariesMediumExample;
-export const BubbleMarkerWithoutBoundariesHigh =
-  BubbleMarkerWithoutBoundariesHighExample;
-
-// Use case 5: No marker with boundaries
-export const NoMarkerWithBoundaries = NoMarkerWithBoundariesExample;
-
-// Use case 6: No marker without boundaries
-export const NoMarkerWithoutBoundaries = NoMarkerWithoutBoundariesExample;
+// Use case 3: No marker (boundaries shown)
+export const NoMarker = NoMarkerExample;
 
 export const VisualTest = MixedExample;
 export const VisualTestWithZoom = {

--- a/examples/bpk-component-price-range/stories.tsx
+++ b/examples/bpk-component-price-range/stories.tsx
@@ -19,15 +19,28 @@
 import BpkPriceRange from '../../packages/bpk-component-price-range';
 
 import {
-  SmallerLowPriceRangeExample,
-  SmallerHighPriceRangeExample,
-  SmallerMediumPriceRangeExample,
-  LargeLowPriceRangeExample,
-  LargeHighPriceRangeExample,
-  LargeMediumPriceRangeExample,
-  VeryLargeHighPriceRangeExample,
-  NoMarkerWithLabelsExample,
-  NoMarkerWithoutLabelsExample,
+  // Use case 1: Dot marker with boundaries
+  DotMarkerWithBoundariesLowExample,
+  DotMarkerWithBoundariesMediumExample,
+  DotMarkerWithBoundariesHighExample,
+  // Use case 2: Bubble marker with boundaries
+  BubbleMarkerWithBoundariesLowExample,
+  BubbleMarkerWithBoundariesMediumExample,
+  BubbleMarkerWithBoundariesHighExample,
+  BubbleMarkerWithBoundariesVeryLargeExample,
+  // Use case 3: Dot marker without boundaries
+  DotMarkerWithoutBoundariesLowExample,
+  DotMarkerWithoutBoundariesMediumExample,
+  DotMarkerWithoutBoundariesHighExample,
+  // Use case 4: Bubble marker without boundaries
+  BubbleMarkerWithoutBoundariesLowExample,
+  BubbleMarkerWithoutBoundariesMediumExample,
+  BubbleMarkerWithoutBoundariesHighExample,
+  // Use case 5: No marker with boundaries
+  NoMarkerWithBoundariesExample,
+  // Use case 6: No marker without boundaries
+  NoMarkerWithoutBoundariesExample,
+  // Mixed
   MixedExample,
 } from './examples';
 
@@ -36,15 +49,43 @@ export default {
   component: BpkPriceRange,
 };
 
-export const SmallerLowPriceRange = SmallerLowPriceRangeExample;
-export const SmallerMediumPriceRange = SmallerMediumPriceRangeExample;
-export const SmallerHighPriceRange = SmallerHighPriceRangeExample;
-export const LargeLowPriceRange = LargeLowPriceRangeExample;
-export const LargeMediumPriceRange = LargeMediumPriceRangeExample;
-export const LargeHighPriceRange = LargeHighPriceRangeExample;
-export const VeryLargeHighPriceRange = VeryLargeHighPriceRangeExample;
-export const NoMarkerWithLabels = NoMarkerWithLabelsExample;
-export const NoMarkerWithoutLabels = NoMarkerWithoutLabelsExample;
+// Use case 1: Dot marker with boundaries
+export const DotMarkerWithBoundariesLow = DotMarkerWithBoundariesLowExample;
+export const DotMarkerWithBoundariesMedium =
+  DotMarkerWithBoundariesMediumExample;
+export const DotMarkerWithBoundariesHigh = DotMarkerWithBoundariesHighExample;
+
+// Use case 2: Bubble marker with boundaries
+export const BubbleMarkerWithBoundariesLow =
+  BubbleMarkerWithBoundariesLowExample;
+export const BubbleMarkerWithBoundariesMedium =
+  BubbleMarkerWithBoundariesMediumExample;
+export const BubbleMarkerWithBoundariesHigh =
+  BubbleMarkerWithBoundariesHighExample;
+export const BubbleMarkerWithBoundariesVeryLarge =
+  BubbleMarkerWithBoundariesVeryLargeExample;
+
+// Use case 3: Dot marker without boundaries
+export const DotMarkerWithoutBoundariesLow =
+  DotMarkerWithoutBoundariesLowExample;
+export const DotMarkerWithoutBoundariesMedium =
+  DotMarkerWithoutBoundariesMediumExample;
+export const DotMarkerWithoutBoundariesHigh =
+  DotMarkerWithoutBoundariesHighExample;
+
+// Use case 4: Bubble marker without boundaries
+export const BubbleMarkerWithoutBoundariesLow =
+  BubbleMarkerWithoutBoundariesLowExample;
+export const BubbleMarkerWithoutBoundariesMedium =
+  BubbleMarkerWithoutBoundariesMediumExample;
+export const BubbleMarkerWithoutBoundariesHigh =
+  BubbleMarkerWithoutBoundariesHighExample;
+
+// Use case 5: No marker with boundaries
+export const NoMarkerWithBoundaries = NoMarkerWithBoundariesExample;
+
+// Use case 6: No marker without boundaries
+export const NoMarkerWithoutBoundaries = NoMarkerWithoutBoundariesExample;
 
 export const VisualTest = MixedExample;
 export const VisualTestWithZoom = {

--- a/packages/bpk-component-price-range/README.md
+++ b/packages/bpk-component-price-range/README.md
@@ -9,12 +9,11 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 ## Usage
 
 ```tsx
-import BpkPriceRange from '@skyscanner/backpack-web/bpk-component-price-range';
+import BpkPriceRange, { MARKER_DISPLAY_TYPES } from '@skyscanner/backpack-web/bpk-component-price-range';
 
 export default () => (
   <BpkPriceRange
-    showPriceOnBoundaries
-    marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+    marker={{ price: '£150', percentage: 50, type: MARKER_DISPLAY_TYPES.BUBBLE }}
     segments={{
       low: {
         price: '£100',
@@ -29,20 +28,22 @@ export default () => (
 );
 ```
 
-### `showPriceOnBoundaries` prop
+### Boundary price visibility
 
-The `showPriceOnBoundaries` prop controls the visibility of the boundary price labels (low and high segment prices).
+The visibility of boundary prices (low and high segment prices) is automatically determined by the marker type:
 
-When `showPriceOnBoundaries` is set to `true`, the price labels for the low and high segments are displayed below the price range bar.
-
-When `showPriceOnBoundaries` is set to `false`, the boundary price labels are hidden.
+| Marker Type | Boundary Prices |
+|-------------|-----------------|
+| `MARKER_DISPLAY_TYPES.BUBBLE` | Shown below the bar |
+| `MARKER_DISPLAY_TYPES.DOT` | Hidden (compact display) |
+| No marker | Shown below the bar |
 
 ### Marker type
 
-The `marker` prop is optional. When provided, it must include a `type` field that determines how the marker is displayed:
+The `marker` prop is optional. When provided, it must include a `type` field that determines how the marker is displayed. Use the exported `MARKER_DISPLAY_TYPES` constant:
 
-- `'bubble'`: Displays the marker as a price bubble above the bar
-- `'dot'`: Displays the marker as a coloured dot on the bar (no price label shown)
+- `MARKER_DISPLAY_TYPES.BUBBLE`: Displays the marker as a price bubble above the bar
+- `MARKER_DISPLAY_TYPES.DOT`: Displays the marker as a coloured dot on the bar (no price label shown)
 
 The marker's colour indicates which price segment it falls into:
 - **Low** (green): When the marker percentage is below the low segment threshold
@@ -51,14 +52,13 @@ The marker's colour indicates which price segment it falls into:
 
 ### Without marker
 
-When the `marker` prop is omitted, only the three-tier price range bars (low/medium/high segments) are displayed:
+When the `marker` prop is omitted, only the three-tier price range bars (low/medium/high segments) are displayed with boundary prices shown:
 
 ```tsx
 import BpkPriceRange from '@skyscanner/backpack-web/bpk-component-price-range';
 
 export default () => (
   <BpkPriceRange
-    showPriceOnBoundaries
     segments={{
       low: {
         price: '£100',
@@ -73,75 +73,42 @@ export default () => (
 );
 ```
 
-## Use Cases
+## Use cases
 
-### Use case 1: Dot marker with boundary prices
+### Use case 1: Dot marker (boundaries hidden)
 
 ```tsx
 <BpkPriceRange
-  showPriceOnBoundaries
-  marker={{ price: '£150', percentage: 50, type: 'dot' }}
+  marker={{ price: '£150', percentage: 50, type: MARKER_DISPLAY_TYPES.DOT }}
   segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
 />
 ```
 
-### Use case 2: Bubble marker with boundary prices
+### Use case 2: Bubble marker (boundaries shown)
 
 ```tsx
 <BpkPriceRange
-  showPriceOnBoundaries
-  marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+  marker={{ price: '£150', percentage: 50, type: MARKER_DISPLAY_TYPES.BUBBLE }}
   segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
 />
 ```
 
-### Use case 3: Dot marker without boundary prices
+### Use case 3: No marker (boundaries shown)
 
 ```tsx
 <BpkPriceRange
-  showPriceOnBoundaries={false}
-  marker={{ price: '£150', percentage: 50, type: 'dot' }}
-  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
-/>
-```
-
-### Use case 4: Bubble marker without boundary prices
-
-```tsx
-<BpkPriceRange
-  showPriceOnBoundaries={false}
-  marker={{ price: '£150', percentage: 50, type: 'bubble' }}
-  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
-/>
-```
-
-### Use case 5: No marker with boundary prices
-
-```tsx
-<BpkPriceRange
-  showPriceOnBoundaries
-  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
-/>
-```
-
-### Use case 6: No marker without boundary prices
-
-```tsx
-<BpkPriceRange
-  showPriceOnBoundaries={false}
   segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
 />
 ```
 
 ## Props
 
-| Property             | PropType                              | Required | Default Value |
-| -------------------- | ------------------------------------- | -------- | ------------- |
-| segments             | `{ low: PriceRangePosition, high: PriceRangePosition }` | true     | -             |
-| showPriceOnBoundaries | `boolean`                            | true     | -             |
-| marker               | `MarkerPriceRangePosition`            | false    | -             |
-| min                  | `number`                              | false    | 0             |
-| max                  | `number`                              | false    | 100           |
+| Property | PropType | Required | Default Value |
+| -------- | -------- | -------- | ------------- |
+| segments | `{ low: PriceRangePosition, high: PriceRangePosition }` | true | - |
+| marker | `MarkerPriceRangePosition` | false | - |
+| min | `number` | false | 0 |
+| max | `number` | false | 100 |
 
 ### Types
 
@@ -152,6 +119,15 @@ type PriceRangePosition = {
 };
 
 type MarkerPriceRangePosition = PriceRangePosition & {
-  type: 'bubble' | 'dot';
+  type: MarkerDisplayType;
 };
+```
+
+### Constants
+
+```ts
+const MARKER_DISPLAY_TYPES = {
+  BUBBLE: 'bubble',
+  DOT: 'dot',
+} as const;
 ```

--- a/packages/bpk-component-price-range/README.md
+++ b/packages/bpk-component-price-range/README.md
@@ -29,6 +29,18 @@ export default () => (
 );
 ```
 
+### `showPriceIndicator` prop
+
+The `showPriceIndicator` prop is confusingly named.
+It controls the visibility of the price labels for the low, medium, and high segments, as well as the display type
+of the marker label (if `marker` prop is provided).
+
+When `showPriceIndicator` is set to `true` (default), the price labels for the low, medium, and high segments are displayed below the price range bar.
+If a `marker` prop is provided, it is a label is shown above the price range bar.
+
+When `showPriceIndicator` is set to `false`, the price labels for the low, medium, and high segments are hidden.
+If a `marker` prop is provided, it is displayed as a dot on the price range bar without a label.
+
 ### Without marker
 
 The `marker` prop is optional. When omitted, only the three-tier price range bars (low/medium/high segments) are displayed:

--- a/packages/bpk-component-price-range/README.md
+++ b/packages/bpk-component-price-range/README.md
@@ -28,3 +28,46 @@ export default () => (
   />
 );
 ```
+
+### Without marker
+
+The `marker` prop is optional. When omitted, only the three-tier price range bars (low/medium/high segments) are displayed:
+
+```ts
+import BpkPriceRange from '@skyscanner/backpack-web/bpk-component-price-range';
+
+export default () => (
+  <BpkPriceRange
+    segments={{
+      low: {
+        price: '£100',
+        percentage: 20,
+      },
+      high: {
+        price: '£200',
+        percentage: 80,
+      },
+    }}
+  />
+);
+```
+
+## Props
+
+| Property            | PropType                                  | Required | Default Value |
+| ------------------- | ----------------------------------------- | -------- | ------------- |
+| segments            | `{ low: Marker, high: Marker }`           | true     | -             |
+| marker              | `Marker` (see below)                      | false    | -             |
+| showPriceIndicator  | `boolean`                                 | false    | true          |
+| min                 | `number`                                  | false    | 0             |
+| max                 | `number`                                  | false    | 100           |
+
+### Marker Type
+
+```ts
+type Marker = {
+  price: string;
+  percentage: number;
+};
+```
+

--- a/packages/bpk-component-price-range/README.md
+++ b/packages/bpk-component-price-range/README.md
@@ -40,7 +40,7 @@ The visibility of boundary prices (low and high segment prices) is automatically
 
 ### Marker type
 
-The `marker` prop is optional. When provided, it must include a `type` field that determines how the marker is displayed. Use the exported `MARKER_DISPLAY_TYPES` constant:
+The `marker` prop is optional. When provided, the `type` field determines how the marker is displayed. If `type` is omitted, it defaults to `MARKER_DISPLAY_TYPES.BUBBLE`. Use the exported `MARKER_DISPLAY_TYPES` constant:
 
 - `MARKER_DISPLAY_TYPES.BUBBLE`: Displays the marker as a price bubble above the bar
 - `MARKER_DISPLAY_TYPES.DOT`: Displays the marker as a coloured dot on the bar (no price label shown)
@@ -87,8 +87,15 @@ export default () => (
 ### Use case 2: Bubble marker (boundaries shown)
 
 ```tsx
+// With explicit type
 <BpkPriceRange
   marker={{ price: '£150', percentage: 50, type: MARKER_DISPLAY_TYPES.BUBBLE }}
+  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
+/>
+
+// With default type (type can be omitted)
+<BpkPriceRange
+  marker={{ price: '£150', percentage: 50 }}
   segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
 />
 ```
@@ -119,7 +126,7 @@ type PriceRangePosition = {
 };
 
 type MarkerPriceRangePosition = PriceRangePosition & {
-  type: MarkerDisplayType;
+  type?: MarkerDisplayType; // Defaults to BUBBLE
 };
 ```
 

--- a/packages/bpk-component-price-range/README.md
+++ b/packages/bpk-component-price-range/README.md
@@ -8,13 +8,13 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 
 ## Usage
 
-```ts
+```tsx
 import BpkPriceRange from '@skyscanner/backpack-web/bpk-component-price-range';
 
 export default () => (
   <BpkPriceRange
-    showPriceIndicator
-    marker={{ price: '£150', percentage: 50 }}
+    showPriceOnBoundaries
+    marker={{ price: '£150', percentage: 50, type: 'bubble' }}
     segments={{
       low: {
         price: '£100',
@@ -29,27 +29,36 @@ export default () => (
 );
 ```
 
-### `showPriceIndicator` prop
+### `showPriceOnBoundaries` prop
 
-The `showPriceIndicator` prop is confusingly named.
-It controls the visibility of the price labels for the low, medium, and high segments, as well as the display type
-of the marker label (if `marker` prop is provided).
+The `showPriceOnBoundaries` prop controls the visibility of the boundary price labels (low and high segment prices).
 
-When `showPriceIndicator` is set to `true` (default), the price labels for the low, medium, and high segments are displayed below the price range bar.
-If a `marker` prop is provided, it is a label is shown above the price range bar.
+When `showPriceOnBoundaries` is set to `true`, the price labels for the low and high segments are displayed below the price range bar.
 
-When `showPriceIndicator` is set to `false`, the price labels for the low, medium, and high segments are hidden.
-If a `marker` prop is provided, it is displayed as a dot on the price range bar without a label.
+When `showPriceOnBoundaries` is set to `false`, the boundary price labels are hidden.
+
+### Marker type
+
+The `marker` prop is optional. When provided, it must include a `type` field that determines how the marker is displayed:
+
+- `'bubble'`: Displays the marker as a price bubble above the bar
+- `'dot'`: Displays the marker as a coloured dot on the bar (no price label shown)
+
+The marker's colour indicates which price segment it falls into:
+- **Low** (green): When the marker percentage is below the low segment threshold
+- **Medium** (yellow): When the marker percentage is between low and high segment thresholds
+- **High** (red): When the marker percentage is above the high segment threshold
 
 ### Without marker
 
-The `marker` prop is optional. When omitted, only the three-tier price range bars (low/medium/high segments) are displayed:
+When the `marker` prop is omitted, only the three-tier price range bars (low/medium/high segments) are displayed:
 
-```ts
+```tsx
 import BpkPriceRange from '@skyscanner/backpack-web/bpk-component-price-range';
 
 export default () => (
   <BpkPriceRange
+    showPriceOnBoundaries
     segments={{
       low: {
         price: '£100',
@@ -62,24 +71,87 @@ export default () => (
     }}
   />
 );
+```
+
+## Use Cases
+
+### Use case 1: Dot marker with boundary prices
+
+```tsx
+<BpkPriceRange
+  showPriceOnBoundaries
+  marker={{ price: '£150', percentage: 50, type: 'dot' }}
+  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
+/>
+```
+
+### Use case 2: Bubble marker with boundary prices
+
+```tsx
+<BpkPriceRange
+  showPriceOnBoundaries
+  marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
+/>
+```
+
+### Use case 3: Dot marker without boundary prices
+
+```tsx
+<BpkPriceRange
+  showPriceOnBoundaries={false}
+  marker={{ price: '£150', percentage: 50, type: 'dot' }}
+  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
+/>
+```
+
+### Use case 4: Bubble marker without boundary prices
+
+```tsx
+<BpkPriceRange
+  showPriceOnBoundaries={false}
+  marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
+/>
+```
+
+### Use case 5: No marker with boundary prices
+
+```tsx
+<BpkPriceRange
+  showPriceOnBoundaries
+  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
+/>
+```
+
+### Use case 6: No marker without boundary prices
+
+```tsx
+<BpkPriceRange
+  showPriceOnBoundaries={false}
+  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
+/>
 ```
 
 ## Props
 
-| Property            | PropType                                  | Required | Default Value |
-| ------------------- | ----------------------------------------- | -------- | ------------- |
-| segments            | `{ low: Marker, high: Marker }`           | true     | -             |
-| marker              | `Marker` (see below)                      | false    | -             |
-| showPriceIndicator  | `boolean`                                 | false    | true          |
-| min                 | `number`                                  | false    | 0             |
-| max                 | `number`                                  | false    | 100           |
+| Property             | PropType                              | Required | Default Value |
+| -------------------- | ------------------------------------- | -------- | ------------- |
+| segments             | `{ low: PriceRangePosition, high: PriceRangePosition }` | true     | -             |
+| showPriceOnBoundaries | `boolean`                            | true     | -             |
+| marker               | `MarkerPriceRangePosition`            | false    | -             |
+| min                  | `number`                              | false    | 0             |
+| max                  | `number`                              | false    | 100           |
 
-### Marker Type
+### Types
 
 ```ts
-type Marker = {
+type PriceRangePosition = {
   price: string;
   percentage: number;
 };
-```
 
+type MarkerPriceRangePosition = PriceRangePosition & {
+  type: 'bubble' | 'dot';
+};
+```

--- a/packages/bpk-component-price-range/index.ts
+++ b/packages/bpk-component-price-range/index.ts
@@ -16,9 +16,8 @@
  * limitations under the License.
  */
 
-import BpkPriceRange, {
-  type Props as BpkPriceRangeProps,
-} from './src/BpkPriceRange';
-
-export type { BpkPriceRangeProps };
-export default BpkPriceRange;
+export { default, type BpkPriceRangeProps } from './src/BpkPriceRange';
+export {
+  MARKER_DISPLAY_TYPES,
+  type MarkerDisplayType,
+} from './src/common-types';

--- a/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
@@ -40,210 +40,421 @@ describe('BpkPriceRange', () => {
     },
   };
 
-  it('should render low price indicator correctly', () => {
-    const { container } = render(
-      <BpkPriceRange
-        marker={{ price: '£50', percentage: 10 }}
-        segments={segments}
-      />,
-    );
+  describe('bubble marker with boundaries (use case 2)', () => {
+    it('should render low bubble marker with boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£50', percentage: 10, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
 
-    expect(
-      container.querySelector('.bpk-price-range__marker'),
-    ).toHaveTextContent('£50');
-    expect(
-      container.querySelector('.bpk-price-range__ranges'),
-    ).toHaveTextContent('£100£200');
-    expect(container.querySelector('.bpk-price-marker')).toHaveClass(
-      'bpk-price-marker--low',
-    );
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).toHaveTextContent('£50');
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).toHaveTextContent('£100£200');
+      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+        'bpk-price-marker--low',
+      );
+    });
+
+    it('should render medium bubble marker with boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
+
+      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+        'bpk-price-marker--medium',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).toHaveTextContent('£100£200');
+    });
+
+    it('should render high bubble marker with boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£300', percentage: 90, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
+
+      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+        'bpk-price-marker--high',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).toHaveTextContent('£100£200');
+    });
   });
 
-  it('should render medium price indicator correctly', () => {
-    const { container } = render(
-      <BpkPriceRange
-        marker={{ price: '£150', percentage: 50 }}
-        segments={segments}
-      />,
-    );
+  describe('dot marker with boundaries (use case 1)', () => {
+    it('should render low dot marker with boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£50', percentage: 10, type: 'dot' }}
+          segments={segments}
+        />,
+      );
 
-    expect(container.querySelector('.bpk-price-marker')).toHaveClass(
-      'bpk-price-marker--medium',
-    );
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toBeInTheDocument();
+      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
+        'bpk-price-range__line--low',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).toHaveTextContent('£100£200');
+    });
+
+    it('should render medium dot marker with boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£150', percentage: 50, type: 'dot' }}
+          segments={segments}
+        />,
+      );
+
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toBeInTheDocument();
+      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
+        'bpk-price-range__line--medium',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).toHaveTextContent('£100£200');
+    });
+
+    it('should render high dot marker with boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£300', percentage: 90, type: 'dot' }}
+          segments={segments}
+        />,
+      );
+
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toBeInTheDocument();
+      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
+        'bpk-price-range__line--high',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).toHaveTextContent('£100£200');
+    });
   });
 
-  it('should render high price indicator correctly', () => {
-    const { container } = render(
-      <BpkPriceRange
-        marker={{ price: '£300', percentage: 90 }}
-        segments={segments}
-      />,
-    );
+  describe('dot marker without boundaries (use case 3)', () => {
+    it('should render low dot marker without boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries={false}
+          marker={{ price: '£50', percentage: 10, type: 'dot' }}
+          segments={segments}
+        />,
+      );
 
-    expect(container.querySelector('.bpk-price-marker')).toHaveClass(
-      'bpk-price-marker--high',
-    );
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toBeInTheDocument();
+      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
+        'bpk-price-range__line--low',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should render medium dot marker without boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries={false}
+          marker={{ price: '£150', percentage: 50, type: 'dot' }}
+          segments={segments}
+        />,
+      );
+
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toBeInTheDocument();
+      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
+        'bpk-price-range__line--medium',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should render high dot marker without boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries={false}
+          marker={{ price: '£300', percentage: 90, type: 'dot' }}
+          segments={segments}
+        />,
+      );
+
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toBeInTheDocument();
+      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
+        'bpk-price-range__line--high',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('should render correctly when hide price marker', () => {
-    const { container } = render(
-      <BpkPriceRange
-        showPriceIndicator={false}
-        marker={{ price: '£50', percentage: 10 }}
-        segments={segments}
-      />,
-    );
+  describe('bubble marker without boundaries (use case 4)', () => {
+    it('should render low bubble marker without boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries={false}
+          marker={{ price: '£50', percentage: 10, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
 
-    expect(
-      container.querySelector('.bpk-price-range__marker'),
-    ).not.toBeInTheDocument();
-    expect(
-      container.querySelector('.bpk-price-range__line--dot'),
-    ).toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).toHaveTextContent('£50');
+      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+        'bpk-price-marker--low',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should render medium bubble marker without boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries={false}
+          marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
+
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).toHaveTextContent('£150');
+      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+        'bpk-price-marker--medium',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should render high bubble marker without boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries={false}
+          marker={{ price: '£300', percentage: 90, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
+
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).toHaveTextContent('£300');
+      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+        'bpk-price-marker--high',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('should not support custom class names', () => {
-    const { container } = render(
-      <BpkPriceRange
-        // @ts-expect-error - ignoring for test
-        className="custom-classname"
-        marker={{ price: '£50', percentage: 10 }}
-        segments={segments}
-      />,
-    );
+  describe('no marker with boundaries (use case 5)', () => {
+    it('should render without marker when marker prop is omitted (with labels)', () => {
+      const { container } = render(
+        <BpkPriceRange showPriceOnBoundaries segments={segments} />,
+      );
 
-    expect(container.className).not.toContain('custom-classname');
+      // Should not render marker or dot
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).not.toBeInTheDocument();
+
+      // Should still render segment bars
+      expect(
+        container.querySelector('.bpk-price-range__line--low'),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--medium'),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--high'),
+      ).toBeInTheDocument();
+
+      // Should render segment labels
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).toHaveTextContent('£100£200');
+    });
   });
 
-  it('should render without marker when marker prop is omitted (with labels)', () => {
-    const { container } = render(<BpkPriceRange segments={segments} />);
+  describe('no marker without boundaries (use case 6)', () => {
+    it('should render without marker when marker prop is omitted (without labels)', () => {
+      const { container } = render(
+        <BpkPriceRange showPriceOnBoundaries={false} segments={segments} />,
+      );
 
-    // Should not render marker or dot
-    expect(
-      container.querySelector('.bpk-price-range__marker'),
-    ).not.toBeInTheDocument();
-    expect(
-      container.querySelector('.bpk-price-range__line--dot'),
-    ).not.toBeInTheDocument();
+      // Should not render marker or dot
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).not.toBeInTheDocument();
 
-    // Should still render segment bars
-    expect(
-      container.querySelector('.bpk-price-range__line--low'),
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector('.bpk-price-range__line--medium'),
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector('.bpk-price-range__line--high'),
-    ).toBeInTheDocument();
+      // Should still render segment bars
+      expect(
+        container.querySelector('.bpk-price-range__line--low'),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--medium'),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--high'),
+      ).toBeInTheDocument();
 
-    // Should render segment labels
-    expect(
-      container.querySelector('.bpk-price-range__ranges'),
-    ).toHaveTextContent('£100£200');
+      // Should not render segment labels
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('should render without marker when marker prop is omitted (without labels)', () => {
-    const { container } = render(
-      <BpkPriceRange showPriceIndicator={false} segments={segments} />,
-    );
+  describe('additional behaviour', () => {
+    it('should not support custom class names', () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          // @ts-expect-error - ignoring for test
+          className="custom-classname"
+          marker={{ price: '£50', percentage: 10, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
 
-    // Should not render marker or dot
-    expect(
-      container.querySelector('.bpk-price-range__marker'),
-    ).not.toBeInTheDocument();
-    expect(
-      container.querySelector('.bpk-price-range__line--dot'),
-    ).not.toBeInTheDocument();
+      expect(container.className).not.toContain('custom-classname');
+    });
 
-    // Should still render segment bars
-    expect(
-      container.querySelector('.bpk-price-range__line--low'),
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector('.bpk-price-range__line--medium'),
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector('.bpk-price-range__line--high'),
-    ).toBeInTheDocument();
+    it('should update marker position when marker value changes', () => {
+      const { container, rerender } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£50', percentage: 10, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
 
-    // Should not render segment labels
-    expect(
-      container.querySelector('.bpk-price-range__ranges'),
-    ).not.toBeInTheDocument();
-  });
+      // Initial render with low marker
+      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+        'bpk-price-marker--low',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).toHaveTextContent('£50');
 
-  it('should update marker position when marker value changes', () => {
-    const { container, rerender } = render(
-      <BpkPriceRange
-        marker={{ price: '£50', percentage: 10 }}
-        segments={segments}
-      />,
-    );
+      // Re-render with high marker
+      rerender(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£300', percentage: 90, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
 
-    // Initial render with low marker
-    expect(container.querySelector('.bpk-price-marker')).toHaveClass(
-      'bpk-price-marker--low',
-    );
-    expect(
-      container.querySelector('.bpk-price-range__marker'),
-    ).toHaveTextContent('£50');
+      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+        'bpk-price-marker--high',
+      );
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).toHaveTextContent('£300');
+    });
 
-    // Re-render with high marker
-    rerender(
-      <BpkPriceRange
-        marker={{ price: '£300', percentage: 90 }}
-        segments={segments}
-      />,
-    );
+    it('should recalculate percentages correctly when min or max changes', () => {
+      const { container, rerender } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          min={0}
+          max={100}
+          marker={{ price: '£50', percentage: 50, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
 
-    expect(container.querySelector('.bpk-price-marker')).toHaveClass(
-      'bpk-price-marker--high',
-    );
-    expect(
-      container.querySelector('.bpk-price-range__marker'),
-    ).toHaveTextContent('£300');
-  });
+      // Get the container with style attribute
+      const priceRangeContainer = container.querySelector('.bpk-price-range');
 
-  it('should recalculate percentages correctly when min or max changes', () => {
-    const { container, rerender } = render(
-      <BpkPriceRange
-        min={0}
-        max={100}
-        marker={{ price: '£50', percentage: 50 }}
-        segments={segments}
-      />,
-    );
+      // Initial render: 50% of range 0-100 should be 0.5
+      // segments.low.percentage = 20, so (20-0)/(100-0) = 0.2
+      // segments.high.percentage = 80, so (80-0)/(100-0) = 0.8
+      let style = priceRangeContainer?.getAttribute('style');
+      expect(style).toContain('--low: 0.2');
+      expect(style).toContain('--high: 0.8');
 
-    // Get the container with style attribute
-    const priceRangeContainer = container.querySelector('.bpk-price-range');
+      // Re-render with different min/max range
+      // Now range is 20-80 (same as segment percentages)
+      rerender(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          min={20}
+          max={80}
+          marker={{ price: '£50', percentage: 50, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
 
-    // Initial render: 50% of range 0-100 should be 0.5
-    // segments.low.percentage = 20, so (20-0)/(100-0) = 0.2
-    // segments.high.percentage = 80, so (80-0)/(100-0) = 0.8
-    let style = priceRangeContainer?.getAttribute('style');
-    expect(style).toContain('--low: 0.2');
-    expect(style).toContain('--high: 0.8');
+      // After re-render: segments should be recalculated
+      // segments.low.percentage = 20, so (20-20)/(80-20) = 0/60 = 0
+      // segments.high.percentage = 80, so (80-20)/(80-20) = 60/60 = 1
+      style = priceRangeContainer?.getAttribute('style');
+      expect(style).toContain('--low: 0');
+      expect(style).toContain('--high: 1');
 
-    // Re-render with different min/max range
-    // Now range is 20-80 (same as segment percentages)
-    rerender(
-      <BpkPriceRange
-        min={20}
-        max={80}
-        marker={{ price: '£50', percentage: 50 }}
-        segments={segments}
-      />,
-    );
-
-    // After re-render: segments should be recalculated
-    // segments.low.percentage = 20, so (20-20)/(80-20) = 0/60 = 0
-    // segments.high.percentage = 80, so (80-20)/(80-20) = 60/60 = 1
-    style = priceRangeContainer?.getAttribute('style');
-    expect(style).toContain('--low: 0');
-    expect(style).toContain('--high: 1');
-
-    // Marker should still be rendered (percentage 50 is within range 20-80)
-    expect(container.querySelector('.bpk-price-marker')).toBeInTheDocument();
+      // Marker should still be rendered (percentage 50 is within range 20-80)
+      expect(container.querySelector('.bpk-price-marker')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
@@ -122,6 +122,34 @@ describe('BpkPriceRange', () => {
   });
 
   describe('bubble marker (use case 2 - boundaries shown)', () => {
+    it('should render bubble marker by default when type is not provided', () => {
+      const { container } = render(
+        <BpkPriceRange
+          marker={{
+            price: '£150',
+            percentage: 50,
+          }}
+          segments={segments}
+        />,
+      );
+
+      // Should render bubble marker
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).toHaveTextContent('£150');
+      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+        'bpk-price-marker--medium',
+      );
+      // Should show boundaries (default bubble behaviour)
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).toHaveTextContent('£100£200');
+      // Should NOT render dot
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).not.toBeInTheDocument();
+    });
+
     it('should render low bubble marker with boundaries correctly', () => {
       const { container } = render(
         <BpkPriceRange

--- a/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
@@ -18,7 +18,8 @@
 
 import { render } from '@testing-library/react';
 
-import BpkPriceRange from './BpkPriceRange';
+import BpkPriceRange, { type BpkPriceRangeProps } from './BpkPriceRange';
+import { MARKER_DISPLAY_TYPES } from './common-types';
 
 window.ResizeObserver =
   window.ResizeObserver ||
@@ -29,7 +30,7 @@ window.ResizeObserver =
   }));
 
 describe('BpkPriceRange', () => {
-  const segments = {
+  const segments: BpkPriceRangeProps['segments'] = {
     low: {
       price: '£100',
       percentage: 20,
@@ -40,12 +41,95 @@ describe('BpkPriceRange', () => {
     },
   };
 
-  describe('bubble marker with boundaries (use case 2)', () => {
+  describe('dot marker (use case 1 - boundaries hidden)', () => {
+    it('should render low dot marker without boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          marker={{
+            price: '£50',
+            percentage: 10,
+            type: MARKER_DISPLAY_TYPES.DOT,
+          }}
+          segments={segments}
+        />,
+      );
+
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toHaveClass('bpk-price-range__line--low');
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should render medium dot marker without boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          marker={{
+            price: '£150',
+            percentage: 50,
+            type: MARKER_DISPLAY_TYPES.DOT,
+          }}
+          segments={segments}
+        />,
+      );
+
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toHaveClass('bpk-price-range__line--medium');
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should render high dot marker without boundaries correctly', () => {
+      const { container } = render(
+        <BpkPriceRange
+          marker={{
+            price: '£300',
+            percentage: 90,
+            type: MARKER_DISPLAY_TYPES.DOT,
+          }}
+          segments={segments}
+        />,
+      );
+
+      expect(
+        container.querySelector('.bpk-price-range__marker'),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector('.bpk-price-range__line--dot'),
+      ).toHaveClass('bpk-price-range__line--high');
+      expect(
+        container.querySelector('.bpk-price-range__ranges'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('bubble marker (use case 2 - boundaries shown)', () => {
     it('should render low bubble marker with boundaries correctly', () => {
       const { container } = render(
         <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£50', percentage: 10, type: 'bubble' }}
+          marker={{
+            price: '£50',
+            percentage: 10,
+            type: MARKER_DISPLAY_TYPES.BUBBLE,
+          }}
           segments={segments}
         />,
       );
@@ -64,8 +148,11 @@ describe('BpkPriceRange', () => {
     it('should render medium bubble marker with boundaries correctly', () => {
       const { container } = render(
         <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+          marker={{
+            price: '£150',
+            percentage: 50,
+            type: MARKER_DISPLAY_TYPES.BUBBLE,
+          }}
           segments={segments}
         />,
       );
@@ -81,8 +168,11 @@ describe('BpkPriceRange', () => {
     it('should render high bubble marker with boundaries correctly', () => {
       const { container } = render(
         <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£300', percentage: 90, type: 'bubble' }}
+          marker={{
+            price: '£300',
+            percentage: 90,
+            type: MARKER_DISPLAY_TYPES.BUBBLE,
+          }}
           segments={segments}
         />,
       );
@@ -96,215 +186,9 @@ describe('BpkPriceRange', () => {
     });
   });
 
-  describe('dot marker with boundaries (use case 1)', () => {
-    it('should render low dot marker with boundaries correctly', () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£50', percentage: 10, type: 'dot' }}
-          segments={segments}
-        />,
-      );
-
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).not.toBeInTheDocument();
-      expect(
-        container.querySelector('.bpk-price-range__line--dot'),
-      ).toBeInTheDocument();
-      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
-        'bpk-price-range__line--low',
-      );
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).toHaveTextContent('£100£200');
-    });
-
-    it('should render medium dot marker with boundaries correctly', () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£150', percentage: 50, type: 'dot' }}
-          segments={segments}
-        />,
-      );
-
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).not.toBeInTheDocument();
-      expect(
-        container.querySelector('.bpk-price-range__line--dot'),
-      ).toBeInTheDocument();
-      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
-        'bpk-price-range__line--medium',
-      );
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).toHaveTextContent('£100£200');
-    });
-
-    it('should render high dot marker with boundaries correctly', () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£300', percentage: 90, type: 'dot' }}
-          segments={segments}
-        />,
-      );
-
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).not.toBeInTheDocument();
-      expect(
-        container.querySelector('.bpk-price-range__line--dot'),
-      ).toBeInTheDocument();
-      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
-        'bpk-price-range__line--high',
-      );
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).toHaveTextContent('£100£200');
-    });
-  });
-
-  describe('dot marker without boundaries (use case 3)', () => {
-    it('should render low dot marker without boundaries correctly', () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries={false}
-          marker={{ price: '£50', percentage: 10, type: 'dot' }}
-          segments={segments}
-        />,
-      );
-
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).not.toBeInTheDocument();
-      expect(
-        container.querySelector('.bpk-price-range__line--dot'),
-      ).toBeInTheDocument();
-      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
-        'bpk-price-range__line--low',
-      );
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).not.toBeInTheDocument();
-    });
-
-    it('should render medium dot marker without boundaries correctly', () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries={false}
-          marker={{ price: '£150', percentage: 50, type: 'dot' }}
-          segments={segments}
-        />,
-      );
-
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).not.toBeInTheDocument();
-      expect(
-        container.querySelector('.bpk-price-range__line--dot'),
-      ).toBeInTheDocument();
-      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
-        'bpk-price-range__line--medium',
-      );
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).not.toBeInTheDocument();
-    });
-
-    it('should render high dot marker without boundaries correctly', () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries={false}
-          marker={{ price: '£300', percentage: 90, type: 'dot' }}
-          segments={segments}
-        />,
-      );
-
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).not.toBeInTheDocument();
-      expect(
-        container.querySelector('.bpk-price-range__line--dot'),
-      ).toBeInTheDocument();
-      expect(container.querySelector('.bpk-price-range__line--dot')).toHaveClass(
-        'bpk-price-range__line--high',
-      );
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe('bubble marker without boundaries (use case 4)', () => {
-    it('should render low bubble marker without boundaries correctly', () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries={false}
-          marker={{ price: '£50', percentage: 10, type: 'bubble' }}
-          segments={segments}
-        />,
-      );
-
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).toHaveTextContent('£50');
-      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
-        'bpk-price-marker--low',
-      );
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).not.toBeInTheDocument();
-    });
-
-    it('should render medium bubble marker without boundaries correctly', () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries={false}
-          marker={{ price: '£150', percentage: 50, type: 'bubble' }}
-          segments={segments}
-        />,
-      );
-
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).toHaveTextContent('£150');
-      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
-        'bpk-price-marker--medium',
-      );
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).not.toBeInTheDocument();
-    });
-
-    it('should render high bubble marker without boundaries correctly', () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries={false}
-          marker={{ price: '£300', percentage: 90, type: 'bubble' }}
-          segments={segments}
-        />,
-      );
-
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).toHaveTextContent('£300');
-      expect(container.querySelector('.bpk-price-marker')).toHaveClass(
-        'bpk-price-marker--high',
-      );
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe('no marker with boundaries (use case 5)', () => {
-    it('should render without marker when marker prop is omitted (with labels)', () => {
-      const { container } = render(
-        <BpkPriceRange showPriceOnBoundaries segments={segments} />,
-      );
+  describe('no marker (use case 3 - boundaries shown)', () => {
+    it('should render without marker when marker prop is omitted', () => {
+      const { container } = render(<BpkPriceRange segments={segments} />);
 
       // Should not render marker or dot
       expect(
@@ -325,42 +209,10 @@ describe('BpkPriceRange', () => {
         container.querySelector('.bpk-price-range__line--high'),
       ).toBeInTheDocument();
 
-      // Should render segment labels
+      // Should render segment labels (boundaries shown when no marker)
       expect(
         container.querySelector('.bpk-price-range__ranges'),
       ).toHaveTextContent('£100£200');
-    });
-  });
-
-  describe('no marker without boundaries (use case 6)', () => {
-    it('should render without marker when marker prop is omitted (without labels)', () => {
-      const { container } = render(
-        <BpkPriceRange showPriceOnBoundaries={false} segments={segments} />,
-      );
-
-      // Should not render marker or dot
-      expect(
-        container.querySelector('.bpk-price-range__marker'),
-      ).not.toBeInTheDocument();
-      expect(
-        container.querySelector('.bpk-price-range__line--dot'),
-      ).not.toBeInTheDocument();
-
-      // Should still render segment bars
-      expect(
-        container.querySelector('.bpk-price-range__line--low'),
-      ).toBeInTheDocument();
-      expect(
-        container.querySelector('.bpk-price-range__line--medium'),
-      ).toBeInTheDocument();
-      expect(
-        container.querySelector('.bpk-price-range__line--high'),
-      ).toBeInTheDocument();
-
-      // Should not render segment labels
-      expect(
-        container.querySelector('.bpk-price-range__ranges'),
-      ).not.toBeInTheDocument();
     });
   });
 
@@ -368,10 +220,13 @@ describe('BpkPriceRange', () => {
     it('should not support custom class names', () => {
       const { container } = render(
         <BpkPriceRange
-          showPriceOnBoundaries
           // @ts-expect-error - ignoring for test
           className="custom-classname"
-          marker={{ price: '£50', percentage: 10, type: 'bubble' }}
+          marker={{
+            price: '£50',
+            percentage: 10,
+            type: MARKER_DISPLAY_TYPES.BUBBLE,
+          }}
           segments={segments}
         />,
       );
@@ -382,8 +237,11 @@ describe('BpkPriceRange', () => {
     it('should update marker position when marker value changes', () => {
       const { container, rerender } = render(
         <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£50', percentage: 10, type: 'bubble' }}
+          marker={{
+            price: '£50',
+            percentage: 10,
+            type: MARKER_DISPLAY_TYPES.BUBBLE,
+          }}
           segments={segments}
         />,
       );
@@ -399,8 +257,11 @@ describe('BpkPriceRange', () => {
       // Re-render with high marker
       rerender(
         <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£300', percentage: 90, type: 'bubble' }}
+          marker={{
+            price: '£300',
+            percentage: 90,
+            type: MARKER_DISPLAY_TYPES.BUBBLE,
+          }}
           segments={segments}
         />,
       );
@@ -416,10 +277,13 @@ describe('BpkPriceRange', () => {
     it('should recalculate percentages correctly when min or max changes', () => {
       const { container, rerender } = render(
         <BpkPriceRange
-          showPriceOnBoundaries
           min={0}
           max={100}
-          marker={{ price: '£50', percentage: 50, type: 'bubble' }}
+          marker={{
+            price: '£50',
+            percentage: 50,
+            type: MARKER_DISPLAY_TYPES.BUBBLE,
+          }}
           segments={segments}
         />,
       );
@@ -438,10 +302,13 @@ describe('BpkPriceRange', () => {
       // Now range is 20-80 (same as segment percentages)
       rerender(
         <BpkPriceRange
-          showPriceOnBoundaries
           min={20}
           max={80}
-          marker={{ price: '£50', percentage: 50, type: 'bubble' }}
+          marker={{
+            price: '£50',
+            percentage: 50,
+            type: MARKER_DISPLAY_TYPES.BUBBLE,
+          }}
           segments={segments}
         />,
       );

--- a/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
@@ -116,9 +116,7 @@ describe('BpkPriceRange', () => {
   });
 
   it('should render without marker when marker prop is omitted (with labels)', () => {
-    const { container } = render(
-      <BpkPriceRange segments={segments} />,
-    );
+    const { container } = render(<BpkPriceRange segments={segments} />);
 
     // Should not render marker or dot
     expect(

--- a/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange-test.tsx
@@ -114,4 +114,138 @@ describe('BpkPriceRange', () => {
 
     expect(container.className).not.toContain('custom-classname');
   });
+
+  it('should render without marker when marker prop is omitted (with labels)', () => {
+    const { container } = render(
+      <BpkPriceRange segments={segments} />,
+    );
+
+    // Should not render marker or dot
+    expect(
+      container.querySelector('.bpk-price-range__marker'),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('.bpk-price-range__line--dot'),
+    ).not.toBeInTheDocument();
+
+    // Should still render segment bars
+    expect(
+      container.querySelector('.bpk-price-range__line--low'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('.bpk-price-range__line--medium'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('.bpk-price-range__line--high'),
+    ).toBeInTheDocument();
+
+    // Should render segment labels
+    expect(
+      container.querySelector('.bpk-price-range__ranges'),
+    ).toHaveTextContent('£100£200');
+  });
+
+  it('should render without marker when marker prop is omitted (without labels)', () => {
+    const { container } = render(
+      <BpkPriceRange showPriceIndicator={false} segments={segments} />,
+    );
+
+    // Should not render marker or dot
+    expect(
+      container.querySelector('.bpk-price-range__marker'),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('.bpk-price-range__line--dot'),
+    ).not.toBeInTheDocument();
+
+    // Should still render segment bars
+    expect(
+      container.querySelector('.bpk-price-range__line--low'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('.bpk-price-range__line--medium'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('.bpk-price-range__line--high'),
+    ).toBeInTheDocument();
+
+    // Should not render segment labels
+    expect(
+      container.querySelector('.bpk-price-range__ranges'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should update marker position when marker value changes', () => {
+    const { container, rerender } = render(
+      <BpkPriceRange
+        marker={{ price: '£50', percentage: 10 }}
+        segments={segments}
+      />,
+    );
+
+    // Initial render with low marker
+    expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+      'bpk-price-marker--low',
+    );
+    expect(
+      container.querySelector('.bpk-price-range__marker'),
+    ).toHaveTextContent('£50');
+
+    // Re-render with high marker
+    rerender(
+      <BpkPriceRange
+        marker={{ price: '£300', percentage: 90 }}
+        segments={segments}
+      />,
+    );
+
+    expect(container.querySelector('.bpk-price-marker')).toHaveClass(
+      'bpk-price-marker--high',
+    );
+    expect(
+      container.querySelector('.bpk-price-range__marker'),
+    ).toHaveTextContent('£300');
+  });
+
+  it('should recalculate percentages correctly when min or max changes', () => {
+    const { container, rerender } = render(
+      <BpkPriceRange
+        min={0}
+        max={100}
+        marker={{ price: '£50', percentage: 50 }}
+        segments={segments}
+      />,
+    );
+
+    // Get the container with style attribute
+    const priceRangeContainer = container.querySelector('.bpk-price-range');
+
+    // Initial render: 50% of range 0-100 should be 0.5
+    // segments.low.percentage = 20, so (20-0)/(100-0) = 0.2
+    // segments.high.percentage = 80, so (80-0)/(100-0) = 0.8
+    let style = priceRangeContainer?.getAttribute('style');
+    expect(style).toContain('--low: 0.2');
+    expect(style).toContain('--high: 0.8');
+
+    // Re-render with different min/max range
+    // Now range is 20-80 (same as segment percentages)
+    rerender(
+      <BpkPriceRange
+        min={20}
+        max={80}
+        marker={{ price: '£50', percentage: 50 }}
+        segments={segments}
+      />,
+    );
+
+    // After re-render: segments should be recalculated
+    // segments.low.percentage = 20, so (20-20)/(80-20) = 0/60 = 0
+    // segments.high.percentage = 80, so (80-20)/(80-20) = 60/60 = 1
+    style = priceRangeContainer?.getAttribute('style');
+    expect(style).toContain('--low: 0');
+    expect(style).toContain('--high: 1');
+
+    // Marker should still be rendered (percentage 50 is within range 20-80)
+    expect(container.querySelector('.bpk-price-marker')).toBeInTheDocument();
+  });
 });

--- a/packages/bpk-component-price-range/src/BpkPriceRange.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange.tsx
@@ -24,9 +24,9 @@ import BpkText, { TEXT_STYLES } from '../../bpk-component-text/src/BpkText';
 import { cssModules } from '../../bpk-react-utils';
 
 import BpkPriceMarker from './BpkPriceMarker';
-import { MARKER_TYPES } from './common-types';
+import { MARKER_DISPLAY_TYPES, MARKER_TYPES } from './common-types';
 
-import type { MarkerType } from './common-types';
+import type { MarkerDisplayType, MarkerType } from './common-types';
 
 import STYLES from './BpkPriceRange.module.scss';
 
@@ -38,13 +38,12 @@ type PriceRangePosition = {
 };
 
 type MarkerPriceRangePosition = PriceRangePosition & {
-  type: 'bubble' | 'dot';
-}
+  type: MarkerDisplayType;
+};
 
-export type Props = {
+export type BpkPriceRangeProps = {
   min?: number;
   max?: number;
-  showPriceOnBoundaries: boolean;
   marker?: MarkerPriceRangePosition;
   segments: {
     low: PriceRangePosition;
@@ -52,13 +51,28 @@ export type Props = {
   };
 };
 
+const getShouldShowPriceOnBoundaries = (
+  markerType: MarkerDisplayType | undefined,
+): boolean => {
+  switch (markerType) {
+    case MARKER_DISPLAY_TYPES.DOT:
+      return false;
+    case MARKER_DISPLAY_TYPES.BUBBLE:
+    case undefined:
+    default:
+      return true;
+  }
+};
+
 const BpkPriceRange = ({
   marker,
   max = 100,
   min = 0,
   segments,
-  showPriceOnBoundaries,
-}: Props) => {
+}: BpkPriceRangeProps) => {
+  const shouldShowPriceOnBoundaries = getShouldShowPriceOnBoundaries(
+    marker?.type,
+  );
   const linesRef = useRef<HTMLDivElement>(null);
   const indicatorRef = useRef<HTMLDivElement>(null);
   const [linesWidth, setLinesWidth] = useState(0);
@@ -107,20 +121,20 @@ const BpkPriceRange = ({
 
   const linesClassName = getClassName(
     'bpk-price-range__lines',
-    showPriceOnBoundaries && 'bpk-price-range__lines--large',
+    shouldShowPriceOnBoundaries && 'bpk-price-range__lines--large',
   );
   const lowClassName = getClassName(
     'bpk-price-range__line--low',
-    showPriceOnBoundaries && 'bpk-price-range__line--lowLarge',
+    shouldShowPriceOnBoundaries && 'bpk-price-range__line--lowLarge',
   );
   const highClassName = getClassName(
     'bpk-price-range__line--high',
-    showPriceOnBoundaries && 'bpk-price-range__line--highLarge',
+    shouldShowPriceOnBoundaries && 'bpk-price-range__line--highLarge',
   );
   const mediumClassName = getClassName('bpk-price-range__line--medium');
 
-  const shouldShowBubble = marker?.type === 'bubble';
-  const shouldShowDot = marker?.type === 'dot';
+  const shouldShowBubble = marker?.type === MARKER_DISPLAY_TYPES.BUBBLE;
+  const shouldShowDot = marker?.type === MARKER_DISPLAY_TYPES.DOT;
   const dotClassName = getClassName(
     `bpk-price-range__line--${type}`,
     'bpk-price-range__line--dot',
@@ -137,7 +151,7 @@ const BpkPriceRange = ({
       }
       className={getClassName(
         'bpk-price-range',
-        showPriceOnBoundaries && 'bpk-price-range--large',
+        shouldShowPriceOnBoundaries && 'bpk-price-range--large',
       )}
       ref={linesRef}
     >
@@ -156,7 +170,7 @@ const BpkPriceRange = ({
         <div className={highClassName} />
         {shouldShowDot && <div className={dotClassName} ref={indicatorRef} />}
       </div>
-      {showPriceOnBoundaries && (
+      {shouldShowPriceOnBoundaries && (
         <div className={getClassName('bpk-price-range__ranges')}>
           <BpkText textStyle={TEXT_STYLES.footnote}>
             {segments.low.price}

--- a/packages/bpk-component-price-range/src/BpkPriceRange.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange.tsx
@@ -62,15 +62,13 @@ const BpkPriceRange = ({
   const calcPercentage = (current: number) =>
     (clamp(current, min, max) - min) / (max - min);
 
-  let type: MarkerType | undefined;
-  if (marker) {
-    if (marker.percentage < segments.low.percentage) {
-      type = MARKER_TYPES.LOW;
-    } else if (marker.percentage > segments.high.percentage) {
-      type = MARKER_TYPES.HIGH;
-    } else {
-      type = MARKER_TYPES.MEDIUM;
-    }
+  let type: MarkerType;
+  if (marker && marker.percentage < segments.low.percentage) {
+    type = MARKER_TYPES.LOW;
+  } else if (marker && marker.percentage > segments.high.percentage) {
+    type = MARKER_TYPES.HIGH;
+  } else {
+    type = MARKER_TYPES.MEDIUM;
   }
 
   useEffect(() => {
@@ -116,13 +114,13 @@ const BpkPriceRange = ({
     showPriceIndicator && 'bpk-price-range__line--highLarge',
   );
   const mediumClassName = getClassName('bpk-price-range__line--medium');
-  const shouldShowDot = !!marker && !!type && !showPriceIndicator;
-  const dotClassName = shouldShowDot
-    ? getClassName(
-        `bpk-price-range__line--${type}`,
-        'bpk-price-range__line--dot',
-      )
-    : undefined;
+
+  const shouldShowMarker = !!marker && showPriceIndicator;
+  const shouldShowDot = !!marker && !showPriceIndicator;
+  const dotClassName = getClassName(
+    `bpk-price-range__line--${type}`,
+    'bpk-price-range__line--dot',
+  );
 
   return (
     <div
@@ -139,7 +137,7 @@ const BpkPriceRange = ({
       )}
       ref={linesRef}
     >
-      {marker && type && showPriceIndicator && (
+      {shouldShowMarker && (
         <div className={getClassName('bpk-price-range__marker')}>
           <BpkPriceMarker
             ref={indicatorRef}
@@ -152,7 +150,7 @@ const BpkPriceRange = ({
         <div className={lowClassName} />
         <div className={mediumClassName} />
         <div className={highClassName} />
-        {dotClassName && <div className={dotClassName} ref={indicatorRef} />}
+        {shouldShowDot && <div className={dotClassName} ref={indicatorRef} />}
       </div>
       {showPriceIndicator && (
         <div className={getClassName('bpk-price-range__ranges')}>

--- a/packages/bpk-component-price-range/src/BpkPriceRange.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange.tsx
@@ -116,7 +116,8 @@ const BpkPriceRange = ({
     showPriceIndicator && 'bpk-price-range__line--highLarge',
   );
   const mediumClassName = getClassName('bpk-price-range__line--medium');
-  const dotClassName = marker && type && !showPriceIndicator
+  const shouldShowDot = !!marker && !!type && !showPriceIndicator;
+  const dotClassName = shouldShowDot
     ? getClassName(
         `bpk-price-range__line--${type}`,
         'bpk-price-range__line--dot',
@@ -151,9 +152,7 @@ const BpkPriceRange = ({
         <div className={lowClassName} />
         <div className={mediumClassName} />
         <div className={highClassName} />
-        {dotClassName && (
-          <div className={dotClassName} ref={indicatorRef} />
-        )}
+        {dotClassName && <div className={dotClassName} ref={indicatorRef} />}
       </div>
       {showPriceIndicator && (
         <div className={getClassName('bpk-price-range__ranges')}>

--- a/packages/bpk-component-price-range/src/BpkPriceRange.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange.tsx
@@ -116,7 +116,7 @@ const BpkPriceRange = ({
     showPriceIndicator && 'bpk-price-range__line--highLarge',
   );
   const mediumClassName = getClassName('bpk-price-range__line--medium');
-  const dotClassName = type
+  const dotClassName = marker && type && !showPriceIndicator
     ? getClassName(
         `bpk-price-range__line--${type}`,
         'bpk-price-range__line--dot',
@@ -151,7 +151,7 @@ const BpkPriceRange = ({
         <div className={lowClassName} />
         <div className={mediumClassName} />
         <div className={highClassName} />
-        {marker && type && !showPriceIndicator && (
+        {dotClassName && (
           <div className={dotClassName} ref={indicatorRef} />
         )}
       </div>

--- a/packages/bpk-component-price-range/src/BpkPriceRange.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange.tsx
@@ -38,7 +38,7 @@ type PriceRangePosition = {
 };
 
 type MarkerPriceRangePosition = PriceRangePosition & {
-  type: MarkerDisplayType;
+  type?: MarkerDisplayType;
 };
 
 export type BpkPriceRangeProps = {
@@ -133,8 +133,11 @@ const BpkPriceRange = ({
   );
   const mediumClassName = getClassName('bpk-price-range__line--medium');
 
-  const shouldShowBubble = marker?.type === MARKER_DISPLAY_TYPES.BUBBLE;
-  const shouldShowDot = marker?.type === MARKER_DISPLAY_TYPES.DOT;
+  const shouldShowMarker = !!marker;
+  const defaultMarkerType = MARKER_DISPLAY_TYPES.BUBBLE;
+  const markerType = marker?.type || defaultMarkerType;
+  const shouldShowBubble = shouldShowMarker && markerType === MARKER_DISPLAY_TYPES.BUBBLE;
+  const shouldShowDot = shouldShowMarker && markerType === MARKER_DISPLAY_TYPES.DOT;
   const dotClassName = getClassName(
     `bpk-price-range__line--${type}`,
     'bpk-price-range__line--dot',

--- a/packages/bpk-component-price-range/src/BpkPriceRange.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange.tsx
@@ -40,7 +40,7 @@ type Marker = {
 export type Props = {
   min?: number;
   max?: number;
-  showPriceIndicator?: boolean;
+  showPriceIndicator?: boolean; // Should be named 'showPriceLabels'.
   marker?: Marker;
   segments: {
     low: Marker;
@@ -53,7 +53,7 @@ const BpkPriceRange = ({
   max = 100,
   min = 0,
   segments,
-  showPriceIndicator = true,
+  showPriceIndicator = true, // Should be named 'showPriceLabels'.
 }: Props) => {
   const linesRef = useRef<HTMLDivElement>(null);
   const indicatorRef = useRef<HTMLDivElement>(null);

--- a/packages/bpk-component-price-range/src/BpkPriceRange.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange.tsx
@@ -32,19 +32,23 @@ import STYLES from './BpkPriceRange.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-type Marker = {
+type PriceRangePosition = {
   price: string;
   percentage: number;
 };
 
+type MarkerPriceRangePosition = PriceRangePosition & {
+  type: 'bubble' | 'dot';
+}
+
 export type Props = {
   min?: number;
   max?: number;
-  showPriceIndicator?: boolean; // Should be named 'showPriceLabels'.
-  marker?: Marker;
+  showPriceOnBoundaries: boolean;
+  marker?: MarkerPriceRangePosition;
   segments: {
-    low: Marker;
-    high: Marker;
+    low: PriceRangePosition;
+    high: PriceRangePosition;
   };
 };
 
@@ -53,7 +57,7 @@ const BpkPriceRange = ({
   max = 100,
   min = 0,
   segments,
-  showPriceIndicator = true, // Should be named 'showPriceLabels'.
+  showPriceOnBoundaries,
 }: Props) => {
   const linesRef = useRef<HTMLDivElement>(null);
   const indicatorRef = useRef<HTMLDivElement>(null);
@@ -103,20 +107,20 @@ const BpkPriceRange = ({
 
   const linesClassName = getClassName(
     'bpk-price-range__lines',
-    showPriceIndicator && 'bpk-price-range__lines--large',
+    showPriceOnBoundaries && 'bpk-price-range__lines--large',
   );
   const lowClassName = getClassName(
     'bpk-price-range__line--low',
-    showPriceIndicator && 'bpk-price-range__line--lowLarge',
+    showPriceOnBoundaries && 'bpk-price-range__line--lowLarge',
   );
   const highClassName = getClassName(
     'bpk-price-range__line--high',
-    showPriceIndicator && 'bpk-price-range__line--highLarge',
+    showPriceOnBoundaries && 'bpk-price-range__line--highLarge',
   );
   const mediumClassName = getClassName('bpk-price-range__line--medium');
 
-  const shouldShowMarker = !!marker && showPriceIndicator;
-  const shouldShowDot = !!marker && !showPriceIndicator;
+  const shouldShowBubble = marker?.type === 'bubble';
+  const shouldShowDot = marker?.type === 'dot';
   const dotClassName = getClassName(
     `bpk-price-range__line--${type}`,
     'bpk-price-range__line--dot',
@@ -133,11 +137,11 @@ const BpkPriceRange = ({
       }
       className={getClassName(
         'bpk-price-range',
-        showPriceIndicator && 'bpk-price-range--large',
+        showPriceOnBoundaries && 'bpk-price-range--large',
       )}
       ref={linesRef}
     >
-      {shouldShowMarker && (
+      {shouldShowBubble && (
         <div className={getClassName('bpk-price-range__marker')}>
           <BpkPriceMarker
             ref={indicatorRef}
@@ -152,7 +156,7 @@ const BpkPriceRange = ({
         <div className={highClassName} />
         {shouldShowDot && <div className={dotClassName} ref={indicatorRef} />}
       </div>
-      {showPriceIndicator && (
+      {showPriceOnBoundaries && (
         <div className={getClassName('bpk-price-range__ranges')}>
           <BpkText textStyle={TEXT_STYLES.footnote}>
             {segments.low.price}

--- a/packages/bpk-component-price-range/src/BpkPriceRange.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange.tsx
@@ -99,7 +99,7 @@ const BpkPriceRange = ({
 
       setPrefilledWidth(actualPrefilledWidth);
     }
-  }, [marker, linesWidth]);
+  }, [marker?.percentage, linesWidth]);
 
   const linesClassName = getClassName(
     'bpk-price-range__lines',

--- a/packages/bpk-component-price-range/src/BpkPriceRange.tsx
+++ b/packages/bpk-component-price-range/src/BpkPriceRange.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import clamp from 'lodash/clamp';
 
@@ -59,10 +59,8 @@ const BpkPriceRange = ({
   const indicatorRef = useRef<HTMLDivElement>(null);
   const [linesWidth, setLinesWidth] = useState(0);
   const [prefilledWidth, setPrefilledWidth] = useState(0);
-  const calcPercentage = useCallback(
-    (current: number) => (clamp(current, min, max) - min) / (max - min),
-    [min, max],
-  );
+  const calcPercentage = (current: number) =>
+    (clamp(current, min, max) - min) / (max - min);
 
   let type: MarkerType | undefined;
   if (marker) {

--- a/packages/bpk-component-price-range/src/accessibility-test.tsx
+++ b/packages/bpk-component-price-range/src/accessibility-test.tsx
@@ -76,6 +76,22 @@ describe('BpkPriceRange accessibility tests', () => {
     });
   });
 
+  describe('default marker type (bubble when type omitted)', () => {
+    it('should not have programmatically-detectable accessibility issues', async () => {
+      const { container } = render(
+        <BpkPriceRange
+          marker={{
+            price: '£150',
+            percentage: 50,
+          }}
+          segments={segments}
+        />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
   describe('no marker (use case 3 - boundaries shown)', () => {
     it('should not have programmatically-detectable accessibility issues', async () => {
       const { container } = render(<BpkPriceRange segments={segments} />);

--- a/packages/bpk-component-price-range/src/accessibility-test.tsx
+++ b/packages/bpk-component-price-range/src/accessibility-test.tsx
@@ -50,4 +50,23 @@ describe('BpkPriceRange accessibility tests', () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
+  it('should not have programmatically-detectable accessibility issues without marker', async () => {
+    const { container } = render(
+      <BpkPriceRange
+        segments={{
+          low: {
+            price: '£100',
+            percentage: 20,
+          },
+          high: {
+            price: '£200',
+            percentage: 80,
+          },
+        }}
+      />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 });

--- a/packages/bpk-component-price-range/src/accessibility-test.tsx
+++ b/packages/bpk-component-price-range/src/accessibility-test.tsx
@@ -29,44 +29,91 @@ window.ResizeObserver =
     unobserve: jest.fn(),
   }));
 
+const segments = {
+  low: {
+    price: '£100',
+    percentage: 20,
+  },
+  high: {
+    price: '£200',
+    percentage: 80,
+  },
+};
+
 describe('BpkPriceRange accessibility tests', () => {
-  it('should not have programmatically-detectable accessibility issues', async () => {
-    const { container } = render(
-      <BpkPriceRange
-        showPriceIndicator
-        marker={{ price: '£150', percentage: 50 }}
-        segments={{
-          low: {
-            price: '£100',
-            percentage: 20,
-          },
-          high: {
-            price: '£200',
-            percentage: 80,
-          },
-        }}
-      />,
-    );
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
+  describe('bubble marker with boundaries (use case 2)', () => {
+    it('should not have programmatically-detectable accessibility issues', async () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
   });
 
-  it('should not have programmatically-detectable accessibility issues without marker', async () => {
-    const { container } = render(
-      <BpkPriceRange
-        segments={{
-          low: {
-            price: '£100',
-            percentage: 20,
-          },
-          high: {
-            price: '£200',
-            percentage: 80,
-          },
-        }}
-      />,
-    );
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
+  describe('dot marker with boundaries (use case 1)', () => {
+    it('should not have programmatically-detectable accessibility issues', async () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries
+          marker={{ price: '£150', percentage: 50, type: 'dot' }}
+          segments={segments}
+        />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('dot marker without boundaries (use case 3)', () => {
+    it('should not have programmatically-detectable accessibility issues', async () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries={false}
+          marker={{ price: '£150', percentage: 50, type: 'dot' }}
+          segments={segments}
+        />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('bubble marker without boundaries (use case 4)', () => {
+    it('should not have programmatically-detectable accessibility issues', async () => {
+      const { container } = render(
+        <BpkPriceRange
+          showPriceOnBoundaries={false}
+          marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+          segments={segments}
+        />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('no marker with boundaries (use case 5)', () => {
+    it('should not have programmatically-detectable accessibility issues', async () => {
+      const { container } = render(
+        <BpkPriceRange showPriceOnBoundaries segments={segments} />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('no marker without boundaries (use case 6)', () => {
+    it('should not have programmatically-detectable accessibility issues', async () => {
+      const { container } = render(
+        <BpkPriceRange showPriceOnBoundaries={false} segments={segments} />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
   });
 });

--- a/packages/bpk-component-price-range/src/accessibility-test.tsx
+++ b/packages/bpk-component-price-range/src/accessibility-test.tsx
@@ -19,7 +19,8 @@
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import BpkPriceRange from './BpkPriceRange';
+import BpkPriceRange, { type BpkPriceRangeProps } from './BpkPriceRange';
+import { MARKER_DISPLAY_TYPES } from './common-types';
 
 window.ResizeObserver =
   window.ResizeObserver ||
@@ -29,7 +30,7 @@ window.ResizeObserver =
     unobserve: jest.fn(),
   }));
 
-const segments = {
+const segments: BpkPriceRangeProps['segments'] = {
   low: {
     price: '£100',
     percentage: 20,
@@ -41,12 +42,15 @@ const segments = {
 };
 
 describe('BpkPriceRange accessibility tests', () => {
-  describe('bubble marker with boundaries (use case 2)', () => {
+  describe('dot marker (use case 1 - boundaries hidden)', () => {
     it('should not have programmatically-detectable accessibility issues', async () => {
       const { container } = render(
         <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£150', percentage: 50, type: 'bubble' }}
+          marker={{
+            price: '£150',
+            percentage: 50,
+            type: MARKER_DISPLAY_TYPES.DOT,
+          }}
           segments={segments}
         />,
       );
@@ -55,12 +59,15 @@ describe('BpkPriceRange accessibility tests', () => {
     });
   });
 
-  describe('dot marker with boundaries (use case 1)', () => {
+  describe('bubble marker (use case 2 - boundaries shown)', () => {
     it('should not have programmatically-detectable accessibility issues', async () => {
       const { container } = render(
         <BpkPriceRange
-          showPriceOnBoundaries
-          marker={{ price: '£150', percentage: 50, type: 'dot' }}
+          marker={{
+            price: '£150',
+            percentage: 50,
+            type: MARKER_DISPLAY_TYPES.BUBBLE,
+          }}
           segments={segments}
         />,
       );
@@ -69,49 +76,9 @@ describe('BpkPriceRange accessibility tests', () => {
     });
   });
 
-  describe('dot marker without boundaries (use case 3)', () => {
+  describe('no marker (use case 3 - boundaries shown)', () => {
     it('should not have programmatically-detectable accessibility issues', async () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries={false}
-          marker={{ price: '£150', percentage: 50, type: 'dot' }}
-          segments={segments}
-        />,
-      );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
-    });
-  });
-
-  describe('bubble marker without boundaries (use case 4)', () => {
-    it('should not have programmatically-detectable accessibility issues', async () => {
-      const { container } = render(
-        <BpkPriceRange
-          showPriceOnBoundaries={false}
-          marker={{ price: '£150', percentage: 50, type: 'bubble' }}
-          segments={segments}
-        />,
-      );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
-    });
-  });
-
-  describe('no marker with boundaries (use case 5)', () => {
-    it('should not have programmatically-detectable accessibility issues', async () => {
-      const { container } = render(
-        <BpkPriceRange showPriceOnBoundaries segments={segments} />,
-      );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
-    });
-  });
-
-  describe('no marker without boundaries (use case 6)', () => {
-    it('should not have programmatically-detectable accessibility issues', async () => {
-      const { container } = render(
-        <BpkPriceRange showPriceOnBoundaries={false} segments={segments} />,
-      );
+      const { container } = render(<BpkPriceRange segments={segments} />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });

--- a/packages/bpk-component-price-range/src/common-types.ts
+++ b/packages/bpk-component-price-range/src/common-types.ts
@@ -23,3 +23,11 @@ export const MARKER_TYPES = {
 } as const;
 
 export type MarkerType = (typeof MARKER_TYPES)[keyof typeof MARKER_TYPES];
+
+export const MARKER_DISPLAY_TYPES = {
+  BUBBLE: 'bubble',
+  DOT: 'dot',
+} as const;
+
+export type MarkerDisplayType =
+  (typeof MARKER_DISPLAY_TYPES)[keyof typeof MARKER_DISPLAY_TYPES];


### PR DESCRIPTION
## Summary

This PR introduces breaking changes to `BpkPriceRange` to improve the component API and enable new use cases for price bands display.

### Key Changes

- **Make `marker` prop optional**: The component can now display only the price range bars without a marker
- **Add `MARKER_DISPLAY_TYPES` constant**: New exported constant with `BUBBLE` and `DOT` options to control marker display style
- **Remove `showPriceOnBoundaries` prop**: Boundary price visibility is now automatically determined by the marker type
- **Default marker type to `BUBBLE`**: When `marker` is provided without a `type`, it defaults to `BUBBLE` behaviour

### Boundary Price Visibility Rules

| Marker Type | Boundary Prices |
|-------------|-----------------|
| `MARKER_DISPLAY_TYPES.BUBBLE` | Shown below the bar |
| `MARKER_DISPLAY_TYPES.DOT` | Hidden (compact display) |
| No marker | Shown below the bar |

## Checklist

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [x] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here

## Migration Guide

### Breaking Changes

1. **`showPriceOnBoundaries` prop removed**
   - Before: Used `showPriceOnBoundaries={false}` to hide boundary prices
   - After: Use `marker={{ type: MARKER_DISPLAY_TYPES.DOT, ... }}` for compact display without boundaries

2. **`marker.type` is now required when using marker with dot style**
   - Before: N/A (only bubble style existed)
   - After: Use `MARKER_DISPLAY_TYPES.BUBBLE` or `MARKER_DISPLAY_TYPES.DOT`

3. **`marker.type` defaults to `BUBBLE` when omitted**
   - If you provide a `marker` without a `type`, it will default to `MARKER_DISPLAY_TYPES.BUBBLE`
   - This is non-breaking for existing bubble marker usage

### Migration Examples

**Before (with boundaries hidden):**
```tsx
<BpkPriceRange
  marker={{ price: '£150', percentage: 50 }}
  showPriceOnBoundaries={false}
  segments={...}
/>
```

<img width="166" height="38" alt="image" src="https://github.com/user-attachments/assets/c0db37cc-aa4e-46ea-98b6-31b9177aca98" />

**After (using dot marker):**
```tsx
import { MARKER_DISPLAY_TYPES } from '@skyscanner/backpack-web/bpk-component-price-range';

<BpkPriceRange
  marker={{ price: '£150', percentage: 50, type: MARKER_DISPLAY_TYPES.DOT }}
  segments={...}
/>
```

No change to UI:
<img width="166" height="38" alt="image" src="https://github.com/user-attachments/assets/21ed0c0c-5b89-498f-8029-85d8aa5c9c18" />

**Before (with boundaries shown):**
```tsx
<BpkPriceRange
  marker={{ price: '£150', percentage: 50 }}
  segments={...}
/>
```

<img width="270" height="90" alt="image" src="https://github.com/user-attachments/assets/7d1fbeb7-54b9-451f-971d-487f6bf0f3fe" />


**After (using bubble marker - default):**
```tsx
// Option 1: Explicit type
<BpkPriceRange
  marker={{ price: '£150', percentage: 50, type: MARKER_DISPLAY_TYPES.BUBBLE }}
  segments={...}
/>

// Option 2: Omit type (defaults to BUBBLE)
<BpkPriceRange
  marker={{ price: '£150', percentage: 50 }}
  segments={...}
/>
```

No change to UI:
<img width="270" height="90" alt="image" src="https://github.com/user-attachments/assets/9144f158-83ca-4047-b28f-cd5b86258f4d" />

**Without marker (new use case):**
```tsx
<BpkPriceRange
  segments={{ low: { price: '£100', percentage: 20 }, high: { price: '£200', percentage: 80 } }}
/>
```

<img width="272" height="60" alt="image" src="https://github.com/user-attachments/assets/e61ab0be-fd4f-4fb2-9c03-463728bc959f" />

## References

- Jira: [LUNA-3186](https://skyscanner.atlassian.net/browse/LUNA-3186)
- Decision doc: [Price Range Breaking Changes](https://skyscanner.atlassian.net/wiki/x/lATgeQ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)