### PR TITLE
[ST-7745][BpkAiBlurb] Use BpkThumbButton in Feedback subcomponent

### DIFF
--- a/packages/bpk-component-ai-blurb/src/BpkAiBlurb.module.scss
+++ b/packages/bpk-component-ai-blurb/src/BpkAiBlurb.module.scss
@@ -18,7 +18,6 @@
 
 @use '../../bpk-mixins/tokens';
 @use '../../bpk-mixins/typography';
-@use '../../bpk-mixins/utils';
 
 .bpk-ai-blurb {
   display: flex;
@@ -46,30 +45,6 @@
     gap: 0 tokens.bpk-spacing-sm();
 
     @include typography.bpk-caption;
-  }
-
-  &__feedback-thumb {
-    display: inline-flex;
-    padding: 0;
-    align-items: center;
-    border: none;
-    background: none;
-    color: tokens.$bpk-text-primary-day;
-    cursor: pointer;
-
-    @include typography.bpk-text-xs;
-
-    svg {
-      fill: currentcolor;
-    }
-
-    &:hover {
-      color: tokens.$bpk-text-secondary-day;
-    }
-
-    &:focus-visible {
-      @include utils.bpk-focus-indicator;
-    }
   }
 
   &__ellipsis {

--- a/packages/bpk-component-ai-blurb/src/BpkAiBlurbFeedback.tsx
+++ b/packages/bpk-component-ai-blurb/src/BpkAiBlurbFeedback.tsx
@@ -19,17 +19,11 @@
 import { useState } from 'react';
 
 import BpkAriaLive from '../../bpk-component-aria-live';
-import BpkSmallThumbsDownIcon from '../../bpk-component-icon/sm/thumbs-down';
-import BpkSmallThumbsUpIcon from '../../bpk-component-icon/sm/thumbs-up';
 import { BpkFlex, BpkSpacing } from '../../bpk-component-layout';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
-import { cssModules } from '../../bpk-react-utils';
+import BpkThumbButton from '../../bpk-component-thumb-button';
 
 import type { BpkAiBlurbFeedbackProps } from './common-types';
-
-import STYLES from './BpkAiBlurb.module.scss';
-
-const getClassName = cssModules(STYLES);
 
 const BpkAiBlurbFeedback = ({
   feedbackText,
@@ -50,22 +44,20 @@ const BpkAiBlurbFeedback = ({
       {!hasVoted && (
         <>
           <BpkText textStyle={TEXT_STYLES.caption}>{feedbackText}</BpkText>
-          <button
-            type="button"
-            className={getClassName('bpk-ai-blurb__feedback-thumb')}
+          <BpkThumbButton
+            type="up"
+            size="small"
+            iconColor="primary"
+            accessibilityLabel={thumbsUpLabel}
             onClick={() => handleVote(true)}
-            aria-label={thumbsUpLabel}
-          >
-            <BpkSmallThumbsUpIcon aria-hidden />
-          </button>
-          <button
-            type="button"
-            className={getClassName('bpk-ai-blurb__feedback-thumb')}
+          />
+          <BpkThumbButton
+            type="down"
+            size="small"
+            iconColor="primary"
+            accessibilityLabel={thumbsDownLabel}
             onClick={() => handleVote(false)}
-            aria-label={thumbsDownLabel}
-          >
-            <BpkSmallThumbsDownIcon aria-hidden />
-          </button>
+          />
         </>
       )}
       <BpkAriaLive visible={hasVoted}>


### PR DESCRIPTION
## Description

Replaces the custom `<button>` elements in the `BpkAiBlurb.Feedback` subcomponent with the `BpkThumbButton` component, using `size="small"` and `iconColor="primary"` (darker colour variant).

This removes duplicated thumb button logic and custom SCSS styles in favour of the dedicated Backpack component.

## Changes

- Replaced custom thumb `<button>` elements with `BpkThumbButton` (`small` size, `primary` icon color)
- Removed unused `&__feedback-thumb` SCSS block and `@use '../../bpk-mixins/utils'` import

## Checklist

- [x] Ensure the PR title includes the name of the component
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a keyboard only
        - [x] Zoom functionality:
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400%
        - [x] Ability to navigate using a screen reader only
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added