### PR TITLE
[BpkText] Remove physical text-align values (left/right) for RTL safety

### DIFF
--- a/packages/bpk-component-text/src/BpkText.module.scss
+++ b/packages/bpk-component-text/src/BpkText.module.scss
@@ -166,7 +166,7 @@ $text-colors: (
     }
   }
 
-  $text-aligns: 'start', 'end', 'left', 'right', 'center', 'justify';
+  $text-aligns: 'start', 'end', 'center', 'justify';
 
   @each $align in $text-aligns {
     &--align-#{$align} {

--- a/packages/bpk-component-text/src/BpkText.tsx
+++ b/packages/bpk-component-text/src/BpkText.tsx
@@ -61,8 +61,6 @@ export const TEXT_STYLES = {
 export const TEXT_ALIGN = {
   start: 'start',
   end: 'end',
-  left: 'left',
-  right: 'right',
   center: 'center',
   justify: 'justify',
 } as const;


### PR DESCRIPTION
Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here

## What does this PR do?

Removes `left` and `right` from `TEXT_ALIGN` (introduced in #4420) to prevent incorrect text alignment in RTL contexts.

`text-align: left` and `text-align: right` are physical direction values — they do not flip automatically when the document direction is RTL. This means a component using `textAlign="left"` would render left-aligned text even in an Arabic or Hebrew context, where text should align to the right.

`start` and `end` are CSS logical properties that resolve correctly for both LTR and RTL:

| Value | LTR | RTL |
|---|---|---|
| `start` | left ✅ | right ✅ |
| `end` | right ✅ | left ✅ |
| `left` | left ✅ | **left ❌** |
| `right` | right ✅ | **right ❌** |

## Changes

- **`BpkText.tsx`**: Removed `left` and `right` keys from `TEXT_ALIGN`.
- **`BpkText.module.scss`**: Removed `.bpk-text--align-left` and `.bpk-text--align-right` CSS classes.

`TEXT_ALIGN` now supports: `start`, `end`, `center`, `justify`.

## Notes

This is a patch against #4420 which shipped in the same release, so there are no consumers to migrate.