### PR TITLE
[BpkProvider] Add propOverrides for global variant swapping

### DIFF
--- a/packages/bpk-component-button/src/BpkButton-test.tsx
+++ b/packages/bpk-component-button/src/BpkButton-test.tsx
@@ -18,6 +18,8 @@
 
 import { fireEvent, render } from '@testing-library/react';
 
+import { BpkProvider } from '../../bpk-component-layout';
+
 import BpkButton from './BpkButton';
 import { SIZE_TYPES, BUTTON_TYPES } from './common-types';
 
@@ -531,6 +533,75 @@ describe('BpkButton', () => {
 
       const button = container.firstElementChild;
       expect(button).toHaveClass('bpk-button--icon-only');
+    });
+  });
+
+  describe('propOverrides via BpkProvider', () => {
+    it('should swap default type when override is configured', () => {
+      const { container } = render(
+        <BpkProvider propOverrides={{ BpkButton: { type: { primary: 'secondary' } } }}>
+          <BpkButton>My button</BpkButton>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="Button"]');
+      expect(el).toHaveClass('bpk-button--secondary');
+      expect(el).not.toHaveClass('bpk-button--primary');
+    });
+
+    it('should not override when type is explicitly provided', () => {
+      const { container } = render(
+        <BpkProvider propOverrides={{ BpkButton: { type: { primary: 'secondary' } } }}>
+          <BpkButton type={BUTTON_TYPES.primary}>My button</BpkButton>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="Button"]');
+      expect(el).toHaveClass('bpk-button--primary');
+    });
+
+    it('should swap default size when override is configured', () => {
+      const { container } = render(
+        <BpkProvider propOverrides={{ BpkButton: { size: { small: 'large' } } }}>
+          <BpkButton>My button</BpkButton>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="Button"]');
+      expect(el).toHaveClass('bpk-button--large');
+    });
+
+    it('should not override size when explicitly provided', () => {
+      const { container } = render(
+        <BpkProvider propOverrides={{ BpkButton: { size: { small: 'large' } } }}>
+          <BpkButton size={SIZE_TYPES.small}>My button</BpkButton>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="Button"]');
+      expect(el).not.toHaveClass('bpk-button--large');
+    });
+
+    it('should ignore invalid override values', () => {
+      const { container } = render(
+        <BpkProvider propOverrides={{ BpkButton: { type: { primary: 'bogus' } } }}>
+          <BpkButton>My button</BpkButton>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="Button"]');
+      expect(el).toHaveClass('bpk-button--primary');
+    });
+
+    it('should use defaults when no overrides are configured', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkButton>My button</BpkButton>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="Button"]');
+      expect(el).toHaveClass('bpk-button--primary');
     });
   });
 });

--- a/packages/bpk-component-button/src/BpkButton.tsx
+++ b/packages/bpk-component-button/src/BpkButton.tsx
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { usePropOverrides } from '../../bpk-component-layout';
+import { usePropOverrides, getValidatedPropOverride } from '../../bpk-component-layout';
 import { BpkSpinner, BpkLargeSpinner, SPINNER_TYPES } from '../../bpk-component-spinner';
 import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
