### PR TITLE
[skill][NO-JIRA]improve-backpack-review-skill

### DIFF
--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -3,9 +3,18 @@ name: backpack-code-review-checklist
 description: Self-improving multi-agent review orchestrator for Backpack component PRs. Runs 6 parallel specialist agents (including a learned-patterns agent that mines past PR comments), then confidence-scores findings. Use for PR review, Constitution compliance checks, and pre-merge validation. Run with "learn" to mine recent PRs and auto-update checklist rules.
 ---
 
-# Backpack Code Review — Multi-Agent Orchestrator (v3.0.4)
+# Backpack Code Review — Multi-Agent Orchestrator (v3.1.2)
 
 <!-- Changelog
+- v3.1.2: Phase 3 scoring agents now explicitly use model: haiku — scoring is a classification
+  task with a fixed rubric and no tool calls; Haiku is sufficient and ~12x cheaper than Sonnet.
+- v3.1.1: Add formal observations tier — issues with confidence 60–(threshold-1) surface in
+  conversation as "Below-threshold observations" (not blocking, never posted to GitHub).
+  Removes reliance on model self-initiative for below-threshold findings.
+- v3.1.0: Revert to v2.1 self-fetch architecture — agents fetch their own scoped diffs;
+  Phase 1.5 uses two-level parallelism (parallel component subagents + parallel PR view calls);
+  Agents 1–5 launch immediately after Phase 1 without waiting for Phase 1.5;
+  Agent 6 launches separately when Phase 1.5 completes.
 - v3.0.5: Restore independent Phase 3 scoring (removes agent self-scoring bias);
   Agent 5 now receives full diff to catch cross-file-type bugs (SCSS+TSX specificity conflicts);
   restore accessibility-test.tsx check for existing components (Constitution IV);
@@ -30,10 +39,11 @@ Threshold: default 75, override via `/backpack-code-review-checklist threshold=8
 
 ```
 Phase 0    Detect run mode — learn vs review; early-exit check (review only)
-Phase 1    Metadata + diff pre-fetch + slice per agent  ┐ run in
-Phase 1.5  Mine learned patterns (feeds Agent 6)        ┘ parallel
-Phase 2    Launch agents IN PARALLEL (agents use pre-fetched diff)
-Phase 3    Independent confidence scoring (parallel scoring agents or orchestrator batch)
+Phase 1    Metadata + RESOLVED/RAISED_SET  ┐ run in parallel; Phase 1.5
+Phase 1.5  Mine learned patterns           ┘ uses parallel component subagents internally
+Phase 2a   Launch Agents 1–5 immediately after Phase 1 (no wait for Phase 1.5)
+Phase 2b   Launch Agent 6 when Phase 1.5 completes (if applicable)
+Phase 3    Independent confidence scoring — after ALL agents finish
 Phase 4    Filter, format, and output
 Phase 5    Orchestrator self-check (internal)
 ```
@@ -81,18 +91,6 @@ If the invocation contains `learn`, read and follow `learn-mode.md`. Stop here.
 - Skim: `.specify/memory/constitution.md`, `CODE_REVIEW_GUIDELINES.md`, relevant `decisions/`
 - Summarise the PR in 2-3 sentences; pass as `[INSERT]` to all agents
 
-**Diff pre-fetch (critical for performance):** Fetch the full diff once:
-```bash
-gh pr diff [NUMBER] --repo Skyscanner/backpack   # PR mode
-git diff main...HEAD                              # local mode
-```
-Slice the fetched diff in memory — do NOT issue additional `gh pr diff` calls:
-- **SCSS slice** → Agent 2: filter to lines belonging to `*.scss` files
-- **TSX/TS slice** → Agents 1, 3, 5: filter to lines belonging to `*.ts`/`*.tsx` files
-- **Full diff** → Agents 4, 6
-
-Pass each slice as `[INSERT SCOPED DIFF]` in the agent's prompt. **Agents must not re-fetch the diff.**
-
 **Inline review comment fetch (PR mode only — skip in local mode):**
 Fetch the current PR's own inline review comments (line-level diff threads):
 ```bash
@@ -120,55 +118,58 @@ Store both sets for use in Phase 4.
 
 **Skip entirely** if >70% of changed files are brand-new (new files have no history to mine).
 
-Otherwise:
-1. Extract component names from changed paths (e.g. `packages/bpk-component-modal/` → `bpk-component-modal`)
-2. For each component (max 3), find its 5 most recently merged PRs:
-   ```bash
-   gh pr list --repo Skyscanner/backpack --state merged --limit 50 \
-     --search "[COMPONENT_NAME]" --json number,title,mergedAt | head -5
-   ```
-3. For each PR, fetch comments:
-   ```bash
-   gh pr view [N] --repo Skyscanner/backpack --json reviews,comments,reviewThreads
-   ```
-4. Collect raw text from `reviews[].body`, `comments[].body`, and inline diff-thread comments
-   (`reviewThreads[].comments[].body`). Pass to Agent 6 as-is.
-   If no comments found, omit Agent 6.
+Otherwise, run as a single background subagent using parallel tool calls internally — no nested subagents:
+
+**Step 1 — parallel `gh pr list` calls (one per component, all in one message):**
+Extract component names from changed paths (max 3). Issue all `gh pr list` calls simultaneously:
+```bash
+gh pr list --repo Skyscanner/backpack --state merged --limit 50 \
+  --search "[COMPONENT_NAME]" --json number,title,mergedAt | head -5
+```
+
+**Step 2 — parallel `gh pr view` calls (all PRs across all components, all in one message):**
+Collect every PR number returned from Step 1 (up to 15 total). Issue all `gh pr view` calls simultaneously:
+```bash
+gh pr view [N] --repo Skyscanner/backpack --json reviews,comments,reviewThreads
+```
+Collect raw text from `reviews[].body`, `comments[].body`, and `reviewThreads[].comments[].body`.
+
+Pass combined raw comment text to Agent 6 as `[INSERT RAW COMMENT TEXT]`.
+If no comments found, omit Agent 6.
 
 ---
 
 ## Phase 2: Launch Agents in Parallel
 
-**Agent pruning:**
+### Phase 2a — Launch Agents 1–5 immediately after Phase 1
 
-| Agent | Launch when | Skip when |
-|-------|------------|-----------|
-| Agent 1 (Constitution & API) | Always | Never |
-| Agent 2 (Sass & Token) | `.scss` files in diff | No `.scss` files |
-| Agent 3 (A11y & Testing) | Always | Never |
-| Agent 4 (History) | Files exist on `main` | >70% of changed files are brand-new |
-| Agent 5 (Bug Scanner) | Always | Never |
-| Agent 6 (Learned Patterns) | Phase 1.5 found comments | No historical comments |
+Do not wait for Phase 1.5. Dispatch in a single message as soon as Phase 1 is complete.
 
-**Dispatch all selected agents in a single message** using multiple Agent tool calls.
+| Agent | Prompt file | Launch when | Self-fetched scope |
+|-------|-------------|-------------|--------------------|
+| Agent 1 | `agents/agent1-constitution.md` | Always | TSX/TS |
+| Agent 2 | `agents/agent2-sass.md` | `.scss` files in changed list | SCSS |
+| Agent 3 | `agents/agent3-a11y.md` | Always | TSX/TS |
+| Agent 4 | `agents/agent4-history.md` | Files exist on `main` | Full diff |
+| Agent 5 | `agents/agent5-bugs.md` | Always | Full diff |
 
-For each agent, **read its prompt file** from `agents/` and fill in the template variables
-before dispatching:
+### Phase 2b — Launch Agent 6 when Phase 1.5 completes
 
-| Agent | Prompt file | Scoped diff to embed |
-|-------|-------------|----------------------|
-| Agent 1 | `agents/agent1-constitution.md` | TSX/TS slice |
-| Agent 2 | `agents/agent2-sass.md` | SCSS slice |
-| Agent 3 | `agents/agent3-a11y.md` | TSX/TS slice |
-| Agent 4 | `agents/agent4-history.md` | Full diff |
-| Agent 5 | `agents/agent5-bugs.md` | Full diff |
-| Agent 6 | `agents/agent6-learned.md` | Full diff + Phase 1.5 comments |
+| Agent | Prompt file | Launch when | Self-fetched scope |
+|-------|-------------|-------------|--------------------|
+| Agent 6 | `agents/agent6-learned.md` | Phase 1.5 found comments | Full diff |
 
-**Template variables to fill in for every agent:** `[NUMBER]`, `[SHA]`, `[INSERT LIST]`, `[INSERT]` (PR summary), `[INSERT SCOPED DIFF]`.
+If Phase 1.5 found no comments, skip Agent 6 entirely.
 
-**Agents use the pre-fetched diff embedded in their prompt.** They may still use the Read
-tool to inspect specific files for deeper context, but must NOT re-fetch the full diff via
-`gh pr diff` or `git diff`.
+---
+
+**Template variables to fill in for every agent:** `[NUMBER]`, `[SHA]`, `[INSERT LIST]`, `[INSERT]` (PR summary).
+Agent 6 additionally receives `[INSERT RAW COMMENT TEXT]` from Phase 1.5.
+
+**Each agent self-fetches its own scoped diff** using the commands documented in its prompt.
+Agents may also use the Read tool for deeper file inspection.
+
+**Wait for all running agents (1–5, and 6 if launched) to complete before starting Phase 3.**
 
 **Each agent returns a JSON array of issues (no confidence score — Phase 3 scores independently):**
 ```json
@@ -198,7 +199,7 @@ priority order: constitution > sass-tokens > a11y-testing > history > bug-scan >
 After all agents return and deduplication is done, collect every issue into a single list.
 
 **Scoring dispatch policy:**
-- If `len(issues) <= 15`: launch **parallel scoring agents** — one per issue, all in one message.
+- If `len(issues) <= 15`: launch **parallel scoring agents** — one per issue, all in one message, using `model: haiku`. Scoring is a classification task with an explicit rubric; it does not require tool calls or complex reasoning.
 - If `len(issues) > 15`: score all issues directly in a single pass (no sub-agents).
 
 **Each scoring agent (or the orchestrator in batch mode) receives:**
@@ -244,7 +245,11 @@ After all agents return and deduplication is done, collect every issue into a si
 
 ## Phase 4: Filter, Format, and Output
 
-**Filter — step 1, confidence:** remove issues with `confidence < threshold`.
+**Filter — step 1, confidence:** split issues into three buckets:
+- `confidence >= threshold` → **blocking issues** — go through steps 2–3 and into output
+- `60 <= confidence < threshold` → **observations** — skip steps 2–3; conversation-only, never posted to GitHub
+- `confidence < 60` → **drop** — false positive or noise
+
 Issues with `threshold <= confidence < 90` are human-gated — include them in output with
 a "Gate rationale" line showing `confidence_explanation`, and require explicit user
 confirmation before posting to GitHub.
@@ -268,7 +273,7 @@ thread `line` is `null`). If it matches, **keep the issue** but prepend the labe
 
 Print the `### Code review` block to the conversation. No GitHub posting.
 
-**If no issues:**
+**If no issues and no observations:**
 ```markdown
 ### Code review
 
@@ -278,7 +283,7 @@ No issues found. Checked by N/6 agents (Constitution, Sass, A11y, History, Bug S
 🤖 Generated with [Claude Code](https://claude.ai/code)
 ```
 
-**If issues found:**
+**If issues found (with optional observations appended):**
 ```markdown
 ### Code review
 
@@ -290,6 +295,27 @@ Found N issues (reviewed by M/6 agents, filtered by confidence scoring):
    [path/file.tsx:42](path/file.tsx#L42)
    [if human-gated] Gate rationale: [confidence_explanation]
 
+[if observations exist]
+Below-threshold observations (confidence 60–74, not blocking):
+
+- **[Title]** (score: N) — [one-line explanation: what, why]
+  [path/file.tsx:42](path/file.tsx#L42)
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+```
+
+**If no issues but observations exist:**
+```markdown
+### Code review
+
+No issues met the threshold. Checked by N/6 agents (Constitution, Sass, A11y, History, Bug Scanner, Learned Patterns).
+[Note any failed agents]
+
+Below-threshold observations (confidence 60–74, not blocking):
+
+- **[Title]** (score: N) — [one-line explanation: what, why]
+  [path/file.tsx:42](path/file.tsx#L42)
+
 🤖 Generated with [Claude Code](https://claude.ai/code)
 ```
 
@@ -300,6 +326,8 @@ Found N issues (reviewed by M/6 agents, filtered by confidence scoring):
 **Conversation:** Print the same `### Code review` block as local mode (for human review),
 but links use full SHA permalinks:
 `https://github.com/Skyscanner/backpack/blob/[SHA]/[PATH]#L[START]-L[END]`
+
+Observations (if any) appear in the conversation block only — they are **never included in the GitHub payload**.
 
 **Autopost: OFF by default in PR mode.** Post only when user explicitly says "post" / "post to GitHub" / `BACKPACK_REVIEW_AUTOPOST=true`.
 

--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -54,7 +54,8 @@ If the invocation contains `learn`, read and follow `learn-mode.md`. Stop here.
 - **PR mode**: message contains a `github.com/.../pull/NNN` URL
   - Extract PR number; run `gh pr view NNN --repo Skyscanner/backpack --json headRefOid,files,state,isDraft,body`
   - Link format: `https://github.com/Skyscanner/backpack/blob/[HEAD_COMMIT_SHA]/[PATH]#L[START]-L[END]`
-  - Autopost: default off. Post only when user explicitly asks or `BACKPACK_REVIEW_AUTOPOST=true`.
+  - **Autopost: ON by default in PR mode.** Uses the GitHub Reviews API to place **inline comments on diff lines**.
+    Override to skip posting: user says "don't post" / "local only" / `BACKPACK_REVIEW_AUTOPOST=false`.
     Issues with confidence 75–90 require human confirmation before posting.
 
 - **Local mode**: no PR URL
