### PR TITLE
[CLOV-1372]BpkBox supporting more properties

### DIFF
--- a/examples/bpk-component-layout/box-examples.tsx
+++ b/examples/bpk-component-layout/box-examples.tsx
@@ -17,11 +17,15 @@
  */
 
 import {
+  BACKGROUND_COLORS,
   BpkBox,
   BpkSpacing,
 } from '../../packages/bpk-component-layout';
+import { TEXT_COLORS } from '../../packages/bpk-component-text';
 
 import Wrapper from './layout-wrapper';
+
+import type { BpkBoxBackgroundColor } from '../../packages/bpk-component-layout';
 
 import STYLES from './examples.module.scss';
 
@@ -177,6 +181,111 @@ export const GridExample = () => (
           <span className={STYLES['bpk-layout-examples__outline']}>
             Grid cell {i}
           </span>
+        </BpkBox>
+      ))}
+    </BpkBox>
+  </Wrapper>
+);
+
+type ColorSwatch = { label: string; value: BpkBoxBackgroundColor };
+
+const SURFACE_SWATCHES: ColorSwatch[] = [
+  { label: 'surfaceDefault', value: BACKGROUND_COLORS.surfaceDefault },
+  { label: 'surfaceElevated', value: BACKGROUND_COLORS.surfaceElevated },
+  { label: 'surfaceLowContrast', value: BACKGROUND_COLORS.surfaceLowContrast },
+  { label: 'surfaceSubtle', value: BACKGROUND_COLORS.surfaceSubtle },
+  { label: 'surfaceTint', value: BACKGROUND_COLORS.surfaceTint },
+  { label: 'surfaceHighlight', value: BACKGROUND_COLORS.surfaceHighlight },
+  { label: 'surfaceHero', value: BACKGROUND_COLORS.surfaceHero },
+  { label: 'surfaceContrast', value: BACKGROUND_COLORS.surfaceContrast },
+];
+
+const STATUS_FILL_SWATCHES: ColorSwatch[] = [
+  { label: 'statusSuccessFill', value: BACKGROUND_COLORS.statusSuccessFill },
+  { label: 'statusDangerFill', value: BACKGROUND_COLORS.statusDangerFill },
+  { label: 'statusWarningFill', value: BACKGROUND_COLORS.statusWarningFill },
+];
+
+const CANVAS_SWATCHES: ColorSwatch[] = [
+  { label: 'canvas', value: BACKGROUND_COLORS.canvas },
+  { label: 'canvasContrast', value: BACKGROUND_COLORS.canvasContrast },
+];
+
+const SwatchGrid = ({ columns, swatches }: { columns: number; swatches: ColorSwatch[] }) => (
+  <BpkBox padding={BpkSpacing.MD}>
+    <BpkBox
+      display="grid"
+      gridTemplateColumns={`repeat(${columns}, minmax(0, 1fr))`}
+      gap={BpkSpacing.SM}
+    >
+      {swatches.map(({ label, value }) => (
+        <BpkBox
+          key={label}
+          backgroundColor={value}
+          padding={BpkSpacing.MD}
+          minHeight="5rem"
+        >
+          <span className={STYLES['bpk-layout-examples__outline']}>{label}</span>
+        </BpkBox>
+      ))}
+    </BpkBox>
+  </BpkBox>
+);
+
+/**
+ * Surface background color swatches – shows all surface tokens available for backgroundColor.
+ *
+ * @returns {JSX.Element} A grid of surface color swatches.
+ */
+export const SurfaceBackgroundColorExample = () => (
+  <Wrapper>
+    <SwatchGrid columns={4} swatches={SURFACE_SWATCHES} />
+  </Wrapper>
+);
+
+/**
+ * Status fill background color swatches – shows status fill tokens for backgroundColor.
+ *
+ * @returns {JSX.Element} A grid of status fill color swatches.
+ */
+export const StatusFillBackgroundColorExample = () => (
+  <Wrapper>
+    <SwatchGrid columns={3} swatches={STATUS_FILL_SWATCHES} />
+  </Wrapper>
+);
+
+/**
+ * Canvas background color swatches – shows canvas tokens for backgroundColor.
+ *
+ * @returns {JSX.Element} A grid of canvas color swatches.
+ */
+export const CanvasBackgroundColorExample = () => (
+  <Wrapper>
+    <SwatchGrid columns={2} swatches={CANVAS_SWATCHES} />
+  </Wrapper>
+);
+
+const TEXT_COLOR_SWATCHES = Object.entries(TEXT_COLORS).map(([label, value]) => ({
+  label,
+  value,
+}));
+
+/**
+ * Text color example – shows all TEXT_COLORS tokens available for the color prop.
+ *
+ * @returns {JSX.Element} A grid of text color swatches.
+ */
+export const ColorExample = () => (
+  <Wrapper>
+    <BpkBox
+      display="grid"
+      gridTemplateColumns="repeat(3, minmax(0, 1fr))"
+      gap={BpkSpacing.SM}
+      padding={BpkSpacing.MD}
+    >
+      {TEXT_COLOR_SWATCHES.map(({ label, value }) => (
+        <BpkBox key={label} color={value} padding={BpkSpacing.SM}>
+          <span className={STYLES['bpk-layout-examples__outline']}>{label}</span>
         </BpkBox>
       ))}
     </BpkBox>

--- a/examples/bpk-component-layout/box.stories.tsx
+++ b/examples/bpk-component-layout/box.stories.tsx
@@ -28,6 +28,10 @@ import {
   PositionExample,
   FlexExample,
   GridExample,
+  SurfaceBackgroundColorExample,
+  StatusFillBackgroundColorExample,
+  CanvasBackgroundColorExample,
+  ColorExample,
 } from './box-examples';
 
 export default {
@@ -63,5 +67,9 @@ export const Responsive = () => <ResponsiveExample />;
 export const Position = () => <PositionExample />;
 export const FlexViaBox = () => <FlexExample />;
 export const GridViaBox = () => <GridExample />;
+export const SurfaceBackgroundColor = () => <SurfaceBackgroundColorExample />;
+export const StatusFillBackgroundColor = () => <StatusFillBackgroundColorExample />;
+export const CanvasBackgroundColor = () => <CanvasBackgroundColorExample />;
+export const Color = () => <ColorExample />;
 
 

--- a/examples/bpk-component-layout/examples.module.scss
+++ b/examples/bpk-component-layout/examples.module.scss
@@ -22,11 +22,11 @@
 .bpk-layout-examples {
   &__frame {
     padding: tokens.bpk-spacing-base();
-    background-color: tokens.$bpk-canvas-contrast-day;
     border-radius: tokens.$bpk-border-radius-md;
+    background-color: tokens.$bpk-canvas-contrast-day;
 
     // Subtle grid to make layout boundaries easier to see.
-    background-size: 8px 8px;
+    background-size: tokens.bpk-spacing-sm() tokens.bpk-spacing-sm();
 
     // Outline the root element of each example (not the inner content).
     // This avoids needing border props on layout primitives.
@@ -41,26 +41,23 @@
   // Use this on regular DOM elements (not layout primitives) to avoid exposing
   // border props on the layout surface.
   &__item {
+    border-radius: tokens.$bpk-border-radius-sm;
     outline: tokens.$bpk-border-size-sm solid tokens.$bpk-line-day;
     outline-offset: 0;
-    border-radius: tokens.$bpk-border-radius-sm;
     background-color: tokens.$bpk-canvas-day;
     box-sizing: border-box;
   }
 
   &__outline {
-    @include typography.bpk-body-default;
-
     display: block;
     width: 100%;
     padding: tokens.bpk-spacing-sm();
-
-    color: tokens.$bpk-text-primary-day;
-    background-color: tokens.$bpk-surface-highlight-day;
-
+    border-radius: tokens.$bpk-border-radius-sm;
     outline: tokens.$bpk-border-size-sm dashed tokens.$bpk-line-day;
     outline-offset: 0;
-    border-radius: tokens.$bpk-border-radius-sm;
+    background-color: tokens.$bpk-surface-highlight-day;
     box-sizing: border-box;
+
+    @include typography.bpk-body-default;
   }
 }

--- a/packages/bpk-component-layout/index.ts
+++ b/packages/bpk-component-layout/index.ts
@@ -41,6 +41,9 @@ export type {
 } from './src/types';
 export type { BpkStackSpecificProps } from './src/types';
 
+export { BACKGROUND_COLORS } from './src/backgroundColors';
+export type { BpkBoxBackgroundColor } from './src/backgroundColors';
+
 // Export token types and utilities
 export type {
   BpkSpacingToken,

--- a/packages/bpk-component-layout/src/BpkBox-test.tsx
+++ b/packages/bpk-component-layout/src/BpkBox-test.tsx
@@ -22,6 +22,7 @@ import '@testing-library/jest-dom';
 
 import { BpkBox } from './BpkBox';
 import { BpkProvider } from './BpkProvider';
+import { BACKGROUND_COLORS } from './backgroundColors';
 import { BpkSpacing } from './tokens';
 
 describe('BpkBox', () => {
@@ -63,6 +64,44 @@ describe('BpkBox', () => {
     expect(div).toBeInTheDocument();
     // We don't assert exact styles because Chakra generates classes & vars,
     // but we at least assert that the element rendered successfully.
+  });
+
+  describe('backgroundColor', () => {
+    it('renders with a surface color token', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox backgroundColor={BACKGROUND_COLORS.surfaceDefault}>Content</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+
+    it('renders with a status fill color token', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox backgroundColor={BACKGROUND_COLORS.statusSuccessFill}>Content</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+
+    it('renders with a canvas color token', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox backgroundColor={BACKGROUND_COLORS.canvas}>Content</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+
+    it('renders without backgroundColor when prop is omitted', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox>No background</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
   });
 
   it('supports basic interaction props: onClick, onFocus, onBlur', () => {

--- a/packages/bpk-component-layout/src/BpkBox.module.scss
+++ b/packages/bpk-component-layout/src/BpkBox.module.scss
@@ -1,0 +1,69 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// backgroundColor keys must stay in sync with backgroundColors.ts
+// color keys must stay in sync with TEXT_COLORS in bpk-component-text
+
+@use '../../bpk-mixins/tokens';
+@use '../../bpk-mixins/surfaces';
+
+$text-colors: (
+  'text-disabled': tokens.$bpk-text-disabled-day,
+  'text-disabled-on-dark': tokens.$bpk-text-disabled-on-dark-day,
+  'text-error': tokens.$bpk-text-error-day,
+  'text-hero': tokens.$bpk-text-hero-day,
+  'text-link': tokens.$bpk-text-link-day,
+  'text-on-dark': tokens.$bpk-text-on-dark-day,
+  'text-on-light': tokens.$bpk-text-on-light-day,
+  'text-primary': tokens.$bpk-text-primary-day,
+  'text-primary-inverse': tokens.$bpk-text-primary-inverse-day,
+  'text-secondary': tokens.$bpk-text-secondary-day,
+  'text-success': tokens.$bpk-text-success-day,
+);
+
+.bpk-box {
+  @include surfaces.bpk-surface-bg-colors;
+
+  @each $color-name, $color-value in $text-colors {
+    // Double-class selector matches BpkText pattern, needed to beat Chakra emotion specificity.
+    // stylelint-disable-next-line selector-class-pattern
+    &.bpk-box--#{$color-name} {
+      color: $color-value;
+    }
+  }
+
+  &--status-success-fill {
+    background-color: tokens.$bpk-status-success-fill-day;
+  }
+
+  &--status-danger-fill {
+    background-color: tokens.$bpk-status-danger-fill-day;
+  }
+
+  &--status-warning-fill {
+    background-color: tokens.$bpk-status-warning-fill-day;
+  }
+
+  &--canvas {
+    background-color: tokens.$bpk-canvas-day;
+  }
+
+  &--canvas-contrast {
+    background-color: tokens.$bpk-canvas-contrast-day;
+  }
+}

--- a/packages/bpk-component-layout/src/BpkBox.tsx
+++ b/packages/bpk-component-layout/src/BpkBox.tsx
@@ -16,21 +16,42 @@
  * limitations under the License.
  */
 
+import { forwardRef } from 'react';
+
 import { Box } from '@chakra-ui/react';
 
-import { getDataComponentAttribute } from '../../bpk-react-utils';
+import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
 import { processBpkComponentProps } from './tokenUtils';
 
 import type { BpkBoxProps } from './types';
 
-export const BpkBox = ({ children, ...props }: BpkBoxProps) => {
-  const processedProps = processBpkComponentProps(props, { component: 'BpkBox' });
-  return (
-    <Box {...getDataComponentAttribute('Box')} {...processedProps}>
-      {children}
-    </Box>
-  );
-};
+import STYLES from './BpkBox.module.scss';
+
+const getClassName = cssModules(STYLES);
+
+export const BpkBox = forwardRef<HTMLElement, BpkBoxProps>(
+  ({ backgroundColor, children, color, ...props }, ref) => {
+    const processedProps = processBpkComponentProps(props, { component: 'BpkBox' });
+    const combinedClass = getClassName(
+      backgroundColor ? `bpk-box--${backgroundColor}` : '',
+      // 'bpk-box' base class is required alongside the modifier to form a two-class
+      // compound selector (.bpk-box.bpk-box--text-*), matching BpkText's pattern and
+      // beating Chakra emotion's default color specificity.
+      color ? 'bpk-box' : '',
+      color ? `bpk-box--${color}` : '',
+    ) || undefined;
+
+    return (
+      // className is allowed here: combinedClass is an internal SCSS module class, not a consumer override.
+      // eslint-disable-next-line @skyscanner/rules/forbid-component-props
+      <Box ref={ref} className={combinedClass} {...getDataComponentAttribute('Box')} {...processedProps}>
+        {children}
+      </Box>
+    );
+  },
+);
+
+BpkBox.displayName = 'BpkBox';
 
 export type { BpkBoxProps };

--- a/packages/bpk-component-layout/src/BpkBox.tsx
+++ b/packages/bpk-component-layout/src/BpkBox.tsx
@@ -31,7 +31,7 @@ import STYLES from './BpkBox.module.scss';
 const getClassName = cssModules(STYLES);
 
 export const BpkBox = forwardRef<HTMLElement, BpkBoxProps>(
-  ({ backgroundColor, children, color, ...props }, ref) => {
+  ({ backgroundColor, boxShadow, children, color, lineClamp, ...props }, ref) => {
     const processedProps = processBpkComponentProps(props, { component: 'BpkBox' });
     const combinedClass = getClassName(
       backgroundColor ? `bpk-box--${backgroundColor}` : '',
@@ -42,10 +42,24 @@ export const BpkBox = forwardRef<HTMLElement, BpkBoxProps>(
       color ? `bpk-box--${color}` : '',
     ) || undefined;
 
+    const lineClampProps = lineClamp != null ? {
+      display: '-webkit-box' as const,
+      WebkitLineClamp: lineClamp,
+      WebkitBoxOrient: 'vertical' as const,
+      overflow: 'hidden' as const,
+    } : {};
+
     return (
-      // className is allowed here: combinedClass is an internal SCSS module class, not a consumer override.
-      // eslint-disable-next-line @skyscanner/rules/forbid-component-props
-      <Box ref={ref} className={combinedClass} {...getDataComponentAttribute('Box')} {...processedProps}>
+      <Box
+        ref={ref}
+        // className is allowed here: combinedClass is an internal SCSS module class, not a consumer override.
+        // eslint-disable-next-line @skyscanner/rules/forbid-component-props
+        className={combinedClass}
+        {...getDataComponentAttribute('Box')}
+        {...processedProps}
+        {...lineClampProps}
+        {...(boxShadow ? { boxShadow } : {})}
+      >
         {children}
       </Box>
     );

--- a/packages/bpk-component-layout/src/backgroundColors.ts
+++ b/packages/bpk-component-layout/src/backgroundColors.ts
@@ -1,0 +1,49 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Values must stay in sync with BpkBox.module.scss
+
+import { SURFACE_COLORS } from '../../bpk-react-utils';
+
+/**
+ * Background color tokens available on BpkBox.
+ *
+ * Values map to CSS class suffixes generated in BpkBox.module.scss.
+ * Surface colors are shared with bpk-react-utils/SURFACE_COLORS (used by BpkPanel etc.).
+ * Status fill and canvas colors are additional to BpkBox.
+ *
+ * @example
+ * import { BACKGROUND_COLORS } from '@skyscanner/backpack-web/bpk-component-layout';
+ * <BpkBox backgroundColor={BACKGROUND_COLORS.surfaceDefault} />
+ */
+export const BACKGROUND_COLORS = {
+  // Surface colors — shared across components via bpk-react-utils
+  ...SURFACE_COLORS,
+
+  // Status fill colors
+  statusSuccessFill: 'status-success-fill',
+  statusDangerFill: 'status-danger-fill',
+  statusWarningFill: 'status-warning-fill',
+
+  // Canvas colors
+  canvas: 'canvas',
+  canvasContrast: 'canvas-contrast',
+} as const;
+
+export type BpkBoxBackgroundColor =
+  (typeof BACKGROUND_COLORS)[keyof typeof BACKGROUND_COLORS];

--- a/packages/bpk-component-layout/src/commonProps.ts
+++ b/packages/bpk-component-layout/src/commonProps.ts
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import type { AriaAttributes, AriaRole } from 'react';
+
 import type {
   BpkSpacingValue,
   BpkSizeValue,
@@ -80,7 +82,7 @@ export interface BpkSpacingProps {
  * - BpkBox reintroduces a minimal set of events (onClick, onFocus, onBlur)
  *   on its own props type.
  */
-export interface BpkCommonLayoutProps extends BpkSpacingProps {
+export interface BpkCommonLayoutProps extends BpkSpacingProps, AriaAttributes {
   // Explicitly exclude className
   className?: never;
 
@@ -90,6 +92,17 @@ export interface BpkCommonLayoutProps extends BpkSpacingProps {
   // Testing & automation attributes
   'data-testid'?: string;
   'data-cy'?: string;
+
+  // HTML attributes
+  id?: string;
+  role?: AriaRole;
+
+  // Structural layout
+  position?: 'static' | 'relative' | 'absolute' | 'fixed' | 'sticky';
+  zIndex?: number;
+  overflow?: 'visible' | 'hidden' | 'scroll' | 'auto';
+  overflowX?: 'visible' | 'hidden' | 'scroll' | 'auto';
+  overflowY?: 'visible' | 'hidden' | 'scroll' | 'auto';
 
   // Explicitly exclude color-related props to keep layout purely structural.
   // These props still exist on the underlying Chakra Box, so we mark them as

--- a/packages/bpk-component-layout/src/types.ts
+++ b/packages/bpk-component-layout/src/types.ts
@@ -19,8 +19,10 @@
 import type { ReactNode } from 'react';
 
 import type StackOptionKeys from './BpkStack.constant';
+import type { BpkBoxBackgroundColor } from './backgroundColors';
 import type { BpkCommonLayoutProps } from './commonProps';
 import type { BpkSpacingValue, BpkResponsiveValue, BpkBasisValue } from './tokens';
+import type { TEXT_COLORS } from '../../bpk-component-text';
 import type {
   BoxProps,
   FlexProps,
@@ -28,6 +30,8 @@ import type {
   GridItemProps,
   StackProps,
 } from '@chakra-ui/react';
+
+type TextColor = (typeof TEXT_COLORS)[keyof typeof TEXT_COLORS];
 
 
 /**
@@ -193,14 +197,23 @@ export interface BpkBoxSpecificProps
  * and reintroduces a minimal set of interaction props.
  */
 type BoxEventProps = Pick<BoxProps,
-  'onClick' | 'onFocus' | 'onBlur'
+  'onClick' | 'onFocus' | 'onBlur' | 'onKeyDown' | 'onKeyUp'
 >;
 
-export interface BpkBoxProps extends BpkCommonLayoutProps, BpkBoxSpecificProps {
+export interface BpkBoxProps
+  extends Omit<BpkCommonLayoutProps, 'backgroundColor' | 'color'>,
+    BpkBoxSpecificProps {
   children?: ReactNode;
   onClick?: BoxEventProps['onClick'];
   onFocus?: BoxEventProps['onFocus'];
   onBlur?: BoxEventProps['onBlur'];
+  onKeyDown?: BoxEventProps['onKeyDown'];
+  onKeyUp?: BoxEventProps['onKeyUp'];
+  backgroundColor?: BpkBoxBackgroundColor;
+  color?: TextColor;
+  cursor?: 'auto' | 'default' | 'pointer' | 'not-allowed';
+  opacity?: number;
+  tabIndex?: number;
 }
 
 /**

--- a/packages/bpk-component-layout/src/types.ts
+++ b/packages/bpk-component-layout/src/types.ts
@@ -201,7 +201,7 @@ type BoxEventProps = Pick<BoxProps,
 >;
 
 export interface BpkBoxProps
-  extends Omit<BpkCommonLayoutProps, 'backgroundColor' | 'color'>,
+  extends Omit<BpkCommonLayoutProps, 'backgroundColor' | 'color' | 'boxShadow'>,
     BpkBoxSpecificProps {
   children?: ReactNode;
   onClick?: BoxEventProps['onClick'];
@@ -214,6 +214,8 @@ export interface BpkBoxProps
   cursor?: 'auto' | 'default' | 'pointer' | 'not-allowed';
   opacity?: number;
   tabIndex?: number;
+  boxShadow?: BoxProps['boxShadow'];
+  lineClamp?: number;
 }
 
 /**


### PR DESCRIPTION
## New files

### `packages/bpk-component-layout/src/BpkBox.module.scss`
SCSS module for `BpkBox` color props. Background colors use the `bpk-surface-bg-colors` mixin (shared with BpkPanel) plus explicit status fill and canvas classes. Text colors use compound selectors (`.bpk-box.bpk-box--text-*`) to beat Chakra emotion specificity, matching BpkText's pattern.

### `packages/bpk-component-layout/src/backgroundColors.ts`
Defines `BACKGROUND_COLORS` (all-caps, matching `TEXT_COLORS` convention). Extends `SURFACE_COLORS` from `bpk-react-utils` and adds `statusSuccessFill`, `statusDangerFill`, `statusWarningFill`, `canvas`, and `canvasContrast`. Exports `BpkBoxBackgroundColor` type.

---

## Modified files

### `packages/bpk-component-layout/src/BpkBox.tsx`
- Added `backgroundColor` and `color` props handled via SCSS class approach with `eslint-disable-next-line` (same pattern as BpkText)
- Wrapped with `React.forwardRef<HTMLElement>` to expose the underlying DOM node

### `packages/bpk-component-layout/src/commonProps.ts`
Added to `BpkCommonLayoutProps` (shared across all layout components):

| Category | Props added |
|---|---|
| HTML attributes | `id`, `role` |
| ARIA | All `aria-*` via `extends AriaAttributes` |
| Structural layout | `position`, `zIndex` |
| Overflow | `overflow`, `overflowX`, `overflowY` |

### `packages/bpk-component-layout/src/types.ts`
Added to `BpkBoxProps` only (interaction / visual, not shared):

| Prop | Type |
|---|---|
| `backgroundColor` | `BpkBoxBackgroundColor` |
| `color` | `TextColor` (from `TEXT_COLORS`) |
| `cursor` | `'auto' \| 'default' \| 'pointer' \| 'not-allowed'` |
| `opacity` | `number` |
| `tabIndex` | `number` |
| `onKeyDown` / `onKeyUp` | `BoxProps` event types |

### `packages/bpk-component-layout/index.ts`
Exported `BACKGROUND_COLORS` and `BpkBoxBackgroundColor`.

### `examples/bpk-component-layout/box-examples.tsx`
Added `SurfaceBackgroundColorExample`, `StatusFillBackgroundColorExample`, `CanvasBackgroundColorExample`, and `ColorExample`.

### `examples/bpk-component-layout/box.stories.tsx`
Added `SurfaceBackgroundColor`, `StatusFillBackgroundColor`, `CanvasBackgroundColor`, and `Color` stories.

---

## Design decisions

- `backgroundColor` and `color` use **SCSS classes**, not Chakra semantic tokens, to keep token usage within the Backpack boundary
- `display: none` was already supported via `BoxProps['display']` — no change needed
- Props that remain intentionally excluded: `className`, `style`, `transform`, `boxShadow`, `transition`, border shorthands, and raw CSS custom properties
