### PR TITLE
[LUNA-3469][BpkSegmentedControl] Change container role to group

### DIFF
--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
@@ -80,6 +80,7 @@ const getContainerAriaProps = (providedId?: string, label?: string) => {
   }
 
   if (label) {
+    props.role = 'group'
     props['aria-label'] = label;
   }
 

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
@@ -77,12 +77,11 @@ const getContainerAriaProps = (providedId?: string, label?: string) => {
   if (providedId) {
     props.role = 'tablist';
     props['aria-orientation'] = 'horizontal';
+  } else {
+    props.role = 'group';
   }
 
   if (label) {
-    if (!providedId) {
-      props.role = 'group';
-    }
     props['aria-label'] = label;
   }
 

--- a/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
+++ b/packages/bpk-component-segmented-control/src/BpkSegmentedControl.tsx
@@ -80,7 +80,9 @@ const getContainerAriaProps = (providedId?: string, label?: string) => {
   }
 
   if (label) {
-    props.role = 'group'
+    if (!providedId) {
+      props.role = 'group';
+    }
     props['aria-label'] = label;
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This change adds a role for the container `<div>` surrounding BpkSegmentedControl. Currently, we apply an aria-label to the container div, but this is a violation of WCAG. You can see AQA Audit complaining about it [here](https://aqa.usablenet.com/#/audit/skyscanner/suites/TS11196/a11yMonitors/A202005-1772773200025/T205050/step1/details/view/AI1/description).

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
