### PR TITLE
[NO-JIRA][dangerfile] Add auto-merge readiness rules

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -208,32 +208,34 @@ const scssChanged = fileChanges.filter((filePath) =>
   filePath.match(/^packages\/bpk-component-[^/]+\/src\/.+\.module\.scss$/),
 );
 
-Promise.all(
-  scssChanged.map((filePath) =>
-    danger.git
-      .diffForFile(filePath)
-      .then((diff) => {
-        const offending = (diff?.added ?? '')
-          .split('\n')
-          .filter(
-            (line) =>
-              physicalPropertyPattern.test(line) ||
-              physicalValuePattern.test(line),
-          );
-        return offending.length
-          ? `- \`${filePath}\`:\n\`\`\`\n${offending.join('\n')}\n\`\`\``
-          : null;
-      })
-      .catch(() => null),
-  ),
-).then((results) => {
+// Danger awaits the default export, so async checks must go through it.
+export default async () => {
+  const results = await Promise.all(
+    scssChanged.map((filePath) =>
+      danger.git
+        .diffForFile(filePath)
+        .then((diff) => {
+          const offending = (diff?.added ?? '')
+            .split('\n')
+            .filter(
+              (line) =>
+                physicalPropertyPattern.test(line) ||
+                physicalValuePattern.test(line),
+            );
+          return offending.length
+            ? `- \`${filePath}\`:\n\`\`\`\n${offending.join('\n')}\n\`\`\``
+            : null;
+        })
+        .catch(() => null),
+    ),
+  );
   const physicalHits = results.filter((r): r is string => r !== null);
   if (physicalHits.length) {
     warn(
       `Physical CSS properties are not RTL-safe. Prefer logical equivalents (inset-inline-*, margin-inline-*, padding-inline-*, border-inline-*, border-start-start-radius, text-align: start/end). Offending additions:\n${physicalHits.join('\n')}`,
     );
   }
-});
+};
 
 const linterWarnings = ["no-console", "no-undef", "@typescript-eslint/no-unused-vars", "jest/no-disabled-tests", "no-alert", "func-names", "react-hooks/exhaustive-deps"]
 const invalidReactChild = ["Functions are not valid as a React child"];

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -163,15 +163,16 @@ if (packagesMissingA11yTest.length) {
   );
 }
 
-// Stories must be colocated with source, not placed under examples/. See
-// decisions/colocated-stories.md.
-const storiesInExamples = fileChanges.filter((filePath) =>
-  filePath.match(/^packages\/bpk-component-[^/]+\/examples\/.*\.stories\.(t|j)sx?$/),
-);
+// Inside bpk-component-* packages, story files must live alongside the
+// component source under src/. See decisions/colocated-stories.md.
+const misplacedStories = fileChanges.filter((filePath) => {
+  const match = filePath.match(/^packages\/bpk-component-[^/]+\/(.+)\.stories\.(t|j)sx?$/);
+  return match !== null && !match[1].startsWith('src/');
+});
 
