### PR TITLE
[MAT2867][BpkScrim] fix: prevent scroll-jump when opening/closing modal on iOS

### DIFF
--- a/packages/bpk-scrim-utils/src/bpk-scrim-content.module.scss
+++ b/packages/bpk-scrim-utils/src/bpk-scrim-content.module.scss
@@ -29,4 +29,10 @@
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+
+  // Re-enable vertical touch panning under body's touch-action: none set by
+  // lockTouchAction on iOS. Without this, touch scrolling inside withScrim
+  // descendants (e.g. modal/drawer content) is blocked via the touch-action
+  // ancestor-chain intersection.
+  touch-action: pan-y;
 }

--- a/packages/bpk-scrim-utils/src/focusStore-test.ts
+++ b/packages/bpk-scrim-utils/src/focusStore-test.ts
@@ -79,6 +79,16 @@ describe('focusStore', () => {
     expect(document.activeElement).not.toBe(button);
   });
 
+  it('should call focus with preventScroll:true to avoid overriding scroll restoration', () => {
+    button.focus();
+    focusStore.storeFocus();
+
+    const focusSpy = jest.spyOn(button, 'focus');
+    focusStore.restoreFocus();
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    focusSpy.mockRestore();
+  });
+
   it('should handle element without focus method gracefully', () => {
     // Simulate a non-HTMLElement activeElement
     const fakeElement = { nodeName: 'fake' } as unknown as Element;

--- a/packages/bpk-scrim-utils/src/focusStore.ts
+++ b/packages/bpk-scrim-utils/src/focusStore.ts
@@ -70,7 +70,7 @@ const focusStore = {
       return;
     }
     try {
-      (storedFocusElement as HTMLElement).focus();
+      (storedFocusElement as HTMLElement).focus({ preventScroll: true });
     } catch {
       // Element may have been detached from the DOM
     }

--- a/packages/bpk-scrim-utils/src/scroll-utils-test.ts
+++ b/packages/bpk-scrim-utils/src/scroll-utils-test.ts
@@ -19,10 +19,12 @@
 import {
   fixBody,
   lockScroll,
+  lockTouchAction,
   restoreScroll,
   storeScroll,
   unfixBody,
   unlockScroll,
+  unlockTouchAction,
 } from './scroll-utils';
 
 describe('scroll-utils', () => {
@@ -97,35 +99,58 @@ describe('scroll-utils', () => {
   });
 
   describe('lockScroll', () => {
-    it('sets overflow, touch-action and overscroll-behavior on the body', () => {
+    it('sets overflow and overscroll-behavior on the body, without touching touch-action', () => {
       lockScroll();
 
       expect(document.body.style.overflow).toBe('hidden');
-      expect(document.body.style.touchAction).toBe('none');
       expect(document.body.style.overscrollBehavior).toBe('contain');
+      expect(document.body.style.touchAction).toBe('');
     });
   });
 
   describe('unlockScroll', () => {
-    it('clears overflow and padding-right, restores touch-action and overscroll-behavior to pre-lock values', () => {
+    it('clears overflow and padding-right, restores overscroll-behavior to pre-lock value', () => {
       lockScroll();
       unlockScroll();
 
       expect(document.body.style.overflow).toBe('');
       expect(document.body.style.paddingRight).toBe('');
-      expect(document.body.style.touchAction).toBe('');
       expect(document.body.style.overscrollBehavior).toBe('');
     });
 
-    it('restores host-app inline touch-action and overscroll-behavior after unlock', () => {
-      document.body.style.touchAction = 'manipulation';
+    it('restores host-app inline overscroll-behavior after unlock', () => {
       document.body.style.overscrollBehavior = 'none';
 
       lockScroll();
       unlockScroll();
 
-      expect(document.body.style.touchAction).toBe('manipulation');
       expect(document.body.style.overscrollBehavior).toBe('none');
+    });
+  });
+
+  describe('lockTouchAction', () => {
+    it('sets touch-action to none on the body', () => {
+      lockTouchAction();
+
+      expect(document.body.style.touchAction).toBe('none');
+    });
+  });
+
+  describe('unlockTouchAction', () => {
+    it('restores touch-action to the pre-lock value (empty when unset)', () => {
+      lockTouchAction();
+      unlockTouchAction();
+
+      expect(document.body.style.touchAction).toBe('');
+    });
+
+    it('restores host-app inline touch-action after unlock', () => {
+      document.body.style.touchAction = 'manipulation';
+
+      lockTouchAction();
+      unlockTouchAction();
+
+      expect(document.body.style.touchAction).toBe('manipulation');
     });
   });
 });

--- a/packages/bpk-scrim-utils/src/scroll-utils-test.ts
+++ b/packages/bpk-scrim-utils/src/scroll-utils-test.ts
@@ -1,0 +1,120 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  fixBody,
+  lockScroll,
+  restoreScroll,
+  storeScroll,
+  unfixBody,
+  unlockScroll,
+} from './scroll-utils';
+
+describe('scroll-utils', () => {
+  const resetBodyStyles = () => {
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+    document.body.style.position = '';
+    document.body.style.top = '';
+    document.body.style.width = '';
+    document.body.style.touchAction = '';
+    document.body.style.overscrollBehavior = '';
+  };
+
+  beforeEach(() => {
+    resetBodyStyles();
+    // reset the module-level scrollOffset by restoring scroll at 0
+    Object.defineProperty(window, 'pageYOffset', {
+      configurable: true,
+      value: 0,
+    });
+    storeScroll();
+  });
+
+  afterEach(() => {
+    resetBodyStyles();
+  });
+
+  describe('storeScroll / restoreScroll', () => {
+    it('restoreScroll scrolls to the offset captured by storeScroll', () => {
+      Object.defineProperty(window, 'pageYOffset', {
+        configurable: true,
+        value: 420,
+      });
+      storeScroll();
+
+      const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation();
+      restoreScroll();
+      expect(scrollToSpy).toHaveBeenCalledWith(0, 420);
+      scrollToSpy.mockRestore();
+    });
+  });
+
+  describe('fixBody', () => {
+    it('sets top, width and position to preserve scroll position', () => {
+      Object.defineProperty(window, 'pageYOffset', {
+        configurable: true,
+        value: 250,
+      });
+      storeScroll();
+      fixBody();
+
+      expect(document.body.style.top).toBe('-250px');
+      expect(document.body.style.width).toBe('100%');
+      expect(document.body.style.position).toBe('fixed');
+    });
+  });
+
+  describe('unfixBody', () => {
+    it('clears top, width and position', () => {
+      Object.defineProperty(window, 'pageYOffset', {
+        configurable: true,
+        value: 100,
+      });
+      storeScroll();
+      fixBody();
+      unfixBody();
+
+      expect(document.body.style.top).toBe('');
+      expect(document.body.style.width).toBe('');
+      expect(document.body.style.position).toBe('');
+    });
+  });
+
+  describe('lockScroll', () => {
+    it('sets overflow, touch-action and overscroll-behavior on the body', () => {
+      lockScroll();
+
+      expect(document.body.style.overflow).toBe('hidden');
+      expect(document.body.style.touchAction).toBe('none');
+      expect(document.body.style.overscrollBehavior).toBe('contain');
+    });
+  });
+
+  describe('unlockScroll', () => {
+    it('clears overflow, padding-right, touch-action and overscroll-behavior', () => {
+      lockScroll();
+      unlockScroll();
+
+      expect(document.body.style.overflow).toBe('');
+      expect(document.body.style.paddingRight).toBe('');
+      expect(document.body.style.touchAction).toBe('');
+      expect(document.body.style.overscrollBehavior).toBe('');
+    });
+  });
+});

--- a/packages/bpk-scrim-utils/src/scroll-utils-test.ts
+++ b/packages/bpk-scrim-utils/src/scroll-utils-test.ts
@@ -40,7 +40,6 @@ describe('scroll-utils', () => {
 
   beforeEach(() => {
     resetBodyStyles();
-    // reset the module-level scrollOffset to 0 before each test
     Object.defineProperty(window, 'pageYOffset', {
       configurable: true,
       value: 0,
@@ -79,6 +78,8 @@ describe('scroll-utils', () => {
       expect(document.body.style.top).toBe('-250px');
       expect(document.body.style.width).toBe('100%');
       expect(document.body.style.position).toBe('fixed');
+
+      unfixBody();
     });
   });
 
@@ -105,6 +106,8 @@ describe('scroll-utils', () => {
       expect(document.body.style.overflow).toBe('hidden');
       expect(document.body.style.overscrollBehavior).toBe('contain');
       expect(document.body.style.touchAction).toBe('');
+
+      unlockScroll();
     });
   });
 
@@ -133,6 +136,8 @@ describe('scroll-utils', () => {
       lockTouchAction();
 
       expect(document.body.style.touchAction).toBe('none');
+
+      unlockTouchAction();
     });
   });
 
@@ -151,6 +156,95 @@ describe('scroll-utils', () => {
       unlockTouchAction();
 
       expect(document.body.style.touchAction).toBe('manipulation');
+    });
+  });
+
+  // Regression tests for nested scrims (e.g. the Nested story in
+  // BpkModal.stories.tsx). Module-level state must be reference-counted so the
+  // inner scrim does not clobber the outer scrim's saved "pre-lock" value.
+  describe('nested locks', () => {
+    it('restores host touch-action only after the outermost unlockTouchAction', () => {
+      document.body.style.touchAction = 'manipulation';
+
+      lockTouchAction(); // outer scrim mounts
+      lockTouchAction(); // inner scrim mounts
+
+      unlockTouchAction(); // inner scrim unmounts — body still needs to be locked
+      expect(document.body.style.touchAction).toBe('none');
+
+      unlockTouchAction(); // outer scrim unmounts — now restore
+      expect(document.body.style.touchAction).toBe('manipulation');
+    });
+
+    it('restores host overscroll-behavior only after the outermost unlockScroll', () => {
+      document.body.style.overscrollBehavior = 'none';
+
+      lockScroll();
+      lockScroll();
+
+      unlockScroll();
+      expect(document.body.style.overscrollBehavior).toBe('contain');
+
+      unlockScroll();
+      expect(document.body.style.overscrollBehavior).toBe('none');
+    });
+
+    it('preserves the outer scroll offset when a nested scrim calls storeScroll', () => {
+      Object.defineProperty(window, 'pageYOffset', {
+        configurable: true,
+        value: 500,
+      });
+      storeScroll();
+      fixBody(); // outer scrim: body now position:fixed at top:-500
+
+      // Inner scrim: pageYOffset reads 0 while body is fixed. storeScroll
+      // must NOT overwrite the saved 500.
+      Object.defineProperty(window, 'pageYOffset', {
+        configurable: true,
+        value: 0,
+      });
+      storeScroll();
+      fixBody();
+
+      unfixBody(); // inner unmount
+      unfixBody(); // outer unmount
+
+      const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation();
+      restoreScroll();
+      expect(scrollToSpy).toHaveBeenCalledWith(0, 500);
+      scrollToSpy.mockRestore();
+    });
+
+    it('keeps the body fixed until the outermost unfixBody', () => {
+      Object.defineProperty(window, 'pageYOffset', {
+        configurable: true,
+        value: 300,
+      });
+      storeScroll();
+
+      fixBody();
+      fixBody();
+
+      unfixBody();
+      expect(document.body.style.position).toBe('fixed');
+      expect(document.body.style.top).toBe('-300px');
+
+      unfixBody();
+      expect(document.body.style.position).toBe('');
+      expect(document.body.style.top).toBe('');
+    });
+
+    it('extra unlock calls are no-ops and do not corrupt future locks', () => {
+      unlockScroll();
+      unlockTouchAction();
+      unfixBody();
+
+      // After an unbalanced unlock, the next lock must still capture and apply.
+      document.body.style.touchAction = 'pan-y';
+      lockTouchAction();
+      expect(document.body.style.touchAction).toBe('none');
+      unlockTouchAction();
+      expect(document.body.style.touchAction).toBe('pan-y');
     });
   });
 });

--- a/packages/bpk-scrim-utils/src/scroll-utils-test.ts
+++ b/packages/bpk-scrim-utils/src/scroll-utils-test.ts
@@ -38,7 +38,7 @@ describe('scroll-utils', () => {
 
   beforeEach(() => {
     resetBodyStyles();
-    // reset the module-level scrollOffset by restoring scroll at 0
+    // reset the module-level scrollOffset to 0 before each test
     Object.defineProperty(window, 'pageYOffset', {
       configurable: true,
       value: 0,
@@ -107,7 +107,7 @@ describe('scroll-utils', () => {
   });
 
   describe('unlockScroll', () => {
-    it('clears overflow, padding-right, touch-action and overscroll-behavior', () => {
+    it('clears overflow and padding-right, restores touch-action and overscroll-behavior to pre-lock values', () => {
       lockScroll();
       unlockScroll();
 
@@ -115,6 +115,17 @@ describe('scroll-utils', () => {
       expect(document.body.style.paddingRight).toBe('');
       expect(document.body.style.touchAction).toBe('');
       expect(document.body.style.overscrollBehavior).toBe('');
+    });
+
+    it('restores host-app inline touch-action and overscroll-behavior after unlock', () => {
+      document.body.style.touchAction = 'manipulation';
+      document.body.style.overscrollBehavior = 'none';
+
+      lockScroll();
+      unlockScroll();
+
+      expect(document.body.style.touchAction).toBe('manipulation');
+      expect(document.body.style.overscrollBehavior).toBe('none');
     });
   });
 });

--- a/packages/bpk-scrim-utils/src/scroll-utils.tsx
+++ b/packages/bpk-scrim-utils/src/scroll-utils.tsx
@@ -77,6 +77,10 @@ export const fixBody = () => {
     return;
   }
 
+  // Set top before position:fixed so the browser doesn't jump to scrollY=0.
+  // scrollOffset is captured by storeScroll() immediately before this call.
+  body.style.top = `-${scrollOffset}px`;
+  body.style.width = '100%';
   body.style.position = 'fixed';
 };
 
@@ -88,6 +92,8 @@ export const unfixBody = () => {
   }
 
   body.style.position = '';
+  body.style.top = '';
+  body.style.width = '';
 };
 
 export const lockScroll = () => {
@@ -101,6 +107,11 @@ export const lockScroll = () => {
 
   body.style.overflow = 'hidden';
   body.style.paddingRight = paddingRight;
+  // On iOS, `overflow: hidden` alone does not prevent touch-scroll or rubber-band
+  // overscroll on the body. `touch-action: none` blocks scroll gestures and
+  // `overscroll-behavior: contain` stops overscroll chaining to the viewport.
+  body.style.touchAction = 'none';
+  body.style.overscrollBehavior = 'contain';
 };
 
 export const unlockScroll = () => {
@@ -112,4 +123,6 @@ export const unlockScroll = () => {
 
   body.style.overflow = '';
   body.style.paddingRight = '';
+  body.style.touchAction = '';
+  body.style.overscrollBehavior = '';
 };

--- a/packages/bpk-scrim-utils/src/scroll-utils.tsx
+++ b/packages/bpk-scrim-utils/src/scroll-utils.tsx
@@ -98,6 +98,12 @@ export const unfixBody = () => {
   body.style.width = '';
 };
 
+// Locks background scroll on the body. Safe to call on all platforms.
+//
+// Sets `overflow: hidden` to prevent the page behind a modal from scrolling,
+// compensates for the hidden scrollbar with `padding-right`, and applies
+// `overscroll-behavior: contain` to stop scroll chaining from modal content to
+// the viewport. None of these block user touch gestures.
 export const lockScroll = () => {
   const body = getBodyElement();
 
@@ -107,15 +113,10 @@ export const lockScroll = () => {
 
   const paddingRight = getScrollBarWidth();
 
-  previousTouchAction = body.style.touchAction;
   previousOverscrollBehavior = body.style.overscrollBehavior;
 
   body.style.overflow = 'hidden';
   body.style.paddingRight = paddingRight;
-  // On iOS, `overflow: hidden` alone does not prevent touch-scroll or rubber-band
-  // overscroll on the body. `touch-action: none` blocks scroll gestures and
-  // `overscroll-behavior: contain` stops overscroll chaining to the viewport.
-  body.style.touchAction = 'none';
   body.style.overscrollBehavior = 'contain';
 };
 
@@ -128,6 +129,33 @@ export const unlockScroll = () => {
 
   body.style.overflow = '';
   body.style.paddingRight = '';
-  body.style.touchAction = previousTouchAction;
   body.style.overscrollBehavior = previousOverscrollBehavior;
+};
+
+// Blocks touch gestures on the body via `touch-action: none`. iOS-only.
+//
+// On iOS Safari, `overflow: hidden` alone does not stop touch-scroll or
+// rubber-band overscroll on the body — `touch-action: none` is needed. Do NOT
+// call this on non-iOS platforms: `touch-action` combines with descendants'
+// effective touch-action, so setting `none` on body blocks touch scrolling in
+// any modal content that doesn't explicitly declare its own `touch-action`.
+export const lockTouchAction = () => {
+  const body = getBodyElement();
+
+  if (!body) {
+    return;
+  }
+
+  previousTouchAction = body.style.touchAction;
+  body.style.touchAction = 'none';
+};
+
+export const unlockTouchAction = () => {
+  const body = getBodyElement();
+
+  if (!body) {
+    return;
+  }
+
+  body.style.touchAction = previousTouchAction;
 };

--- a/packages/bpk-scrim-utils/src/scroll-utils.tsx
+++ b/packages/bpk-scrim-utils/src/scroll-utils.tsx
@@ -17,6 +17,8 @@
  */
 
 let scrollOffset = 0;
+let previousTouchAction = '';
+let previousOverscrollBehavior = '';
 
 const getWindow = () => (typeof window !== 'undefined' ? window : null);
 
@@ -105,6 +107,9 @@ export const lockScroll = () => {
 
   const paddingRight = getScrollBarWidth();
 
+  previousTouchAction = body.style.touchAction;
+  previousOverscrollBehavior = body.style.overscrollBehavior;
+
   body.style.overflow = 'hidden';
   body.style.paddingRight = paddingRight;
   // On iOS, `overflow: hidden` alone does not prevent touch-scroll or rubber-band
@@ -123,6 +128,6 @@ export const unlockScroll = () => {
 
   body.style.overflow = '';
   body.style.paddingRight = '';
-  body.style.touchAction = '';
-  body.style.overscrollBehavior = '';
+  body.style.touchAction = previousTouchAction;
+  body.style.overscrollBehavior = previousOverscrollBehavior;
 };

--- a/packages/bpk-scrim-utils/src/scroll-utils.tsx
+++ b/packages/bpk-scrim-utils/src/scroll-utils.tsx
@@ -16,9 +16,19 @@
  * limitations under the License.
  */
 
+// Module-level state is intentional: the <body> element is a global singleton,
+// so nested scrims must coordinate through a shared counter. Each lock/unlock
+// pair maintains its own depth counter so the "save original value, apply
+// locked value" logic only runs on the 0↔1 transition. Inner nested calls are
+// no-ops that simply bump the counter. This prevents the inner scrim from
+// overwriting the outer scrim's saved "pre-lock" value — see the Nested story
+// in BpkModal.stories.tsx.
 let scrollOffset = 0;
-let previousTouchAction = '';
-let previousOverscrollBehavior = '';
+let savedTouchAction = '';
+let savedOverscrollBehavior = '';
+let fixBodyDepth = 0;
+let lockScrollDepth = 0;
+let lockTouchActionDepth = 0;
 
 const getWindow = () => (typeof window !== 'undefined' ? window : null);
 
@@ -57,6 +67,13 @@ const getScrollBarWidth = () => {
 };
 
 export const storeScroll = () => {
+  // Skip while an outer scrim already fixed the body: pageYOffset reads 0 once
+  // the body is position:fixed, so capturing it would clobber the outer
+  // scroll position and cause restoreScroll to jump back to the top on close.
+  if (fixBodyDepth > 0) {
+    return;
+  }
+
   const window = getWindow();
 
   if (window) {
@@ -79,31 +96,33 @@ export const fixBody = () => {
     return;
   }
 
-  // Set top before position:fixed so the browser doesn't jump to scrollY=0.
-  // scrollOffset is captured by storeScroll() immediately before this call.
-  body.style.top = `-${scrollOffset}px`;
-  body.style.width = '100%';
-  body.style.position = 'fixed';
+  if (fixBodyDepth === 0) {
+    // Set top before position:fixed so the browser doesn't jump to scrollY=0.
+    // scrollOffset is captured by storeScroll() immediately before this call.
+    body.style.top = `-${scrollOffset}px`;
+    body.style.width = '100%';
+    body.style.position = 'fixed';
+  }
+  fixBodyDepth += 1;
 };
 
 export const unfixBody = () => {
   const body = getBodyElement();
 
-  if (!body) {
+  if (!body || fixBodyDepth === 0) {
     return;
   }
 
-  body.style.position = '';
-  body.style.top = '';
-  body.style.width = '';
+  fixBodyDepth -= 1;
+  if (fixBodyDepth === 0) {
+    body.style.position = '';
+    body.style.top = '';
+    body.style.width = '';
+  }
 };
 
 // Locks background scroll on the body. Safe to call on all platforms.
-//
-// Sets `overflow: hidden` to prevent the page behind a modal from scrolling,
-// compensates for the hidden scrollbar with `padding-right`, and applies
-// `overscroll-behavior: contain` to stop scroll chaining from modal content to
-// the viewport. None of these block user touch gestures.
+// None of these block user touch gestures.
 export const lockScroll = () => {
   const body = getBodyElement();
 
@@ -111,25 +130,28 @@ export const lockScroll = () => {
     return;
   }
 
-  const paddingRight = getScrollBarWidth();
-
-  previousOverscrollBehavior = body.style.overscrollBehavior;
-
-  body.style.overflow = 'hidden';
-  body.style.paddingRight = paddingRight;
-  body.style.overscrollBehavior = 'contain';
+  if (lockScrollDepth === 0) {
+    savedOverscrollBehavior = body.style.overscrollBehavior;
+    body.style.overflow = 'hidden';
+    body.style.paddingRight = getScrollBarWidth();
+    body.style.overscrollBehavior = 'contain';
+  }
+  lockScrollDepth += 1;
 };
 
 export const unlockScroll = () => {
   const body = getBodyElement();
 
-  if (!body) {
+  if (!body || lockScrollDepth === 0) {
     return;
   }
 
-  body.style.overflow = '';
-  body.style.paddingRight = '';
-  body.style.overscrollBehavior = previousOverscrollBehavior;
+  lockScrollDepth -= 1;
+  if (lockScrollDepth === 0) {
+    body.style.overflow = '';
+    body.style.paddingRight = '';
+    body.style.overscrollBehavior = savedOverscrollBehavior;
+  }
 };
 
 // Blocks touch gestures on the body via `touch-action: none`. iOS-only.
@@ -146,16 +168,22 @@ export const lockTouchAction = () => {
     return;
   }
 
-  previousTouchAction = body.style.touchAction;
-  body.style.touchAction = 'none';
+  if (lockTouchActionDepth === 0) {
+    savedTouchAction = body.style.touchAction;
+    body.style.touchAction = 'none';
+  }
+  lockTouchActionDepth += 1;
 };
 
 export const unlockTouchAction = () => {
   const body = getBodyElement();
 
-  if (!body) {
+  if (!body || lockTouchActionDepth === 0) {
     return;
   }
 
-  body.style.touchAction = previousTouchAction;
+  lockTouchActionDepth -= 1;
+  if (lockTouchActionDepth === 0) {
+    body.style.touchAction = savedTouchAction;
+  }
 };

--- a/packages/bpk-scrim-utils/src/withScrim-test.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim-test.tsx
@@ -122,11 +122,6 @@ describe('BpkScrim', () => {
     beforeEach(() => {
       TestComponent = () => <div>TestComponent</div>;
       Component = withScrim(TestComponent);
-      jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-      jest.useRealTimers();
     });
 
     it('should mount correctly when is iPhone', () => {
@@ -143,12 +138,32 @@ describe('BpkScrim', () => {
           isIphone
         />,
       );
-      jest.runAllTimers();
       expect(storeScroll).toHaveBeenCalled();
       expect(lockScroll).toHaveBeenCalled();
       expect(fixBody).toHaveBeenCalled();
       expect(focusStore.storeFocus).toHaveBeenCalled();
       expect(mockSetAttribute).toHaveBeenCalledWith('aria-hidden', 'true');
+    });
+
+    it('should call storeScroll and fixBody synchronously before lockScroll on iPhone', () => {
+      render(
+        <Component
+          onClose={jest.fn()}
+          getApplicationElement={jest.fn(() => ({
+            style: {},
+            setAttribute: jest.fn(),
+            removeAttribute: jest.fn(),
+          }))}
+          isIphone
+        />,
+      );
+      const storeScrollOrder = (storeScroll as jest.Mock).mock
+        .invocationCallOrder[0];
+      const fixBodyOrder = (fixBody as jest.Mock).mock.invocationCallOrder[0];
+      const lockScrollOrder = (lockScroll as jest.Mock).mock
+        .invocationCallOrder[0];
+      expect(storeScrollOrder).toBeLessThan(fixBodyOrder);
+      expect(fixBodyOrder).toBeLessThan(lockScrollOrder);
     });
 
     it('should mount correctly when is not iPhone', () => {
@@ -165,7 +180,6 @@ describe('BpkScrim', () => {
           isIphone={false}
         />,
       );
-      jest.runAllTimers();
       expect(lockScroll).toHaveBeenCalled();
       expect(focusStore.storeFocus).toHaveBeenCalled();
       expect(storeScroll).not.toHaveBeenCalled();
@@ -183,7 +197,7 @@ describe('BpkScrim', () => {
       Component = withScrim(TestComponent);
     });
 
-    it('should unmount correctly when is iPhone', async () => {
+    it('should unmount correctly when is iPhone', () => {
       const mockSetAttribute = jest.fn();
       const mockRemoveAttribute = jest.fn();
       const { unmount } = render(
@@ -201,11 +215,31 @@ describe('BpkScrim', () => {
 
       expect(unlockScroll).toHaveBeenCalled();
       expect(unfixBody).toHaveBeenCalled();
+      expect(restoreScroll).toHaveBeenCalled();
       expect(focusStore.restoreFocus).toHaveBeenCalled();
       expect(focusScope.unscopeFocus).toHaveBeenCalled();
       expect(mockRemoveAttribute).toHaveBeenCalledWith('aria-hidden');
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(restoreScroll).toHaveBeenCalled();
+    });
+
+    it('should call unfixBody before restoreScroll on iPhone unmount', () => {
+      const { unmount } = render(
+        <Component
+          onClose={jest.fn()}
+          getApplicationElement={jest.fn(() => ({
+            style: {},
+            setAttribute: jest.fn(),
+            removeAttribute: jest.fn(),
+          }))}
+          isIphone
+        />,
+      );
+      unmount();
+
+      const unfixBodyOrder = (unfixBody as jest.Mock).mock
+        .invocationCallOrder[0];
+      const restoreScrollOrder = (restoreScroll as jest.Mock).mock
+        .invocationCallOrder[0];
+      expect(unfixBodyOrder).toBeLessThan(restoreScrollOrder);
     });
 
     it('should unmount correctly when is not iPhone', () => {

--- a/packages/bpk-scrim-utils/src/withScrim-test.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim-test.tsx
@@ -25,10 +25,12 @@ import focusStore from './focusStore';
 import {
   fixBody,
   lockScroll,
+  lockTouchAction,
   restoreScroll,
   storeScroll,
   unfixBody,
   unlockScroll,
+  unlockTouchAction,
 } from './scroll-utils';
 import withScrim from './withScrim';
 
@@ -50,9 +52,11 @@ jest.mock('./focusStore', () => ({
 
 jest.mock('./scroll-utils', () => ({
   lockScroll: jest.fn(),
+  lockTouchAction: jest.fn(),
   restoreScroll: jest.fn(),
   storeScroll: jest.fn(),
   unlockScroll: jest.fn(),
+  unlockTouchAction: jest.fn(),
   fixBody: jest.fn(),
   unfixBody: jest.fn(),
 }));
@@ -141,6 +145,7 @@ describe('BpkScrim', () => {
       expect(storeScroll).toHaveBeenCalled();
       expect(lockScroll).toHaveBeenCalled();
       expect(fixBody).toHaveBeenCalled();
+      expect(lockTouchAction).toHaveBeenCalled();
       expect(focusStore.storeFocus).toHaveBeenCalled();
       expect(mockSetAttribute).toHaveBeenCalledWith('aria-hidden', 'true');
     });
@@ -184,6 +189,7 @@ describe('BpkScrim', () => {
       expect(focusStore.storeFocus).toHaveBeenCalled();
       expect(storeScroll).not.toHaveBeenCalled();
       expect(fixBody).not.toHaveBeenCalled();
+      expect(lockTouchAction).not.toHaveBeenCalled();
       expect(mockSetAttribute).toHaveBeenCalledWith('aria-hidden', 'true');
     });
   });
@@ -216,6 +222,7 @@ describe('BpkScrim', () => {
       expect(unlockScroll).toHaveBeenCalled();
       expect(unfixBody).toHaveBeenCalled();
       expect(restoreScroll).toHaveBeenCalled();
+      expect(unlockTouchAction).toHaveBeenCalled();
       expect(focusStore.restoreFocus).toHaveBeenCalled();
       expect(focusScope.unscopeFocus).toHaveBeenCalled();
       expect(mockRemoveAttribute).toHaveBeenCalledWith('aria-hidden');
@@ -260,6 +267,7 @@ describe('BpkScrim', () => {
       expect(unlockScroll).toHaveBeenCalled();
       expect(restoreScroll).not.toHaveBeenCalled();
       expect(unfixBody).not.toHaveBeenCalled();
+      expect(unlockTouchAction).not.toHaveBeenCalled();
       expect(focusStore.restoreFocus).toHaveBeenCalled();
       expect(focusScope.unscopeFocus).toHaveBeenCalled();
       expect(mockRemoveAttribute).toHaveBeenCalledWith('aria-hidden');

--- a/packages/bpk-scrim-utils/src/withScrim.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim.tsx
@@ -86,7 +86,7 @@ const withScrim = <P extends object>(
 
       /**
        * iPhones & iPads need to have a fixed body and scrolling stored to prevent some iOS
-       * specific issues occuring. iOS Safari does not prevent scrolling on the underlying
+       * specific issues occurring. iOS Safari does not prevent scrolling on the underlying
        * content — without these fixes users can scroll below a modal or dialog that uses
        * withScrim. See: https://markus.oberlehner.net/blog/simple-solution-to-prevent-body-scrolling-on-ios/
        *

--- a/packages/bpk-scrim-utils/src/withScrim.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim.tsx
@@ -84,33 +84,25 @@ const withScrim = <P extends object>(
       const { getApplicationElement, isIpad, isIphone } = this.props;
       const applicationElement = getApplicationElement();
 
-      requestAnimationFrame(() => {
-        /**
-         * iPhones & iPads need to have a fixed body
-         * and scrolling stored to prevent some iOS specific issues occuring
-         *
-         * Issue description:
-         * iOS safari does not prevent scrolling on the underlying content.
-         * Without the below fixes this results in users being able to scroll below any modal or dialog that uses withScrim.
-         *
-         * The fixes can be summaried here: https://markus.oberlehner.net/blog/simple-solution-to-prevent-body-scrolling-on-ios/
-         *
-         * The most dangerous of the fixes below is the fixBody, this function applies changes to the <body> style.
-         * This has the potential to override any custom styles already applied. The assumption here is that no one internally is making these changes to body.
-         *
-         * There is a corresponding set of functions in the componentWillUnmount block that deals with undoing these changes.
-         */
-        if (isIphone || isIpad) {
-          storeScroll();
-          fixBody();
-        }
-        /**
-         * lockScroll and the associated unlockScroll is how we control the scroll behaviour of the application when the scrim is active.
-         * The desired behaviour is to prevent the user from scrolling content behind the scrim. The above iOS fixes are in place because lockScroll alone does not solve due to iOS specific issues.
-         */
-
-        lockScroll();
-      });
+      /**
+       * iPhones & iPads need to have a fixed body and scrolling stored to prevent some iOS
+       * specific issues occuring. iOS Safari does not prevent scrolling on the underlying
+       * content — without these fixes users can scroll below a modal or dialog that uses
+       * withScrim. See: https://markus.oberlehner.net/blog/simple-solution-to-prevent-body-scrolling-on-ios/
+       *
+       * The most dangerous of the fixes below is fixBody — it applies changes to the <body>
+       * style and has the potential to override any custom styles already applied. The
+       * assumption here is that no one internally is making these changes to body.
+       *
+       * These must run synchronously (not inside requestAnimationFrame) so the body is
+       * locked before the first paint, otherwise a visible scroll-jump occurs on open.
+       * componentWillUnmount has a corresponding set of calls that undo these changes.
+       */
+      if (isIphone || isIpad) {
+        storeScroll();
+        fixBody();
+      }
+      lockScroll();
 
       if (applicationElement) {
         applicationElement.setAttribute('aria-hidden', 'true');
@@ -126,8 +118,10 @@ const withScrim = <P extends object>(
       const applicationElement = getApplicationElement();
 
       if (isIphone || isIpad) {
-        setTimeout(restoreScroll, 0);
+        // unfixBody before restoreScroll: restoring scroll while body is still fixed
+        // prevents a second visual jump on close.
         unfixBody();
+        restoreScroll();
       }
       unlockScroll();
 

--- a/packages/bpk-scrim-utils/src/withScrim.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim.tsx
@@ -32,10 +32,12 @@ import focusStore from './focusStore';
 import {
   fixBody,
   lockScroll,
+  lockTouchAction,
   restoreScroll,
   storeScroll,
   unfixBody,
   unlockScroll,
+  unlockTouchAction,
 } from './scroll-utils';
 
 import STYLES from './bpk-scrim-content.module.scss';
@@ -101,6 +103,7 @@ const withScrim = <P extends object>(
       if (isIphone || isIpad) {
         storeScroll();
         fixBody();
+        lockTouchAction();
       }
       lockScroll();
 
@@ -122,6 +125,7 @@ const withScrim = <P extends object>(
         // prevents a second visual jump on close.
         unfixBody();
         restoreScroll();
+        unlockTouchAction();
       }
       unlockScroll();
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remove `requestAnimationFrame` / `setTimeout` wrappers in `withScrim` so that `storeScroll`, `fixBody`, and `lockScroll` run synchronously on mount. This ensures the body is locked before the first paint, eliminating the visible scroll-jump when opening a modal on iOS. On unmount, `unfixBody` is now called before `restoreScroll` to prevent a second visual jump on close. `lockScroll` also gains `touch-action: none` and `overscroll-behavior: contain` to block iOS rubber-band overscroll.

**Before**

https://github.com/user-attachments/assets/317fa87c-4bfa-451f-86e9-8636a9e92ed6

**After**

https://github.com/user-attachments/assets/184ac1eb-0b64-436e-9919-55a8e11361b8


Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here