### PR TITLE
Remove unused object-assign polyfill dependency

### DIFF
--- a/packages/bpk-react-utils/src/Portal.tsx
+++ b/packages/bpk-react-utils/src/Portal.tsx
@@ -20,8 +20,6 @@ import { Component } from 'react';
 import type { JSX, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent, ReactNode, RefObject, TouchEvent as ReactTouchEvent } from 'react';
 import { createPortal } from 'react-dom';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import assign from 'object-assign';
 
 const KEYCODES = {
   ESCAPE: 'Escape',
@@ -254,7 +252,7 @@ class Portal extends Component<Props, State> {
     document.addEventListener('keydown', this.onDocumentKeyDown, false);
 
     if (this.props.style) {
-      assign(portalElement.style, this.props.style);
+      Object.assign(portalElement.style, this.props.style);
     }
 
     if (this.props.className) {

--- a/packages/bpk-react-utils/src/TransitionInitialMount.tsx
+++ b/packages/bpk-react-utils/src/TransitionInitialMount.tsx
@@ -18,13 +18,7 @@
 
 import type { ReactNode } from 'react';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import assign from 'object-assign';
 import CSSTransition from 'react-transition-group/CSSTransition';
-
-// Object.assign() is used unpolyfilled in react-transition-group.
-// It will use the native implementation if it's present and isn't buggy.
-Object.assign = assign;
 
 type Props = {
   appearClassName: string;

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -25,7 +25,6 @@
         "lodash.clamp": "^4.0.3",
         "lodash.debounce": "^4.0.8",
         "normalize.css": "4.2.0",
-        "object-assign": "^4.1.1",
         "prop-types": "^15.7.2",
         "react-autosuggest": "^9.4.3",
         "react-table": "^7.8.0",

--- a/packages/package.json
+++ b/packages/package.json
@@ -39,7 +39,6 @@
     "lodash.clamp": "^4.0.3",
     "lodash.debounce": "^4.0.8",
     "normalize.css": "4.2.0",
-    "object-assign": "^4.1.1",
     "prop-types": "^15.7.2",
     "react-autosuggest": "^9.4.3",
     "react-table": "^7.8.0",


### PR DESCRIPTION
## Summary
- Remove `object-assign` package from dependencies — `Object.assign` is natively supported in all modern browsers and Node.js
- Replace `assign()` call in `Portal.tsx` with native `Object.assign()`
- Remove the polyfill override (`Object.assign = assign`) in `TransitionInitialMount.tsx` which was a workaround for `react-transition-group`

## Test plan
- [x] All 83 tests in `bpk-react-utils` pass (12 test suites)
- [ ] Verify Portal styling works correctly in Storybook
- [ ] Verify CSS transitions with `TransitionInitialMount` work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)