### PR TITLE
[BpkText] Add textAlign prop

### DIFF
--- a/packages/bpk-component-text/index.ts
+++ b/packages/bpk-component-text/index.ts
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-import component, { TEXT_COLORS, TEXT_STYLES } from './src/BpkText';
+import component, { TEXT_ALIGN, TEXT_COLORS, TEXT_STYLES } from './src/BpkText';
 
 export default component;
-export { TEXT_COLORS, TEXT_STYLES };
-export type { Tag, TextStyle, TextColor } from './src/BpkText';
+export { TEXT_ALIGN, TEXT_COLORS, TEXT_STYLES };
+export type { Tag, TextAlign, TextStyle, TextColor } from './src/BpkText';

--- a/packages/bpk-component-text/src/BpkText-test.tsx
+++ b/packages/bpk-component-text/src/BpkText-test.tsx
@@ -22,7 +22,7 @@ import '@testing-library/jest-dom';
 
 import { textSuccessDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
-import BpkText, { TEXT_COLORS } from './BpkText';
+import BpkText, { TEXT_ALIGN, TEXT_COLORS } from './BpkText';
 
 import type { Tag, TextStyle } from './BpkText';
 
@@ -99,6 +99,24 @@ describe('BpkText', () => {
       expect(getByText(text)).toHaveClass(`bpk-text bpk-text--${textStyle}`);
     });
   });
+  describe('textAlign prop', () => {
+    it('should not add an align class when textAlign is not provided', () => {
+      const { getByText } = render(<BpkText>{text}</BpkText>);
+
+      expect(getByText(text).className).not.toContain('bpk-text--align-');
+    });
+
+    Object.values(TEXT_ALIGN).forEach((alignValue) => {
+      it(`should render correctly with textAlign="${alignValue}"`, () => {
+        const { getByText } = render(
+          <BpkText textAlign={alignValue}>{text}</BpkText>,
+        );
+
+        expect(getByText(text)).toHaveClass(`bpk-text--align-${alignValue}`);
+      });
+    });
+  });
+
   describe('text color prop', () => {
     it('should render correctly with prop color is token textSecondary', () => {
       const { getByText } = render(

--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -165,4 +165,12 @@ $text-colors: (
       color: $color-value;
     }
   }
+
+  $text-aligns: 'start', 'end', 'left', 'right', 'center', 'justify';
+
+  @each $align in $text-aligns {
+    &--align-#{$align} {
+      text-align: #{$align};
+    }
+  }
 }

--- a/packages/bpk-component-text/src/BpkText.stories.tsx
+++ b/packages/bpk-component-text/src/BpkText.stories.tsx
@@ -18,7 +18,7 @@
 
 import { withDefaultProps, cssModules } from '../../bpk-react-utils';
 
-import BpkText, { TEXT_COLORS, TEXT_STYLES } from './BpkText';
+import BpkText, { TEXT_ALIGN, TEXT_COLORS, TEXT_STYLES } from './BpkText';
 
 import type { Meta } from '@storybook/react';
 
@@ -248,6 +248,21 @@ export const LabelStyles = {
 
 export const LarkenStyles = {
   render: () => <LarkenStylesExample />,
+};
+
+const TextAlignExample = () => (
+  <div>
+    {Object.values(TEXT_ALIGN).map((align) => (
+      <BpkText key={align} tagName="p" textAlign={align}>
+        textAlign=&quot;{align}&quot; — The quick brown fox jumps over the lazy
+        dog
+      </BpkText>
+    ))}
+  </div>
+);
+
+export const TextAlignProp = {
+  render: () => <TextAlignExample />,
 };
 
 export const ColorProp = {

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -58,6 +58,15 @@ export const TEXT_STYLES = {
   editorial3: 'editorial-3',
 } as const;
 
+export const TEXT_ALIGN = {
+  start: 'start',
+  end: 'end',
+  left: 'left',
+  right: 'right',
+  center: 'center',
+  justify: 'justify',
+} as const;
+
 export const TEXT_COLORS = {
   textDisabled: 'text-disabled',
   textDisabledOnDark: 'text-disabled-on-dark',
@@ -72,6 +81,7 @@ export const TEXT_COLORS = {
   textSuccess: 'text-success',
 } as const;
 
+export type TextAlign = (typeof TEXT_ALIGN)[keyof typeof TEXT_ALIGN];
 export type TextColor = (typeof TEXT_COLORS)[keyof typeof TEXT_COLORS];
 export type TextStyle = (typeof TEXT_STYLES)[keyof typeof TEXT_STYLES];
 export type Tag =
@@ -91,6 +101,7 @@ type Props = {
   tagName?: Tag;
   className?: string | null;
   color?: TextColor | null;
+  textAlign?: TextAlign | null;
   id?: string;
   [rest: string]: any;
 };
@@ -100,6 +111,7 @@ const BpkText = ({
   className = null,
   color = null,
   tagName: TagName = 'span',
+  textAlign = null,
   textStyle = TEXT_STYLES.bodyDefault,
   ...rest
 }: Props) => {
@@ -107,6 +119,7 @@ const BpkText = ({
     'bpk-text',
     `bpk-text--${textStyle}`,
     color ? `bpk-text--${color}` : '',
+    textAlign ? `bpk-text--align-${textAlign}` : '',
     className,
   );
 


### PR DESCRIPTION
Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here

## What does this PR do?

Adds a new optional `textAlign` prop to `BpkText` to control text alignment declaratively, without needing a custom `className`.

## Changes

- **`BpkText.tsx`**: Added `TEXT_ALIGN` constant, `TextAlign` type, and `textAlign` prop. When provided, applies a `bpk-text--align-{value}` CSS class.
- **`BpkText.module.scss`**: Added `@each` loop generating `.bpk-text--align-{start|end|left|right|center|justify}` modifier classes.
- **`index.ts`**: Exported `TEXT_ALIGN` constant and `TextAlign` type as part of the public API.
- **`BpkText-test.tsx`**: Added tests covering the no-class default behaviour and all six alignment values.
- **`BpkText.stories.tsx`**: Added `TextAlignProp` story demonstrating all six alignment variants.

## How to test

```tsx
import BpkText, { TEXT_ALIGN } from '@skyscanner/backpack-web/bpk-component-text';

// Centred text
<BpkText textAlign={TEXT_ALIGN.center}>Hello world</BpkText>

// No prop — browser default (start) applies
<BpkText>Hello world</BpkText>
```

## Notes

- Non-breaking addition — `textAlign` is optional and defaults to `null` (no class added, preserving existing browser default `text-align` behaviour).
- Supported values: `start`, `end`, `left`, `right`, `center`, `justify`.