@@ -60,15 +60,16 @@ const BpkButton = ({
 }: Props) => {
   const overrides = usePropOverrides('BpkButton');
 
-  const type: ButtonType =
-    typeProp !== undefined
-      ? typeProp
-      : (overrides?.type?.[BUTTON_TYPES.primary] as ButtonType | undefined) ?? BUTTON_TYPES.primary;
+  const allowedButtonTypes: readonly ButtonType[] = Object.values(BUTTON_TYPES);
+  const allowedSizeTypes: readonly SizeType[] = Object.values(SIZE_TYPES);
 
-  const size: SizeType =
-    sizeProp !== undefined
-      ? sizeProp
-      : (overrides?.size?.[SIZE_TYPES.small] as SizeType | undefined) ?? SIZE_TYPES.small;
+  const type = typeProp
+    ?? getValidatedPropOverride<ButtonType>(overrides?.type, BUTTON_TYPES.primary, allowedButtonTypes)
+    ?? BUTTON_TYPES.primary;
+
+  const size = sizeProp
+    ?? getValidatedPropOverride<SizeType>(overrides?.size, SIZE_TYPES.small, allowedSizeTypes)
+    ?? SIZE_TYPES.small;
 
   const isDisabled = disabled || loading;
   const isLinkType = type === BUTTON_TYPES.link || type === BUTTON_TYPES.linkOnDark;

--- a/packages/bpk-component-button/src/BpkButton.tsx
+++ b/packages/bpk-component-button/src/BpkButton.tsx
@@ -15,12 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { usePropOverrides } from '../../bpk-component-layout';
 import { BpkSpinner, BpkLargeSpinner, SPINNER_TYPES } from '../../bpk-component-spinner';
 import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
 import { BUTTON_TYPES, SIZE_TYPES } from './common-types';
 
-import type { ButtonType, Props } from './common-types';
+import type { ButtonType, SizeType, Props } from './common-types';
 
 import COMMON_STYLES from './BpkButton.module.scss';
 
@@ -51,12 +52,24 @@ const BpkButton = ({
   loading = false,
   onClick = () => {},
   rel: propRel = undefined,
-  size = SIZE_TYPES.small,
+  size: sizeProp,
   submit = false,
   trailingIcon = null,
-  type = BUTTON_TYPES.primary,
+  type: typeProp,
   ...rest
 }: Props) => {
+  const overrides = usePropOverrides('BpkButton');
+
+  const type: ButtonType =
+    typeProp !== undefined
+      ? typeProp
+      : (overrides?.type?.[BUTTON_TYPES.primary] as ButtonType | undefined) ?? BUTTON_TYPES.primary;
+
+  const size: SizeType =
+    sizeProp !== undefined
+      ? sizeProp
+      : (overrides?.size?.[SIZE_TYPES.small] as SizeType | undefined) ?? SIZE_TYPES.small;
+
   const isDisabled = disabled || loading;
   const isLinkType = type === BUTTON_TYPES.link || type === BUTTON_TYPES.linkOnDark;
   const alternate = type === BUTTON_TYPES.linkOnDark;

--- a/packages/bpk-component-chip/src/BpkSelectableChip-test.tsx
+++ b/packages/bpk-component-chip/src/BpkSelectableChip-test.tsx
@@ -18,6 +18,8 @@
 
 import { render } from '@testing-library/react';
 
+import { BpkProvider } from '../../bpk-component-layout';
+
 import BpkSelectableChip from './BpkSelectableChip';
 import { CHIP_TYPES } from './commonTypes';
 
@@ -109,5 +111,64 @@ describe('BpkSelectableChip', () => {
   it('should render correctly with a "className" attribute', () => {
     const { asFragment } = render(<TestChip className="custom-class" />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  describe('propOverrides via BpkProvider', () => {
+    it('should swap default type when override is configured', () => {
+      const { container } = render(
+        <BpkProvider propOverrides={{ BpkSelectableChip: { type: { default: 'on-dark' } } }}>
+          <BpkSelectableChip onClick={() => null} accessibilityLabel="Toggle">
+            Toggle me
+          </BpkSelectableChip>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="SelectableChip"]');
+      expect(el).toHaveClass('bpk-chip--on-dark');
+      expect(el).not.toHaveClass('bpk-chip--default');
+    });
+
+    it('should not override when type is explicitly provided', () => {
+      const { container } = render(
+        <BpkProvider propOverrides={{ BpkSelectableChip: { type: { default: 'on-dark' } } }}>
+          <BpkSelectableChip
+            type={CHIP_TYPES.default}
+            onClick={() => null}
+            accessibilityLabel="Toggle"
+          >
+            Toggle me
+          </BpkSelectableChip>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="SelectableChip"]');
+      expect(el).toHaveClass('bpk-chip--default');
+    });
+
+    it('should ignore invalid override values', () => {
+      const { container } = render(
+        <BpkProvider propOverrides={{ BpkSelectableChip: { type: { default: 'bogus' } } }}>
+          <BpkSelectableChip onClick={() => null} accessibilityLabel="Toggle">
+            Toggle me
+          </BpkSelectableChip>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="SelectableChip"]');
+      expect(el).toHaveClass('bpk-chip--default');
+    });
+
+    it('should use defaults when no overrides are configured', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkSelectableChip onClick={() => null} accessibilityLabel="Toggle">
+            Toggle me
+          </BpkSelectableChip>
+        </BpkProvider>,
+      );
+
+      const el = container.querySelector('[data-backpack-ds-component="SelectableChip"]');
+      expect(el).toHaveClass('bpk-chip--default');
+    });
   });
 });

--- a/packages/bpk-component-chip/src/BpkSelectableChip.tsx
+++ b/packages/bpk-component-chip/src/BpkSelectableChip.tsx
@@ -18,7 +18,7 @@
 
 import type { ReactNode } from 'react';
 
-import { usePropOverrides } from '../../bpk-component-layout';
+import { usePropOverrides, getValidatedPropOverride } from '../../bpk-component-layout';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
@@ -51,10 +51,11 @@ const BpkSelectableChip = ({
 }: Props) => {
   const overrides = usePropOverrides('BpkSelectableChip');
 
-  const type =
-    typeProp !== undefined
-      ? typeProp
-      : (overrides?.type?.[CHIP_TYPES.default] as typeof CHIP_TYPES[keyof typeof CHIP_TYPES] | undefined) ?? CHIP_TYPES.default;
+  const allowedChipTypes = Object.values(CHIP_TYPES);
+
+  const type = typeProp
+    ?? getValidatedPropOverride(overrides?.type, CHIP_TYPES.default, allowedChipTypes)
+    ?? CHIP_TYPES.default;
 
   const classNames = getClassName(
     'bpk-chip',

--- a/packages/bpk-component-chip/src/BpkSelectableChip.tsx
+++ b/packages/bpk-component-chip/src/BpkSelectableChip.tsx
@@ -18,6 +18,7 @@
 
 import type { ReactNode } from 'react';
 
+import { usePropOverrides } from '../../bpk-component-layout';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
@@ -45,9 +46,16 @@ const BpkSelectableChip = ({
   role = 'checkbox',
   selected = false,
   trailingAccessoryView = null,
-  type = CHIP_TYPES.default,
+  type: typeProp,
   ...rest
 }: Props) => {
+  const overrides = usePropOverrides('BpkSelectableChip');
+
+  const type =
+    typeProp !== undefined
+      ? typeProp
+      : (overrides?.type?.[CHIP_TYPES.default] as typeof CHIP_TYPES[keyof typeof CHIP_TYPES] | undefined) ?? CHIP_TYPES.default;
+
   const classNames = getClassName(
     'bpk-chip',
     `bpk-chip--${type}`,

--- a/packages/bpk-component-layout/index.ts
+++ b/packages/bpk-component-layout/index.ts
@@ -60,7 +60,7 @@ export { BACKGROUND_COLORS } from './src/backgroundColors';
 export type { BpkLayoutBackgroundColor } from './src/backgroundColors';
 
 // Export prop overrides context
-export { usePropOverrides } from './src/BpkPropOverridesContext';
+export { usePropOverrides, getValidatedPropOverride } from './src/BpkPropOverridesContext';
 export type {
   PropOverridesConfig,
   ComponentOverrides,

--- a/packages/bpk-component-layout/index.ts
+++ b/packages/bpk-component-layout/index.ts
@@ -58,3 +58,11 @@ export {
 // Export color constants and types
 export { BACKGROUND_COLORS } from './src/backgroundColors';
 export type { BpkLayoutBackgroundColor } from './src/backgroundColors';
+
+// Export prop overrides context
+export { usePropOverrides } from './src/BpkPropOverridesContext';
+export type {
+  PropOverridesConfig,
+  ComponentOverrides,
+  PropOverrideMap,
+} from './src/BpkPropOverridesContext';

--- a/packages/bpk-component-layout/src/BpkPropOverridesContext-test.tsx
+++ b/packages/bpk-component-layout/src/BpkPropOverridesContext-test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+
+import { getValidatedPropOverride, usePropOverrides } from './BpkPropOverridesContext';
+import { BpkProvider } from './BpkProvider';
+
+const OverrideReader = ({ componentName }: { componentName: string }) => {
+  const overrides = usePropOverrides(componentName);
+  return <span data-testid="overrides">{JSON.stringify(overrides)}</span>;
+};
+
+describe('usePropOverrides', () => {
+  it('returns null when no provider is present', () => {
+    const { getByTestId } = render(<OverrideReader componentName="BpkButton" />);
+    expect(getByTestId('overrides').textContent).toBe('null');
+  });
+
+  it('returns null when provider has no entry for the component', () => {
+    const { getByTestId } = render(
+      <BpkProvider propOverrides={{ BpkChip: { type: { default: 'on-dark' } } }}>
+        <OverrideReader componentName="BpkButton" />
+      </BpkProvider>,
+    );
+    expect(getByTestId('overrides').textContent).toBe('null');
+  });
+
+  it('returns overrides for the requested component', () => {
+    const overrides = { type: { primary: 'secondary' } };
+    const { getByTestId } = render(
+      <BpkProvider propOverrides={{ BpkButton: overrides }}>
+        <OverrideReader componentName="BpkButton" />
+      </BpkProvider>,
+    );
+    expect(JSON.parse(getByTestId('overrides').textContent!)).toEqual(overrides);
+  });
+
+  it('returns null when propOverrides is not provided', () => {
+    const { getByTestId } = render(
+      <BpkProvider>
+        <OverrideReader componentName="BpkButton" />
+      </BpkProvider>,
+    );
+    expect(getByTestId('overrides').textContent).toBe('null');
+  });
+});
+
+describe('getValidatedPropOverride', () => {
+  const allowedTypes = ['primary', 'secondary', 'destructive'] as const;
+
+  it('returns the override value when both source and target are valid', () => {
+    const result = getValidatedPropOverride(
+      { primary: 'secondary' },
+      'primary',
+      allowedTypes,
+    );
+    expect(result).toBe('secondary');
+  });
+
+  it('returns null when the override map is null', () => {
+    expect(getValidatedPropOverride(null, 'primary', allowedTypes)).toBeNull();
+  });
+
+  it('returns null when the override map is undefined', () => {
+    expect(getValidatedPropOverride(undefined, 'primary', allowedTypes)).toBeNull();
+  });
+
+  it('returns null when the source value is not in the allowed set', () => {
+    const result = getValidatedPropOverride(
+      { bogus: 'secondary' } as Record<string, string>,
+      'bogus',
+      allowedTypes,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the target value is not in the allowed set', () => {
+    const result = getValidatedPropOverride(
+      { primary: 'invalid' as any },
+      'primary',
+      allowedTypes,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no mapping exists for the source value', () => {
+    const result = getValidatedPropOverride(
+      { secondary: 'destructive' },
+      'primary',
+      allowedTypes,
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/packages/bpk-component-layout/src/BpkPropOverridesContext.tsx
+++ b/packages/bpk-component-layout/src/BpkPropOverridesContext.tsx
@@ -22,13 +22,18 @@ import { createContext, useContext } from 'react';
  * Maps old prop values to new prop values for a single prop.
  * e.g. { primary: 'secondary' } means "swap primary for secondary"
  */
-export type PropOverrideMap = Record<string, string>;
+export type PropOverrideMap<TValue extends string = string> = Partial<
+  Record<TValue, TValue>
+>;
 
 /**
  * Maps prop names to their override maps for a single component.
  * e.g. { type: { primary: 'secondary' }, size: { small: 'large' } }
  */
-export type ComponentOverrides = Record<string, PropOverrideMap>;
+export type ComponentOverrides<
+  TPropName extends string = string,
+  TValue extends string = string,
+> = Partial<Record<TPropName, PropOverrideMap<TValue>>>;
 
 /**
  * Maps component names to their prop overrides.
@@ -37,6 +42,39 @@ export type ComponentOverrides = Record<string, PropOverrideMap>;
 export type PropOverridesConfig = Record<string, ComponentOverrides>;
 
 const BpkPropOverridesContext = createContext<PropOverridesConfig | null>(null);
+
+/**
+ * Safely resolves an override value only when both the current value and
+ * the configured replacement are present in the allowed set.
+ *
+ * @param {Object} overrideMap - The map of old values to new values.
+ * @param {string} value - The current prop value to look up.
+ * @param {Array} allowedValues - The allowed set of values for the prop.
+ * @returns {string} The validated replacement value, or null if none applies.
+ */
+export const getValidatedPropOverride = <TValue extends string>(
+  overrideMap: PropOverrideMap<TValue> | null | undefined,
+  value: string,
+  allowedValues: readonly TValue[],
+): TValue | null => {
+  if (!overrideMap) {
+    return null;
+  }
+
+  const allowedValueSet = new Set<string>(allowedValues);
+
+  if (!allowedValueSet.has(value)) {
+    return null;
+  }
+
+  const overriddenValue = overrideMap[value as TValue];
+
+  if (!overriddenValue || !allowedValueSet.has(overriddenValue)) {
+    return null;
+  }
+
+  return overriddenValue;
+};
 
 /**
  * Returns the override config for a specific component, or null if

--- a/packages/bpk-component-layout/src/BpkPropOverridesContext.tsx
+++ b/packages/bpk-component-layout/src/BpkPropOverridesContext.tsx
@@ -1,0 +1,56 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext } from 'react';
+
+/**
+ * Maps old prop values to new prop values for a single prop.
+ * e.g. { primary: 'secondary' } means "swap primary for secondary"
+ */
+export type PropOverrideMap = Record<string, string>;
+
+/**
+ * Maps prop names to their override maps for a single component.
+ * e.g. { type: { primary: 'secondary' }, size: { small: 'large' } }
+ */
+export type ComponentOverrides = Record<string, PropOverrideMap>;
+
+/**
+ * Maps component names to their prop overrides.
+ * e.g. { BpkButton: { type: { primary: 'secondary' } } }
+ */
+export type PropOverridesConfig = Record<string, ComponentOverrides>;
+
+const BpkPropOverridesContext = createContext<PropOverridesConfig | null>(null);
+
+/**
+ * Returns the override config for a specific component, or null if
+ * no overrides are configured (either no provider or no entry for
+ * the given component).
+ *
+ * @param {string} componentName - The display name of the component, e.g. 'BpkButton'
+ * @returns {ComponentOverrides | null} The override config for the component, or null
+ */
+export const usePropOverrides = (
+  componentName: string,
+): ComponentOverrides | null => {
+  const config = useContext(BpkPropOverridesContext);
+  return config?.[componentName] ?? null;
+};
+
+export const BpkPropOverridesProvider = BpkPropOverridesContext.Provider;

--- a/packages/bpk-component-layout/src/BpkProvider.stories.tsx
+++ b/packages/bpk-component-layout/src/BpkProvider.stories.tsx
@@ -30,13 +30,15 @@ import {
   BpkVessel,
   BpkVStack,
 } from '..';
-import BpkButton from '../../bpk-component-button';
+import BpkButton, { BUTTON_TYPES } from '../../bpk-component-button';
+import BpkSelectableChip from '../../bpk-component-chip/src/BpkSelectableChip';
 import BpkText, {
   TEXT_STYLES,
 } from '../../bpk-component-text';
 
 import LayoutWrapper from './BpkLayout.stories-wrapper';
 
+import type { PropOverridesConfig } from '..';
 import type { Meta } from '@storybook/react';
 
 import STYLES from './BpkLayout.stories.module.scss';
@@ -441,6 +443,112 @@ const VisualTest = () => (
   </>
 );
 
+const OVERRIDE_PRESETS: Record<string, PropOverridesConfig> = {
+  'None (default)': {},
+  'Button: primary → secondary': {
+    BpkButton: { type: { primary: 'secondary' } },
+  },
+  'Button: primary → destructive': {
+    BpkButton: { type: { primary: 'destructive' } },
+  },
+  'Button: small → large': {
+    BpkButton: { size: { small: 'large' } },
+  },
+  'Chip: default → on-dark': {
+    BpkSelectableChip: { type: { default: 'on-dark' } },
+  },
+  'Combined: button + chip': {
+    BpkButton: { type: { primary: 'featured' }, size: { small: 'large' } },
+    BpkSelectableChip: { type: { default: 'on-image' } },
+  },
+};
+
+const PropOverridesExample = () => {
+  const [presetKey, setPresetKey] = useState<string>('None (default)');
+  const config = OVERRIDE_PRESETS[presetKey];
+
+  return (
+    <div style={{ padding: '1rem', maxWidth: 600 }}>
+      <BpkText textStyle={TEXT_STYLES.heading3} tagName="h2">
+        Prop Overrides / Variant Swap
+      </BpkText>
+      <p style={{ margin: '0.5rem 0 1rem' }}>
+        Select a preset to swap component variants globally via BpkProvider.
+        Explicit props always win over overrides.
+      </p>
+
+      <label htmlFor="preset-select" style={{ fontWeight: 'bold', display: 'block', marginBottom: '0.25rem' }}>
+        Override preset:
+      </label>
+      <select
+        id="preset-select"
+        value={presetKey}
+        onChange={(e) => setPresetKey(e.target.value)}
+        style={{ marginBottom: '1.5rem', padding: '0.25rem' }}
+      >
+        {Object.keys(OVERRIDE_PRESETS).map((key) => (
+          <option key={key} value={key}>{key}</option>
+        ))}
+      </select>
+
+      <BpkProvider propOverrides={Object.keys(config).length > 0 ? config : undefined}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+          <div>
+            <BpkText textStyle={TEXT_STYLES.heading4} tagName="h3">
+              BpkButton (no explicit type — uses override)
+            </BpkText>
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+              <BpkButton onClick={() => {}}>Default button</BpkButton>
+            </div>
+          </div>
+
+          <div>
+            <BpkText textStyle={TEXT_STYLES.heading4} tagName="h3">
+              BpkButton (explicit type=&quot;featured&quot; — unaffected)
+            </BpkText>
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+              <BpkButton type={BUTTON_TYPES.featured} onClick={() => {}}>
+                Featured (explicit)
+              </BpkButton>
+            </div>
+          </div>
+
+          <div>
+            <BpkText textStyle={TEXT_STYLES.heading4} tagName="h3">
+              BpkButton — all variants for reference
+            </BpkText>
+            <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginTop: '0.5rem' }}>
+              <BpkButton type={BUTTON_TYPES.primary} onClick={() => {}}>Primary</BpkButton>
+              <BpkButton type={BUTTON_TYPES.secondary} onClick={() => {}}>Secondary</BpkButton>
+              <BpkButton type={BUTTON_TYPES.destructive} onClick={() => {}}>Destructive</BpkButton>
+              <BpkButton type={BUTTON_TYPES.featured} onClick={() => {}}>Featured</BpkButton>
+              <BpkButton type={BUTTON_TYPES.link} onClick={() => {}}>Link</BpkButton>
+            </div>
+          </div>
+
+          <div>
+            <BpkText textStyle={TEXT_STYLES.heading4} tagName="h3">
+              BpkSelectableChip (no explicit type — uses override)
+            </BpkText>
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+              <BpkSelectableChip accessibilityLabel="Chip" onClick={() => {}}>
+                Default chip
+              </BpkSelectableChip>
+            </div>
+          </div>
+        </div>
+      </BpkProvider>
+
+      <details style={{ marginTop: '1.5rem' }}>
+        <summary style={{ cursor: 'pointer', fontWeight: 'bold' }}>Config (JSON)</summary>
+        <pre style={{ background: '#f5f5f5', padding: '0.5rem', fontSize: '0.8rem' }}>
+          {JSON.stringify(config, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+};
+
 const meta = {
   title: 'bpk-component-layout',
   component: BpkProvider,
@@ -469,4 +577,8 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
+};
+
+export const PropOverrides = {
+  render: () => <PropOverridesExample />,
 };

--- a/packages/bpk-component-layout/src/BpkProvider.stories.tsx
+++ b/packages/bpk-component-layout/src/BpkProvider.stories.tsx
@@ -31,7 +31,7 @@ import {
   BpkVStack,
 } from '..';
 import BpkButton, { BUTTON_TYPES } from '../../bpk-component-button';
-import BpkSelectableChip from '../../bpk-component-chip/src/BpkSelectableChip';
+import BpkSelectableChip from '../../bpk-component-chip';
 import BpkText, {
   TEXT_STYLES,
 } from '../../bpk-component-text';

--- a/packages/bpk-component-layout/src/BpkProvider.tsx
+++ b/packages/bpk-component-layout/src/BpkProvider.tsx
@@ -19,13 +19,18 @@
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 
+
 import { LocaleProvider } from '@ark-ui/react';
 import { ChakraProvider, createSystem, defaultBaseConfig } from '@chakra-ui/react';
 
+import { BpkPropOverridesProvider } from './BpkPropOverridesContext';
 import { createBpkConfig } from './theme';
+
+import type { PropOverridesConfig } from './BpkPropOverridesContext';
 
 export interface BpkProviderProps {
   children: ReactNode;
+  propOverrides?: PropOverridesConfig;
 }
 
 /**
@@ -129,12 +134,20 @@ const useArkLocale = (): string => {
  * @param {BpkProviderProps} props - The provider props.
  * @returns {JSX.Element} The provider wrapping its children with Chakra and Ark context.
  */
-export const BpkProvider = ({ children }: BpkProviderProps): JSX.Element => {
+export const BpkProvider = ({ children, propOverrides }: BpkProviderProps) => {
   const locale = useArkLocale();
 
-  return (
+  const inner = (
     <ChakraProvider value={bpkSystem}>
       <LocaleProvider locale={locale}>{children}</LocaleProvider>
     </ChakraProvider>
+  );
+
+  if (!propOverrides) return inner;
+
+  return (
+    <BpkPropOverridesProvider value={propOverrides}>
+      {inner}
+    </BpkPropOverridesProvider>
   );
 };


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
-->

## Summary

Adds a `propOverrides` prop to `BpkProvider` that enables global remapping of component props from a single entry point. This is a prototype for A/B testing variant swaps — e.g. swapping all BpkButton `primary` variants to `secondary` without touching individual component call sites.

- New `BpkPropOverridesContext` with `usePropOverrides` hook
- `BpkProvider` accepts optional `propOverrides` config
- `BpkButton` and `BpkSelectableChip` wired up as initial consumers
- Explicit props always win over context overrides
- Interactive Storybook story with preset selector for testing

### Checklist

- [x] Storybook examples created/updated
- [ ] Tests (existing tests pass; dedicated override tests TBD)
- [ ] Component README updates (prototype, not yet documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)