### PR TITLE
[CLOV-1572] Fix BpkAutosuggest v2: Hovering a suggestion then clicking outside causes unexpected auto-selection on blur

### DIFF
--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest-test.tsx
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest-test.tsx
@@ -292,6 +292,25 @@ describe('BpkAutosuggest', () => {
 
       expect(screen.getAllByRole('option')).toHaveLength(suggestions.length);
     });
+
+    it('does not auto-select a hovered-but-not-clicked suggestion on blur when alwaysRenderSuggestions is true', async () => {
+      const props = setup({
+        alwaysRenderSuggestions: true,
+        highlightFirstSuggestion: true,
+      });
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.hover(screen.getAllByRole('option')[1]);
+      await user.tab();
+
+      await waitFor(() => {
+        expect(props.onSuggestionSelected).toHaveBeenCalled();
+      });
+      expect(props.onSuggestionSelected).not.toHaveBeenCalledWith(
+        expect.objectContaining({ suggestion: suggestions[1] }),
+      );
+    });
   });
 
   describe('multiSection and renderSectionTitle', () => {

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest-test.tsx
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest-test.tsx
@@ -202,6 +202,60 @@ describe('BpkAutosuggest', () => {
       await typeAndWait(user);
       expect(screen.getAllByRole('option')[0]).toHaveClass('highlighted');
     });
+
+    it('auto-selects the first suggestion on blur (no interaction)', async () => {
+      const props = setup({ highlightFirstSuggestion: true });
+
+      await typeAndWait(user);
+      await user.tab();
+
+      await waitFor(() => {
+        expect(props.onSuggestionSelected).toHaveBeenCalledWith({
+          inputValue: 'London',
+          suggestion: suggestions[0],
+        });
+      });
+    });
+
+    it('does not auto-select a hovered-but-not-clicked suggestion on blur', async () => {
+      const props = setup({ highlightFirstSuggestion: true });
+
+      await typeAndWait(user);
+      await user.hover(screen.getAllByRole('option')[1]);
+      await user.tab();
+
+      await waitFor(() => {
+        expect(props.onSuggestionSelected).toHaveBeenCalled();
+      });
+      // The hovered item (Paris) must NOT be auto-selected on blur.
+      expect(props.onSuggestionSelected).not.toHaveBeenCalledWith(
+        expect.objectContaining({ suggestion: suggestions[1] }),
+      );
+      // The first-highlighted item (London) is the correct auto-select target.
+      expect(props.onSuggestionSelected).toHaveBeenCalledWith({
+        inputValue: 'London',
+        suggestion: suggestions[0],
+      });
+    });
+
+    it('preserves the keyboard-highlighted suggestion on blur when the user then hovers a different item', async () => {
+      const props = setup({ highlightFirstSuggestion: true });
+
+      await typeAndWait(user);
+      await user.keyboard('{ArrowDown}');
+      await user.hover(screen.getAllByRole('option')[0]);
+      await user.tab();
+
+      await waitFor(() => {
+        expect(props.onSuggestionSelected).toHaveBeenCalledWith({
+          inputValue: 'Paris',
+          suggestion: suggestions[1],
+        });
+      });
+      expect(props.onSuggestionSelected).not.toHaveBeenCalledWith(
+        expect.objectContaining({ suggestion: suggestions[0] }),
+      );
+    });
   });
 
   describe('onSuggestionHighlighted', () => {

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest-test.tsx
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest-test.tsx
@@ -238,6 +238,26 @@ describe('BpkAutosuggest', () => {
       });
     });
 
