### PR TITLE
[IRN-6372] [BpkBottomSheet] - aria title read on Android TalkBack

### DIFF
--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -24,6 +24,7 @@ import BpkCloseButton from '../../bpk-component-close-button';
 import BpkLink from '../../bpk-component-link';
 import BpkNavigationBar from '../../bpk-component-navigation-bar';
 import { TEXT_STYLES } from '../../bpk-component-text/src/BpkText';
+import BpkVisuallyHidden from '../../bpk-component-visually-hidden';
 import { BpkDialogWrapper, cssModules } from '../../bpk-react-utils';
 
 import STYLES from './BpkBottomSheet.module.scss';
@@ -74,13 +75,13 @@ interface CommonProps {
 export type Props = CommonProps & ({ ariaLabelledby: string } | { ariaLabel: string; });
 
 const getContentStyles = (paddingStyles: PaddingStyles): string => {
-  const { 
+  const {
     bottom = PADDING_TYPE.lg,
-    end, 
-    start = PADDING_TYPE.lg, 
-    top = PADDING_TYPE.none 
+    end,
+    start = PADDING_TYPE.lg,
+    top = PADDING_TYPE.none
   } = paddingStyles;
-  
+
   const classNames = ['bpk-bottom-sheet--content'];
 
   // Add padding classes for each side if not 'none'
@@ -155,6 +156,7 @@ const BpkBottomSheet = ({
   );
 
   const headingId = `bpk-bottom-sheet-heading-${id}`;
+  const headingIsHidden = !title && 'ariaLabel' in ariaProps;
   const dialogClassName = getClassName(
     'bpk-bottom-sheet',
     wide && 'bpk-bottom-sheet--wide',
@@ -185,7 +187,7 @@ const BpkBottomSheet = ({
       <>
         <header className={getClassName('bpk-bottom-sheet--header-wrapper')}>
           <BpkNavigationBar
-            id={headingId}
+            id={headingIsHidden ? `bpk-bottom-sheet-title-hidden-${id}` : headingId}
             title={title}
             titleTextStyle={TEXT_STYLES.label1}
             titleTagName={title ? 'h2' : 'span'}
@@ -199,6 +201,12 @@ const BpkBottomSheet = ({
               ) : null
             }
           />
+          {/* non-visible header element required for Android TalkBack to announce ariaLabel when no title provided on open BottomSheet */}
+          {headingIsHidden && (
+            <BpkVisuallyHidden as="h2">
+              <span id={`bpk-bottom-sheet-title-hidden-${id}`}>{ariaProps.ariaLabel}</span>
+            </BpkVisuallyHidden>
+          )}
         </header>
         <div className={contentStyle}>{children}</div>
       </>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
