### PR TITLE
[BpkBarchart][BpkPrice] Fix broken storybook stories with missing named imports

### DIFF
--- a/packages/bpk-component-barchart/src/BpkBarchart.stories.js
+++ b/packages/bpk-component-barchart/src/BpkBarchart.stories.js
@@ -28,12 +28,11 @@ import { updateOnDirectionChange } from '../../bpk-component-rtl-toggle';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { cssModules, withDefaultProps, wrapDisplayName } from '../../bpk-react-utils';
 
-import BpkBarchart, {
-  BpkChartGridLines,
-  BpkChartAxis,
-  BpkChartMargin,
-} from './BpkBarchart';
+import BpkBarchart from './BpkBarchart';
 import data from './BpkBarchart.stories.data.json';
+import BpkChartAxis from './BpkChartAxis';
+import BpkChartGridLines from './BpkChartGridLines';
+import BpkChartMargin from './BpkChartMargin';
 import {
   ORIENTATION_X,
   ORIENTATION_Y,

--- a/packages/bpk-component-price/src/BpkPrice.stories.tsx
+++ b/packages/bpk-component-price/src/BpkPrice.stories.tsx
@@ -20,7 +20,9 @@
 import NewWindowIcon from '../../bpk-component-icon/sm/new-window';
 
 // @ts-expect-error Untyped import
-import BpkPrice, { SIZES, ALIGNS } from './BpkPrice';
+import BpkPrice from './BpkPrice';
+// @ts-expect-error Untyped import
+import { SIZES, ALIGNS } from './common-types';
 
 import type { Meta } from '@storybook/react';
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
-->

During the CSF3 story colocation migration, some stories were updated to import named exports (`BpkChartGridLines`, `BpkChartAxis`, `BpkChartMargin`, `SIZES`, `ALIGNS`) from component files that only have default exports. This caused those imports to resolve to `undefined`, breaking the affected stories.

**Changes:**
- `BpkBarchart.stories.js`: Import `BpkChartAxis`, `BpkChartGridLines`, and `BpkChartMargin` directly from their own source files instead of as named exports from `./BpkBarchart`
- `BpkPrice.stories.tsx`: Import `SIZES` and `ALIGNS` from `./common-types` instead of as named exports from `./BpkPrice`

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here