### PR TITLE
[QUAR-1552] Add wrapTitle prop to BpkNavigationBar to prevent title truncation

### DIFF
--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet-test.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet-test.tsx
@@ -225,9 +225,9 @@ describe('BpkBottomSheet', () => {
     expect(hiddenSpan?.textContent).toBe('my accessible title');
   });
 
-  it('renders title without truncation when a long title is provided', () => {
+  it('passes wrapTitle to the navigation bar so the title is not truncated', () => {
     const longTitle = 'This is a very long bottom sheet title that should wrap onto multiple lines without being truncated';
-    render(
+    const { container } = render(
       <BpkBottomSheet
         {...props}
         title={longTitle}
@@ -236,7 +236,8 @@ describe('BpkBottomSheet', () => {
       </BpkBottomSheet>,
     );
 
-    expect(screen.getByText(longTitle)).toBeInTheDocument();
+    const titleEl = container.querySelector('.bpk-navigation-bar__title--wrap');
+    expect(titleEl).toBeInTheDocument();
   });
 
   it('adds correct id to custom title element for aria-labelledby reference', () => {

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet-test.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet-test.tsx
@@ -225,6 +225,20 @@ describe('BpkBottomSheet', () => {
     expect(hiddenSpan?.textContent).toBe('my accessible title');
   });
 
+  it('renders title without truncation when a long title is provided', () => {
+    const longTitle = 'This is a very long bottom sheet title that should wrap onto multiple lines without being truncated';
+    render(
+      <BpkBottomSheet
+        {...props}
+        title={longTitle}
+      >
+        Bottom Sheet content
+      </BpkBottomSheet>,
+    );
+
+    expect(screen.getByText(longTitle)).toBeInTheDocument();
+  });
+
   it('adds correct id to custom title element for aria-labelledby reference', () => {
     const { container } = render(
       <BpkBottomSheet

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.stories.js
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.stories.js
@@ -186,7 +186,7 @@ const EscapeCloseExample = () => (
 
 const OverflowingExample = () => (
   <BottomSheetContainer
-    title="Bottom Sheet title"
+    title="Bottom Sheet title which is very very very very long. Can break into several lines"
     closeLabel="Close Bottom Sheet"
   >
     <>{Children.toArray(content)}</>
@@ -195,7 +195,7 @@ const OverflowingExample = () => (
 
 const LongHeaderTextExample = () => (
   <BottomSheetContainer
-    title="Bottom Sheet title which is long"
+    title="Bottom Sheet title which is very very very very long. Can break into several lines"
     closeLabel="Close Bottom Sheet"
   >
     This is a default bottom sheet. You can put anything you want in here.
@@ -204,7 +204,7 @@ const LongHeaderTextExample = () => (
 
 const LongHeaderTextWithActionButtonExample = () => (
   <BottomSheetContainer
-    title="Bottom Sheet title which is long"
+    title="Bottom Sheet title which is very very very very long. Can break into several lines"
     closeLabel="Close Bottom Sheet"
     actionText="Action"
     onAction={action('Action clicked')}

--- a/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -200,6 +200,7 @@ const BpkBottomSheet = ({
             title={titleWithId}
             titleTextStyle={TEXT_STYLES.label1}
             titleTagName={hasTitle ? 'h2' : 'span'}
+            wrapTitle
             className={getClassName('bpk-bottom-sheet--header')}
             leadingButton={
               <BpkCloseButton label={closeLabel} onClick={handleClose} />

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar-test.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar-test.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import BpkNavigationBar, { BAR_STYLES } from './BpkNavigationBar';
 import BpkNavigationIconButton from './BpkNavigationBarIconButton';
@@ -120,5 +120,17 @@ describe('BpkNavigationBar', () => {
     );
 
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should apply the wrap modifier class to the title when wrapTitle is set', () => {
+    render(<BpkNavigationBar id="test" title="test" wrapTitle />);
+
+    expect(screen.getByText('test').parentElement).toHaveClass('bpk-navigation-bar__title--wrap');
+  });
+
+  it('should not apply the wrap modifier class to the title by default', () => {
+    render(<BpkNavigationBar id="test" title="test" />);
+
+    expect(screen.getByText('test').parentElement).not.toHaveClass('bpk-navigation-bar__title--wrap');
   });
 });

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
@@ -68,6 +68,12 @@
     &--on-dark {
       color: tokens.$bpk-text-primary-inverse-day;
     }
+
+    &--wrap {
+      white-space: normal;
+      overflow: visible;
+      text-overflow: unset;
+    }
   }
 
   &__title-container {

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.module.scss
@@ -70,9 +70,9 @@
     }
 
     &--wrap {
+      text-overflow: unset;
       white-space: normal;
       overflow: visible;
-      text-overflow: unset;
     }
   }
 

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.stories.js
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.stories.js
@@ -92,6 +92,30 @@ const LongTitleTextExample = () => (
   </div>
 );
 
+const LongTitleTextWrappingExample = () => (
+  <div className={getClassNames('bpk-navigation-bar-story')}>
+    <BpkNavigationBar
+      id="test"
+      title="Backpack navigation bar with a very long title that wraps onto multiple lines"
+      wrapTitle
+      leadingButton={
+        <BpkNavigationBarIconButton
+          onClick={action('back clicked')}
+          icon={ArrowIconWithRtl}
+          label="back"
+        />
+      }
+      trailingButton={
+        <BpkNavigationBarIconButton
+          onClick={action('close clicked')}
+          icon={CloseIcon}
+          label="close"
+        />
+      }
+    />
+  </div>
+);
+
 const CustomTitleExample = () => (
   <div className={getClassNames('bpk-navigation-bar-story')}>
     <BpkNavigationBar
@@ -317,6 +341,10 @@ export const Default = {
 
 export const LongTitleText = {
   render: () => <LongTitleTextExample />,
+};
+
+export const LongTitleTextWrapping = {
+  render: () => <LongTitleTextWrappingExample />,
 };
 
 export const CustomTitle = {

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
@@ -38,6 +38,7 @@ export type Props = {
   title: ReactNode;
   titleTextStyle?: TextStyle;
   titleTagName?: Tag;
+  wrapTitle?: boolean;
   className?: string;
   leadingButton?: ReactElement | null;
   trailingButton?: ReactElement | null;
@@ -57,6 +58,7 @@ const BpkNavigationBar = (props: Props) => {
     titleTagName = "span",
     titleTextStyle = TEXT_STYLES.heading5,
     trailingButton,
+    wrapTitle = false,
     ...rest
   } = props;
 
@@ -91,6 +93,7 @@ const BpkNavigationBar = (props: Props) => {
         <span className={getClassNames(
           'bpk-navigation-bar__title',
           `bpk-navigation-bar__title--${barStyle}`,
+          wrapTitle && 'bpk-navigation-bar__title--wrap',
         )}>
           <BpkText
             id={titleId}

--- a/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
+++ b/packages/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
@@ -38,6 +38,8 @@ export type Props = {
   title: ReactNode;
   titleTextStyle?: TextStyle;
   titleTagName?: Tag;
+  /** When true, prevents the title from being truncated with an ellipsis and allows it to wrap onto multiple lines.
+   * Note: this prop only applies when `title` is a string; ReactNode titles are not truncated and wrap naturally. */
   wrapTitle?: boolean;
   className?: string;
   leadingButton?: ReactElement | null;

--- a/packages/bpk-stylesheets/base.js
+++ b/packages/bpk-stylesheets/base.js
@@ -1,1 +1,1 @@
-(()=>{"use strict";(()=>{if("undefined"==typeof document)return;const o=[];o.push("ontouchstart"in window||window.DocumentTouch&&document instanceof DocumentTouch?"touch-support":"no-touch-support"),document.documentElement.className+=` ${o.map(o=>`bpk-${o}`).join(" ")}`})()})();
+(()=>{"use strict";(()=>{if("undefined"==typeof document)return;const o=[];o.push("ontouchstart"in window||window.DocumentTouch&&document instanceof DocumentTouch?"touch-support":"no-touch-support"),document.documentElement.className+=` ${o.map((o=>`bpk-${o}`)).join(" ")}`})()})();

--- a/packages/bpk-stylesheets/base.js
+++ b/packages/bpk-stylesheets/base.js
@@ -1,1 +1,1 @@
-(()=>{"use strict";(()=>{if("undefined"==typeof document)return;const o=[];o.push("ontouchstart"in window||window.DocumentTouch&&document instanceof DocumentTouch?"touch-support":"no-touch-support"),document.documentElement.className+=` ${o.map((o=>`bpk-${o}`)).join(" ")}`})()})();
+(()=>{"use strict";(()=>{if("undefined"==typeof document)return;const o=[];o.push("ontouchstart"in window||window.DocumentTouch&&document instanceof DocumentTouch?"touch-support":"no-touch-support"),document.documentElement.className+=` ${o.map(o=>`bpk-${o}`).join(" ")}`})()})();


### PR DESCRIPTION
## Summary

- Adds a `wrapTitle` boolean prop to `BpkNavigationBar` that disables `white-space: nowrap` / `text-overflow: ellipsis` on the title element, allowing long titles to wrap onto multiple lines
- **`BpkBottomSheet` now passes `wrapTitle` unconditionally so bottom sheet titles always wrap (fixes truncation of long localised titles e.g. `de-DE` DSA modal title)**
- Adds a Storybook story to `BpkNavigationBar` demonstrating long-title wrapping behaviour
- Adds unit tests for the new prop in both `BpkNavigationBar` and `BpkBottomSheet`

Jira: https://skyscanner.atlassian.net/browse/QUAR-1552

## Test plan

- [ ] `BpkNavigationBar` renders title without ellipsis when `wrapTitle` is set
- [ ] `BpkBottomSheet` titles wrap onto multiple lines instead of truncating
- [ ] Storybook story for `BpkNavigationBar` shows long-title wrapping
- [ ] Unit tests pass for both `BpkNavigationBar` and `BpkBottomSheet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)