-if (storiesInExamples.length) {
+if (misplacedStories.length) {
   fail(
-    `Stories must be colocated with the component source (packages/bpk-component-*/src/*.stories.tsx), not under examples/. Please move: ${storiesInExamples.join(
+    `Stories inside bpk-component-* packages must be colocated with the component source under src/. Please move: ${misplacedStories.join(
       ', ',
     )}`,
   );

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -122,6 +122,100 @@ if (nonModuleCssFiles.length) {
   );
 }
 
+// New component packages must include a README.md (convention: all 95 existing
+// component packages ship one). See CODE_REVIEW_GUIDELINES.md.
+const newComponentPackages = Array.from(
+  new Set(
+    createdFiles
+      .map((f) => f.match(/^(packages\/bpk-component-[^/]+)\//))
+      .filter((m): m is RegExpMatchArray => m !== null)
+      .map((m) => m[1]),
+  ),
+).filter((pkg) => createdFiles.includes(`${pkg}/package.json`));
+
+const packagesMissingReadme = newComponentPackages.filter(
+  (pkg) => !fs.existsSync(`${pkg}/README.md`),
+);
+
+if (packagesMissingReadme.length) {
+  fail(
+    `New component packages must include a README.md. Missing for: ${packagesMissingReadme.join(
+      ', ',
+    )}`,
+  );
+}
+
+// New component packages must include an accessibility test. See
+// decisions/accessibility-tests.md. Detects any `accessibility-test.*` file in src/.
+const packagesMissingA11yTest = newComponentPackages.filter((pkg) => {
+  const srcDir = `${pkg}/src`;
+  if (!fs.existsSync(srcDir)) return true;
+  return !fs
+    .readdirSync(srcDir)
+    .some((name) => /^accessibility-test\.(t|j)sx?$/.test(name));
+});
+
+if (packagesMissingA11yTest.length) {
+  fail(
+    `New component packages must include an accessibility test (src/accessibility-test.tsx using jest-axe). Missing for: ${packagesMissingA11yTest.join(
+      ', ',
+    )}`,
+  );
+}
+
+// Stories must be colocated with source, not placed under examples/. See
+// decisions/colocated-stories.md.
+const storiesInExamples = fileChanges.filter((filePath) =>
+  filePath.match(/^packages\/bpk-component-[^/]+\/examples\/.*\.stories\.(t|j)sx?$/),
+);
+
+if (storiesInExamples.length) {
+  fail(
+    `Stories must be colocated with the component source (packages/bpk-component-*/src/*.stories.tsx), not under examples/. Please move: ${storiesInExamples.join(
+      ', ',
+    )}`,
+  );
+}
+
+// Physical CSS properties break RTL. See decisions/rtl-ark-localeprovider.md.
+// Warn on newly-introduced physical properties in component module SCSS —
+// scoped to added diff lines so existing violations don't block unrelated PRs.
+// When the codebase is migrated, replace this with `stylelint-use-logical`.
+const physicalPropertyPattern =
+  /^\s*(left|right|margin-left|margin-right|padding-left|padding-right|border-left|border-right|border-top-left-radius|border-top-right-radius|border-bottom-left-radius|border-bottom-right-radius)\s*:/;
+const physicalValuePattern = /^\s*(text-align|float|clear)\s*:\s*(left|right)\b/;
+
+const scssChanged = fileChanges.filter((filePath) =>
+  filePath.match(/^packages\/bpk-component-[^/]+\/src\/.+\.module\.scss$/),
+);
+
+Promise.all(
+  scssChanged.map((filePath) =>
+    danger.git
+      .diffForFile(filePath)
+      .then((diff) => {
+        const offending = (diff?.added ?? '')
+          .split('\n')
+          .filter(
+            (line) =>
+              physicalPropertyPattern.test(line) ||
+              physicalValuePattern.test(line),
+          );
+        return offending.length
+          ? `- \`${filePath}\`:\n\`\`\`\n${offending.join('\n')}\n\`\`\``
+          : null;
+      })
+      .catch(() => null),
+  ),
+).then((results) => {
+  const physicalHits = results.filter((r): r is string => r !== null);
+  if (physicalHits.length) {
+    warn(
+      `Physical CSS properties are not RTL-safe. Prefer logical equivalents (inset-inline-*, margin-inline-*, padding-inline-*, border-inline-*, border-start-start-radius, text-align: start/end). Offending additions:\n${physicalHits.join('\n')}`,
+    );
+  }
+});
+
 const linterWarnings = ["no-console", "no-undef", "@typescript-eslint/no-unused-vars", "jest/no-disabled-tests", "no-alert", "func-names", "react-hooks/exhaustive-deps"]
 const invalidReactChild = ["Functions are not valid as a React child"];
 const invalidFormField = ["You provided .* to a form field without"];

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -204,38 +204,35 @@ const physicalPropertyPattern = new RegExp(
 );
 const physicalValuePattern = /^\s*(text-align|float|clear)\s*:\s*(left|right)\b/;
 
-const scssChanged = fileChanges.filter((filePath) =>
+// Scan only newly-created SCSS files — modified files would flag pre-existing
+// violations across the ~92 non-migrated components. Once the codebase is
+// cleaned up, replace this rule with stylelint-use-logical at error severity.
+const scssCreated = createdFiles.filter((filePath) =>
   filePath.match(/^packages\/bpk-component-[^/]+\/src\/.+\.module\.scss$/),
 );
 
-// Danger awaits the default export, so async checks must go through it.
-export default async () => {
-  const results = await Promise.all(
-    scssChanged.map((filePath) =>
-      danger.git
-        .diffForFile(filePath)
-        .then((diff) => {
-          const offending = (diff?.added ?? '')
-            .split('\n')
-            .filter(
-              (line) =>
-                physicalPropertyPattern.test(line) ||
-                physicalValuePattern.test(line),
-            );
-          return offending.length
-            ? `- \`${filePath}\`:\n\`\`\`\n${offending.join('\n')}\n\`\`\``
-            : null;
-        })
-        .catch(() => null),
-    ),
+const physicalHits = scssCreated
+  .map((filePath) => {
+    if (!fs.existsSync(filePath)) return null;
+    const offending = fs
+      .readFileSync(filePath, 'utf8')
+      .split('\n')
+      .filter(
+        (line) =>
+          physicalPropertyPattern.test(line) ||
+          physicalValuePattern.test(line),
+      );
+    return offending.length
+      ? `- \`${filePath}\`:\n\`\`\`\n${offending.join('\n')}\n\`\`\``
+      : null;
+  })
+  .filter((r): r is string => r !== null);
+
+if (physicalHits.length) {
+  warn(
+    `Physical CSS properties are not RTL-safe. Prefer logical equivalents (inset-inline-*, margin-inline-*, padding-inline-*, border-inline-*, border-start-start-radius, text-align: start/end). Offending lines:\n${physicalHits.join('\n')}`,
   );
-  const physicalHits = results.filter((r): r is string => r !== null);
-  if (physicalHits.length) {
-    warn(
-      `Physical CSS properties are not RTL-safe. Prefer logical equivalents (inset-inline-*, margin-inline-*, padding-inline-*, border-inline-*, border-start-start-radius, text-align: start/end). Offending additions:\n${physicalHits.join('\n')}`,
-    );
-  }
-};
+}
 
 const linterWarnings = ["no-console", "no-undef", "@typescript-eslint/no-unused-vars", "jest/no-disabled-tests", "no-alert", "func-names", "react-hooks/exhaustive-deps"]
 const invalidReactChild = ["Functions are not valid as a React child"];

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -182,8 +182,26 @@ if (misplacedStories.length) {
 // Warn on newly-introduced physical properties in component module SCSS —
 // scoped to added diff lines so existing violations don't block unrelated PRs.
 // When the codebase is migrated, replace this with `stylelint-use-logical`.
-const physicalPropertyPattern =
-  /^\s*(left|right|margin-left|margin-right|padding-left|padding-right|border-left|border-right|border-top-left-radius|border-top-right-radius|border-bottom-left-radius|border-bottom-right-radius)\s*:/;
+const physicalPropertyPattern = new RegExp(
+  '^\\s*(' +
+    // Inset (position offsets)
+    'top|right|bottom|left|' +
+    // Size
+    'width|height|min-width|min-height|max-width|max-height|' +
+    // Margin
+    'margin-top|margin-right|margin-bottom|margin-left|' +
+    // Padding
+    'padding-top|padding-right|padding-bottom|padding-left|' +
+    // Border (shorthands and per-side)
+    'border-top|border-right|border-bottom|border-left|' +
+    'border-top-width|border-right-width|border-bottom-width|border-left-width|' +
+    'border-top-style|border-right-style|border-bottom-style|border-left-style|' +
+    'border-top-color|border-right-color|border-bottom-color|border-left-color|' +
+    // Border radius corners
+    'border-top-left-radius|border-top-right-radius|' +
+    'border-bottom-left-radius|border-bottom-right-radius' +
+    ')\\s*:',
+);
 const physicalValuePattern = /^\s*(text-align|float|clear)\s*:\s*(left|right)\b/;
 
 const scssChanged = fileChanges.filter((filePath) =>


### PR DESCRIPTION
Adds four Danger checks so existing component-package conventions are enforced automatically rather than left to reviewer judgement — a prerequisite to enabling auto-merge.

- Fail: new component package without `README.md`
- Fail: new component package without `src/accessibility-test.*` (per `decisions/accessibility-tests.md`)
- Fail: `.stories.*` under `packages/bpk-component-*/examples/` (per `decisions/colocated-stories.md`)
- Warn: newly-added physical CSS properties in component `.module.scss` (per `decisions/rtl-ark-localeprovider.md`) — diff-scoped, so ~92 existing violations don't block unrelated PRs; will be replaced by `stylelint-use-logical` once migrated

Follow-ups (out of scope): clean up 52 existing lint warnings to enable `--max-warnings=0`; add custom rules for PascalCase component filenames, `index.ts` export completeness, and `key={dir}` on Ark Zag components.

Add `skip-changelog` — CI/tooling change only.

Smoke test pr: https://github.com/Skyscanner/backpack/pull/4432