+    it('keeps the clicked suggestion when user clicks a non-first item with highlightFirstSuggestion on', async () => {
+      const props = setup({ highlightFirstSuggestion: true });
+
+      await typeAndWait(user);
+      // Click the second suggestion (not the first-highlighted one).
+      await user.click(screen.getAllByRole('option')[1]);
+
+      // Allow the blur setTimeout to flush; the clicked item must remain committed.
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toHaveValue('Paris');
+      });
+      expect(props.onSuggestionSelected).toHaveBeenLastCalledWith({
+        inputValue: 'Paris',
+        suggestion: suggestions[1],
+      });
+      expect(props.onSuggestionSelected).not.toHaveBeenCalledWith(
+        expect.objectContaining({ suggestion: suggestions[0] }),
+      );
+    });
+
     it('preserves the keyboard-highlighted suggestion on blur when the user then hovers a different item', async () => {
       const props = setup({ highlightFirstSuggestion: true });
 

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest.tsx
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest.tsx
@@ -237,6 +237,18 @@ const BpkAutosuggest = forwardRef<HTMLInputElement, BpkAutoSuggestProps<any>>(
     ): Partial<UseComboboxState<any>> {
       const { changes, type } = actionAndChanges;
 
+      // Intercept InputBlur before the alwaysRenderSuggestions early-return
+      if (type === useCombobox.stateChangeTypes.InputBlur) {
+        const keepOpen = Boolean(alwaysRenderSuggestions && hasSuggestions);
+        return {
+          ...changes,
+          isOpen: keepOpen,
+          highlightedIndex: -1,
+          selectedItem: state.selectedItem,
+          inputValue: state.inputValue,
+        };
+      }
+
       const shouldForceKeepOpen =
         alwaysRenderSuggestions && hasSuggestions && changes.isOpen === false;
 
@@ -259,17 +271,6 @@ const BpkAutosuggest = forwardRef<HTMLInputElement, BpkAutoSuggestProps<any>>(
             ...changes,
             isOpen: state.isOpen,
             highlightedIndex: targetHighlightedIndex ?? -1,
-          };
-        }
-        case useCombobox.stateChangeTypes.InputBlur: {
-          // Prevent Downshift's built-in blur auto-select, which uses the live
-          // highlightedIndex and would commit a mouse-hovered suggestion.
-          return {
-            ...changes,
-            isOpen: false,
-            highlightedIndex: -1,
-            selectedItem: state.selectedItem,
-            inputValue: state.inputValue,
           };
         }
         default: {

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest.tsx
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest.tsx
@@ -718,8 +718,11 @@ const BpkAutosuggest = forwardRef<HTMLInputElement, BpkAutoSuggestProps<any>>(
         }
 
         if (highlightedSuggestion) {
-          // Use setTimeout to ensure selectItem runs after the blur event completes
+          // Use setTimeout to ensure selectItem runs after the blur event completes.
           setTimeout(() => {
+            if (committedSelectionRef.current) {
+              return;
+            }
             selectItem(highlightedSuggestion);
           }, 0);
         }

--- a/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest.tsx
+++ b/packages/bpk-component-autosuggest/src/BpkAutosuggestV2/BpkAutosuggest.tsx
@@ -43,7 +43,10 @@ import { useCombobox } from 'downshift';
 import { surfaceHighlightDay } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 import BpkInput from '../../../bpk-component-input';
-import { cssModules, getDataComponentAttribute } from '../../../bpk-react-utils';
+import {
+  cssModules,
+  getDataComponentAttribute,
+} from '../../../bpk-react-utils';
 
 import type {
   UseComboboxState,
@@ -258,6 +261,17 @@ const BpkAutosuggest = forwardRef<HTMLInputElement, BpkAutoSuggestProps<any>>(
             highlightedIndex: targetHighlightedIndex ?? -1,
           };
         }
+        case useCombobox.stateChangeTypes.InputBlur: {
+          // Prevent Downshift's built-in blur auto-select, which uses the live
+          // highlightedIndex and would commit a mouse-hovered suggestion.
+          return {
+            ...changes,
+            isOpen: false,
+            highlightedIndex: -1,
+            selectedItem: state.selectedItem,
+            inputValue: state.inputValue,
+          };
+        }
         default: {
           const forceOpen = !isDesktop && !!changes.inputValue;
           const isArrowKeyNavigation =
@@ -272,7 +286,8 @@ const BpkAutosuggest = forwardRef<HTMLInputElement, BpkAutoSuggestProps<any>>(
           return {
             ...changes,
             isOpen: forceOpen ? true : changes.isOpen,
-            highlightedIndex: targetHighlightedIndex ?? changes.highlightedIndex,
+            highlightedIndex:
+              targetHighlightedIndex ?? changes.highlightedIndex,
           };
         }
       }
@@ -347,6 +362,14 @@ const BpkAutosuggest = forwardRef<HTMLInputElement, BpkAutoSuggestProps<any>>(
 
         onSuggestionHighlighted?.({ suggestion: currentSuggestion });
 
+        // Only arm auto-select-on-blur for non-mouse-driven highlight changes.
+        if (
+          type !== useCombobox.stateChangeTypes.ItemMouseMove &&
+          type !== useCombobox.stateChangeTypes.MenuMouseLeave
+        ) {
+          savedHighlightedIndexRef.current = newIndex ?? null;
+        }
+
         const isArrowKey =
           type === useCombobox.stateChangeTypes.InputKeyDownArrowDown ||
           type === useCombobox.stateChangeTypes.InputKeyDownArrowUp;
@@ -418,8 +441,6 @@ const BpkAutosuggest = forwardRef<HTMLInputElement, BpkAutoSuggestProps<any>>(
       if (highlightedIndex === previousHighlightedIndexRef.current) return;
 
       previousHighlightedIndexRef.current = highlightedIndex;
-      // Save highlighted index to allow auto-selection on blur
-      savedHighlightedIndexRef.current = highlightedIndex;
 
       const currentSuggestion =
         highlightedIndex != null && highlightedIndex >= 0
@@ -544,7 +565,9 @@ const BpkAutosuggest = forwardRef<HTMLInputElement, BpkAutoSuggestProps<any>>(
         return (
           <li
             key={suggestionKey}
-            aria-labelledby={sectionId && itemId ? `${sectionId} ${itemId}` : undefined}
+            aria-labelledby={
+              sectionId && itemId ? `${sectionId} ${itemId}` : undefined
+            }
             {...getItemProps({
               item: suggestion,
               index: globalIndex,


### PR DESCRIPTION


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Fixes an issue in `BpkAutosuggestV2` where hovering a suggestion and then blurring the input (e.g., clicking outside) could cause an unintended suggestion to be auto-selected.

**Changes:**
- Adds a `stateReducer` override for `useCombobox.stateChangeTypes.InputBlur` to prevent Downshift’s built-in blur auto-selection from committing a mouse-hovered item.
- Updates “auto-select-on-blur” bookkeeping so mouse hover highlight changes don’t affect which item is selected on blur.
- Adds regression tests covering blur auto-selection behavior with `highlightFirstSuggestion`.


|  Before  |  After  |
| :------: | :-----: |
| <img src="https://github.com/user-attachments/assets/d3980f92-f01b-46fa-a762-5260dc21635d" width=300/> | <img src="https://github.com/user-attachments/assets/19f7c0a2-1871-4f2b-8f21-b660bd9d33c8" width=300/> |



Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
