### PR TITLE
[NO JIRA] backpack-code-review-checklist SKILL

### DIFF
--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -7,13 +7,15 @@ description: |
   Backpack conventions before merge, (4) Identifying violations in API design, token usage,
   accessibility, or documentation. Covers Constitution principles (I-XIII), decisions/
   guidelines, API encapsulation rules, private token restrictions, design approval workflow,
-  icon alignment helpers, hover mixin usage, token semantic correctness, and snapshot
-  currency. Essential for maintaining Backpack quality standards and catching non-obvious
-  violations like className props in new components, wrong icon alignment wrapper,
-  raw :hover instead of bpk-hover mixin, or cross-component private token usage.
+  icon alignment helpers, hover mixin usage, token semantic correctness, snapshot
+  currency, and enum/variant prop typing conventions. Essential for maintaining Backpack
+  quality standards and catching non-obvious violations like className props in new
+  components, wrong icon alignment wrapper, raw :hover instead of bpk-hover mixin,
+  cross-component private token usage, or bare string union types that should be
+  expressed as `as const` constant objects.
 author: Claude Code
-version: 1.2.0
-date: 2026-03-03
+version: 1.3.0
+date: 2026-03-19
 ---
 
 # Backpack Code Review Checklist
@@ -342,6 +344,50 @@ npm run jest -- accessibility-test
 - [ ] JSDoc comments for public APIs
 - [ ] `@deprecated` tags for deprecated APIs
 - [ ] Console warnings for deprecated prop usage
+- [ ] Variant/enum props expressed as `as const` constant objects, NOT bare string union types
+
+**Enum/variant prop pattern (`as const` object + derived type) — REQUIRED for all new variant/enum props:**
+
+Bare string union types force consumers to memorise string literals and get no import-time
+constant to reference. Every variant or enum prop MUST be expressed as an exported `as const`
+object so consumers can write `type={BUTTON_TYPES.primary}` instead of `type="primary"`.
+
+Real-world example from `packages/bpk-component-button/src/common-types.tsx`:
+
+```typescript
+// ✅ CORRECT — exported constants let consumers avoid magic strings
+export const BUTTON_TYPES = {
+  primary: 'primary',
+  primaryOnDark: 'primary-on-dark',
+  secondary: 'secondary',
+  destructive: 'destructive',
+  // ...
+} as const;
+
+export const SIZE_TYPES = {
+  small: 'small',
+  large: 'large',
+} as const;
+
+export type ButtonType = (typeof BUTTON_TYPES)[keyof typeof BUTTON_TYPES];
+export type SizeType = (typeof SIZE_TYPES)[keyof typeof SIZE_TYPES];
+
+// ❌ WRONG — bare union: consumers must memorise 'primary' | 'secondary' strings
+export type ButtonType = 'primary' | 'secondary' | 'destructive';
+```
+
+The constant must also be exported from the package `index.ts` so consumers can import it:
+```typescript
+// packages/bpk-component-foo/index.ts
+export { BUTTON_TYPES, SIZE_TYPES } from './src/common-types';
+```
+
+**Check:**
+```bash
+# Find bare string union types that are candidates for as-const objects
+# (look for export type with string literal unions)
+rg "export type Bpk\w+(Variant|Type|Size|Color|Mode)\s*=\s*'" packages/bpk-component-*/src/
+```
 
 **Example:**
 ```typescript
@@ -506,6 +552,7 @@ After completing review:
 - For every CSS property written directly in the new SCSS — did I grep `bpk-mixins/` to confirm no mixin exists for it?
 - For every package import — did I open that package's `index.tsx` to see the full API and confirm the right variant is used?
 - For every token used — did I verify the token *name* semantically matches the UI state (not just the colour value)?
+- For every variant/enum prop type — is it a bare string union that should instead be an `as const` constant object with a derived type? Is the constant exported from `index.ts`?
 
 ## Notes
 
@@ -624,6 +671,8 @@ function hexToRgb(hex) {
 - ❌ Accepting that a CSS value looks right without checking if `bpk-mixins/` already abstracts it
 - ❌ Accepting that an import compiles without checking the full package API for a better-fitting variant
 - ❌ Accepting that a token produces the right colour without checking if the token name fits the UI state
+- ❌ Defining variant/enum prop types as bare string unions (`'primary' | 'secondary' | 'destructive'`) instead of `as const` constant objects like `BUTTON_TYPES` — consumers lose autocomplete and must memorise string literals
+- ❌ Defining a constant object like `BUTTON_TYPES` but forgetting to export it from the package `index.ts`
 
 ### SemVer Impact
 

--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -7,13 +7,15 @@ description: |
   Backpack conventions before merge, (4) Identifying violations in API design, token usage,
   accessibility, or documentation. Covers Constitution principles (I-XIII), decisions/
   guidelines, API encapsulation rules, private token restrictions, design approval workflow,
-  icon alignment helpers, hover mixin usage, token semantic correctness, and snapshot
-  currency. Essential for maintaining Backpack quality standards and catching non-obvious
-  violations like className props in new components, wrong icon alignment wrapper,
-  raw :hover instead of bpk-hover mixin, or cross-component private token usage.
+  icon alignment helpers, hover mixin usage, token semantic correctness, snapshot
+  currency, and enum/variant prop typing conventions. Essential for maintaining Backpack
+  quality standards and catching non-obvious violations like className props in new
+  components, wrong icon alignment wrapper, raw :hover instead of bpk-hover mixin,
+  cross-component private token usage, or bare string union types that should be
+  expressed as `as const` constant objects.
 author: Claude Code
-version: 1.2.0
-date: 2026-03-03
+version: 1.3.0
+date: 2026-03-23
 ---
 
 # Backpack Code Review Checklist
@@ -342,6 +344,50 @@ npm run jest -- accessibility-test
 - [ ] JSDoc comments for public APIs
 - [ ] `@deprecated` tags for deprecated APIs
 - [ ] Console warnings for deprecated prop usage
+- [ ] Variant/enum props expressed as `as const` constant objects, NOT bare string union types
+
+**Enum/variant prop pattern (`as const` object + derived type) — REQUIRED for all new variant/enum props:**
+
+Bare string union types force consumers to memorise string literals and get no import-time
+constant to reference. Every variant or enum prop MUST be expressed as an exported `as const`
+object so consumers can write `type={BUTTON_TYPES.primary}` instead of `type="primary"`.
+
+Real-world example from `packages/bpk-component-button/src/common-types.tsx`:
+
+```typescript
+// ✅ CORRECT — exported constants let consumers avoid magic strings
+export const BUTTON_TYPES = {
+  primary: 'primary',
+  primaryOnDark: 'primary-on-dark',
+  secondary: 'secondary',
+  destructive: 'destructive',
+  // ...
+} as const;
+
+export const SIZE_TYPES = {
+  small: 'small',
+  large: 'large',
+} as const;
+
+export type ButtonType = (typeof BUTTON_TYPES)[keyof typeof BUTTON_TYPES];
+export type SizeType = (typeof SIZE_TYPES)[keyof typeof SIZE_TYPES];
+
+// ❌ WRONG — bare union: consumers must memorise 'primary' | 'secondary' strings
+export type ButtonType = 'primary' | 'secondary' | 'destructive';
+```
+
+The constant must also be exported from the package `index.ts` so consumers can import it:
+```typescript
+// packages/bpk-component-foo/index.ts
+export { BUTTON_TYPES, SIZE_TYPES } from './src/common-types';
+```
+
+**Check:**
+```bash
+# Find bare string union types that are candidates for as-const objects
+# (look for export type with string literal unions)
+rg "export type Bpk\w+(Variant|Type|Size|Color|Mode)\s*=\s*'" packages/bpk-component-*/src/
+```
 
 **Example:**
 ```typescript
