### PR TITLE
[BpkAccordion][BpkAriaLive][BpkAutosuggest] Use logical properties for RTL

### DIFF
--- a/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
+++ b/packages/bpk-component-accordion/src/BpkAccordionItem.module.scss
@@ -19,7 +19,6 @@
 @use '../../bpk-mixins/tokens';
 @use '../../bpk-mixins/borders';
 @use '../../bpk-mixins/margins';
-@use '../../bpk-mixins/utils';
 
 .bpk-accordion {
   &__item--with-divider {
@@ -40,13 +39,9 @@
     border: 0;
     background-color: transparent;
     color: tokens.$bpk-text-primary-day;
-    text-align: left;
+    text-align: start;
     cursor: pointer;
     appearance: none;
-
-    @include utils.bpk-rtl {
-      text-align: right;
-    }
   }
 
   &__flex-container {

--- a/packages/bpk-component-aria-live/src/BpkAriaLive.stories.module.scss
+++ b/packages/bpk-component-aria-live/src/BpkAriaLive.stories.module.scss
@@ -52,8 +52,8 @@
   }
 
   &__chip {
-    margin-right: tokens.bpk-spacing-base();
     margin-bottom: tokens.bpk-spacing-base();
+    margin-inline-end: tokens.bpk-spacing-base();
   }
 
   &__aria-live {

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggest.module.scss
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggest.module.scss
@@ -20,7 +20,6 @@
 @use '../../bpk-mixins/borders';
 @use '../../bpk-mixins/layers';
 @use '../../bpk-mixins/typography';
-@use '../../bpk-mixins/utils';
 
 $arrow-size: tokens.bpk-spacing-sm() * 3;
 
@@ -104,19 +103,14 @@ $arrow-size: tokens.bpk-spacing-sm() * 3;
     padding: tokens.bpk-spacing-base();
 
     &--indent {
-      padding-left: tokens.bpk-spacing-xl();
+      padding-inline-start: tokens.bpk-spacing-xl();
     }
 
     &-icon {
       display: flex;
-      margin-right: tokens.bpk-spacing-md();
       vertical-align: top;
       fill: tokens.$bpk-text-secondary-day;
-
-      @include utils.bpk-rtl {
-        margin-right: 0;
-        margin-left: tokens.bpk-spacing-md();
-      }
+      margin-inline-end: tokens.bpk-spacing-md();
     }
 
     &-content {

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest.module.scss
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest.module.scss
@@ -80,19 +80,14 @@
     padding: tokens.bpk-spacing-base();
 
     &--indent {
-      padding-left: tokens.bpk-spacing-xl();
+      padding-inline-start: tokens.bpk-spacing-xl();
     }
 
     &-icon {
       display: table-cell;
-      margin-right: tokens.bpk-spacing-md();
       vertical-align: top;
       fill: tokens.$bpk-text-secondary-day;
-
-      @include utils.bpk-rtl {
-        margin-right: 0;
-        margin-left: tokens.bpk-spacing-md();
-      }
+      margin-inline-end: tokens.bpk-spacing-md();
     }
 
     &-content {


### PR DESCRIPTION
Replace physical CSS properties with logical equivalents so these components flow correctly in RTL without needing an explicit \`bpk-rtl\` mixin override.

- **BpkAccordionItem**: \`text-align: left\` → \`text-align: start\`; removed \`utils.bpk-rtl\` override and \`utils\` import.
- **BpkAriaLive stories**: \`margin-right\` → \`margin-inline-end\` on the chip spacing.
- **BpkAutosuggest**: \`padding-left\` → \`padding-inline-start\`; \`margin-right\` → \`margin-inline-end\` on the suggestion icon; removed the \`utils.bpk-rtl\` block and \`utils\` import.

Add \`patch\` label — visual behaviour in LTR is unchanged; RTL now relies on native logical-property flipping.

- [x] Tests (existing SCSS snapshot/visual coverage)
- [ ] Accessibility tests — keyboard/zoom/screen reader unchanged; no interaction or semantics modified