### PR TITLE
[NO-JIRA][BpkComparisonTray] Fix responsive layout and close button positioning

### DIFF
--- a/packages/bpk-component-comparison-table/src/BpkComparisonTray/BpkComparisonTray.module.scss
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTray/BpkComparisonTray.module.scss
@@ -27,6 +27,12 @@
 .bpk-comparison-tray {
   width: 355 * tokens.$bpk-one-pixel-rem;
   max-width: 100%;
+
+  @include breakpoints.bpk-breakpoint-mobile {
+    width: auto;
+    min-width: 0;
+    flex: 1;
+  }
 }
 
 // Filled item — relative for close button positioning
@@ -35,12 +41,6 @@
   width: 62 * tokens.$bpk-one-pixel-rem;
   height: 28 * tokens.$bpk-one-pixel-rem;
   flex-shrink: 0;
-
-  @include breakpoints.bpk-breakpoint-mobile {
-    width: auto;
-    min-width: 0;
-    flex: 1;
-  }
 }
 
 // Inner image container — clips image to rounded corners without clipping the close button
@@ -59,7 +59,11 @@
 }
 
 // Close button — 16×16, dark bg, white border, overlaps top-right corner
+/* stylelint-disable order/order, order/properties-order */
 .bpk-comparison-tray__item-close {
+  // bpk-touch-tappable sets position: relative — position: absolute must come after to override it
+  @include utils.bpk-touch-tappable;
+
   position: absolute;
   top: 0;
   right: 0;
@@ -76,7 +80,6 @@
   color: tokens.$bpk-text-primary-inverse-day;
   cursor: pointer;
 
-  @include utils.bpk-touch-tappable;
   @include shadows.bpk-box-shadow-lg;
 
   svg {
@@ -90,6 +93,7 @@
     @include utils.bpk-focus-indicator;
   }
 }
+/* stylelint-enable order/order, order/properties-order */
 
 // Placeholder item — dashed border
 .bpk-comparison-tray__item-placeholder {
@@ -99,10 +103,4 @@
   border: tokens.$bpk-one-pixel-rem dashed tokens.$bpk-line-day;
 
   @include radii.bpk-border-radius-xs;
-
-  @include breakpoints.bpk-breakpoint-mobile {
-    width: auto;
-    min-width: 0;
-    flex: 1;
-  }
 }


### PR DESCRIPTION
## Description

Two fixes for `BpkComparisonTray`:

### 1. Responsive layout on small screens
The tray had a fixed width of `355px` with `max-width: 100%`, but on mobile viewports the inner items (with `flex-shrink: 0`) prevented the tray from fitting within the screen, causing horizontal overflow.

**Fix:** Moved the mobile breakpoint responsive styles (`width: auto; min-width: 0; flex: 1`) from the individual items/placeholders to the outer `.bpk-comparison-tray` wrapper. This lets the tray container itself adapt to its parent's available space on small screens, while items keep their fixed proportions.

### 2. Close button positioning
`bpk-touch-tappable` mixin sets `position: relative`, which was overriding the `position: absolute` on the close button, causing it to not be correctly positioned at the top-right corner of the item.

**Fix:** Moved `@include utils.bpk-touch-tappable` above `position: absolute` so the absolute positioning takes precedence.

---

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here