@@ -228,7 +229,13 @@ check whether it matches a RAISED_SET thread (same `file`, overlapping line rang
 If it matches, **keep the issue** but prepend the label:
 `⚠️ Already raised in PR discussion — still open.`
 
-**Output only** the final `### Code review` block — no phase diagnostics, no tables.
+**Output differs by mode:**
+
+---
+
+### Local mode output
+
+Print the `### Code review` block to the conversation. No GitHub posting.
 
 **If no issues:**
 ```markdown
@@ -249,18 +256,79 @@ Found N issues (reviewed by M/6 agents, filtered by confidence scoring):
 
 1. [Title] *(recurring pattern)* — [explanation: what, why, fix. Link to codebase precedent if one exists.]
 
-   [link]
+   [path/file.tsx:42](path/file.tsx#L42)
    [if human-gated] Gate rationale: [confidence_explanation]
 
 🤖 Generated with [Claude Code](https://claude.ai/code)
 ```
 
-**Output rules:**
-- `*(recurring pattern)*` suffix for `source: learned-patterns` issues
-- Explanation: (a) what is wrong, (b) why, (c) what to use instead
-- Links: PR mode = full SHA permalink; local mode = VSCode-clickable `[file:line](file#Lline)`
+---
+
+### PR mode output
+
+**Conversation:** Print the same `### Code review` block as local mode (for human review),
+but links use full SHA permalinks:
+`https://github.com/Skyscanner/backpack/blob/[SHA]/[PATH]#L[START]-L[END]`
+
+**Autopost: ON by default in PR mode.** Skip only when user says "don't post" / "local only" / `BACKPACK_REVIEW_AUTOPOST=false`.
+
+Post a single GitHub PR review using the Reviews API (NOT a plain PR comment).
+This places each issue as an **inline comment on the relevant diff line**, grouped under one review.
+
+```bash
+# Build the payload as a JSON file (required — --field cannot accept JSON arrays)
+cat > /tmp/bpk_review_[NUMBER].json << 'ENDJSON'
+{
+  "commit_id": "[SHA]",
+  "event": "COMMENT",
+  "body": "### Code review\n\nFound N issues (reviewed by M/6 agents).\n\n🤖 Generated with [Claude Code](https://claude.ai/code)",
+  "comments": [
+    {
+      "path": "packages/bpk-component-foo/src/BpkFoo.tsx",
+      "line": 45,
+      "start_line": 42,
+      "side": "RIGHT",
+      "body": "**[Title]** *(recurring pattern)*\n\n[explanation: what, why, fix]\n\n[if human-gated] Gate rationale: [confidence_explanation]"
+    }
+  ]
+}
+ENDJSON
+
+gh api repos/Skyscanner/backpack/pulls/[NUMBER]/reviews \
+  --method POST \
+  --input /tmp/bpk_review_[NUMBER].json \
+  --jq '{id: .id, state: .state, html_url: .html_url}'
+```
+
+**Inline comment body format** (per issue):
+```
+**[Title]** [*(recurring pattern)*]
+
+[explanation: (a) what is wrong, (b) why, (c) what to use instead]
+
+[if human-gated] ⚠️ Gate rationale: [confidence_explanation]
+[if RAISED_SET match] ⚠️ Already raised in PR discussion — still open.
+```
+
+**Line mapping rules:**
+- Single-line issue (`startLine == endLine`): set `"line": startLine`, omit `start_line`
+- Multi-line issue: set `"start_line": startLine, "line": endLine, "side": "RIGHT"`
+- If a line falls outside the PR diff (not a changed line), fall back to the nearest
+  changed line in the same file, or skip the inline comment and include that issue only
+  in the review body summary instead.
+
+**Human gate:** Issues with `threshold <= confidence < 90` require explicit user confirmation
+before the review is posted. Show the full preview (inline comments + review body) and ask
+"Post this review? (y/n)". Do not post any part of it until confirmed.
+
+**No partial posting:** Either post all issues as one review, or don't post at all.
+
+---
+
+**Shared output rules (both modes):**
+- `*(recurring pattern)*` label for `source: learned-patterns` issues
+- Explanation always covers: (a) what is wrong, (b) why, (c) what to use instead
 - No strengths section, compliance table, or required-actions checklist
-- Autopost: default off; human gate issues require explicit confirmation; no partial posting
 
 ---
 
@@ -270,7 +338,6 @@ Found N issues (reviewed by M/6 agents, filtered by confidence scoring):
 - Verify design approval evidence is present and substantive
 - Check private token misuse and token semantic-name correctness
 - Check license headers on changed source files
-- Review snapshot currency when rendered output changed
 - Perform mixin investigation for direct CSS properties
 - Perform package-export investigation for imported Backpack helpers
 - Verify token colour match AND semantic meaning

--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -3,9 +3,13 @@ name: backpack-code-review-checklist
 description: Self-improving multi-agent review orchestrator for Backpack component PRs. Runs 6 parallel specialist agents (including a learned-patterns agent that mines past PR comments), then confidence-scores findings. Use for PR review, Constitution compliance checks, and pre-merge validation. Run with "learn" to mine recent PRs and auto-update checklist rules.
 ---
 
-# Backpack Code Review — Multi-Agent Orchestrator (v3.1.2)
+# Backpack Code Review — Multi-Agent Orchestrator (v3.1.3)
 
 <!-- Changelog
+- v3.1.3: Fix Phase 1.5 broken gh command (reviewThreads is not a valid gh pr view JSON field —
+  replace with gh api REST calls); remove unconditional Phase 1.5 skip for all-new files —
+  new components are highest-risk for anti-patterns, widen mining scope instead;
+  Agent 6 now always launches when Phase 1.5 completes (not gated on comment count).
 - v3.1.2: Phase 3 scoring agents now explicitly use model: haiku — scoring is a classification
   task with a fixed rubric and no tool calls; Haiku is sufficient and ~12x cheaper than Sonnet.
 - v3.1.1: Add formal observations tier — issues with confidence 60–(threshold-1) surface in
@@ -40,7 +44,7 @@ Threshold: default 75, override via `/backpack-code-review-checklist threshold=8
 ```
 Phase 0    Detect run mode — learn vs review; early-exit check (review only)
 Phase 1    Metadata + RESOLVED/RAISED_SET  ┐ run in parallel; Phase 1.5
-Phase 1.5  Mine learned patterns           ┘ uses parallel component subagents internally
+Phase 1.5  Mine learned patterns           ┘ uses parallel tool calls internally, no nested subagents
 Phase 2a   Launch Agents 1–5 immediately after Phase 1 (no wait for Phase 1.5)
 Phase 2b   Launch Agent 6 when Phase 1.5 completes (if applicable)
 Phase 3    Independent confidence scoring — after ALL agents finish
@@ -78,7 +82,7 @@ If the invocation contains `learn`, read and follow `learn-mode.md`. Stop here.
 
 **Launch both steps at the same time** — Phase 1 runs directly in the orchestrator (bash commands); Phase 1.5 is dispatched as a background subagent. They are independent and must not block each other.
 
-### Phase 1: Metadata + Diff Pre-fetch
+### Phase 1: Metadata + Review Thread Collection
 
 - PR number, head commit SHA, changed file paths, PR body (already done in Phase 0)
 - **Read the full PR description** to extract motivation, design decisions, known trade-offs,
@@ -116,26 +120,39 @@ Store both sets for use in Phase 4.
 
 ### Phase 1.5: Mine Learned Patterns
 
-**Skip entirely** if >70% of changed files are brand-new (new files have no history to mine).
-
-Otherwise, run as a single background subagent using parallel tool calls internally — no nested subagents:
+Always run as a single background subagent using parallel tool calls internally — no nested subagents.
+When dispatching, pass the changed file list (newline-separated full paths) from Phase 0.
 
 **Step 1 — parallel `gh pr list` calls (one per component, all in one message):**
-Extract component names from changed paths (max 3). Issue all `gh pr list` calls simultaneously:
-```bash
-gh pr list --repo Skyscanner/backpack --state merged --limit 50 \
-  --search "[COMPONENT_NAME]" --json number,title,mergedAt | head -5
-```
+Extract component names from changed paths (max 3).
+- **Normal case** (≤70% brand-new files): search by component name — finds PRs for the same component:
+  ```bash
+  gh pr list --repo Skyscanner/backpack --state merged --limit 5 \
+    --search "[COMPONENT_NAME]" --json number,title,mergedAt
+  ```
+- **All-new-files case** (>70% brand-new): widen the query to recent PRs generally, because new component
+  authors are the highest-risk group for anti-patterns they haven't seen yet. Search a broader set:
+  ```bash
+  gh pr list --repo Skyscanner/backpack --state merged --limit 20 \
+    --search "bpk-component" --json number,title,mergedAt
+  ```
 
-**Step 2 — parallel `gh pr view` calls (all PRs across all components, all in one message):**
-Collect every PR number returned from Step 1 (up to 15 total). Issue all `gh pr view` calls simultaneously:
+**Step 2 — parallel `gh api` calls (all PRs across all components, all in one message):**
+Collect every PR number returned from Step 1 (up to 15 total). For each PR, issue two parallel calls — one for
+PR-level comments and one for inline diff comments — all in a single message:
 ```bash
-gh pr view [N] --repo Skyscanner/backpack --json reviews,comments,reviewThreads
+# PR-level (issue) comments — includes review summaries
+gh api repos/Skyscanner/backpack/issues/[N]/comments --paginate \
+  --jq '[.[].body]'
+
+# Inline diff comments — line-level review threads
+gh api repos/Skyscanner/backpack/pulls/[N]/comments --paginate \
+  --jq '[.[].body]'
 ```
-Collect raw text from `reviews[].body`, `comments[].body`, and `reviewThreads[].comments[].body`.
+Collect and concatenate all returned body strings into raw comment text.
 
 Pass combined raw comment text to Agent 6 as `[INSERT RAW COMMENT TEXT]`.
-If no comments found, omit Agent 6.
+Always launch Agent 6 when Phase 1.5 completes, even if few comments were found — Agent 6 handles empty input gracefully.
 
 ---
 
@@ -157,9 +174,9 @@ Do not wait for Phase 1.5. Dispatch in a single message as soon as Phase 1 is co
 
 | Agent | Prompt file | Launch when | Self-fetched scope |
 |-------|-------------|-------------|--------------------|
-| Agent 6 | `agents/agent6-learned.md` | Phase 1.5 found comments | Full diff |
+| Agent 6 | `agents/agent6-learned.md` | Always (after Phase 1.5) | Full diff |
 
-If Phase 1.5 found no comments, skip Agent 6 entirely.
+Always launch Agent 6 after Phase 1.5 completes. Agent 6 handles the case where no historical comments were found by returning `[]`.
 
 ---
 
@@ -200,7 +217,11 @@ After all agents return and deduplication is done, collect every issue into a si
 
 **Scoring dispatch policy:**
 - If `len(issues) <= 15`: launch **parallel scoring agents** — one per issue, all in one message, using `model: haiku`. Scoring is a classification task with an explicit rubric; it does not require tool calls or complex reasoning.
-- If `len(issues) > 15`: score all issues directly in a single pass (no sub-agents).
+- If `len(issues) > 15`: score all issues directly in a single orchestrator pass (no sub-agents).
+  Use the same scoring prompt below, but wrap all issues in one request:
+  > Score each issue 0–100 using the rubric below. Return a JSON array:
+  > `[{"index": 0, "score": N, "confidence_explanation": "...", "rule_id": "...", "supporting_lines": [...]}]`
+  > Issues: [LIST ALL ISSUES WITH TITLE, EXPLANATION, CODE SNIPPET, RULE REFERENCE]
 
 **Each scoring agent (or the orchestrator in batch mode) receives:**
 - The issue title + explanation
@@ -296,7 +317,7 @@ Found N issues (reviewed by M/6 agents, filtered by confidence scoring):
    [if human-gated] Gate rationale: [confidence_explanation]
 
 [if observations exist]
-Below-threshold observations (confidence 60–74, not blocking):
+Below-threshold observations (confidence 60–(threshold-1), not blocking):
 
 - **[Title]** (score: N) — [one-line explanation: what, why]
   [path/file.tsx:42](path/file.tsx#L42)
@@ -311,7 +332,7 @@ Below-threshold observations (confidence 60–74, not blocking):
 No issues met the threshold. Checked by N/6 agents (Constitution, Sass, A11y, History, Bug Scanner, Learned Patterns).
 [Note any failed agents]
 
-Below-threshold observations (confidence 60–74, not blocking):
+Below-threshold observations (confidence 60–(threshold-1), not blocking):
 
 - **[Title]** (score: N) — [one-line explanation: what, why]
   [path/file.tsx:42](path/file.tsx#L42)

--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -66,7 +66,7 @@ If the invocation contains `learn`, read and follow `learn-mode.md`. Stop here.
 
 ## Phase 1 + Phase 1.5: Run in Parallel
 
-**Launch both steps simultaneously** — they are independent.
+**Launch both steps at the same time** — Phase 1 runs directly in the orchestrator (bash commands); Phase 1.5 is dispatched as a background subagent. They are independent and must not block each other.
 
 ### Phase 1: Metadata + Diff Pre-fetch
 
@@ -86,9 +86,9 @@ If the invocation contains `learn`, read and follow `learn-mode.md`. Stop here.
 gh pr diff [NUMBER] --repo Skyscanner/backpack   # PR mode
 git diff main...HEAD                              # local mode
 ```
-Slice into scoped sections to embed directly in each agent's prompt:
-- **SCSS slice** → Agent 2: `gh pr diff [N] --repo Skyscanner/backpack -- '*.scss'`
-- **TSX/TS slice** → Agents 1, 3, 5: filter lines for `.ts`/`.tsx` files
+Slice the fetched diff in memory — do NOT issue additional `gh pr diff` calls:
+- **SCSS slice** → Agent 2: filter to lines belonging to `*.scss` files
+- **TSX/TS slice** → Agents 1, 3, 5: filter to lines belonging to `*.ts`/`*.tsx` files
 - **Full diff** → Agents 4, 6
 
 Pass each slice as `[INSERT SCOPED DIFF]` in the agent's prompt. **Agents must not re-fetch the diff.**
@@ -106,9 +106,10 @@ Otherwise:
    ```
 3. For each PR, fetch comments:
    ```bash
-   gh pr view [N] --repo Skyscanner/backpack --json reviews,comments
+   gh pr view [N] --repo Skyscanner/backpack --json reviews,comments,reviewThreads
    ```
-4. Collect raw text from `reviews[].body` and `comments[].body`. Pass to Agent 6 as-is.
+4. Collect raw text from `reviews[].body`, `comments[].body`, and inline diff-thread comments
+   (`reviewThreads[].comments[].body`). Pass to Agent 6 as-is.
    If no comments found, omit Agent 6.
 
 ---
@@ -122,7 +123,7 @@ Otherwise:
 | Agent 1 (Constitution & API) | Always | Never |
 | Agent 2 (Sass & Token) | `.scss` files in diff | No `.scss` files |
 | Agent 3 (A11y & Testing) | Always | Never |
-| Agent 4 (History) | Files exist on `main` | All files are brand-new |
+| Agent 4 (History) | Files exist on `main` | >70% of changed files are brand-new |
 | Agent 5 (Bug Scanner) | Always | Never |
 | Agent 6 (Learned Patterns) | Phase 1.5 found comments | No historical comments |
 
@@ -190,8 +191,10 @@ in their JSON output (see Phase 2). No separate pass needed.
 
 ## Phase 4: Filter, Format, and Output
 
-**Filter:** use each issue's `confidence` field; remove issues with `confidence < threshold`;
-mark `threshold <= confidence < 90` as `requires_human_gate=true`.
+**Filter:** use each issue's `confidence` field; remove issues with `confidence < threshold`.
+Issues with `threshold <= confidence < 90` are human-gated — include them in output with
+a "Gate rationale" line showing `confidence_explanation`, and require explicit user
+confirmation before posting to GitHub.
 
 **Output only** the final `### Code review` block — no phase diagnostics, no tables.
 
@@ -231,16 +234,16 @@ Found N issues (reviewed by M/6 agents, filtered by confidence scoring):
 
 ## Phase 5: Orchestrator Self-Check (Internal — do not print)
 
-- Checked `className`/`style` leakage for new components
-- Verified design approval evidence present and substantive
-- Checked private token misuse and token semantic-name correctness
-- Checked license headers on changed source files
-- Reviewed snapshot currency when rendered output changed
-- Performed mixin investigation for direct CSS properties
-- Performed package-export investigation for imported Backpack helpers
-- Verified token colour match AND semantic meaning
-- Included diagnostics for any failed agents
-- Enforced autopost guardrails
+- Check `className`/`style` leakage for new components
+- Verify design approval evidence is present and substantive
+- Check private token misuse and token semantic-name correctness
+- Check license headers on changed source files
+- Review snapshot currency when rendered output changed
+- Perform mixin investigation for direct CSS properties
+- Perform package-export investigation for imported Backpack helpers
+- Verify token colour match AND semantic meaning
+- Include diagnostics for any failed agents
+- Enforce autopost guardrails
 
 ---
 

--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -1,30 +1,26 @@
 ---
 name: backpack-code-review-checklist
 description: Self-improving multi-agent review orchestrator for Backpack component PRs. Runs 6 parallel specialist agents (including a learned-patterns agent that mines past PR comments), then confidence-scores findings. Use for PR review, Constitution compliance checks, and pre-merge validation. Run with "learn" to mine recent PRs and auto-update checklist rules.
-version: 3.0.3
-changelog: |
-  - v3.0.3: Fix blind spot — Phase 1 now fetches current PR's own inline review comments
-    and builds a RESOLVED_SET (issues already fixed in-PR) and RAISED_SET (still-open
-    discussions). Phase 4 drops RESOLVED_SET matches and annotates RAISED_SET matches,
-    preventing false positives on issues already caught and addressed by human reviewers.
-  - v3.0.2: Performance optimisation — orchestrator pre-fetches diff once and slices per
-    agent (eliminates 6× redundant gh pr diff calls); agents self-score (confidence field
-    in JSON output, eliminating separate Phase 3 pass); Phase 1.5 runs parallel with
-    Phase 1; Phase 1.5 skipped when >70% files are brand-new.
-  - v3.0.1: Learned 9 rules from 40 recent PRs (learn mode, 2026-03-26). Added to agent1:
-    semver label accuracy, versioned sub-component naming, variants via type prop, no build
-    artifacts, Ark-UI internal usage, unversioned src/ layout. Added to agent2: semantic
-    spacing token for icon-to-text. Added to agent5: Ark-UI keyboard state sync, icon
-    alignment helper size mismatch.
-  - v3.0.0: Restructured into multi-file layout. Agent prompts moved to agents/*.md,
-    Learn Mode to learn-mode.md, domain knowledge to domain-knowledge.md.
-    Added Phase 1.5 (PR comment mining) and Agent 6 (Learned Patterns).
-  - v2.1.0: Architecture overhaul — agents self-fetch data, full tool access, early-exit check.
-  - v2.0.0: Multi-agent orchestrator with confidence scoring, History Agent, Bug Scanner.
-  - v1.0.0: Initial checklist.
 ---
 
-# Backpack Code Review — Multi-Agent Orchestrator
+# Backpack Code Review — Multi-Agent Orchestrator (v3.0.4)
+
+<!-- Changelog
+- v3.0.5: Restore independent Phase 3 scoring (removes agent self-scoring bias);
+  Agent 5 now receives full diff to catch cross-file-type bugs (SCSS+TSX specificity conflicts);
+  restore accessibility-test.tsx check for existing components (Constitution IV);
+  fix .line null fallback to original_line in RESOLVED_SET/RAISED_SET matching.
+- v3.0.4: Revert autopost default to OFF (opt-in via "post" / BACKPACK_REVIEW_AUTOPOST=true);
+  remove early-exit on "PR already has Claude review" to allow re-review after author pushes fixes.
+- v3.0.3: Fix blind spot — Phase 1 now fetches current PR's own inline review comments
+  and builds a RESOLVED_SET/RAISED_SET; Phase 4 drops/annotates matches.
+- v3.0.2: Performance — orchestrator pre-fetches diff once, agents self-score, Phase 1.5 parallel.
+- v3.0.1: Learned 9 rules from 40 recent PRs.
+- v3.0.0: Multi-file layout, agents/*.md, learn-mode.md, Agent 6 (Learned Patterns).
+- v2.1.0: Agents self-fetch data, full tool access, early-exit check.
+- v2.0.0: Multi-agent orchestrator with confidence scoring.
+- v1.0.0: Initial checklist.
+-->
 
 Dispatches **6 parallel specialist agents**, each with its own prompt file in `agents/`.
 A confidence-scoring pass filters false positives.
@@ -36,8 +32,8 @@ Threshold: default 75, override via `/backpack-code-review-checklist threshold=8
 Phase 0    Detect run mode — learn vs review; early-exit check (review only)
 Phase 1    Metadata + diff pre-fetch + slice per agent  ┐ run in
 Phase 1.5  Mine learned patterns (feeds Agent 6)        ┘ parallel
-Phase 2    Launch agents IN PARALLEL (agents use pre-fetched diff; self-score)
-Phase 3    [eliminated — agents self-score inline]
+Phase 2    Launch agents IN PARALLEL (agents use pre-fetched diff)
+Phase 3    Independent confidence scoring (parallel scoring agents or orchestrator batch)
 Phase 4    Filter, format, and output
 Phase 5    Orchestrator self-check (internal)
 ```
@@ -54,8 +50,8 @@ If the invocation contains `learn`, read and follow `learn-mode.md`. Stop here.
 - **PR mode**: message contains a `github.com/.../pull/NNN` URL
   - Extract PR number; run `gh pr view NNN --repo Skyscanner/backpack --json headRefOid,files,state,isDraft,body`
   - Link format: `https://github.com/Skyscanner/backpack/blob/[HEAD_COMMIT_SHA]/[PATH]#L[START]-L[END]`
-  - **Autopost: ON by default in PR mode.** Uses the GitHub Reviews API to place **inline comments on diff lines**.
-    Override to skip posting: user says "don't post" / "local only" / `BACKPACK_REVIEW_AUTOPOST=false`.
+  - **Autopost: OFF by default in PR mode.** Output to conversation only unless user explicitly says "post" / "post to GitHub" / `BACKPACK_REVIEW_AUTOPOST=true`.
+    When autopost is enabled, uses the GitHub Reviews API to place **inline comments on diff lines**.
     Issues with confidence 75–90 require human confirmation before posting.
 
 - **Local mode**: no PR URL
@@ -65,7 +61,6 @@ If the invocation contains `learn`, read and follow `learn-mode.md`. Stop here.
 **Step 0.2 — Early exit** (PR mode only). Skip review if:
 - PR is closed, merged, or draft
 - PR is trivial/automated (only changelog or dependency bumps)
-- PR already has a code review comment from Claude
 
 ---
 
@@ -102,8 +97,11 @@ Pass each slice as `[INSERT SCOPED DIFF]` in the agent's prompt. **Agents must n
 Fetch the current PR's own inline review comments (line-level diff threads):
 ```bash
 gh api repos/Skyscanner/backpack/pulls/[NUMBER]/comments --paginate \
-  --jq '[.[] | {id:.id, path:.path, line:.line, body:.body, in_reply_to_id:.in_reply_to_id}]'
+  --jq '[.[] | {id:.id, path:.path, line:(.line // .original_line), body:.body, in_reply_to_id:.in_reply_to_id}]'
 ```
+Note: `.line` is `null` for outdated comments (position became stale after a subsequent push).
+Fall back to `.original_line` so these threads are still captured in RESOLVED_SET/RAISED_SET.
+
 Group comments into threads by `in_reply_to_id` (top-level = no `in_reply_to_id`; replies share the root's `id`).
 
 Classify each thread into one of two sets:
@@ -111,6 +109,8 @@ Classify each thread into one of two sets:
   (`github.com/Skyscanner/backpack/pull/NNN/commits/` or `github.com/Skyscanner/backpack/commit/`),
   or the words "Done", "Fixed", "Fixed in", "updated in", "addressed in", "resolved"
   (case-insensitive). Record `{path, line, summary}` for each thread.
+  If `line` is still `null` after the fallback, record with `line: null` and match by `path` only
+  (skip line-range check) — still suppresses the false positive.
 - **RAISED_SET**: thread has a top-level comment but NO resolution signal in any reply.
   Record `{path, line, summary}` for each thread.
 
@@ -161,7 +161,7 @@ before dispatching:
 | Agent 2 | `agents/agent2-sass.md` | SCSS slice |
 | Agent 3 | `agents/agent3-a11y.md` | TSX/TS slice |
 | Agent 4 | `agents/agent4-history.md` | Full diff |
-| Agent 5 | `agents/agent5-bugs.md` | TSX/TS slice |
+| Agent 5 | `agents/agent5-bugs.md` | Full diff |
 | Agent 6 | `agents/agent6-learned.md` | Full diff + Phase 1.5 comments |
 
 **Template variables to fill in for every agent:** `[NUMBER]`, `[SHA]`, `[INSERT LIST]`, `[INSERT]` (PR summary), `[INSERT SCOPED DIFF]`.
@@ -170,7 +170,7 @@ before dispatching:
 tool to inspect specific files for deeper context, but must NOT re-fetch the full diff via
 `gh pr diff` or `git diff`.
 
-**Each agent returns a JSON array with inline confidence scores (no separate Phase 3):**
+**Each agent returns a JSON array of issues (no confidence score — Phase 3 scores independently):**
 ```json
 [
   {
@@ -182,22 +182,10 @@ tool to inspect specific files for deeper context, but must NOT re-fetch the ful
     "source": "constitution|sass-tokens|a11y-testing|history|bug-scan|learned-patterns",
     "rule_id": "constitution.xi.classname-restriction",
     "rule": "Constitution XI — className restriction",
-    "confidence": 85,
-    "confidence_explanation": "Constitution XI explicitly requires Omit<…,'className'|'style'>; new file confirmed via git show",
     "supporting_lines": [{ "file": "...", "startLine": 42, "endLine": 45 }]
   }
 ]
 ```
-
-**Confidence scoring rubric (agents must apply this when setting `confidence`):**
-- **0**: False positive or pre-existing issue
-- **25**: Might be real; stylistic, not explicitly required by Constitution/decisions
-- **50**: Real but minor nitpick
-- **75**: Verified — Constitution/decisions explicitly requires this, PR contradicts it
-- **100**: Certain — NON-NEGOTIABLE violation (license, className leak, missing a11y test)
-
-Score 0 for: pre-existing violations, context-dependent non-bugs, pedantic nitpicks,
-linter-catchable issues, quality opinions without rule backing, grandfathered className.
 
 **After aggregation — deduplication:** If two issues share the same `file` AND overlapping
 `startLine–endLine` AND similar `title`, merge into one. Keep the more specific `rule_id`;
@@ -205,10 +193,52 @@ priority order: constitution > sass-tokens > a11y-testing > history > bug-scan >
 
 ---
 
-## Phase 3: [Eliminated]
+## Phase 3: Confidence Scoring
 
-Confidence scoring is now inline — agents report `confidence` and `confidence_explanation`
-in their JSON output (see Phase 2). No separate pass needed.
+After all agents return and deduplication is done, collect every issue into a single list.
+
+**Scoring dispatch policy:**
+- If `len(issues) <= 15`: launch **parallel scoring agents** — one per issue, all in one message.
+- If `len(issues) > 15`: score all issues directly in a single pass (no sub-agents).
+
+**Each scoring agent (or the orchestrator in batch mode) receives:**
+- The issue title + explanation
+- The relevant code snippet from the diff
+- The relevant Constitution/decision rule text (if applicable)
+- The issue metadata (`rule_id`, `supporting_lines`)
+
+**Scoring prompt:**
+
+> Score this issue 0–100 for confidence that it is a real, actionable issue in this PR:
+>
+> **Issue:** [TITLE + EXPLANATION]
+> **Code:** [RELEVANT SNIPPET]
+> **Rule reference:** [CONSTITUTION/DECISION SECTION, if any]
+> **Metadata:** [RULE_ID + SUPPORTING_LINES]
+>
+> Rubric:
+> - **0**: False positive, or pre-existing issue not introduced by this PR
+> - **25**: Might be real; stylistic, not explicitly required by Constitution/decisions
+> - **50**: Real but minor nitpick; unlikely to matter in practice
+> - **75**: Verified — Constitution/decisions explicitly requires this; PR contradicts it
+> - **100**: Certain — NON-NEGOTIABLE violation (license header, className leak, missing a11y test)
+>
+> For Constitution issues: verify the rule **verbatim**. If you cannot find it, score 0.
+> If the rule exists but violation requires interpretation, score ≤ 50.
+> Score ≥ 75 only after reading the exact rule text AND confirming the changed code contradicts it.
+>
+> For bug issues: verify the bug can actually occur given the surrounding code context.
+> For history issues: verify the past feedback is relevant to the current change.
+>
+> Return ONLY: `{"score": NUMBER, "confidence_explanation": "brief explanation", "rule_id": "string", "supporting_lines": [{"file":"...","startLine":1,"endLine":2}]}`
+
+**False positive patterns — always score 0:**
+- Pre-existing issues not introduced in this PR
+- Something that looks like a bug but isn't, given context
+- Pedantic nitpicks a senior engineer wouldn't flag
+- Issues a linter/typechecker would catch
+
+**After scoring**, attach `confidence` and `confidence_explanation` to each issue.
 
 ---
 
@@ -220,13 +250,14 @@ a "Gate rationale" line showing `confidence_explanation`, and require explicit u
 confirmation before posting to GitHub.
 
 **Filter — step 2, RESOLVED_SET (PR mode only):** For each remaining issue, check whether
-it matches a RESOLVED_SET thread — same `file` (`path`) AND `line` falls within
-`startLine–endLine` of the issue. If it matches, **drop the issue entirely** (already
-caught and fixed by human reviewers in-PR). Do not report it.
+it matches a RESOLVED_SET thread — same `file` (`path`) AND (thread `line` falls within
+`startLine–endLine` of the issue, OR thread `line` is `null` — match by `path` only).
+If it matches, **drop the issue entirely** (already caught and fixed by human reviewers in-PR).
+Do not report it.
 
 **Filter — step 3, RAISED_SET annotation (PR mode only):** For each remaining issue,
-check whether it matches a RAISED_SET thread (same `file`, overlapping line range).
-If it matches, **keep the issue** but prepend the label:
+check whether it matches a RAISED_SET thread — same `file`, AND (overlapping line range OR
+thread `line` is `null`). If it matches, **keep the issue** but prepend the label:
 `⚠️ Already raised in PR discussion — still open.`
 
 **Output differs by mode:**
@@ -270,7 +301,7 @@ Found N issues (reviewed by M/6 agents, filtered by confidence scoring):
 but links use full SHA permalinks:
 `https://github.com/Skyscanner/backpack/blob/[SHA]/[PATH]#L[START]-L[END]`
 
-**Autopost: ON by default in PR mode.** Skip only when user says "don't post" / "local only" / `BACKPACK_REVIEW_AUTOPOST=false`.
+**Autopost: OFF by default in PR mode.** Post only when user explicitly says "post" / "post to GitHub" / `BACKPACK_REVIEW_AUTOPOST=true`.
 
 Post a single GitHub PR review using the Reviews API (NOT a plain PR comment).
 This places each issue as an **inline comment on the relevant diff line**, grouped under one review.

--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -1,135 +1,152 @@
 ---
 name: backpack-code-review-checklist
-description: |
-  Multi-agent review orchestrator for Backpack component PRs.
-  Runs 5 parallel specialist agents, then confidence-scores findings to reduce false positives.
-  Use for PR review, Constitution compliance checks, and pre-merge validation.
-author: Claude Code
-version: 2.1.0
-date: 2026-03-20
+description: Self-improving multi-agent review orchestrator for Backpack component PRs. Runs 6 parallel specialist agents (including a learned-patterns agent that mines past PR comments), then confidence-scores findings. Use for PR review, Constitution compliance checks, and pre-merge validation. Run with "learn" to mine recent PRs and auto-update checklist rules.
+version: 3.0.2
 changelog: |
-  - v2.1.0: Architecture overhaul — agents self-fetch data instead of orchestrator injection.
-    Removed diff chunking protocol and sandbox restrictions. Agents now have full tool access
-    (Bash, Read, Grep, Glob, gh CLI) enabling iterative investigation and true parallelism.
-    Added early-exit check for closed/draft/trivial PRs. Simplified Phase 1 to lightweight
-    metadata collection only. Retained all Backpack domain knowledge and confidence scoring.
-  - v2.0.0: Rewrote as multi-agent orchestrator with confidence scoring; added History Agent
-    and Bug Scanner; retained detailed Backpack review checks (TS/docs/design/a11y/testing);
-    added orchestrator self-check, configurable threshold, autopost guardrails,
-    privacy/access-control guidance, final-only output, clarified Agent 1 scope/autopost
-    no-partial-post behavior, and surfaced confidence explanations for human-gated findings.
-  - v1.2.0: Added investigation methods for CSS properties, package imports, and token semantics.
-  - v1.1.0: Added snapshot currency checks.
+  - v3.0.2: Performance optimisation — orchestrator pre-fetches diff once and slices per
+    agent (eliminates 6× redundant gh pr diff calls); agents self-score (confidence field
+    in JSON output, eliminating separate Phase 3 pass); Phase 1.5 runs parallel with
+    Phase 1; Phase 1.5 skipped when >70% files are brand-new.
+  - v3.0.1: Learned 9 rules from 40 recent PRs (learn mode, 2026-03-26). Added to agent1:
+    semver label accuracy, versioned sub-component naming, variants via type prop, no build
+    artifacts, Ark-UI internal usage, unversioned src/ layout. Added to agent2: semantic
+    spacing token for icon-to-text. Added to agent5: Ark-UI keyboard state sync, icon
+    alignment helper size mismatch.
+  - v3.0.0: Restructured into multi-file layout. Agent prompts moved to agents/*.md,
+    Learn Mode to learn-mode.md, domain knowledge to domain-knowledge.md.
+    Added Phase 1.5 (PR comment mining) and Agent 6 (Learned Patterns).
+  - v2.1.0: Architecture overhaul — agents self-fetch data, full tool access, early-exit check.
+  - v2.0.0: Multi-agent orchestrator with confidence scoring, History Agent, Bug Scanner.
   - v1.0.0: Initial checklist.
 ---
 
 # Backpack Code Review — Multi-Agent Orchestrator
 
-## Overview
-
-This skill reviews Backpack component PRs by dispatching **5 parallel specialist agents**,
-each focused on a narrow domain. A separate scoring pass filters false positives. The
-confidence threshold is configurable (default 75, override via `/backpack-code-review-checklist threshold=80`).
+Dispatches **6 parallel specialist agents**, each with its own prompt file in `agents/`.
+A confidence-scoring pass filters false positives.
+Threshold: default 75, override via `/backpack-code-review-checklist threshold=80`.
 
 ## Execution Flow
 
 ```
-Phase 0  Detect review mode + early-exit check
-Phase 1  Lightweight metadata (PR number, SHA, file list, reference docs)
-Phase 2  Launch 5 specialist agents IN PARALLEL (agents self-fetch data)
-Phase 3  Confidence scoring (batch)
-Phase 4  Filter (>= threshold), format, and output
-Phase 5  Autopost gate (internal)
+Phase 0    Detect run mode — learn vs review; early-exit check (review only)
+Phase 1    Metadata + diff pre-fetch + slice per agent  ┐ run in
+Phase 1.5  Mine learned patterns (feeds Agent 6)        ┘ parallel
+Phase 2    Launch agents IN PARALLEL (agents use pre-fetched diff; self-score)
+Phase 3    [eliminated — agents self-score inline]
+Phase 4    Filter, format, and output
+Phase 5    Orchestrator self-check (internal)
 ```
-
-**Key architecture decision:** Agents have full tool access (Bash, Read, Grep, Glob, `gh` CLI).
-Each agent fetches its own data (diff, files, history) independently. This enables true
-parallelism — all 5 agents start working immediately without waiting for a central data
-collection phase. The orchestrator's role is coordination and synthesis, not data fetching.
 
 ---
 
-## Phase 0: Detect Review Mode + Early Exit
+## Phase 0: Detect Run Mode + Early Exit
 
-**Before doing anything else**, determine the review mode and check if review is needed.
+**Step 0.0 — Detect Learn Mode:**
+If the invocation contains `learn`, read and follow `learn-mode.md`. Stop here.
 
-**Step 0.1** — Determine review mode:
+**Step 0.1 — Determine review mode:**
 
-- **PR mode**: user message contains a `github.com/.../pull/NNN` URL
-  - Extract the PR number
-  - Run `gh pr view NNN --repo Skyscanner/backpack --json headRefOid,files,state,isDraft,body`
-  - Link format (use full 40-character SHA): `https://github.com/Skyscanner/backpack/blob/[HEAD_COMMIT_SHA]/[PATH]#L[START]-L[END]`
-  - Autopost guardrail:
-    - Default is **no autopost**. Print review to conversation first.
-    - Post to PR only if user explicitly asks, or `BACKPACK_REVIEW_AUTOPOST=true`.
-    - Findings with confidence `threshold`–90 require human confirmation before posting.
+- **PR mode**: message contains a `github.com/.../pull/NNN` URL
+  - Extract PR number; run `gh pr view NNN --repo Skyscanner/backpack --json headRefOid,files,state,isDraft,body`
+  - Link format: `https://github.com/Skyscanner/backpack/blob/[HEAD_COMMIT_SHA]/[PATH]#L[START]-L[END]`
+  - Autopost: default off. Post only when user explicitly asks or `BACKPACK_REVIEW_AUTOPOST=true`.
+    Issues with confidence 75–90 require human confirmation before posting.
 
 - **Local mode**: no PR URL
-  - Use `git diff main...HEAD` to get changes
-  - Output review to conversation only — do NOT post to GitHub
+  - Use `git diff main...HEAD`; output to conversation only, no GitHub posting
   - Link format: `[path/file.tsx:29](path/file.tsx#L29)`
 
-**Step 0.2** — Early exit check (PR mode only). Skip review if:
-- PR is closed or merged
-- PR is a draft
-- PR is trivial/automated (e.g. only changelog, only dependency bumps)
+**Step 0.2 — Early exit** (PR mode only). Skip review if:
+- PR is closed, merged, or draft
+- PR is trivial/automated (only changelog or dependency bumps)
 - PR already has a code review comment from Claude
 
-If any condition is met, inform the user and stop.
+---
 
-## Phase 1: Lightweight Metadata Collection
+## Phase 1 + Phase 1.5: Run in Parallel
 
-The orchestrator collects only **lightweight metadata** — not the diff itself. Agents will
-fetch their own data using their full tool access (Bash, Read, Grep, Glob, `gh` CLI).
+**Launch both steps simultaneously** — they are independent.
 
-**Step 1.1** — Collect PR metadata (already done in Phase 0):
-- PR number, head commit SHA, list of changed file paths, PR body/description
+### Phase 1: Metadata + Diff Pre-fetch
 
-**Step 1.2** — Read reference documents (skim for relevant sections):
-- `.specify/memory/constitution.md` — Core principles I-XIII
-- `CODE_REVIEW_GUIDELINES.md` — Quality standards
-- `decisions/` — Relevant decision records (modern-sass-api.md, accessibility-tests.md, etc.)
+- PR number, head commit SHA, changed file paths, PR body (already done in Phase 0)
+- **Read the full PR description** to extract motivation, design decisions, known trade-offs,
+  and any reviewer notes. In local mode, first check for an open PR on the current branch:
+  ```bash
+  gh pr list --repo Skyscanner/backpack --head $(git branch --show-current) --json number,body,state
+  ```
+  If a PR exists, read its description. If not, fall back to commit messages:
+  `git log main...HEAD --format='%s%n%b'`
+- Skim: `.specify/memory/constitution.md`, `CODE_REVIEW_GUIDELINES.md`, relevant `decisions/`
+- Summarise the PR in 2-3 sentences; pass as `[INSERT]` to all agents
 
-**Step 1.3** — Summarise what this PR does in 2-3 sentences based on file list and PR body.
+**Diff pre-fetch (critical for performance):** Fetch the full diff once:
+```bash
+gh pr diff [NUMBER] --repo Skyscanner/backpack   # PR mode
+git diff main...HEAD                              # local mode
+```
+Slice into scoped sections to embed directly in each agent's prompt:
+- **SCSS slice** → Agent 2: `gh pr diff [N] --repo Skyscanner/backpack -- '*.scss'`
+- **TSX/TS slice** → Agents 1, 3, 5: filter lines for `.ts`/`.tsx` files
+- **Full diff** → Agents 4, 6
 
-That's it. The orchestrator does NOT fetch the diff, does NOT build history context, and
-does NOT do any chunking. Each agent fetches exactly what it needs.
+Pass each slice as `[INSERT SCOPED DIFF]` in the agent's prompt. **Agents must not re-fetch the diff.**
 
-## Phase 2: Launch 5 Specialist Agents in Parallel
+### Phase 1.5: Mine Learned Patterns
 
-**Agent pruning:** Based on the file list from Phase 1, determine which agents to launch.
-Not all agents are needed for every PR:
+**Skip entirely** if >70% of changed files are brand-new (new files have no history to mine).
+
+Otherwise:
+1. Extract component names from changed paths (e.g. `packages/bpk-component-modal/` → `bpk-component-modal`)
+2. For each component (max 3), find its 5 most recently merged PRs:
+   ```bash
+   gh pr list --repo Skyscanner/backpack --state merged --limit 50 \
+     --search "[COMPONENT_NAME]" --json number,title,mergedAt | head -5
+   ```
+3. For each PR, fetch comments:
+   ```bash
+   gh pr view [N] --repo Skyscanner/backpack --json reviews,comments
+   ```
+4. Collect raw text from `reviews[].body` and `comments[].body`. Pass to Agent 6 as-is.
+   If no comments found, omit Agent 6.
+
+---
+
+## Phase 2: Launch Agents in Parallel
+
+**Agent pruning:**
 
 | Agent | Launch when | Skip when |
 |-------|------------|-----------|
-| Agent 1 (Constitution & API) | Always | Never — applies to all PRs |
-| Agent 2 (Sass & Token) | Changed files include `.scss` | No `.scss` files in diff |
-| Agent 3 (A11y & Testing) | Always | Never — test coverage applies to all PRs |
-| Agent 4 (History) | Changed files exist on `main` (i.e. not all-new files) | All files are new (no history to check) |
-| Agent 5 (Bug Scanner) | Always | Never — bug scanning applies to all PRs |
+| Agent 1 (Constitution & API) | Always | Never |
+| Agent 2 (Sass & Token) | `.scss` files in diff | No `.scss` files |
+| Agent 3 (A11y & Testing) | Always | Never |
+| Agent 4 (History) | Files exist on `main` | All files are brand-new |
+| Agent 5 (Bug Scanner) | Always | Never |
+| Agent 6 (Learned Patterns) | Phase 1.5 found comments | No historical comments |
 
-Launch the selected agents in a **single message** using multiple Agent tool calls.
+**Dispatch all selected agents in a single message** using multiple Agent tool calls.
 
-Each agent receives from the orchestrator: (a) the PR number (or "local mode"), (b) the
-head commit SHA, (c) the list of changed file paths, (d) the PR summary from Phase 1,
-and (e) its domain-specific Backpack rules.
+For each agent, **read its prompt file** from `agents/` and fill in the template variables
+before dispatching:
 
-**Each agent self-fetches its own data** using Bash, Read, Grep, Glob, and `gh` CLI.
-Agents should use **scoped fetches** — e.g. `gh pr diff [N] -- '*.scss'` instead of
-fetching the entire diff — to minimise redundant data across agents. Agents can do
-iterative investigation — reading additional files, checking mixin sources, examining
-package exports — without being limited to pre-injected context.
+| Agent | Prompt file | Scoped diff to embed |
+|-------|-------------|----------------------|
+| Agent 1 | `agents/agent1-constitution.md` | TSX/TS slice |
+| Agent 2 | `agents/agent2-sass.md` | SCSS slice |
+| Agent 3 | `agents/agent3-a11y.md` | TSX/TS slice |
+| Agent 4 | `agents/agent4-history.md` | Full diff |
+| Agent 5 | `agents/agent5-bugs.md` | TSX/TS slice |
+| Agent 6 | `agents/agent6-learned.md` | Full diff + Phase 1.5 comments |
 
-Phase 2 requirements:
-- Dispatch specialist agents in one turn (single message, multiple Agent calls).
-- If one agent fails, record the failure and continue with others (see agent status below).
-- Aggregate results: sort by file path, then startLine, then source.
-- **Deduplication (before Phase 3):** If two issues share the same `file` AND overlapping
-  `startLine–endLine` ranges AND similar `title` (semantic match), merge them into one.
-  Keep the issue with the more specific `rule_id`; if equal, keep the one from the
-  higher-priority source (constitution > sass-tokens > a11y-testing > history > bug-scan).
+**Template variables to fill in for every agent:** `[NUMBER]`, `[SHA]`, `[INSERT LIST]`, `[INSERT]` (PR summary), `[INSERT SCOPED DIFF]`.
 
-Each agent MUST return a JSON array of issues:
+**Agents use the pre-fetched diff embedded in their prompt.** They may still use the Read
+tool to inspect specific files for deeper context, but must NOT re-fetch the full diff via
+`gh pr diff` or `git diff`.
+
+**Each agent returns a JSON array with inline confidence scores (no separate Phase 3):**
 ```json
 [
   {
@@ -138,374 +155,64 @@ Each agent MUST return a JSON array of issues:
     "file": "packages/bpk-component-foo/src/BpkFoo.tsx",
     "startLine": 42,
     "endLine": 45,
-    "source": "constitution|sass-tokens|a11y-testing|history|bug-scan",
+    "source": "constitution|sass-tokens|a11y-testing|history|bug-scan|learned-patterns",
     "rule_id": "constitution.xi.classname-restriction",
     "rule": "Constitution XI — className restriction",
-    "supporting_lines": [
-      { "file": "packages/bpk-component-foo/src/BpkFoo.tsx", "startLine": 42, "endLine": 45 }
-    ]
+    "confidence": 85,
+    "confidence_explanation": "Constitution XI explicitly requires Omit<…,'className'|'style'>; new file confirmed via git show",
+    "supporting_lines": [{ "file": "...", "startLine": 42, "endLine": 45 }]
   }
 ]
 ```
 
-If an agent finds no issues, it returns `[]`.
+**Confidence scoring rubric (agents must apply this when setting `confidence`):**
+- **0**: False positive or pre-existing issue
+- **25**: Might be real; stylistic, not explicitly required by Constitution/decisions
+- **50**: Real but minor nitpick
+- **75**: Verified — Constitution/decisions explicitly requires this, PR contradicts it
+- **100**: Certain — NON-NEGOTIABLE violation (license, className leak, missing a11y test)
+
+Score 0 for: pre-existing violations, context-dependent non-bugs, pedantic nitpicks,
+linter-catchable issues, quality opinions without rule backing, grandfathered className.
+
+**After aggregation — deduplication:** If two issues share the same `file` AND overlapping
+`startLine–endLine` AND similar `title`, merge into one. Keep the more specific `rule_id`;
+priority order: constitution > sass-tokens > a11y-testing > history > bug-scan > learned-patterns.
 
 ---
 
-### Agent 1: Constitution & API Agent
+## Phase 3: [Eliminated]
 
-**Scope:** Naming, license, API encapsulation, TypeScript, documentation, and design approval checks.
-
-**Prompt to give this agent:**
-
-> You are reviewing a Backpack design system PR. Your ONLY job is to check Constitution
-> compliance for naming, licensing, and API design. Return issues as JSON.
-> This agent intentionally covers API/TS/docs/design checks. Sass/token checks are handled
-> by Agent 2, and accessibility/testing checks are handled by Agent 3.
->
-> **PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode" with `git diff main...HEAD`
-> **Head commit SHA:** [SHA]
-> **Changed files:** [INSERT LIST]
-> **PR summary:** [INSERT]
->
-> **Step 1: Fetch the diff and read changed files.**
-> Use `gh pr diff [NUMBER] --repo Skyscanner/backpack` or `git diff main...HEAD`.
-> Focus on `.ts`, `.tsx`, `README.md`, and `examples/` files relevant to your scope.
-> Read changed files directly with the Read tool for deeper inspection.
->
-> **Step 2: Check each changed file against these rules:**
->
-> **Naming & File Conventions (Constitution II)**
-> - Component files: PascalCase (`BpkFoo.tsx`)
-> - Style files: `.module.scss` matching component name
-> - Test files: `*-test.tsx` and `accessibility-test.tsx`
-> - Package names: `bpk-component-[name]` (kebab-case)
-> - CSS classes: BEM with `bpk-` prefix (`bpk-foo__element`)
->
-> **License Headers (NON-NEGOTIABLE)**
-> - ALL `.ts`, `.tsx`, `.scss`, `.js` files must have Apache 2.0 header
-> - Must contain "Copyright 2016 Skyscanner Ltd"
-> - Check with: `grep -L "Copyright 2016 Skyscanner" [files]`
->
-> **API Encapsulation (Constitution XI — CRITICAL)**
-> - NEW components MUST NOT accept `className` or `style` props
-> - Correct pattern: `Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className' | 'style'>`
-> - Wrong pattern: bare `ComponentPropsWithoutRef<'div'>` which leaks className
-> - Existing components may grandfather className. Determine if file is new:
->   `git show main:[filepath]` — exit code 0 = existing (grandfathered), exit code 128 = new file (must enforce restriction)
-> - Accessibility props (e.g. `accessibilityLabel`) must be REQUIRED, not optional
->
-> **TypeScript (Constitution V)**
-> - All new code in TypeScript
-> - Proper prop type interfaces
-> - JSDoc/TSDoc comments for public APIs
-> - `@deprecated` tags for deprecated APIs
->
-> **Documentation (Constitution IX)**
-> - README.md with usage examples
-> - Storybook stories in `examples/`
-> - British English for prose
-> - Public props documented with JSDoc/TSDoc
->
-> **Design Approval (Constitution X — CONDITIONAL)**
-> - Only required when PR includes **visual changes**: `.scss` files, `.stories.tsx` files,
->   new component directories, or Figma references in the description.
-> - Skip for: pure bug fixes, dependency bumps, snapshot-only updates, docs-only PRs,
->   test-only changes, and refactors with no visual impact.
-> - When required: check PR description for design approval evidence.
->   Missing design approval on a visual-change PR = blocking issue.
->
-> Only flag issues in **changed files**. Ignore pre-existing violations.
-> Return JSON array of issues. If none found, return `[]`.
+Confidence scoring is now inline — agents report `confidence` and `confidence_explanation`
+in their JSON output (see Phase 2). No separate pass needed.
 
 ---
-
-### Agent 2: Sass & Token Agent
-
-**Scope:** Modern Sass API, token usage, mixin investigation, private token detection.
-
-**Prompt to give this agent:**
-
-> You are reviewing Backpack SCSS changes. Your ONLY job is to check Sass API and token
-> compliance. Return issues as JSON.
->
-> **PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode"
-> **Head commit SHA:** [SHA]
-> **Changed files:** [INSERT LIST]
-> **PR summary:** [INSERT]
->
-> **Step 1: Fetch the diff and read changed SCSS files.**
-> Use `gh pr diff [NUMBER]` or `git diff main...HEAD`. Focus on `.scss` files relevant
-> to your scope. Read the full content of each changed SCSS file with the Read tool.
->
-> **Step 2: Check each changed SCSS file against these rules:**
->
-> **Modern Sass API (Constitution III — NON-NEGOTIABLE)**
-> - Must use `@use` syntax, NEVER `@import`
-> - Granular imports: `@use '../../bpk-mixins/tokens'`, `@use '../../bpk-mixins/utils'`
-> - Namespace prefixes: `tokens.bpk-spacing-md()`, `tokens.$bpk-core-primary-day`
-> - CSS Modules (`.module.scss`)
-> - All sizing in `rem`, not `px` or `em`
->
-> **Step 3: Mixin investigation (CRITICAL — use your tools):**
-> For these **known high-risk CSS patterns** (not every CSS property):
-> `:hover`, `transition`, `z-index`, `::before`/`::after` pseudo-elements
-> 1. Grep `packages/bpk-mixins/` for an existing mixin that abstracts this pattern
-> 2. Read 2-3 similar existing components to see how they handle the same pattern
-> 3. If a mixin exists and the new code bypasses it, flag it as a violation
->
-> Known mixin mappings (not exhaustive — always search):
-> - `:hover` -> `@include utils.bpk-hover { }` (gates behind `.bpk-no-touch-support`)
-> - `transition: ... 0.2s` -> `tokens.$bpk-duration-sm` token
-> - `::before` touch-target -> `@include utils.bpk-touch-tappable`
->
-> **Token Usage (Constitution III)**
-> - All visual params must use design tokens (no magic numbers)
-> - Do NOT use `$bpk-private-*` tokens from other components
-> - Verify token SEMANTIC meaning matches usage context, not just colour value:
->   - `$bpk-text-disabled-*` = disabled/non-interactive elements only
->   - `$bpk-text-secondary-*` = active but de-emphasised interactive elements
->   - `$bpk-surface-hero-*` = hero/prominent background areas
->   - `$bpk-status-danger-*` = error/destructive states
->   - `$bpk-core-accent-*` = selected/primary action states
->
-> **Step 4: Package import investigation:**
-> For each `import X from '../../bpk-component-Y'`:
-> 1. Read `packages/bpk-component-Y/index.tsx` to see full export list
-> 2. Look for size/variant suffixes (Large, Small, OnDark, V2)
-> 3. Verify the imported variant matches context
->
-> Only flag issues in **changed lines**. Ignore pre-existing violations.
-> Return JSON array of issues. If none found, return `[]`.
-
----
-
-### Agent 3: Accessibility & Testing Agent
-
-**Scope:** Accessibility compliance, test coverage, snapshot currency.
-
-**Prompt to give this agent:**
-
-> You are reviewing Backpack accessibility and testing. Your ONLY job is to check a11y
-> and test compliance. Return issues as JSON.
->
-> **PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode"
-> **Head commit SHA:** [SHA]
-> **Changed files:** [INSERT LIST]
-> **PR summary:** [INSERT]
->
-> **Step 1: Fetch the diff and read changed component + test files.**
-> Use `gh pr diff` or `git diff main...HEAD`. Read the full content of changed TSX and
-> test files. Also read related test files that may not be in the diff.
->
-> **Step 2: Check accessibility (Constitution IV — NON-NEGOTIABLE):**
-> - `accessibility-test.tsx` file must exist for any component
-> - Must use `jest-axe` for automated checks
-> - Tests must exercise the public interface
-> - Check for: keyboard navigation, ARIA labels, touch targets >= 44x44px
-> - Verify colour contrast considerations in SCSS
->
-> **Step 3: Check testing coverage (Constitution VIII):**
-> - Unit tests (Jest + Testing Library) exist for all new code
-> - Coverage thresholds: branches >= 70%, functions/lines/statements >= 75%
-> - Storybook stories exist in `examples/` directory
->
-> **Step 4: Snapshot currency (commonly missed):**
-> After ANY change to rendered output, snapshots MUST be regenerated.
-> 1. Read the `.snap` file for this component
-> 2. Verify it matches the current component output
-> 3. Look for stale attributes or class names
->
-> Only flag issues in **changed files**. Ignore pre-existing violations.
-> Return JSON array of issues. If none found, return `[]`.
-
----
-
-### Agent 4: History Agent
-
-**Scope:** Git blame, past PR comments, recurring patterns.
-
-**Prompt to give this agent:**
-
-> You are analysing the git history of files changed in a Backpack PR to find context-based
-> issues. Return issues as JSON.
->
-> **PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode"
-> **Head commit SHA:** [SHA]
-> **Changed files:** [INSERT LIST]
-> **PR summary:** [INSERT]
->
-> **Step 1: Fetch the diff.**
-> Use `gh pr diff` or `git diff main...HEAD`.
->
-> **Step 2: For each changed file, investigate history using your tools:**
-> ```bash
-> git log --oneline -10 -- [file]
-> git log --oneline --all --grep="revert" -- [file]
-> gh pr list --repo Skyscanner/backpack --state merged --limit 10 --search "[filename]"
-> ```
->
-> **Step 3: For the most relevant past PRs, check their review comments:**
-> ```bash
-> gh pr view [PAST_PR_NUMBER] --repo Skyscanner/backpack --comments
-> ```
->
-> **Step 4: Analyse patterns:**
-> - Check if recently reverted code is being reintroduced
-> - Identify hotspot files (frequent recent changes = higher scrutiny)
-> - Check if past review comments flagged the same patterns now being introduced
->
-> Only report issues **directly relevant to the current PR's changes**.
-> Do not flag pre-existing issues unrelated to this PR.
-> Return JSON array of issues. If none found, return `[]`.
-
----
-
-### Agent 5: Bug Scanner
-
-**Scope:** Shallow scan of the diff only, looking for obvious logic bugs.
-
-**Prompt to give this agent:**
-
-> You are scanning a Backpack PR diff for obvious bugs. Your ONLY job is to find logic
-> errors, not style issues. Return issues as JSON.
->
-> **PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode"
-> **Head commit SHA:** [SHA]
-> **Changed files:** [INSERT LIST]
-> **PR summary:** [INSERT]
->
-> **Step 1: Fetch the diff.**
-> Use `gh pr diff` or `git diff main...HEAD`. Focus ONLY on the changed lines.
->
-> **Step 2: Scan for bugs:**
-> - Logic errors (wrong condition, off-by-one, missing null check)
-> - Missing event handler cleanup (addEventListener without removeEventListener)
-> - React-specific bugs (missing deps in useEffect, stale closures, key prop issues)
-> - Type mismatches that TypeScript might not catch (wrong enum variant, swapped args)
-> - Accessibility bugs (onClick without onKeyDown, missing role, wrong ARIA attribute)
-> - CSS bugs (z-index conflicts, missing overflow handling, RTL issues)
->
-> **Do NOT flag:**
-> - Style issues or nitpicks
-> - Pre-existing issues not introduced in this PR
-> - Things a linter or type checker would catch
-> - General code quality opinions
-> - Missing tests (Agent 3 handles this)
-> - Token or Sass issues (Agent 2 handles this)
->
-> Be conservative. Only flag things you are confident are actual bugs.
-> Return JSON array of issues. If none found, return `[]`.
-
----
-
-## Phase 3: Confidence Scoring
-
-After all 5 agents return, collect every issue into a single list.
-
-**Scoring dispatch policy:**
-- If `len(issues) <= 15`: launch **parallel scoring agents** — one per issue, all in one turn.
-- If `len(issues) > 15`: the orchestrator scores all issues directly in a single pass
-  (no sub-agents). Use the same scoring rubric below but process as a batch.
-
-Phase 3 requirements:
-- Preserve issue index so each score maps back to one issue deterministically.
-
-Each scoring agent receives:
-- The issue description
-- The relevant code snippet from the PR
-- The relevant Constitution/decision rule (if applicable)
-- The issue metadata (`rule_id`, `supporting_lines`)
-
-Confidence threshold:
-- Default: `75`
-- Override via inline argument: `/backpack-code-review-checklist threshold=80`
-- The orchestrator parses the user's invocation message for `threshold=N` and uses that value throughout.
-
-**Scoring prompt for each issue:**
-
-> Score this issue on a scale from 0-100 for confidence that it is a real, actionable issue:
->
-> **Issue:** [TITLE + EXPLANATION]
-> **Code:** [RELEVANT SNIPPET]
-> **Rule reference:** [CONSTITUTION/DECISION SECTION, if any]
-> **Issue metadata:** [RULE_ID + SUPPORTING_LINES]
->
-> Scoring rubric:
-> - **0**: False positive. Does not stand up to scrutiny, or is a pre-existing issue.
-> - **25**: Might be real but could be a false positive. If stylistic, not explicitly
->   required by Constitution or decisions/.
-> - **50**: Real issue but minor. A nitpick or unlikely to matter in practice.
-> - **75**: Verified real issue. Constitution or decisions/ explicitly requires this.
->   The PR's approach is insufficient. Will impact functionality or consistency.
-> - **100**: Certain. NON-NEGOTIABLE violation (license header, className leak in new
->   component, missing accessibility test). Verified by reading the actual code.
->
-> For Constitution/decision issues: verify the rule ACTUALLY says what the issue claims.
-> - If you cannot find the rule **verbatim**, score 0.
-> - If the rule exists but the violation requires interpretation (not explicitly stated), score 50 max.
-> - Score >= 75 **only** if you have read the exact rule text AND confirmed the changed code contradicts it.
->
-> For bug issues: verify the bug can actually occur given the surrounding code context.
->
-> For history issues: verify the past feedback is relevant to the current change.
->
-> Return ONLY a JSON object:
-> `{"score": NUMBER, "confidence_explanation": "brief explanation", "rule_id": "string", "supporting_lines": [{"file":"...","startLine":1,"endLine":2}]}`
-
-**False positive patterns to score 0:**
-- Pre-existing issues not introduced in this PR
-- Something that looks like a bug but isn't given context
-- Pedantic nitpicks a senior engineer wouldn't flag
-- Issues a linter/typechecker/compiler would catch
-- General quality opinions not backed by Constitution/decisions
-- Issues silenced by lint-ignore comments
-- Intentional functionality changes directly related to the PR's purpose
-- Grandfathered patterns in existing components (e.g. className in old components)
 
 ## Phase 4: Filter, Format, and Output
 
-**Filter:**
-- Let `threshold` = value from inline argument, or `75` if not specified
-- Remove all issues with `score < threshold`
-- Mark all issues with `threshold <= score < 90` as `requires_human_gate=true`
+**Filter:** use each issue's `confidence` field; remove issues with `confidence < threshold`;
+mark `threshold <= confidence < 90` as `requires_human_gate=true`.
 
-**Visibility mode:**
-- Output **only** final `### Code review` block.
-- Do not display Phase-by-Phase diagnostics (raw issue tables, scoring tables, self-check details).
+**Output only** the final `### Code review` block — no phase diagnostics, no tables.
 
-**Agent status (always include):**
-
-After aggregation, record which agents returned successfully and which failed:
-- Successful: agent returned `[]` or a valid JSON array of issues.
-- Failed: agent threw an error, timed out, or returned malformed output.
-
-**If no issues remain:**
-
+**If no issues:**
 ```markdown
 ### Code review
 
-No issues found. Checked by N/5 agents (Constitution, Sass, A11y, History, Bug Scanner).
-[If any agent failed: "Note: Agent N ([name]) failed — [brief reason]. Remaining agents completed successfully."]
+No issues found. Checked by N/6 agents (Constitution, Sass, A11y, History, Bug Scanner, Learned Patterns).
+[Note any failed agents]
 
 🤖 Generated with [Claude Code](https://claude.ai/code)
 ```
 
-**If issues remain, format as flat numbered list:**
-
+**If issues found:**
 ```markdown
 ### Code review
 
-Found N issues (reviewed by M/5 agents, filtered by confidence scoring):
-[If any agent failed: "Note: Agent N ([name]) failed — [brief reason]."]
+Found N issues (reviewed by M/6 agents, filtered by confidence scoring):
+[Note any failed agents]
 
-1. [Concise title] — [explanation: what is wrong, why it matters, what to use instead.
-   Reference correct pattern from codebase if one exists.]
-
-   [link to offending lines — format depends on PR vs local mode]
-   [if human-gated] Gate rationale: [confidence_explanation]
-
-2. [Next issue] — [explanation]
+1. [Title] *(recurring pattern)* — [explanation: what, why, fix. Link to codebase precedent if one exists.]
 
    [link]
    [if human-gated] Gate rationale: [confidence_explanation]
@@ -513,54 +220,19 @@ Found N issues (reviewed by M/5 agents, filtered by confidence scoring):
 🤖 Generated with [Claude Code](https://claude.ai/code)
 ```
 
-Internal metadata (`source`, `confidence`, `rule_id`, `human_gate`, `confidence_explanation`)
-may be used by the orchestrator for gating decisions, but should not be printed in final output.
-
-**Link format rules:**
-
-- **PR mode** — GitHub permalink with full SHA:
-  ```
-  https://github.com/Skyscanner/backpack/blob/[HEAD_COMMIT_SHA]/[FILE_PATH]#L[START]-L[END]
-  ```
-  Autopost policy:
-  - Default: do not post automatically.
-  - Post only when user explicitly requests, or `BACKPACK_REVIEW_AUTOPOST=true`.
-  - If any issue has `requires_human_gate=true`, require explicit confirmation before posting.
-  - Partial posting is not allowed when any issue is human-gated.
-  - After confirmation, post the full filtered result set (not a subset).
-
-  After passing guardrails, post to PR:
-  ```bash
-  gh pr review NNN --comment --body "$(cat <<'EOF'
-  [review body]
-  EOF
-  )"
-  ```
-
-- **Local mode** — VSCode-clickable link:
-  ```markdown
-  [packages/bpk-component-foo/src/BpkFoo.tsx:42](packages/bpk-component-foo/src/BpkFoo.tsx#L42)
-  ```
-
 **Output rules:**
-- Count real issues only — do not pad with nits
-- Each title max ~10 words; dash separates from explanation
-- Explanation must include: (a) what is wrong, (b) why, (c) what to use instead
-- Link to a correct precedent in the repo when one exists
-- For `requires_human_gate=true` issues, include `Gate rationale: [confidence_explanation]`
-- Default output must be user-facing and authoritative: focus on issues and fixes, not review process internals
-- Do NOT include strengths section, compliance score table, or required-actions checklist
-- Do NOT print `Phase 0-5` headings or internal tables
+- `*(recurring pattern)*` suffix for `source: learned-patterns` issues
+- Explanation: (a) what is wrong, (b) why, (c) what to use instead
+- Links: PR mode = full SHA permalink; local mode = VSCode-clickable `[file:line](file#Lline)`
+- No strengths section, compliance table, or required-actions checklist
+- Autopost: default off; human gate issues require explicit confirmation; no partial posting
 
 ---
 
-## Phase 5: Orchestrator Self-Check (Internal)
+## Phase 5: Orchestrator Self-Check (Internal — do not print)
 
-This phase is internal by default. Do not print it in normal output mode.
-
-Before finalising output, confirm all of the following:
 - Checked `className`/`style` leakage for new components
-- Verified design approval evidence is present and substantive
+- Verified design approval evidence present and substantive
 - Checked private token misuse and token semantic-name correctness
 - Checked license headers on changed source files
 - Reviewed snapshot currency when rendered output changed
@@ -568,84 +240,23 @@ Before finalising output, confirm all of the following:
 - Performed package-export investigation for imported Backpack helpers
 - Verified token colour match AND semantic meaning
 - Included diagnostics for any failed agents
-- Enforced autopost guardrails (`BACKPACK_REVIEW_AUTOPOST`, human gate for 75-90)
+- Enforced autopost guardrails
 
 ---
 
 ## Privacy and Access Control
 
-- Sensitive data handling:
-  - Never include secrets/tokens/credentials in agent prompts or output.
-  - Agents read files from the local repo and call `gh` CLI — no external services beyond GitHub.
-- GitHub token scopes (minimum):
-  - Read: repository read access for PR diff/comments/history.
-  - Write: pull request comment permission (only when autopost is enabled).
+- Never include secrets/tokens/credentials in agent prompts or output
+- Agents use only local repo files and `gh` CLI — no external services beyond GitHub
+- GitHub token scopes: read (diff/comments/history); write (PR comments, autopost only)
 
 ---
-
-## Reference: Domain Knowledge
-
-The following sections provide reference material. Agent prompts include the key rules
-inline; these sections provide additional detail for edge cases.
-
-### API Design: New vs Existing Components
-
-**New components (after Constitution ratification):**
-- MUST NOT accept `className` or `style` props
-- Correct: `Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className' | 'style'>`
-
-**Existing components (grandfathered):**
-- MAY keep `className`/`style` for backward compatibility
-- Discourage use in documentation
-
-### Token Hierarchy
-
-**Token Reference**: [backpack-foundations/base.common.js](https://github.com/Skyscanner/backpack-foundations/blob/main/packages/bpk-foundations-web/tokens/base.common.js)
-
-| Category | Pattern | Example |
-|----------|---------|---------|
-| Core | `$bpk-core-*` | `$bpk-core-primary-day` |
-| Surface | `$bpk-surface-*` | `$bpk-surface-default-day` |
-| Text | `$bpk-text-*` | `$bpk-text-primary-day` |
-| Status | `$bpk-status-*` | `$bpk-status-danger-spot-day` |
-| Line | `$bpk-line-*` | `$bpk-line-day` |
-| Spacing | functions | `tokens.bpk-spacing-base()` |
-| Private | `$bpk-private-[component]-*` | DO NOT use cross-component |
-
-### Color Value Matching
-
-Backpack tokens use RGB notation (`rgb(239, 243, 248)`). When matching Figma/design colours:
-1. Convert HEX to RGB
-2. Search in backpack-foundations `base.common.js`
-3. Use the matching token, not the raw value
-4. If no semantic token exists, flag need for a new foundations token rather than raw colour fallback
-
-### Design Approval Workflow
-
-1. Design review completed before implementation, or explicit Backpack designer approval
-2. Figma design artefacts cover all component states
-3. Responsive behaviour and accessibility notes are documented
-4. PR description links or references the approval evidence
-
-### Common Traps
-
-- Assuming existing component patterns are correct (they may be grandfathered)
-- Copying private tokens from other components
-- Using px because "it's just one value"
-- Making `accessibilityLabel` optional "to be flexible"
-- Leaving snapshot files stale after changing rendered output
-- Accepting CSS values without checking if `bpk-mixins/` abstracts them
-- Accepting imports without checking the full package API for a better variant
-- Accepting token colour match without verifying the token name fits the UI state
 
 ## References
 
 - [Backpack Constitution](/.specify/memory/constitution.md)
-- [Modern Sass API Decision](/decisions/modern-sass-api.md)
-- [Accessibility Tests Decision](/decisions/accessibility-tests.md)
-- [Component SCSS Filenames Decision](/decisions/component-scss-filenames.md)
-- [Versioning Rules](/decisions/versioning-rules.md)
-- [Deprecated API](/decisions/deprecated-api.md)
 - [Code Review Guidelines](/CODE_REVIEW_GUIDELINES.md)
-- [Backpack Documentation](https://www.skyscanner.design/)
-- [Anthropic Code Review Plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review) — Architecture inspiration
+- [decisions/](/decisions/) — Sass API, accessibility tests, versioning, deprecated API
+- [domain-knowledge.md](domain-knowledge.md) — Token hierarchy, colour matching, common traps
+- [learn-mode.md](learn-mode.md) — Self-improvement workflow
+- [agents/](agents/) — Individual agent prompts

--- a/.claude/skills/backpack-code-review-checklist/SKILL.md
+++ b/.claude/skills/backpack-code-review-checklist/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: backpack-code-review-checklist
 description: Self-improving multi-agent review orchestrator for Backpack component PRs. Runs 6 parallel specialist agents (including a learned-patterns agent that mines past PR comments), then confidence-scores findings. Use for PR review, Constitution compliance checks, and pre-merge validation. Run with "learn" to mine recent PRs and auto-update checklist rules.
-version: 3.0.2
+version: 3.0.3
 changelog: |
+  - v3.0.3: Fix blind spot — Phase 1 now fetches current PR's own inline review comments
+    and builds a RESOLVED_SET (issues already fixed in-PR) and RAISED_SET (still-open
+    discussions). Phase 4 drops RESOLVED_SET matches and annotates RAISED_SET matches,
+    preventing false positives on issues already caught and addressed by human reviewers.
   - v3.0.2: Performance optimisation — orchestrator pre-fetches diff once and slices per
     agent (eliminates 6× redundant gh pr diff calls); agents self-score (confidence field
     in JSON output, eliminating separate Phase 3 pass); Phase 1.5 runs parallel with
@@ -92,6 +96,24 @@ Slice the fetched diff in memory — do NOT issue additional `gh pr diff` calls:
 - **Full diff** → Agents 4, 6
 
 Pass each slice as `[INSERT SCOPED DIFF]` in the agent's prompt. **Agents must not re-fetch the diff.**
+
+**Inline review comment fetch (PR mode only — skip in local mode):**
+Fetch the current PR's own inline review comments (line-level diff threads):
+```bash
+gh api repos/Skyscanner/backpack/pulls/[NUMBER]/comments --paginate \
+  --jq '[.[] | {id:.id, path:.path, line:.line, body:.body, in_reply_to_id:.in_reply_to_id}]'
+```
+Group comments into threads by `in_reply_to_id` (top-level = no `in_reply_to_id`; replies share the root's `id`).
+
+Classify each thread into one of two sets:
+- **RESOLVED_SET**: thread has at least one reply containing a resolution signal — a commit URL
+  (`github.com/Skyscanner/backpack/pull/NNN/commits/` or `github.com/Skyscanner/backpack/commit/`),
+  or the words "Done", "Fixed", "Fixed in", "updated in", "addressed in", "resolved"
+  (case-insensitive). Record `{path, line, summary}` for each thread.
+- **RAISED_SET**: thread has a top-level comment but NO resolution signal in any reply.
+  Record `{path, line, summary}` for each thread.
+
+Store both sets for use in Phase 4.
 
 ### Phase 1.5: Mine Learned Patterns
 
@@ -191,10 +213,20 @@ in their JSON output (see Phase 2). No separate pass needed.
 
 ## Phase 4: Filter, Format, and Output
 
-**Filter:** use each issue's `confidence` field; remove issues with `confidence < threshold`.
+**Filter — step 1, confidence:** remove issues with `confidence < threshold`.
 Issues with `threshold <= confidence < 90` are human-gated — include them in output with
 a "Gate rationale" line showing `confidence_explanation`, and require explicit user
 confirmation before posting to GitHub.
+
+**Filter — step 2, RESOLVED_SET (PR mode only):** For each remaining issue, check whether
+it matches a RESOLVED_SET thread — same `file` (`path`) AND `line` falls within
+`startLine–endLine` of the issue. If it matches, **drop the issue entirely** (already
+caught and fixed by human reviewers in-PR). Do not report it.
+
+**Filter — step 3, RAISED_SET annotation (PR mode only):** For each remaining issue,
+check whether it matches a RAISED_SET thread (same `file`, overlapping line range).
+If it matches, **keep the issue** but prepend the label:
+`⚠️ Already raised in PR discussion — still open.`
 
 **Output only** the final `### Code review` block — no phase diagnostics, no tables.
 

--- a/.claude/skills/backpack-code-review-checklist/agents/agent1-constitution.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent1-constitution.md
@@ -86,6 +86,13 @@ Use the Read tool only when you need to inspect a specific file in full depth
 - When required: check PR description for design approval evidence.
   Missing design approval on a visual-change PR = blocking issue.
 
+### Package Import Investigation
+
+For each `import X from '../../bpk-component-Y'` in the changed files:
+1. Read `packages/bpk-component-Y/index.tsx` to see full export list
+2. Look for size/variant suffixes (Large, Small, OnDark, V2)
+3. Verify the imported variant matches context
+
 Only flag issues in **changed files**. Ignore pre-existing violations.
 Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
 `"confidence_explanation"` fields. If none found, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent1-constitution.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent1-constitution.md
@@ -1,0 +1,91 @@
+# Agent 1: Constitution & API Agent
+
+You are reviewing a Backpack design system PR. Your ONLY job is to check Constitution
+compliance for naming, licensing, and API design. Return issues as JSON.
+This agent intentionally covers API/TS/docs/design checks. Sass/token checks are handled
+by Agent 2, and accessibility/testing checks are handled by Agent 3.
+
+**PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode" with `git diff main...HEAD`
+**Head commit SHA:** [SHA]
+**Changed files:** [INSERT LIST]
+**PR summary:** [INSERT]
+**Pre-fetched diff (TSX/TS files only):**
+```diff
+[INSERT SCOPED DIFF]
+```
+
+## Step 1: Use the pre-fetched diff above
+
+The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
+Use the Read tool only when you need to inspect a specific file in full depth
+(e.g., to check license header of a file not fully shown in the diff).
+
+## Step 2: Check each changed file against these rules
+
+### Naming & File Conventions (Constitution II)
+- Component files: PascalCase (`BpkFoo.tsx`)
+- Style files: `.module.scss` matching component name
+- Test files: `*-test.tsx` and `accessibility-test.tsx`
+- Package names: `bpk-component-[name]` (kebab-case)
+- CSS classes: BEM with `bpk-` prefix (`bpk-foo__element`)
+- **Versioned sub-component naming**: version suffix goes immediately after `Bpk+ComponentName`,
+  before the sub-component name — `BpkFooV2Label`, NOT `BpkFooLabelV2`
+- **Unversioned components**: source files go directly under `src/` (e.g. `src/BpkFoo.tsx`),
+  not in a subdirectory like `src/BpkFoo/BpkFoo.tsx`
+
+### License Headers (NON-NEGOTIABLE)
+- ALL `.ts`, `.tsx`, `.scss`, `.js` files must have Apache 2.0 header
+- Must contain "Copyright 2016 Skyscanner Ltd"
+- Check with: `grep -L "Copyright 2016 Skyscanner" [files]`
+
+### API Encapsulation (Constitution XI — CRITICAL)
+- NEW components MUST NOT accept `className` or `style` props
+- Correct pattern: `Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className' | 'style'>`
+- Wrong pattern: bare `ComponentPropsWithoutRef<'div'>` which leaks className
+- Existing components may grandfather className. Determine if file is new:
+  `git show main:[filepath]` — exit code 0 = existing (grandfathered), exit code 128 = new file (must enforce restriction)
+- Accessibility props (e.g. `accessibilityLabel`) must be REQUIRED, not optional
+
+### TypeScript (Constitution V)
+- All new code in TypeScript
+- Proper prop type interfaces
+- JSDoc/TSDoc comments for public APIs
+- `@deprecated` tags for deprecated APIs
+
+### Documentation (Constitution IX)
+- README.md with usage examples
+- Storybook stories in `examples/`
+- British English for prose
+- Public props documented with JSDoc/TSDoc
+
+### Semver Label Accuracy
+- Check the PR's GitHub label against `decisions/versioning-rules.md`
+- Adding new public exports, new props, or new CSS custom properties → `minor`
+- Pure bug fixes with no new API surface → `patch`
+- Flag when the label understates the change (e.g. `patch` on a PR that adds named exports)
+
+### Variants API Pattern
+- New props expressing mutually-exclusive visual states must use a string union `type` prop
+  (following BpkButton's pattern), NOT separate boolean flags (e.g. `striped?: boolean`)
+- Wrong: `<BpkFoo striped large />` — Right: `<BpkFoo type="striped" />`
+
+### No Build Artifacts in Diff
+- Flag any `typecheck.txt`, `specs/` directories, or files containing absolute machine paths
+  (e.g. `/Users/developer-name/...`) that appear to be local tooling output
+
+### New Ark-UI Components Must Use Ark-UI Primitives
+- If a PR adds a `V2`/`V3` component or the PR summary references Ark-UI, verify the
+  implementation wraps the corresponding Ark-UI primitive rather than reimplementing
+  accessibility/state from scratch. Check by grepping for `@ark-ui/react` imports.
+
+### Design Approval (Constitution X — CONDITIONAL)
+- Only required when PR includes **visual changes**: `.scss` files, `.stories.tsx` files,
+  new component directories, or Figma references in the description.
+- Skip for: pure bug fixes, dependency bumps, snapshot-only updates, docs-only PRs,
+  test-only changes, and refactors with no visual impact.
+- When required: check PR description for design approval evidence.
+  Missing design approval on a visual-change PR = blocking issue.
+
+Only flag issues in **changed files**. Ignore pre-existing violations.
+Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
+`"confidence_explanation"` fields. If none found, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent1-constitution.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent1-constitution.md
@@ -9,14 +9,16 @@ by Agent 2, and accessibility/testing checks are handled by Agent 3.
 **Head commit SHA:** [SHA]
 **Changed files:** [INSERT LIST]
 **PR summary:** [INSERT]
-**Pre-fetched diff (TSX/TS files only):**
-```diff
-[INSERT SCOPED DIFF]
+## Step 1: Fetch the diff
+
+**PR mode:**
+```bash
+gh pr diff [NUMBER] --repo Skyscanner/backpack -- '*.ts' '*.tsx'
 ```
-
-## Step 1: Use the pre-fetched diff above
-
-The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
+**Local mode:**
+```bash
+git diff main...HEAD -- '*.ts' '*.tsx'
+```
 Use the Read tool only when you need to inspect a specific file in full depth
 (e.g., to check license header of a file not fully shown in the diff).
 

--- a/.claude/skills/backpack-code-review-checklist/agents/agent1-constitution.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent1-constitution.md
@@ -94,5 +94,4 @@ For each `import X from '../../bpk-component-Y'` in the changed files:
 3. Verify the imported variant matches context
 
 Only flag issues in **changed files**. Ignore pre-existing violations.
-Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
-`"confidence_explanation"` fields. If none found, return `[]`.
+Return JSON array of issues. Confidence scoring is handled by Phase 3 — do NOT include confidence fields.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent2-sass.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent2-sass.md
@@ -53,13 +53,6 @@ Known mixin mappings (not exhaustive — always search):
   adjacent text, use `tokens.$bpk-spacing-icon-text` rather than size-based functions like
   `tokens.bpk-spacing-md()` even when the computed rem values are equal — semantic name wins
 
-## Step 4: Package import investigation
-
-For each `import X from '../../bpk-component-Y'`:
-1. Read `packages/bpk-component-Y/index.tsx` to see full export list
-2. Look for size/variant suffixes (Large, Small, OnDark, V2)
-3. Verify the imported variant matches context
-
 Only flag issues in **changed lines**. Ignore pre-existing violations.
 Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
 `"confidence_explanation"` fields. If none found, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent2-sass.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent2-sass.md
@@ -54,5 +54,4 @@ Known mixin mappings (not exhaustive — always search):
   `tokens.bpk-spacing-md()` even when the computed rem values are equal — semantic name wins
 
 Only flag issues in **changed lines**. Ignore pre-existing violations.
-Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
-`"confidence_explanation"` fields. If none found, return `[]`.
+Return JSON array of issues. Confidence scoring is handled by Phase 3 — do NOT include confidence fields.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent2-sass.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent2-sass.md
@@ -7,14 +7,16 @@ compliance. Return issues as JSON.
 **Head commit SHA:** [SHA]
 **Changed files:** [INSERT LIST]
 **PR summary:** [INSERT]
-**Pre-fetched diff (SCSS files only):**
-```diff
-[INSERT SCOPED DIFF]
+## Step 1: Fetch the diff
+
+**PR mode:**
+```bash
+gh pr diff [NUMBER] --repo Skyscanner/backpack -- '*.scss'
 ```
-
-## Step 1: Use the pre-fetched diff above
-
-The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
+**Local mode:**
+```bash
+git diff main...HEAD -- '*.scss'
+```
 Use the Read tool only when you need to inspect a specific SCSS file in full depth.
 
 ## Step 2: Check each changed SCSS file against these rules

--- a/.claude/skills/backpack-code-review-checklist/agents/agent2-sass.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent2-sass.md
@@ -1,0 +1,65 @@
+# Agent 2: Sass & Token Agent
+
+You are reviewing Backpack SCSS changes. Your ONLY job is to check Sass API and token
+compliance. Return issues as JSON.
+
+**PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode"
+**Head commit SHA:** [SHA]
+**Changed files:** [INSERT LIST]
+**PR summary:** [INSERT]
+**Pre-fetched diff (SCSS files only):**
+```diff
+[INSERT SCOPED DIFF]
+```
+
+## Step 1: Use the pre-fetched diff above
+
+The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
+Use the Read tool only when you need to inspect a specific SCSS file in full depth.
+
+## Step 2: Check each changed SCSS file against these rules
+
+### Modern Sass API (Constitution III — NON-NEGOTIABLE)
+- Must use `@use` syntax, NEVER `@import`
+- Granular imports: `@use '../../bpk-mixins/tokens'`, `@use '../../bpk-mixins/utils'`
+- Namespace prefixes: `tokens.bpk-spacing-md()`, `tokens.$bpk-core-primary-day`
+- CSS Modules (`.module.scss`)
+- All sizing in `rem`, not `px` or `em`
+
+## Step 3: Mixin investigation (CRITICAL — use your tools)
+
+For these **known high-risk CSS patterns** (not every CSS property):
+`:hover`, `transition`, `z-index`, `::before`/`::after` pseudo-elements
+
+1. Grep `packages/bpk-mixins/` for an existing mixin that abstracts this pattern
+2. Read 2-3 similar existing components to see how they handle the same pattern
+3. If a mixin exists and the new code bypasses it, flag it as a violation
+
+Known mixin mappings (not exhaustive — always search):
+- `:hover` -> `@include utils.bpk-hover { }` (gates behind `.bpk-no-touch-support`)
+- `transition: ... 0.2s` -> `tokens.$bpk-duration-sm` token
+- `::before` touch-target -> `@include utils.bpk-touch-tappable`
+
+### Token Usage (Constitution III)
+- All visual params must use design tokens (no magic numbers)
+- Do NOT use `$bpk-private-*` tokens from other components
+- Verify token SEMANTIC meaning matches usage context, not just colour value:
+  - `$bpk-text-disabled-*` = disabled/non-interactive elements only
+  - `$bpk-text-secondary-*` = active but de-emphasised interactive elements
+  - `$bpk-surface-hero-*` = hero/prominent background areas
+  - `$bpk-status-danger-*` = error/destructive states
+  - `$bpk-core-accent-*` = selected/primary action states
+- **Semantic spacing for icon-to-text gaps**: when setting `gap`/`margin` between an icon and
+  adjacent text, use `tokens.$bpk-spacing-icon-text` rather than size-based functions like
+  `tokens.bpk-spacing-md()` even when the computed rem values are equal — semantic name wins
+
+## Step 4: Package import investigation
+
+For each `import X from '../../bpk-component-Y'`:
+1. Read `packages/bpk-component-Y/index.tsx` to see full export list
+2. Look for size/variant suffixes (Large, Small, OnDark, V2)
+3. Verify the imported variant matches context
+
+Only flag issues in **changed lines**. Ignore pre-existing violations.
+Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
+`"confidence_explanation"` fields. If none found, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent3-a11y.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent3-a11y.md
@@ -1,0 +1,41 @@
+# Agent 3: Accessibility & Testing Agent
+
+You are reviewing Backpack accessibility and testing. Your ONLY job is to check a11y
+and test compliance. Return issues as JSON.
+
+**PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode"
+**Head commit SHA:** [SHA]
+**Changed files:** [INSERT LIST]
+**PR summary:** [INSERT]
+**Pre-fetched diff (TSX/TS files only):**
+```diff
+[INSERT SCOPED DIFF]
+```
+
+## Step 1: Use the pre-fetched diff above
+
+The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
+Use the Read tool only when you need to inspect a specific test or component file in full depth.
+
+## Step 2: Check accessibility (Constitution IV — NON-NEGOTIABLE)
+- `accessibility-test.tsx` file must exist for any component
+- Must use `jest-axe` for automated checks
+- Tests must exercise the public interface
+- Check for: keyboard navigation, ARIA labels, touch targets >= 44x44px
+- Verify colour contrast considerations in SCSS
+
+## Step 3: Check testing coverage (Constitution VIII)
+- Unit tests (Jest + Testing Library) exist for all new code
+- Coverage thresholds: branches >= 70%, functions/lines/statements >= 75%
+- Storybook stories exist in `examples/` directory
+
+## Step 4: Snapshot currency (commonly missed)
+
+After ANY change to rendered output, snapshots MUST be regenerated.
+1. Read the `.snap` file for this component
+2. Verify it matches the current component output
+3. Look for stale attributes or class names
+
+Only flag issues in **changed files**. Ignore pre-existing violations.
+Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
+`"confidence_explanation"` fields. If none found, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent3-a11y.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent3-a11y.md
@@ -15,26 +15,25 @@ and test compliance. Return issues as JSON.
 ## Step 1: Use the pre-fetched diff above
 
 The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
-Use the Read tool only when you need to inspect a specific test or component file in full depth.
+**Do NOT read files unless the diff itself gives you a specific question you cannot answer
+from the diff alone** (e.g. you see `aria-label={label}` in the diff and need to confirm
+what `label` resolves to in the component source). Each Read must be justified.
 
-## Step 2: Check accessibility (Constitution IV — NON-NEGOTIABLE)
-- `accessibility-test.tsx` file must exist for any component
-- Must use `jest-axe` for automated checks
-- Tests must exercise the public interface
-- Check for: keyboard navigation, ARIA labels, touch targets >= 44x44px
-- Verify colour contrast considerations in SCSS
+## Step 2: Check accessibility — diff-only analysis
 
-## Step 3: Check testing coverage (Constitution VIII)
-- Unit tests (Jest + Testing Library) exist for all new code
-- Coverage thresholds: branches >= 70%, functions/lines/statements >= 75%
-- Storybook stories exist in `examples/` directory
+From the diff lines only (do NOT read source files to hunt for issues):
+- Does any changed line introduce `aria-label=""`, `aria-label={undefined}`, or remove an aria attribute?
+- Does any changed JSX omit a required accessible name prop (`label`, `aria-label`, `alt`)?
+- Does any `onClick` handler lack a corresponding `onKeyDown` / `role`?
+- Are touch targets affected (padding/size token removed)?
 
-## Step 4: Snapshot currency (commonly missed)
+Only flag issues that are **visible in the changed lines**. Do not speculatively read component sources.
 
-After ANY change to rendered output, snapshots MUST be regenerated.
-1. Read the `.snap` file for this component
-2. Verify it matches the current component output
-3. Look for stale attributes or class names
+## Step 3: Check testing coverage — new code only
+
+Only flag if the diff adds **new JSX branches or new props** with no corresponding test in the diff.
+Do NOT check whether `accessibility-test.tsx` exists for every changed file — only flag if a new
+component directory is created in this PR with no test file at all.
 
 Only flag issues in **changed files**. Ignore pre-existing violations.
 Return JSON array of issues. Each issue must include `"confidence"` (0–100) and

--- a/.claude/skills/backpack-code-review-checklist/agents/agent3-a11y.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent3-a11y.md
@@ -29,12 +29,24 @@ From the diff lines only (do NOT read source files to hunt for issues):
 
 Only flag issues that are **visible in the changed lines**. Do not speculatively read component sources.
 
-## Step 3: Check testing coverage — new code only
+## Step 3: Check testing coverage
 
-Only flag if the diff adds **new JSX branches or new props** with no corresponding test in the diff.
-Do NOT check whether `accessibility-test.tsx` exists for every changed file — only flag if a new
-component directory is created in this PR with no test file at all.
+**Constitution IV — accessibility test file (NON-NEGOTIABLE):**
+For each `packages/bpk-component-*/` directory that appears in the changed files list,
+verify that an `accessibility-test.tsx` exists in that directory:
+```bash
+gh api repos/Skyscanner/backpack/contents/packages/[COMPONENT_DIR] \
+  --jq '[.[].name] | map(select(. == "accessibility-test.tsx")) | length'
+```
+Flag if missing. This applies to both new and existing components — Phase 3 will score this at 100 (NON-NEGOTIABLE, Constitution IV).
+
+**New logic/branches:**
+Only flag if the diff adds new JSX branches or new props with no corresponding test in the diff.
+
+**Snapshot files (CI handles this):**
+Do NOT check `.snap` files for staleness — this is enforced by CI (`npm test` fails if
+snapshots are out of date). Only flag if you see a `.snap` file being deleted or a test
+being removed that would leave a stale snapshot unreachable.
 
 Only flag issues in **changed files**. Ignore pre-existing violations.
-Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
-`"confidence_explanation"` fields. If none found, return `[]`.
+Return JSON array of issues. Confidence scoring is handled by Phase 3 — do NOT include confidence fields.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent3-a11y.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent3-a11y.md
@@ -7,17 +7,19 @@ and test compliance. Return issues as JSON.
 **Head commit SHA:** [SHA]
 **Changed files:** [INSERT LIST]
 **PR summary:** [INSERT]
-**Pre-fetched diff (TSX/TS files only):**
-```diff
-[INSERT SCOPED DIFF]
+## Step 1: Fetch the diff
+
+**PR mode:**
+```bash
+gh pr diff [NUMBER] --repo Skyscanner/backpack -- '*.ts' '*.tsx'
 ```
-
-## Step 1: Use the pre-fetched diff above
-
-The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
-**Do NOT read files unless the diff itself gives you a specific question you cannot answer
-from the diff alone** (e.g. you see `aria-label={label}` in the diff and need to confirm
-what `label` resolves to in the component source). Each Read must be justified.
+**Local mode:**
+```bash
+git diff main...HEAD -- '*.ts' '*.tsx'
+```
+**Do NOT read source files speculatively** — only use the Read tool when the diff raises
+a specific question you cannot answer without seeing the full file (e.g. you see
+`aria-label={label}` and need to confirm what `label` resolves to). Each Read must be justified.
 
 ## Step 2: Check accessibility — diff-only analysis
 

--- a/.claude/skills/backpack-code-review-checklist/agents/agent4-history.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent4-history.md
@@ -38,5 +38,4 @@ gh pr view [PAST_PR_NUMBER] --repo Skyscanner/backpack --comments
 
 Only report issues **directly relevant to the current PR's changes**.
 Do not flag pre-existing issues unrelated to this PR.
-Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
-`"confidence_explanation"` fields. If none found, return `[]`.
+Return JSON array of issues. Confidence scoring is handled by Phase 3 — do NOT include confidence fields.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent4-history.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent4-history.md
@@ -1,0 +1,42 @@
+# Agent 4: History Agent
+
+You are analysing the git history of files changed in a Backpack PR to find context-based
+issues. Return issues as JSON.
+
+**PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode"
+**Head commit SHA:** [SHA]
+**Changed files:** [INSERT LIST]
+**PR summary:** [INSERT]
+**Pre-fetched diff (full):**
+```diff
+[INSERT SCOPED DIFF]
+```
+
+## Step 1: Use the pre-fetched diff above
+
+The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
+Use `git log` and `gh pr view` only for history lookups.
+
+## Step 2: For each changed file, investigate history using your tools
+
+```bash
+git log --oneline -10 -- [file]
+git log --oneline --all --grep="revert" -- [file]
+gh pr list --repo Skyscanner/backpack --state merged --limit 10 --search "[filename]"
+```
+
+## Step 3: For the most relevant past PRs, check their review comments
+
+```bash
+gh pr view [PAST_PR_NUMBER] --repo Skyscanner/backpack --comments
+```
+
+## Step 4: Analyse patterns
+- Check if recently reverted code is being reintroduced
+- Identify hotspot files (frequent recent changes = higher scrutiny)
+- Check if past review comments flagged the same patterns now being introduced
+
+Only report issues **directly relevant to the current PR's changes**.
+Do not flag pre-existing issues unrelated to this PR.
+Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
+`"confidence_explanation"` fields. If none found, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent4-history.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent4-history.md
@@ -7,15 +7,17 @@ issues. Return issues as JSON.
 **Head commit SHA:** [SHA]
 **Changed files:** [INSERT LIST]
 **PR summary:** [INSERT]
-**Pre-fetched diff (full):**
-```diff
-[INSERT SCOPED DIFF]
+## Step 1: Fetch the diff
+
+**PR mode:**
+```bash
+gh pr diff [NUMBER] --repo Skyscanner/backpack
 ```
-
-## Step 1: Use the pre-fetched diff above
-
-The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
-Use `git log` and `gh pr view` only for history lookups.
+**Local mode:**
+```bash
+git diff main...HEAD
+```
+Use `git log` and `gh pr view` for history lookups.
 
 ## Step 2: For each changed file, investigate history using your tools
 

--- a/.claude/skills/backpack-code-review-checklist/agents/agent5-bugs.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent5-bugs.md
@@ -7,15 +7,17 @@ errors, not style issues. Return issues as JSON.
 **Head commit SHA:** [SHA]
 **Changed files:** [INSERT LIST]
 **PR summary:** [INSERT]
-**Pre-fetched diff (TSX/TS files only):**
+**Pre-fetched diff (full diff — all file types):**
 ```diff
-[INSERT SCOPED DIFF]
+[INSERT FULL DIFF]
 ```
 
 ## Step 1: Use the pre-fetched diff above
 
 The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
-Focus ONLY on the changed lines shown above.
+Focus ONLY on the changed lines shown above. The full diff is provided so you can catch
+cross-file-type bugs (e.g. CSS specificity conflicts between SCSS and TSX, animation/state
+coupling, z-index issues that only appear when both sides are visible).
 
 ## Step 2: Scan for bugs
 - Logic errors (wrong condition, off-by-one, missing null check)
@@ -40,5 +42,5 @@ Focus ONLY on the changed lines shown above.
 - Token or Sass issues (Agent 2 handles this)
 
 Be conservative. Only flag things you are confident are actual bugs.
-Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
-`"confidence_explanation"` fields. If none found, return `[]`.
+Return JSON array of issues. Confidence scoring is handled by Phase 3 — do NOT include
+`confidence` fields. If none found, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent5-bugs.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent5-bugs.md
@@ -1,0 +1,44 @@
+# Agent 5: Bug Scanner
+
+You are scanning a Backpack PR diff for obvious bugs. Your ONLY job is to find logic
+errors, not style issues. Return issues as JSON.
+
+**PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode"
+**Head commit SHA:** [SHA]
+**Changed files:** [INSERT LIST]
+**PR summary:** [INSERT]
+**Pre-fetched diff (TSX/TS files only):**
+```diff
+[INSERT SCOPED DIFF]
+```
+
+## Step 1: Use the pre-fetched diff above
+
+The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
+Focus ONLY on the changed lines shown above.
+
+## Step 2: Scan for bugs
+- Logic errors (wrong condition, off-by-one, missing null check)
+- Missing event handler cleanup (addEventListener without removeEventListener)
+- React-specific bugs (missing deps in useEffect, stale closures, key prop issues)
+- Type mismatches that TypeScript might not catch (wrong enum variant, swapped args)
+- Accessibility bugs (onClick without onKeyDown, missing role, wrong ARIA attribute)
+- CSS bugs (z-index conflicts, missing overflow handling, RTL issues)
+- **Ark-UI keyboard state sync**: if a custom `onKeyDown` handler is added to an Ark-UI–backed
+  component, verify it calls the underlying input's `.click()` (or equivalent) so Ark-UI's
+  internal selection state stays in sync for uncontrolled usage; missing this leaves the visual
+  indicator frozen after keyboard interaction
+- **Icon alignment helper size mismatch**: `withButtonAlignment` uses `iconSizeSm` metrics —
+  icons from `lg/` paths or explicitly large icons must use `withLargeButtonAlignment` instead
+
+## Do NOT flag
+- Style issues or nitpicks
+- Pre-existing issues not introduced in this PR
+- Things a linter or type checker would catch
+- General code quality opinions
+- Missing tests (Agent 3 handles this)
+- Token or Sass issues (Agent 2 handles this)
+
+Be conservative. Only flag things you are confident are actual bugs.
+Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
+`"confidence_explanation"` fields. If none found, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent5-bugs.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent5-bugs.md
@@ -7,17 +7,19 @@ errors, not style issues. Return issues as JSON.
 **Head commit SHA:** [SHA]
 **Changed files:** [INSERT LIST]
 **PR summary:** [INSERT]
-**Pre-fetched diff (full diff — all file types):**
-```diff
-[INSERT FULL DIFF]
+## Step 1: Fetch the diff
+
+**PR mode:**
+```bash
+gh pr diff [NUMBER] --repo Skyscanner/backpack
 ```
-
-## Step 1: Use the pre-fetched diff above
-
-The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
-Focus ONLY on the changed lines shown above. The full diff is provided so you can catch
-cross-file-type bugs (e.g. CSS specificity conflicts between SCSS and TSX, animation/state
-coupling, z-index issues that only appear when both sides are visible).
+**Local mode:**
+```bash
+git diff main...HEAD
+```
+Fetch the full diff (all file types) to catch cross-file-type bugs (e.g. CSS specificity
+conflicts between SCSS and TSX, animation/state coupling, z-index issues that only appear
+when both sides are visible). Focus ONLY on the changed lines.
 
 ## Step 2: Scan for bugs
 - Logic errors (wrong condition, off-by-one, missing null check)

--- a/.claude/skills/backpack-code-review-checklist/agents/agent6-learned.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent6-learned.md
@@ -25,7 +25,7 @@ git diff main...HEAD
 
 ## Step 2: Cluster the historical comments into patterns
 
-Group semantically similar comments. For each cluster with ≥ 2 occurrences:
+Group semantically similar comments. For each cluster with ≥ 3 occurrences:
 - Extract the rule being enforced (what reviewers were asking for)
 - Note whether it's component-specific or general
 

--- a/.claude/skills/backpack-code-review-checklist/agents/agent6-learned.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent6-learned.md
@@ -53,12 +53,10 @@ Same JSON array as other agents:
     "rule": "Recurring pattern from past PR reviews",
     "supporting_lines": [
       { "file": "...", "startLine": 42, "endLine": 45 }
-    ],
-    "confidence": 80,
-    "confidence_explanation": "Pattern appeared in 3 of 5 past PRs for this component; current PR reproduces the same structure."
+    ]
   }
 ]
 ```
 
-Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
-`"confidence_explanation"` fields. If no learned patterns apply to this PR, return `[]`.
+Return JSON array of issues. Confidence scoring is handled by Phase 3 — do NOT include
+confidence fields. If no learned patterns apply to this PR, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/agents/agent6-learned.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent6-learned.md
@@ -7,18 +7,21 @@ recurring patterns not covered by the static checklist. Return issues as JSON.
 **Head commit SHA:** [SHA]
 **Changed files:** [INSERT LIST]
 **PR summary:** [INSERT]
-**Pre-fetched diff (full):**
-```diff
-[INSERT SCOPED DIFF]
-```
 **Historical review comments (raw text from Phase 1.5):**
 ```
 [INSERT RAW COMMENT TEXT]
 ```
 
-## Step 1: Use the pre-fetched diff above
+## Step 1: Fetch the diff
 
-The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
+**PR mode:**
+```bash
+gh pr diff [NUMBER] --repo Skyscanner/backpack
+```
+**Local mode:**
+```bash
+git diff main...HEAD
+```
 
 ## Step 2: Cluster the historical comments into patterns
 

--- a/.claude/skills/backpack-code-review-checklist/agents/agent6-learned.md
+++ b/.claude/skills/backpack-code-review-checklist/agents/agent6-learned.md
@@ -1,0 +1,64 @@
+# Agent 6: Learned Patterns Agent
+
+You are analysing historical PR review comments for Backpack components to surface
+recurring patterns not covered by the static checklist. Return issues as JSON.
+
+**PR number:** [NUMBER] (repo: Skyscanner/backpack) — or "local mode"
+**Head commit SHA:** [SHA]
+**Changed files:** [INSERT LIST]
+**PR summary:** [INSERT]
+**Pre-fetched diff (full):**
+```diff
+[INSERT SCOPED DIFF]
+```
+**Historical review comments (raw text from Phase 1.5):**
+```
+[INSERT RAW COMMENT TEXT]
+```
+
+## Step 1: Use the pre-fetched diff above
+
+The diff is already provided. Do NOT run `gh pr diff` or `git diff` again.
+
+## Step 2: Cluster the historical comments into patterns
+
+Group semantically similar comments. For each cluster with ≥ 2 occurrences:
+- Extract the rule being enforced (what reviewers were asking for)
+- Note whether it's component-specific or general
+
+## Step 3: Cross-reference patterns against the current PR diff
+
+For each recurring pattern, check whether the current PR's changed code triggers the
+same issue. If yes, create an issue entry.
+
+## Exclusion rules (do NOT flag)
+- Issues already caught by Agents 1–5 (naming, Sass, a11y, TypeScript, bugs)
+- One-off comments that appeared only once in history
+- Comments that are now outdated (about APIs that have since changed)
+- Pre-existing code not touched by this PR
+
+## Output format
+
+Same JSON array as other agents:
+```json
+[
+  {
+    "title": "Brief issue title (max 10 words)",
+    "explanation": "What pattern recurs in past reviews, why reviewers flag it, and how the current PR triggers it.",
+    "file": "packages/bpk-component-foo/src/BpkFoo.tsx",
+    "startLine": 42,
+    "endLine": 45,
+    "source": "learned-patterns",
+    "rule_id": "learned.[component].[short-slug]",
+    "rule": "Recurring pattern from past PR reviews",
+    "supporting_lines": [
+      { "file": "...", "startLine": 42, "endLine": 45 }
+    ],
+    "confidence": 80,
+    "confidence_explanation": "Pattern appeared in 3 of 5 past PRs for this component; current PR reproduces the same structure."
+  }
+]
+```
+
+Return JSON array of issues. Each issue must include `"confidence"` (0–100) and
+`"confidence_explanation"` fields. If no learned patterns apply to this PR, return `[]`.

--- a/.claude/skills/backpack-code-review-checklist/domain-knowledge.md
+++ b/.claude/skills/backpack-code-review-checklist/domain-knowledge.md
@@ -1,0 +1,54 @@
+# Domain Knowledge Reference
+
+Reference material for edge cases. Agent prompts include the key rules inline;
+consult this file for additional detail.
+
+## API Design: New vs Existing Components
+
+**New components (after Constitution ratification):**
+- MUST NOT accept `className` or `style` props
+- Correct: `Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className' | 'style'>`
+
+**Existing components (grandfathered):**
+- MAY keep `className`/`style` for backward compatibility
+- Discourage use in documentation
+
+## Token Hierarchy
+
+**Token Reference**: [backpack-foundations/base.common.js](https://github.com/Skyscanner/backpack-foundations/blob/main/packages/bpk-foundations-web/tokens/base.common.js)
+
+| Category | Pattern | Example |
+|----------|---------|---------|
+| Core | `$bpk-core-*` | `$bpk-core-primary-day` |
+| Surface | `$bpk-surface-*` | `$bpk-surface-default-day` |
+| Text | `$bpk-text-*` | `$bpk-text-primary-day` |
+| Status | `$bpk-status-*` | `$bpk-status-danger-spot-day` |
+| Line | `$bpk-line-*` | `$bpk-line-day` |
+| Spacing | functions | `tokens.bpk-spacing-base()` |
+| Private | `$bpk-private-[component]-*` | DO NOT use cross-component |
+
+## Color Value Matching
+
+Backpack tokens use RGB notation (`rgb(239, 243, 248)`). When matching Figma/design colours:
+1. Convert HEX to RGB
+2. Search in backpack-foundations `base.common.js`
+3. Use the matching token, not the raw value
+4. If no semantic token exists, flag need for a new foundations token rather than raw colour fallback
+
+## Design Approval Workflow
+
+1. Design review completed before implementation, or explicit Backpack designer approval
+2. Figma design artefacts cover all component states
+3. Responsive behaviour and accessibility notes are documented
+4. PR description links or references the approval evidence
+
+## Common Traps
+
+- Assuming existing component patterns are correct (they may be grandfathered)
+- Copying private tokens from other components
+- Using px because "it's just one value"
+- Making `accessibilityLabel` optional "to be flexible"
+- Leaving snapshot files stale after changing rendered output
+- Accepting CSS values without checking if `bpk-mixins/` abstracts them
+- Accepting imports without checking the full package API for a better variant
+- Accepting token colour match without verifying the token name fits the UI state

--- a/.claude/skills/backpack-code-review-checklist/learn-mode.md
+++ b/.claude/skills/backpack-code-review-checklist/learn-mode.md
@@ -22,8 +22,11 @@ For each PR, fetch review comments:
 ```bash
 gh pr view [NUMBER] \
   --repo Skyscanner/backpack \
-  --json reviews,comments
+  --json reviews,comments,reviewThreads
 ```
+
+Collect text from `reviews[].body`, `comments[].body`, and inline diff-thread comments
+(`reviewThreads[].comments[].body`).
 
 ## Step B — Cluster Recurring Comments
 
@@ -48,7 +51,7 @@ Launch a single analysis agent with all collected comment text:
 > [
 >   {
 >     "rule": "One-sentence rule statement",
->     "domain": "constitution|sass-tokens|a11y-testing|bug-scan|new",
+>     "domain": "constitution|sass-tokens|a11y-testing|history|bug-scan|new",
 >     "occurrences": 5,
 >     "examples": ["verbatim quote 1", "verbatim quote 2"],
 >     "confidence": "HIGH|MEDIUM|LOW"

--- a/.claude/skills/backpack-code-review-checklist/learn-mode.md
+++ b/.claude/skills/backpack-code-review-checklist/learn-mode.md
@@ -93,8 +93,9 @@ Ask the user:
 On confirmation, use the Edit tool to insert the approved rules into the relevant
 files in `agents/`.
 
-Also update the `version` field in `SKILL.md` frontmatter (patch increment) and prepend
-to the `changelog` field:
+Also update `SKILL.md`: increment the version number in the heading line
+(`# Backpack Code Review — Multi-Agent Orchestrator (vX.Y.Z)`) and prepend
+to the changelog comment block:
 ```
-  - v[NEW]: Learned [X] rules from [N] recent PRs (learn mode, [DATE]).
+- v[NEW]: Learned [X] rules from [N] recent PRs (learn mode, [DATE]).
 ```

--- a/.claude/skills/backpack-code-review-checklist/learn-mode.md
+++ b/.claude/skills/backpack-code-review-checklist/learn-mode.md
@@ -1,0 +1,97 @@
+# Learn Mode
+
+Triggered by: `/backpack-code-review-checklist learn [--limit N] [--component COMP]`
+
+Defaults: `--limit 40`, all components. This mode does NOT perform a PR review.
+It mines recent merged PRs, identifies recurring review patterns not yet in the agent
+prompt files, and proposes edits. All writes require explicit user confirmation.
+
+## Step A — Fetch Recent Merged PRs
+
+```bash
+gh pr list \
+  --repo Skyscanner/backpack \
+  --state merged \
+  --limit [N] \
+  --json number,title,mergedAt,files
+```
+
+If `--component COMP` is specified, filter to PRs touching `packages/bpk-component-[COMP]/`.
+
+For each PR, fetch review comments:
+```bash
+gh pr view [NUMBER] \
+  --repo Skyscanner/backpack \
+  --json reviews,comments
+```
+
+## Step B — Cluster Recurring Comments
+
+Launch a single analysis agent with all collected comment text:
+
+> You are analysing Backpack PR review comments to extract recurring rules.
+>
+> **Raw comments from [N] merged PRs:**
+> [INSERT ALL COMMENT TEXT]
+>
+> **Task:**
+> 1. Group semantically similar review comments together.
+> 2. For each group with ≥ 3 occurrences, extract:
+>    - A concise rule (what the reviewer was enforcing)
+>    - Which agent domain it belongs to (constitution/sass-tokens/a11y-testing/history/bug-scan/new)
+>    - 2-3 representative verbatim quotes
+>    - Confidence that it's a real, stable rule (vs. reviewer opinion): HIGH/MEDIUM/LOW
+> 3. Ignore: one-off comments, personal opinions, merge conflicts, CI noise.
+>
+> Output as JSON:
+> ```json
+> [
+>   {
+>     "rule": "One-sentence rule statement",
+>     "domain": "constitution|sass-tokens|a11y-testing|bug-scan|new",
+>     "occurrences": 5,
+>     "examples": ["verbatim quote 1", "verbatim quote 2"],
+>     "confidence": "HIGH|MEDIUM|LOW"
+>   }
+> ]
+> ```
+
+## Step C — Diff Against Current Agent Files
+
+Read each file in the `agents/` directory. For each extracted rule (confidence = HIGH or MEDIUM):
+- Check whether the rule is already covered in the relevant agent file.
+- If covered: discard.
+- If NOT covered: mark as a candidate addition.
+
+## Step D — Output Proposed Additions
+
+Present candidates as a markdown diff grouped by agent file:
+
+```
+## Proposed rule additions (based on [N] merged PRs, [DATE])
+
+### agents/agent1-constitution.md
++ - **[Rule title]**: [Rule description]. (Seen in [X] PRs — e.g. "quote")
+
+### agents/agent2-sass.md
++ - **[Rule title]**: [Rule description]. (Seen in [X] PRs)
+
+### New rules (consider adding to agents/agent5-bugs.md or a new agent file)
++ - **[Rule title]**: [Rule description]. (Seen in [X] PRs)
+```
+
+LOW confidence candidates are listed separately under `## Low-confidence candidates (review manually)`.
+
+## Step E — Write Patch on Confirmation
+
+Ask the user:
+> Apply these additions? Reply: `yes` (all HIGH+MEDIUM), `no`, or `select N,M` (specific items only).
+
+On confirmation, use the Edit tool to insert the approved rules into the relevant
+files in `agents/`.
+
+Also update the `version` field in `SKILL.md` frontmatter (patch increment) and prepend
+to the `changelog` field:
+```
+  - v[NEW]: Learned [X] rules from [N] recent PRs (learn mode, [DATE]).
+```

--- a/.claude/skills/backpack-code-review-checklist/learn-mode.md
+++ b/.claude/skills/backpack-code-review-checklist/learn-mode.md
@@ -20,13 +20,16 @@ If `--component COMP` is specified, filter to PRs touching `packages/bpk-compone
 
 For each PR, fetch review comments:
 ```bash
-gh pr view [NUMBER] \
-  --repo Skyscanner/backpack \
-  --json reviews,comments,reviewThreads
+# PR-level comments (includes review summaries)
+gh api repos/Skyscanner/backpack/issues/[NUMBER]/comments --paginate \
+  --jq '[.[].body]'
+
+# Inline diff comments (line-level review threads)
+gh api repos/Skyscanner/backpack/pulls/[NUMBER]/comments --paginate \
+  --jq '[.[].body]'
 ```
 
-Collect text from `reviews[].body`, `comments[].body`, and inline diff-thread comments
-(`reviewThreads[].comments[].body`).
+Collect text from both endpoints above.
 
 ## Step B — Cluster Recurring Comments
 


### PR DESCRIPTION
## Summary

Major upgrade of the `backpack-code-review-checklist` skill from v2.1.0 to v3.1.3.

This PR restructures the skill into a multi-file architecture, adds a self-improving learned-patterns agent, introduces RESOLVED/RAISED deduplication against existing PR threads, and adds a formal observations tier for below-threshold findings.

## Execution Flow

```mermaid
flowchart TD
    P0["**Phase 0**\nDetect run mode · Early-exit check"]

    P0 -->|parallel| P1
    P0 -->|parallel| P15

    P1["**Phase 1**\nMetadata · PR description\nBuild RESOLVED_SET / RAISED_SET"]
    P15["**Phase 1.5** *(background subagent)*\nMine historical PR comments\nparallel gh api calls internally"]

    P1 -->|"immediately\n(no wait for Phase 1.5)"| P2a
    P15 --> P2b

    subgraph agents ["Phase 2 — Specialist Agents"]
        P2a["**Agents 1–5** in parallel\n① Constitution\n② Sass / design tokens\n③ Accessibility & testing\n④ Git history & hotspots\n⑤ Bug scanner"]
        P2b["**Agent 6**\nLearned patterns\n(cross-ref vs current diff)"]
    end

    P2a --> P3
    P2b --> P3

    P3["**Phase 3**\nConfidence scoring\nhaiku · parallel per issue"]
    P3 --> P4

    P4["**Phase 4**\nFilter by confidence threshold\nApply RESOLVED / RAISED sets\nFormat & output"]
    P4 --> P5

    P5["**Phase 5** *(internal)*\nOrchestrator self-check"]

    style P15 fill:#f5f5f5,stroke:#999
    style P5 fill:#f5f5f5,stroke:#999
```

## Changes

### Architecture: Multi-file layout (v3.0.0)

Previously, all 5 agent prompts were embedded inline inside `SKILL.md`. They are now extracted into individual files under `agents/`, with new supporting files:

| New file | Purpose |
|---|---|
| `agents/agent1-constitution.md` | Constitution & API compliance agent |
| `agents/agent2-sass.md` | Sass & design token agent |
| `agents/agent3-a11y.md` | Accessibility & testing agent |
| `agents/agent4-history.md` | Git history & hotspot agent |
| `agents/agent5-bugs.md` | Bug scanner agent |
| `agents/agent6-learned.md` | **New** — learned patterns agent (mines past PR comments) |
| `domain-knowledge.md` | Backpack-specific token/colour/component domain knowledge |
| `learn-mode.md` | Self-improvement workflow (run with `learn`) |

### New: Phase 1.5 + Agent 6 — Learned Patterns (v3.0.0)

A new pre-review phase mines recently merged PRs for each changed component, collects raw reviewer comments, and passes them to Agent 6. Agent 6 clusters historical comments into recurring patterns and cross-references them against the current diff — surfacing issues the static checklist would otherwise miss.

Phase 1.5 runs as a **single background subagent using parallel tool calls internally** (no nested subagents). It is independent of Phase 1 and both run in parallel. Agents 1–5 launch immediately after Phase 1 without waiting for Phase 1.5; Agent 6 launches when Phase 1.5 completes.

For new components (>70% brand-new files), Phase 1.5 widens its search to recent `bpk-component` PRs generally — new component authors are highest-risk for anti-patterns they haven't seen yet.

### New rules learned from 40 recent PRs (v3.0.1)

9 rules were extracted via learn mode and embedded directly into agent prompts:

- **Agent 1**: semver label accuracy, versioned sub-component naming, variants via `type` prop, no build artifacts in source, Ark-UI internal-usage restriction, unversioned `src/` layout convention
- **Agent 2**: semantic spacing token for icon-to-text gaps (`$bpk-spacing-icon-text`)
- **Agent 5**: Ark-UI keyboard state sync bug pattern, icon alignment helper size mismatch

### New: RESOLVED_SET / RAISED_SET deduplication (v3.0.3)

Phase 1 now fetches the current PR's own inline review threads and classifies them:

- **RESOLVED_SET**: threads with a resolution signal (commit URL, "Done", "Fixed", "addressed in", etc.) — matching issues are **dropped** from output (already caught and fixed)
- **RAISED_SET**: open threads with no resolution — matching issues are **kept** but annotated with ⚠️ Already raised in PR discussion — still open

This prevents the skill from re-reporting issues already caught by human reviewers.

### New: Observations tier (v3.1.1)

Issues with `60 <= confidence < threshold` are surfaced as below-threshold observations in the conversation — they are informational only and never posted to GitHub. Previously these were silently dropped.

### Independent Phase 3 confidence scoring (v3.0.5 / v3.1.2)

Confidence scoring runs as an independent Phase 3 pass after all agents complete (not self-scored by agents). For ≤15 issues, parallel haiku scoring agents are launched — one per issue. For >15 issues, all issues are batched into a single orchestrator pass. Haiku is used for scoring (~12x cheaper than Sonnet; classification task with a fixed rubric).

### Other changes

- **Autopost: OFF by default** (v3.0.4) — post to GitHub only when user explicitly says "post" / `BACKPACK_REVIEW_AUTOPOST=true`
- **Human gate**: issues with `threshold <= confidence < 90` require explicit confirmation before posting
- Phase 1.5 history mining uses `gh api` REST calls for PR comments (not `gh pr view` JSON fields)

## Test Plan

- [ ] Run `/backpack-code-review-checklist <PR URL>` — verify review completes and output is well-formed
- [ ] Run on a PR with `.scss` changes — verify Agent 2 fires and receives SCSS-scoped diff
- [ ] Run on a PR where >70% files are brand-new — verify Phase 1.5 widens search to recent `bpk-component` PRs
- [ ] Run on a PR that already has resolved inline review comments — verify those issues are suppressed
- [ ] Run on a PR with open (unresolved) inline comments — verify those issues are annotated with ⚠️
- [ ] Run `/backpack-code-review-checklist learn` — verify learn mode executes via `learn-mode.md`
- [ ] Confirm below-threshold findings (confidence 60–74) appear as observations (not blocking)
- [ ] Verify autopost is OFF by default; post only when explicitly requested
