### PR TITLE
[NO JIRA][BpkBadge] Change badge font style from footnote to caption

### DIFF
--- a/packages/backpack-web/src/bpk-mixins/_badges.scss
+++ b/packages/backpack-web/src/bpk-mixins/_badges.scss
@@ -45,11 +45,11 @@
     tokens.$bpk-border-radius-xs
   );
   @include typography.bpk-text;
-  @include typography.bpk-footnote;
+  @include typography.bpk-caption;
   @include utils.bpk-themeable-property(
     font-size,
     --bpk-badge-font-size,
-    tokens.$bpk-font-size-sm
+    tokens.$bpk-font-size-xs
   );
   @include utils.bpk-themeable-property(
     font-weight,
@@ -59,7 +59,7 @@
   @include utils.bpk-themeable-property(
     line-height,
     --bpk-badge-line-height,
-    tokens.$bpk-line-height-sm
+    tokens.$bpk-line-height-xs
   );
 }
 


### PR DESCRIPTION
## What

Changes `BpkBadge` typography from `footnote` to `caption`, making the badge text smaller.

- Replaces `@include typography.bpk-footnote` with `@include typography.bpk-caption`
- Also updates the `bpk-themeable-property` fallback values so the change actually takes effect:
  - `--bpk-badge-font-size`: `$bpk-font-size-sm` → `$bpk-font-size-xs`
  - `--bpk-badge-line-height`: `$bpk-line-height-sm` → `$bpk-line-height-xs`

> **Note:** The original PR only swapped the mixin but left the `bpk-themeable-property` fallbacks as `sm`, which meant the later CSS declarations overrode the mixin — resulting in no visible change. Both the mixin and the fallbacks must be updated together.

## Before / After

<img src="https://github.com/user-attachments/assets/3a6ae244-0daa-4672-9f79-7ac25b06b26c" width="600" alt="Before and After comparison of BpkBadge font size change" />

Before storybook link: https://backpack.github.io/storybook/?path=/story/bpk-component-badge--default
After storybook link: https://backpack.github.io/storybook-prs/4318/?path=/story/bpk-component-badge--default

## Checklist
- [x] Tests pass
- [x] Storybook examples updated
