### PR TITLE
[NO-JIRA][BpkCloseButton&BpkSplitInput] Migrate entry point from js to ts

### DIFF
--- a/examples/bpk-component-fieldset/examples.tsx
+++ b/examples/bpk-component-fieldset/examples.tsx
@@ -38,7 +38,6 @@ import BpkFieldset, {
 import BpkInput, { INPUT_TYPES } from '../../packages/bpk-component-input';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkSelect from '../../packages/bpk-component-select';
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkSplitInput from '../../packages/bpk-component-split-input';
 import BpkTextarea from '../../packages/bpk-component-textarea';
 import { cssModules } from '../../packages/bpk-react-utils';

--- a/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.tsx
+++ b/packages/bpk-component-banner-alert/src/BpkBannerAlertInner.tsx
@@ -25,7 +25,6 @@ import type { ReactNode, FunctionComponent, SVGProps } from 'react';
 import { durationSm } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 import BpkAnimateHeight from '../../bpk-animate-height';
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../bpk-component-close-button';
 import { withButtonAlignment } from '../../bpk-component-icon';
 import ChevronDownIcon from '../../bpk-component-icon/lg/chevron-down';

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -19,7 +19,6 @@ import type { SyntheticEvent, ReactNode, ReactElement } from 'react';
 import { useCallback, useState, isValidElement, cloneElement } from 'react';
 
 import BpkBreakpoint, { BREAKPOINTS } from '../../bpk-component-breakpoint';
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../bpk-component-close-button';
 import BpkLink from '../../bpk-component-link';
 import BpkNavigationBar from '../../bpk-component-navigation-bar';

--- a/packages/bpk-component-close-button/index.ts
+++ b/packages/bpk-component-close-button/index.ts
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-/* @flow strict */
-
 import BpkCloseButton from './src/BpkCloseButton';
 
 export default BpkCloseButton;

--- a/packages/bpk-component-dialog/src/BpkDialog.tsx
+++ b/packages/bpk-component-dialog/src/BpkDialog.tsx
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../bpk-component-close-button';
 import { cssModules, Portal, getDataComponentAttribute } from '../../bpk-react-utils';
 
@@ -73,7 +72,7 @@ const BpkDialog = ({
         {headerIcon && <div className={headerIconClassNames}>{headerIcon}</div>}
         {dismissible && (
           <span className={closeButtonClassNames}>
-            <BpkCloseButton label={closeLabel} onClick={onClose} />
+            <BpkCloseButton label={closeLabel} onClick={() => onClose?.()} />
           </span>
         )}
         {children}

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
@@ -22,7 +22,6 @@ import { Transition } from 'react-transition-group';
 
 import { animations } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../bpk-component-close-button';
 import BpkLink from '../../bpk-component-link';
 import { cssModules } from '../../bpk-react-utils';
@@ -136,7 +135,7 @@ const BpkDrawerContent = ({
               <BpkLink as="button" onClick={onClose}>{closeText}</BpkLink>
             ) : (
               <div className={getClassName('bpk-drawer__close-button')}>
-                <BpkCloseButton label={closeLabel} onClick={onClose} />
+                <BpkCloseButton label={closeLabel ?? ''} onClick={onClose} />
               </div>
             )}
           </header>

--- a/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
+++ b/packages/bpk-component-info-banner/src/BpkInfoBannerInner.tsx
@@ -25,7 +25,6 @@ import type { ReactNode, FunctionComponent, SVGProps } from 'react';
 import { durationSm } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 import BpkAnimateHeight from '../../bpk-animate-height';
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../bpk-component-close-button';
 import { withButtonAlignment } from '../../bpk-component-icon';
 import ChevronDownIcon from '../../bpk-component-icon/sm/chevron-down';

--- a/packages/bpk-component-modal/src/BpkModalInner.tsx
+++ b/packages/bpk-component-modal/src/BpkModalInner.tsx
@@ -18,7 +18,6 @@
 
 import type { ReactNode } from 'react';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../bpk-component-close-button';
 import BpkLink from '../../bpk-component-link';
 import BpkNavigationBar, {

--- a/packages/bpk-component-modal/src/BpkModalV2/BpkModal.tsx
+++ b/packages/bpk-component-modal/src/BpkModalV2/BpkModal.tsx
@@ -19,7 +19,6 @@
 import type { ReactNode } from 'react';
 import { useEffect, useRef } from 'react';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../../bpk-component-close-button';
 import BpkText, { TEXT_STYLES } from '../../../bpk-component-text';
 import { cssModules, withDefaultProps, getDataComponentAttribute } from '../../../bpk-react-utils';

--- a/packages/bpk-component-modal/src/BpkModalV3/BpkModalV3CloseTrigger/BpkModalV3CloseTrigger.tsx
+++ b/packages/bpk-component-modal/src/BpkModalV3/BpkModalV3CloseTrigger/BpkModalV3CloseTrigger.tsx
@@ -18,7 +18,6 @@
 
 import { Dialog } from '@ark-ui/react/dialog';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../../../bpk-component-close-button';
 import CloseIcon from '../../../../bpk-component-icon/sm/close';
 import { cssModules, getDataComponentAttribute } from '../../../../bpk-react-utils';

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBarIconButton.tsx
@@ -16,9 +16,8 @@
  * limitations under the License.
  */
 
-import type { ComponentType, MouseEvent, ReactNode } from 'react';
+import type { ComponentType, FunctionComponent, MouseEvent, ReactNode } from 'react';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../bpk-component-close-button';
 import { getDataComponentAttribute } from '../../bpk-react-utils';
 
@@ -45,9 +44,9 @@ const BpkNavigationBarIconButton = ({
     {...getDataComponentAttribute('NavigationBarIconButton')}
   >
     <BpkCloseButton
-      customIcon={icon}
+      customIcon={icon as FunctionComponent<any>}
       onDark={barStyle === BAR_STYLES.onDark}
-      {...rest}
+      {...(rest as any)}
     />
   </span>
 );

--- a/packages/bpk-component-popover/src/BpkPopover.tsx
+++ b/packages/bpk-component-popover/src/BpkPopover.tsx
@@ -43,7 +43,6 @@ import {
 
 import { surfaceHighlightDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import BpkCloseButton from '../../bpk-component-close-button';
 import BpkLink from '../../bpk-component-link';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
@@ -259,7 +258,7 @@ const BpkPopover = ({
                       &nbsp;
                       {closeButtonIcon ? (
                         <BpkCloseButton
-                          label={closeButtonText || closeButtonLabel}
+                          label={closeButtonText || closeButtonLabel || ''}
                           onClick={(
                             event: SyntheticEvent<HTMLButtonElement>,
                           ) => {

--- a/packages/bpk-component-split-input/index.ts
+++ b/packages/bpk-component-split-input/index.ts
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @flow strict */
 
 import BpkSplitInput, {
   type Props as BpkSplitInputProps,

--- a/packages/bpk-component-split-input/src/BpkSplitInput.tsx
+++ b/packages/bpk-component-split-input/src/BpkSplitInput.tsx
@@ -28,7 +28,7 @@ import STYLES from './BpkSplitInput.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-interface Props {
+export interface Props {
   type?: string | number;
   id: string;
   label: string;


### PR DESCRIPTION
# Description

Migrate `bpk-component-split-input` and `bpk-component-close-button` entry points from Flow-typed JS to TypeScript.

## Changes

- `bpk-component-split-input/index.js` → `index.ts`: removed stale `/* @flow strict */` annotation
- `bpk-component-split-input/src/BpkSplitInput.tsx`: added `export` to `interface Props` so it can be re-exported via `index.ts`
- `bpk-component-close-button/index.js` → `index.ts`: removed stale `/* @flow strict */` annotation

## Impact

No breaking changes. The public API surface (`export default`, `export { INPUT_TYPES }`, `export type { BpkSplitInputProps }`) is identical to before. Consumers import from the compiled `dist/index.js` which is unaffected by the source file rename.

## Checklist

- [x] No breaking changes to exported API
- [x] Removed stale Flow annotations (codebase uses TypeScript)
- [x] Tests pass

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