@@ -506,6 +552,7 @@ After completing review:
 - For every CSS property written directly in the new SCSS — did I grep `bpk-mixins/` to confirm no mixin exists for it?
 - For every package import — did I open that package's `index.tsx` to see the full API and confirm the right variant is used?
 - For every token used — did I verify the token *name* semantically matches the UI state (not just the colour value)?
+- For every variant/enum prop type — is it a bare string union that should instead be an `as const` constant object with a derived type? Is the constant exported from `index.ts`?
 
 ## Notes
 
@@ -624,6 +671,8 @@ function hexToRgb(hex) {
 - ❌ Accepting that a CSS value looks right without checking if `bpk-mixins/` already abstracts it
 - ❌ Accepting that an import compiles without checking the full package API for a better-fitting variant
 - ❌ Accepting that a token produces the right colour without checking if the token name fits the UI state
+- ❌ Defining variant/enum prop types as bare string unions (`'primary' | 'secondary' | 'destructive'`) instead of `as const` constant objects like `BUTTON_TYPES` — consumers lose autocomplete and must memorise string literals
+- ❌ Defining a constant object like `BUTTON_TYPES` but forgetting to export it from the package `index.ts`
 
 ### SemVer Impact
 

--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -7,15 +7,13 @@ description: |
   Backpack conventions before merge, (4) Identifying violations in API design, token usage,
   accessibility, or documentation. Covers Constitution principles (I-XIII), decisions/
   guidelines, API encapsulation rules, private token restrictions, design approval workflow,
-  icon alignment helpers, hover mixin usage, token semantic correctness, snapshot
-  currency, and enum/variant prop typing conventions. Essential for maintaining Backpack
-  quality standards and catching non-obvious violations like className props in new
-  components, wrong icon alignment wrapper, raw :hover instead of bpk-hover mixin,
-  cross-component private token usage, or bare string union types that should be
-  expressed as `as const` constant objects.
+  icon alignment helpers, hover mixin usage, token semantic correctness, and snapshot
+  currency. Essential for maintaining Backpack quality standards and catching non-obvious
+  violations like className props in new components, wrong icon alignment wrapper,
+  raw :hover instead of bpk-hover mixin, or cross-component private token usage.
 author: Claude Code
-version: 1.3.0
-date: 2026-03-19
+version: 1.2.0
+date: 2026-03-03
 ---
 
 # Backpack Code Review Checklist
@@ -344,50 +342,6 @@ npm run jest -- accessibility-test
 - [ ] JSDoc comments for public APIs
 - [ ] `@deprecated` tags for deprecated APIs
 - [ ] Console warnings for deprecated prop usage
-- [ ] Variant/enum props expressed as `as const` constant objects, NOT bare string union types
-
-**Enum/variant prop pattern (`as const` object + derived type) — REQUIRED for all new variant/enum props:**
-
-Bare string union types force consumers to memorise string literals and get no import-time
-constant to reference. Every variant or enum prop MUST be expressed as an exported `as const`
-object so consumers can write `type={BUTTON_TYPES.primary}` instead of `type="primary"`.
-
-Real-world example from `packages/bpk-component-button/src/common-types.tsx`:
-
-```typescript
-// ✅ CORRECT — exported constants let consumers avoid magic strings
-export const BUTTON_TYPES = {
-  primary: 'primary',
-  primaryOnDark: 'primary-on-dark',
-  secondary: 'secondary',
-  destructive: 'destructive',
-  // ...
-} as const;
-
-export const SIZE_TYPES = {
-  small: 'small',
-  large: 'large',
-} as const;
-
-export type ButtonType = (typeof BUTTON_TYPES)[keyof typeof BUTTON_TYPES];
-export type SizeType = (typeof SIZE_TYPES)[keyof typeof SIZE_TYPES];
-
-// ❌ WRONG — bare union: consumers must memorise 'primary' | 'secondary' strings
-export type ButtonType = 'primary' | 'secondary' | 'destructive';
-```
-
-The constant must also be exported from the package `index.ts` so consumers can import it:
-```typescript
-// packages/bpk-component-foo/index.ts
-export { BUTTON_TYPES, SIZE_TYPES } from './src/common-types';
-```
-
-**Check:**
-```bash
-# Find bare string union types that are candidates for as-const objects
-# (look for export type with string literal unions)
-rg "export type Bpk\w+(Variant|Type|Size|Color|Mode)\s*=\s*'" packages/bpk-component-*/src/
-```
 
 **Example:**
 ```typescript
@@ -552,7 +506,6 @@ After completing review:
 - For every CSS property written directly in the new SCSS — did I grep `bpk-mixins/` to confirm no mixin exists for it?
 - For every package import — did I open that package's `index.tsx` to see the full API and confirm the right variant is used?
 - For every token used — did I verify the token *name* semantically matches the UI state (not just the colour value)?
-- For every variant/enum prop type — is it a bare string union that should instead be an `as const` constant object with a derived type? Is the constant exported from `index.ts`?
 
 ## Notes
 
@@ -671,8 +624,6 @@ function hexToRgb(hex) {
 - ❌ Accepting that a CSS value looks right without checking if `bpk-mixins/` already abstracts it
 - ❌ Accepting that an import compiles without checking the full package API for a better-fitting variant
 - ❌ Accepting that a token produces the right colour without checking if the token name fits the UI state
-- ❌ Defining variant/enum prop types as bare string unions (`'primary' | 'secondary' | 'destructive'`) instead of `as const` constant objects like `BUTTON_TYPES` — consumers lose autocomplete and must memorise string literals
-- ❌ Defining a constant object like `BUTTON_TYPES` but forgetting to export it from the package `index.ts`
 
 ### SemVer Impact
 

--- a/examples/bpk-component-card-v2/examples.tsx
+++ b/examples/bpk-component-card-v2/examples.tsx
@@ -18,7 +18,7 @@
 
 import BpkBadge from '../../packages/bpk-component-badge/src/BpkBadge';
 import BpkButton from '../../packages/bpk-component-button';
-import { BpkCardV2, CARD_V2_SURFACE_COLORS, CARD_V2_VARIANTS } from '../../packages/bpk-component-card';
+import { BpkCardV2, CARD_V2_SURFACE_COLORS, CARD_V2_VARIANTS, type BpkCardV2SurfaceColor } from '../../packages/bpk-component-card';
 import BpkCarousel from '../../packages/bpk-component-carousel';
 import BpkJourneyArrow from '../../packages/bpk-component-journey-arrow';
 import { BpkBox, BpkFlex, BpkGrid, BpkHStack, BpkSpacing, BpkVStack } from '../../packages/bpk-component-layout';
@@ -80,7 +80,7 @@ const VariantsExample = () => (
   </div>
 );
 
-const DARK_SURFACE_COLORS = [CARD_V2_SURFACE_COLORS.surfaceHero, CARD_V2_SURFACE_COLORS.surfaceContrast];
+const DARK_SURFACE_COLORS: BpkCardV2SurfaceColor[] = [CARD_V2_SURFACE_COLORS.surfaceHero, CARD_V2_SURFACE_COLORS.surfaceContrast];
 
 const SurfaceColorsExample = () => (
   <BpkFlex wrap="wrap" gap={BpkSpacing.Base} paddingTop={BpkSpacing.Base}>
@@ -389,7 +389,7 @@ const AllExamples = () => (
       </BpkText>
       <FlightsCardExample />
     </BpkBox>
-    <BpkBox paddingTop={BpkSpacing.LG}>
+    <BpkBox paddingTop={BpkSpacing.LG} paddingBottom={BpkSpacing.XL}>
       <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">
         Custom Padding
       </BpkText>

--- a/examples/bpk-component-card-v2/examples.tsx
+++ b/examples/bpk-component-card-v2/examples.tsx
@@ -18,7 +18,7 @@
 
 import BpkBadge from '../../packages/bpk-component-badge/src/BpkBadge';
 import BpkButton from '../../packages/bpk-component-button';
-import { BpkCardV2 } from '../../packages/bpk-component-card';
+import { BpkCardV2, CARD_V2_SURFACE_COLORS, CARD_V2_VARIANTS } from '../../packages/bpk-component-card';
 import BpkCarousel from '../../packages/bpk-component-carousel';
 import BpkJourneyArrow from '../../packages/bpk-component-journey-arrow';
 import { BpkBox, BpkFlex, BpkGrid, BpkHStack, BpkSpacing, BpkVStack } from '../../packages/bpk-component-layout';
@@ -31,29 +31,15 @@ import BpkStarRating from '../../packages/bpk-component-star-rating';
 import BpkText, { TEXT_COLORS, TEXT_STYLES } from '../../packages/bpk-component-text';
 import { cssModules } from '../../packages/bpk-react-utils';
 
-import type {
-  BpkCardV2SurfaceColor,
-  BpkCardV2Variant,
-} from '../../packages/bpk-component-card';
-
 import STYLES from './examples.module.scss';
 
 const getClassName = cssModules(STYLES);
 
 const noop = () => {};
 
-const SURFACE_COLORS: BpkCardV2SurfaceColor[] = [
-  'surfaceDefault',
-  'surfaceElevated',
-  'surfaceTint',
-  'surfaceSubtle',
-  'surfaceHero',
-  'surfaceContrast',
-  'surfaceLowContrast',
-  'surfaceHighlight',
-];
+const SURFACE_COLORS = Object.values(CARD_V2_SURFACE_COLORS);
 
-const VARIANTS: BpkCardV2Variant[] = ['default', 'outlined', 'noElevation'];
+const VARIANTS = Object.values(CARD_V2_VARIANTS);
 
 const DefaultExample = () => (
   <BpkBox width="20rem">
@@ -94,7 +80,7 @@ const VariantsExample = () => (
   </div>
 );
 
-const DARK_SURFACE_COLORS: BpkCardV2SurfaceColor[] = ['surfaceHero', 'surfaceContrast'];
+const DARK_SURFACE_COLORS = [CARD_V2_SURFACE_COLORS.surfaceHero, CARD_V2_SURFACE_COLORS.surfaceContrast];
 
 const SurfaceColorsExample = () => (
   <BpkFlex wrap="wrap" gap={BpkSpacing.Base} paddingTop={BpkSpacing.Base}>
@@ -102,7 +88,7 @@ const SurfaceColorsExample = () => (
       const textColor = DARK_SURFACE_COLORS.includes(color) ? TEXT_COLORS.textOnDark : undefined;
       return (
         <BpkBox key={color} width="20rem">
-          <BpkCardV2.Root bgColor={color} variant="outlined">
+          <BpkCardV2.Root bgColor={color} variant={CARD_V2_VARIANTS.outlined}>
             <BpkCardV2.Header>
               <BpkText textStyle={TEXT_STYLES.heading5} tagName="h3" color={textColor}>
                 {color}
@@ -176,7 +162,7 @@ const PackagesCardExample = () => (
       </BpkCardV2.Body>
 
       <BpkCardV2.Footer padding={BpkSpacing.MD} paddingTop={BpkSpacing.None}>
-        <BpkCardV2.Root bgColor='surfaceLowContrast' variant='noElevation'>
+        <BpkCardV2.Root bgColor={CARD_V2_SURFACE_COLORS.surfaceLowContrast} variant={CARD_V2_VARIANTS.noElevation}>
           <BpkCardV2.Body templateColumns={{ base: '1fr', desktop: '1fr auto' }} justify="space-between" gap={BpkSpacing.MD}>
             <BpkFlex gap={BpkSpacing.LG} direction={{ base: 'column', desktop: 'row' }}>
               <DealOption text="Cheapest • Meals not included  •  £1,740" />
@@ -332,7 +318,7 @@ const HotelCardExample = () => (
 const CustomPaddingExample = () => (
   <BpkFlex wrap="wrap" gap={BpkSpacing.Base} paddingTop={BpkSpacing.Base}>
     <BpkBox width="20rem">
-      <BpkCardV2.Root variant="outlined">
+      <BpkCardV2.Root variant={CARD_V2_VARIANTS.outlined}>
         <BpkCardV2.Header padding={BpkSpacing.LG}>
           <BpkText textStyle={TEXT_STYLES.heading5} tagName="h3">
             Large padding
@@ -347,7 +333,7 @@ const CustomPaddingExample = () => (
       </BpkCardV2.Root>
     </BpkBox>
     <BpkBox width="20rem">
-      <BpkCardV2.Root variant="outlined">
+      <BpkCardV2.Root variant={CARD_V2_VARIANTS.outlined}>
         <BpkCardV2.Header
           paddingTop={BpkSpacing.SM}
           paddingBottom={BpkSpacing.SM}
@@ -403,7 +389,7 @@ const AllExamples = () => (
       </BpkText>
       <FlightsCardExample />
     </BpkBox>
-    <BpkBox paddingTop={BpkSpacing.LG} paddingBottom={BpkSpacing.XL}>
+    <BpkBox paddingTop={BpkSpacing.LG}>
       <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">
         Custom Padding
       </BpkText>

--- a/packages/bpk-component-card/index.ts
+++ b/packages/bpk-component-card/index.ts
@@ -31,6 +31,7 @@ export type {
   BpkCardV2Variant,
   BpkCardV2Namespace,
 } from './src/BpkCardV2/common-types';
+export { CARD_V2_SURFACE_COLORS, CARD_V2_VARIANTS } from './src/BpkCardV2/common-types';
 
 export { ORIENTATION, BpkDividedCard, BpkCardWrapper, BpkCardV2 };
 

--- a/packages/bpk-component-card/src/BpkCardV2/BpkCardV2-test.tsx
+++ b/packages/bpk-component-card/src/BpkCardV2/BpkCardV2-test.tsx
@@ -24,6 +24,7 @@ import { render, screen } from '@testing-library/react';
 import { BpkProvider, BpkSpacing } from '../../../bpk-component-layout';
 
 import BpkCardV2 from './BpkCardV2';
+import { CARD_V2_SURFACE_COLORS, CARD_V2_VARIANTS } from './common-types';
 
 const toKebab = (s: string) => s.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 
@@ -147,16 +148,7 @@ describe('BpkCardV2', () => {
   });
 
   describe('Surface Colors', () => {
-    const surfaceColors = [
-      'surfaceDefault',
-      'surfaceElevated',
-      'surfaceTint',
-      'surfaceSubtle',
-      'surfaceHero',
-      'surfaceContrast',
-      'surfaceLowContrast',
-      'surfaceHighlight',
-    ] as const;
+    const surfaceColors = Object.values(CARD_V2_SURFACE_COLORS);
 
     surfaceColors.forEach((color) => {
       it(`applies ${color} surface color as BEM modifier class`, () => {
@@ -194,12 +186,22 @@ describe('BpkCardV2', () => {
 
     it('applies outlined variant class when specified', () => {
       const { container } = renderWithProvider(
-        <BpkCardV2.Root variant="outlined">Content</BpkCardV2.Root>,
+        <BpkCardV2.Root variant={CARD_V2_VARIANTS.outlined}>Content</BpkCardV2.Root>,
       );
 
       const card = container.querySelector('[class*="bpk-card-v2"]');
 
       expect(card).toHaveClass('bpk-card-v2--outlined');
+    });
+
+    it('applies carsPrompt variant class when specified', () => {
+      const { container } = renderWithProvider(
+        <BpkCardV2.Root variant={CARD_V2_VARIANTS.carsPrompt}>Content</BpkCardV2.Root>,
+      );
+
+      const card = container.querySelector('[class*="bpk-card-v2"]');
+
+      expect(card).toHaveClass('bpk-card-v2--cars-prompt');
     });
   });
 

--- a/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.module.scss
+++ b/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.module.scss
@@ -65,6 +65,22 @@
   }
 }
 
+// Cars prompt variant - interactive card with background-color change on hover, no shadow
+.bpk-card-v2--cars-prompt {
+  box-shadow: none;
+  cursor: default;
+
+  @include utils.bpk-hover {
+    background-color: tokens.$bpk-surface-subtle-day;
+    box-shadow: none;
+  }
+
+  &:active {
+    background-color: tokens.$bpk-surface-subtle-day;
+    box-shadow: none;
+  }
+}
+
 // Divider between sections in multi-column layout
 // Horizontal on mobile, vertical on desktop
 .bpk-card-v2__divider {

--- a/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.module.scss
+++ b/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.module.scss
@@ -68,7 +68,6 @@
 // Cars prompt variant - interactive card with background-color change on hover, no shadow
 .bpk-card-v2--cars-prompt {
   box-shadow: none;
-  cursor: default;
 
   @include utils.bpk-hover {
     background-color: tokens.$bpk-surface-subtle-day;

--- a/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.module.scss
+++ b/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.module.scss
@@ -79,6 +79,13 @@
     background-color: tokens.$bpk-surface-subtle-day;
     box-shadow: none;
   }
+
+  &:focus-visible {
+    background-color: tokens.$bpk-surface-subtle-day;
+    box-shadow: none;
+
+    @include utils.bpk-focus-indicator;
+  }
 }
 
 // Divider between sections in multi-column layout

--- a/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.module.scss
+++ b/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.module.scss
@@ -67,6 +67,7 @@
 
 // Cars prompt variant - interactive card with background-color change on hover, no shadow
 .bpk-card-v2--cars-prompt {
+  background-color: tokens.$bpk-surface-default-day;
   box-shadow: none;
 
   @include utils.bpk-hover {

--- a/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.tsx
+++ b/packages/bpk-component-card/src/BpkCardV2/BpkCardV2.tsx
@@ -41,7 +41,7 @@ import type { BpkCardV2Namespace } from './common-types';
  *
  * @example
  * // Multi-column layout (70/30 on desktop, stacked on mobile)
- * <BpkCardV2.Root bgColor="surfaceElevated">
+ * <BpkCardV2.Root bgColor={CARD_V2_SURFACE_COLORS.surfaceElevated}>
  *   <BpkCardV2.Body templateColumns={{ base: '1fr', tablet: '7fr auto 3fr' }}>
  *     <BpkCardV2.Section>Main content</BpkCardV2.Section>
  *     <BpkCardV2.Divider />

--- a/packages/bpk-component-card/src/BpkCardV2/README.md
+++ b/packages/bpk-component-card/src/BpkCardV2/README.md
@@ -1,0 +1,106 @@
+# BpkCardV2
+
+`BpkCardV2` is a composable card component built from explicit subcomponents: `Header`, `Body`, `Footer`, `Section`, and `Divider`. It supports multiple visual variants, customisable surface colors, and responsive multi-column layouts.
+
+## Installation
+
+Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a complete installation guide.
+
+## Usage
+
+### Basic usage
+
+```tsx
+import { BpkCardV2 } from '@skyscanner/backpack-web/bpk-component-card';
+
+export default () => (
+  <BpkCardV2.Root>
+    <BpkCardV2.Header>Card title</BpkCardV2.Header>
+    <BpkCardV2.Body>Card body content.</BpkCardV2.Body>
+    <BpkCardV2.Footer>Footer content</BpkCardV2.Footer>
+  </BpkCardV2.Root>
+);
+```
+
+### Variants
+
+Use the `variant` prop to control the card's visual treatment. Available values are exported from `CARD_V2_VARIANTS`.
+
+| Variant | Description |
+|---|---|
+| `default` | Drop shadow that lifts on hover. Pointer cursor. |
+| `outlined` | Border instead of shadow. No hover elevation. |
+| `noElevation` | No shadow, no border. Flat appearance. |
+| `carsPrompt` | Bespoke variant — see below. |
+
+```tsx
+import {
+  BpkCardV2,
+  CARD_V2_VARIANTS,
+} from '@skyscanner/backpack-web/bpk-component-card';
+
+export default () => (
+  <BpkCardV2.Root variant={CARD_V2_VARIANTS.outlined}>
+    <BpkCardV2.Body>Outlined card</BpkCardV2.Body>
+  </BpkCardV2.Root>
+);
+```
+
+### Surface colors
+
+Use the `bgColor` prop to set the card's background surface color. Available values are exported from `CARD_V2_SURFACE_COLORS`. Defaults to `surfaceDefault`.
+
+```tsx
+import {
+  BpkCardV2,
+  CARD_V2_SURFACE_COLORS,
+} from '@skyscanner/backpack-web/bpk-component-card';
+
+export default () => (
+  <BpkCardV2.Root bgColor={CARD_V2_SURFACE_COLORS.surfaceElevated}>
+    <BpkCardV2.Body>Elevated surface card</BpkCardV2.Body>
+  </BpkCardV2.Root>
+);
+```
+
+### Multi-column layout
+
+Use `templateColumns` on `BpkCardV2.Body` to create responsive multi-column layouts. Add a `BpkCardV2.Divider` between `BpkCardV2.Section` children and include an `auto` column in `templateColumns` to reserve space for it.
+
+```tsx
+import { BpkCardV2 } from '@skyscanner/backpack-web/bpk-component-card';
+
+export default () => (
+  <BpkCardV2.Root>
+    <BpkCardV2.Body templateColumns={{ base: '1fr', tablet: '7fr auto 3fr' }}>
+      <BpkCardV2.Section>Main content</BpkCardV2.Section>
+      <BpkCardV2.Divider />
+      <BpkCardV2.Section>Sidebar content</BpkCardV2.Section>
+    </BpkCardV2.Body>
+  </BpkCardV2.Root>
+);
+```
+
+On mobile the columns stack vertically; the `Divider` renders as a horizontal rule. On tablet and above the columns are laid out side-by-side and the `Divider` renders as a vertical rule.
+
+### `carsPrompt` variant
+
+> **Note:** `carsPrompt` is a bespoke variant with fixed, opinionated styles. It does not support `bgColor` or any other background customisation.
+
+The `carsPrompt` variant renders an interactive card that transitions its background color on hover and active states. The background colors are defined by the design and cannot be overridden.
+
+Passing `bgColor` alongside `variant="carsPrompt"` is a **TypeScript error** — the prop is typed as `never` for this variant.
+
+```tsx
+import {
+  BpkCardV2,
+  CARD_V2_VARIANTS,
+} from '@skyscanner/backpack-web/bpk-component-card';
+
+export default () => (
+  // bgColor must not be set here — TypeScript will report an error if you try.
+  <BpkCardV2.Root variant={CARD_V2_VARIANTS.carsPrompt} onClick={handleClick}>
+    <BpkCardV2.Body>Cars prompt content</BpkCardV2.Body>
+  </BpkCardV2.Root>
+);
+```

--- a/packages/bpk-component-card/src/BpkCardV2/accessibility-test.tsx
+++ b/packages/bpk-component-card/src/BpkCardV2/accessibility-test.tsx
@@ -138,6 +138,18 @@ describe('BpkCardV2 Accessibility', () => {
       expect(results).toHaveNoViolations();
     });
 
+    it('has no accessibility violations - carsPrompt variant', async () => {
+      const { container } = renderWithProvider(
+        <BpkCardV2.Root variant={CARD_V2_VARIANTS.carsPrompt} aria-label="Cars prompt card">
+          <BpkCardV2.Body>Content</BpkCardV2.Body>
+        </BpkCardV2.Root>,
+      );
+
+      const results = await axe(container);
+
+      expect(results).toHaveNoViolations();
+    });
+
     it('has no accessibility violations - complex layout', async () => {
       const { container } = renderWithProvider(
         <BpkCardV2.Root variant={CARD_V2_VARIANTS.default} bgColor={CARD_V2_SURFACE_COLORS.surfaceDefault} aria-label="Complex card">

--- a/packages/bpk-component-card/src/BpkCardV2/accessibility-test.tsx
+++ b/packages/bpk-component-card/src/BpkCardV2/accessibility-test.tsx
@@ -24,6 +24,7 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 import { BpkProvider } from '../../../bpk-component-layout';
 
 import BpkCardV2 from './BpkCardV2';
+import { CARD_V2_SURFACE_COLORS, CARD_V2_VARIANTS } from './common-types';
 
 expect.extend(toHaveNoViolations);
 
@@ -115,7 +116,7 @@ describe('BpkCardV2 Accessibility', () => {
 
     it('has no accessibility violations - outlined variant', async () => {
       const { container } = renderWithProvider(
-        <BpkCardV2.Root variant="outlined" aria-label="Outlined card">
+        <BpkCardV2.Root variant={CARD_V2_VARIANTS.outlined} aria-label="Outlined card">
           <BpkCardV2.Body>Content</BpkCardV2.Body>
         </BpkCardV2.Root>,
       );
@@ -127,7 +128,7 @@ describe('BpkCardV2 Accessibility', () => {
 
     it('has no accessibility violations - with different surface colors', async () => {
       const { container } = renderWithProvider(
-        <BpkCardV2.Root bgColor="surfaceElevated" aria-label="Elevated card">
+        <BpkCardV2.Root bgColor={CARD_V2_SURFACE_COLORS.surfaceElevated} aria-label="Elevated card">
           <BpkCardV2.Body>Content</BpkCardV2.Body>
         </BpkCardV2.Root>,
       );
@@ -139,7 +140,7 @@ describe('BpkCardV2 Accessibility', () => {
 
     it('has no accessibility violations - complex layout', async () => {
       const { container } = renderWithProvider(
-        <BpkCardV2.Root variant="default" bgColor="surfaceDefault" aria-label="Complex card">
+        <BpkCardV2.Root variant={CARD_V2_VARIANTS.default} bgColor={CARD_V2_SURFACE_COLORS.surfaceDefault} aria-label="Complex card">
           <BpkCardV2.Header>Product Details</BpkCardV2.Header>
           <BpkCardV2.Body templateColumns="65fr auto 35fr">
             <BpkCardV2.Section>
@@ -179,7 +180,7 @@ describe('BpkCardV2 Accessibility', () => {
 
     it('maintains color contrast in outlined variant', async () => {
       const { container } = renderWithProvider(
-        <BpkCardV2.Root variant="outlined">
+        <BpkCardV2.Root variant={CARD_V2_VARIANTS.outlined}>
           <BpkCardV2.Body>Text content</BpkCardV2.Body>
         </BpkCardV2.Root>,
       );

--- a/packages/bpk-component-card/src/BpkCardV2/common-types.ts
+++ b/packages/bpk-component-card/src/BpkCardV2/common-types.ts
@@ -21,18 +21,28 @@ import type { ForwardRefExoticComponent, HTMLAttributes, ReactNode, RefAttribute
 import type { BpkBoxProps, BpkFlexProps, BpkGridProps } from '../../../bpk-component-layout';
 
 /** Surface color token options for BpkCardV2 background */
-export type BpkCardV2SurfaceColor =
-  | 'surfaceDefault'
-  | 'surfaceElevated'
-  | 'surfaceTint'
-  | 'surfaceSubtle'
-  | 'surfaceHero'
-  | 'surfaceContrast'
-  | 'surfaceLowContrast'
-  | 'surfaceHighlight';
+export const CARD_V2_SURFACE_COLORS = {
+  surfaceDefault: 'surfaceDefault',
+  surfaceElevated: 'surfaceElevated',
+  surfaceTint: 'surfaceTint',
+  surfaceSubtle: 'surfaceSubtle',
+  surfaceHero: 'surfaceHero',
+  surfaceContrast: 'surfaceContrast',
+  surfaceLowContrast: 'surfaceLowContrast',
+  surfaceHighlight: 'surfaceHighlight',
+} as const;
+
+export type BpkCardV2SurfaceColor = (typeof CARD_V2_SURFACE_COLORS)[keyof typeof CARD_V2_SURFACE_COLORS];
 
 /** Visual variant options for BpkCardV2 */
-export type BpkCardV2Variant = 'default' | 'outlined' | 'noElevation';
+export const CARD_V2_VARIANTS = {
+  default: 'default',
+  outlined: 'outlined',
+  noElevation: 'noElevation',
+  carsPrompt: 'carsPrompt',
+} as const;
+
+export type BpkCardV2Variant = (typeof CARD_V2_VARIANTS)[keyof typeof CARD_V2_VARIANTS];
 
 /**
  * BpkCardV2 root component props.
@@ -41,7 +51,7 @@ export type BpkCardV2Variant = 'default' | 'outlined' | 'noElevation';
  * Supports multiple surface colors, visual variants, and responsive multi-column layouts.
  *
  * @example
- * <BpkCardV2 variant="default" bgColor="surfaceDefault">
+ * <BpkCardV2 variant={CARD_V2_VARIANTS.default} bgColor={CARD_V2_SURFACE_COLORS.surfaceDefault}>
  *   <BpkCardV2.Header>Title</BpkCardV2.Header>
  *   <BpkCardV2.Body>Content</BpkCardV2.Body>
  *   <BpkCardV2.Footer>Footer</BpkCardV2.Footer>

--- a/packages/bpk-component-card/src/BpkCardV2/common-types.ts
+++ b/packages/bpk-component-card/src/BpkCardV2/common-types.ts
@@ -44,11 +44,19 @@ export const CARD_V2_VARIANTS = {
 
 export type BpkCardV2Variant = (typeof CARD_V2_VARIANTS)[keyof typeof CARD_V2_VARIANTS];
 
+type BpkCardV2BaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style'> & {
+  /** Card content - use Header, Body, Footer subcomponents */
+  children: ReactNode;
+};
+
 /**
  * BpkCardV2 root component props.
  *
  * Composable card component with explicit Header/Body/Footer subcomponents.
  * Supports multiple surface colors, visual variants, and responsive multi-column layouts.
+ *
+ * Note: `bgColor` is not supported for the `carsPrompt` variant — its background is fixed
+ * by design and cannot be customised.
  *
  * @example
  * <BpkCardV2 variant={CARD_V2_VARIANTS.default} bgColor={CARD_V2_SURFACE_COLORS.surfaceDefault}>
@@ -57,16 +65,19 @@ export type BpkCardV2Variant = (typeof CARD_V2_VARIANTS)[keyof typeof CARD_V2_VA
  *   <BpkCardV2.Footer>Footer</BpkCardV2.Footer>
  * </BpkCardV2>
  */
-export type BpkCardV2Props = Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style'> & {
-  /** Visual variant controlling styling treatment (shadow/border) */
-  variant?: BpkCardV2Variant;
-
-  /** Background surface color token (default: surfaceDefault) */
-  bgColor?: BpkCardV2SurfaceColor;
-
-  /** Card content - use Header, Body, Footer subcomponents */
-  children: ReactNode;
-};
+export type BpkCardV2Props = BpkCardV2BaseProps & (
+  | {
+      /** Visual variant controlling styling treatment (shadow/border) */
+      variant?: Exclude<BpkCardV2Variant, 'carsPrompt'>;
+      /** Background surface color token (default: surfaceDefault) */
+      bgColor?: BpkCardV2SurfaceColor;
+    }
+  | {
+      /** Cars prompt variant — bgColor is fixed and cannot be set */
+      variant: 'carsPrompt';
+      bgColor?: never;
+    }
+);
 
 /**
  * BpkCardV2.Header component props.

--- a/packages/bpk-component-card/src/BpkCardV2/integration-test.tsx
+++ b/packages/bpk-component-card/src/BpkCardV2/integration-test.tsx
@@ -24,6 +24,7 @@ import userEvent from '@testing-library/user-event';
 import { BpkProvider } from '../../../bpk-component-layout';
 
 import BpkCardV2 from './BpkCardV2';
+import { CARD_V2_SURFACE_COLORS } from './common-types';
 
 const toKebab = (s: string) => s.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 
@@ -197,7 +198,7 @@ describe('BpkCardV2 Integration Tests', () => {
             <BpkCardV2.Section>
               <div>
                 <h3>Main Section</h3>
-                <BpkCardV2.Root bgColor="surfaceElevated">
+                <BpkCardV2.Root bgColor={CARD_V2_SURFACE_COLORS.surfaceElevated}>
                   <BpkCardV2.Body>Nested card</BpkCardV2.Body>
                 </BpkCardV2.Root>
               </div>

--- a/packages/bpk-component-card/src/BpkCardV2/snapshot-test.tsx
+++ b/packages/bpk-component-card/src/BpkCardV2/snapshot-test.tsx
@@ -25,6 +25,7 @@ import { BpkProvider } from '../../../bpk-component-layout';
 import BpkText, { TEXT_STYLES } from '../../../bpk-component-text';
 
 import BpkCardV2 from './BpkCardV2';
+import { CARD_V2_SURFACE_COLORS, CARD_V2_VARIANTS } from './common-types';
 
 const renderWithProvider = (ui: ReactElement) =>
   render(<BpkProvider>{ui}</BpkProvider>);
@@ -74,7 +75,7 @@ describe('BpkCardV2 Snapshots', () => {
 
   it('matches snapshot - outlined variant', () => {
     const { container } = renderWithProvider(
-      <BpkCardV2.Root variant="outlined">
+      <BpkCardV2.Root variant={CARD_V2_VARIANTS.outlined}>
         <BpkCardV2.Header>Outlined Card</BpkCardV2.Header>
         <BpkCardV2.Body>Content with border instead of shadow</BpkCardV2.Body>
       </BpkCardV2.Root>,
@@ -85,7 +86,7 @@ describe('BpkCardV2 Snapshots', () => {
 
   it('matches snapshot - elevated surface color', () => {
     const { container } = renderWithProvider(
-      <BpkCardV2.Root bgColor="surfaceElevated">
+      <BpkCardV2.Root bgColor={CARD_V2_SURFACE_COLORS.surfaceElevated}>
         <BpkCardV2.Body>Elevated background surface</BpkCardV2.Body>
       </BpkCardV2.Root>,
     );
@@ -95,7 +96,7 @@ describe('BpkCardV2 Snapshots', () => {
 
   it('matches snapshot - complex layout with all sections', () => {
     const { container } = renderWithProvider(
-      <BpkCardV2.Root variant="default" bgColor="surfaceDefault">
+      <BpkCardV2.Root variant={CARD_V2_VARIANTS.default} bgColor={CARD_V2_SURFACE_COLORS.surfaceDefault}>
         <BpkCardV2.Header>Product</BpkCardV2.Header>
         <BpkCardV2.Body templateColumns="65fr auto 35fr">
           <BpkCardV2.Section>

--- a/packages/bpk-component-card/src/BpkCardV2/subcomponents/Root.tsx
+++ b/packages/bpk-component-card/src/BpkCardV2/subcomponents/Root.tsx
@@ -19,8 +19,7 @@
 import { forwardRef } from 'react';
 
 import { cssModules, getDataComponentAttribute } from '../../../../bpk-react-utils';
-
-import type { BpkCardV2Props } from '../common-types';
+import { CARD_V2_SURFACE_COLORS, CARD_V2_VARIANTS, type BpkCardV2Props } from '../common-types';
 
 import STYLES from '../BpkCardV2.module.scss';
 
@@ -45,7 +44,7 @@ const toKebab = (s: string) => s.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`)
  * @example
  * // Multi-column layout (70/30 on desktop, stacked on mobile).
  * // The `auto` column in templateColumns reserves space for the Divider.
- * <BpkCardV2.Root bgColor="surfaceElevated">
+ * <BpkCardV2.Root bgColor={CARD_V2_SURFACE_COLORS.surfaceElevated}>
  *   <BpkCardV2.Body templateColumns={{ base: '1fr', tablet: '7fr auto 3fr' }}>
  *     <BpkCardV2.Section>Main content</BpkCardV2.Section>
  *     <BpkCardV2.Divider />
@@ -56,9 +55,9 @@ const toKebab = (s: string) => s.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`)
 const Root = forwardRef<HTMLDivElement, BpkCardV2Props>(
   (
     {
-      bgColor = 'surfaceDefault',
+      bgColor = CARD_V2_SURFACE_COLORS.surfaceDefault,
       children,
-      variant = 'default',
+      variant = CARD_V2_VARIANTS.default,
       ...rest
     },
     ref,


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
This PR based on https://github.com/Skyscanner/backpack/pull/4297
Remember to include the following changes:Updates the backpack-code-review-checklist Claude Code skill (v1.2.0 → v1.3.0) to include a new checklist rule and guidance around how variant/enum props should be typed.

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
