### PR TITLE
[CLOV-1540] Remove unused @popperjs/core dependency

### DIFF
--- a/packages/bpk-component-datepicker/src/BpkDatepicker-test.tsx
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker-test.tsx
@@ -32,17 +32,6 @@ import BpkDatepicker from './BpkDatepicker';
 
 // mock breakpoint to always match
 jest.mock('../../bpk-component-breakpoint/src/useMediaQuery', () => jest.fn(() => true));
-jest.mock('@popperjs/core', () => {
-  const PopperJS = jest.requireActual('@popperjs/core');
-  return {
-    __esModule: true,
-    ...PopperJS,
-    createPopper: jest.fn(() => ({
-      update: jest.fn(),
-      destroy: jest.fn(),
-    })),
-  };
-});
 
 const formatDate = (date: Date) => format(date, 'dd/MM/yyyy');
 

--- a/packages/bpk-component-datepicker/src/accessibility-test.tsx
+++ b/packages/bpk-component-datepicker/src/accessibility-test.tsx
@@ -28,16 +28,6 @@ import {
 } from '../../bpk-component-calendar/test-utils';
 // mock breakpoint to always match
 jest.mock('../../bpk-component-breakpoint/src/useMediaQuery', () => jest.fn(() => true));
-jest.mock('@popperjs/core', () => {
-  const originalModule = jest.requireActual('@popperjs/core');
-  return {
-    ...originalModule,
-    createPopper: jest.fn(() => ({
-      update: jest.fn(),
-      destroy: jest.fn(),
-    })),
-  };
-});
 
 // eslint-disable-next-line import/first
 import BpkDatepicker from './BpkDatepicker';

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -12,7 +12,6 @@
         "@ark-ui/react": "^5.34.1",
         "@chakra-ui/react": "^3.33.0",
         "@floating-ui/react": "^0.26.12",
-        "@popperjs/core": "^2.11.8",
         "@radix-ui/react-compose-refs": "^1.1.1",
         "@radix-ui/react-slider": "1.3.5",
         "@react-google-maps/api": "^2.19.3",
@@ -557,16 +556,6 @@
       "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.8.2.tgz",
       "integrity": "sha512-wfZ4kzvHXQ9pG3wuIGTUCcbC7Op8pqIQZNIRY/bqWQu67WTHxZUHUPSZgQMhguI8Tz4ot+DNf4Qhha0bhLvNEQ==",
       "license": "MIT"
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",

--- a/packages/package.json
+++ b/packages/package.json
@@ -25,7 +25,6 @@
     "@ark-ui/react": "^5.34.1",
     "@chakra-ui/react": "^3.33.0",
     "@floating-ui/react": "^0.26.12",
-    "@popperjs/core": "^2.11.8",
     "@radix-ui/react-compose-refs": "^1.1.1",
     "@radix-ui/react-slider": "1.3.5",
     "@react-google-maps/api": "^2.19.3",


### PR DESCRIPTION
## Summary
- Remove `@popperjs/core` from dependencies — it has zero runtime usage across the entire codebase
- Clean up leftover `jest.mock('@popperjs/core')` in datepicker tests that were no longer needed
- The datepicker component migrated from Popper to `@floating-ui/react` previously, but the old dependency and test mocks were never cleaned up

Test bundlesize in consumers
|42.9.0 (stable)|42.9.0-dev-v24390905836.1|
|---| --- |
|134.42KB  | 134.38KB | 

</div><div class="pm-table-sticky-sentinel-bottom" data-testid="sticky-sentinel-bottom"></div></div></span></div></div></div></div>

## Test plan
- [x] `bpk-component-datepicker` unit tests pass (12/12)
- [x] `bpk-component-datepicker` accessibility tests pass
- [x] Verified `@popperjs/core` is not imported in any source file (`grep` across all `.ts/.tsx/.js/.jsx`)
- [x] Verified no other dependency transitively requires it (`npm ls @popperjs/core` returns empty)
- [x] Re-ran tests after `npm install` to confirm no breakage with package fully removed from `node_modules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)