### PR TITLE
[NO-JIRA][BpkPopover] Fix focus outline on container div

### DIFF
--- a/packages/bpk-component-popover/src/BpkPopover.module.scss
+++ b/packages/bpk-component-popover/src/BpkPopover.module.scss
@@ -39,6 +39,10 @@ $arrow-size: tokens.bpk-spacing-lg();
     transition: opacity tokens.$bpk-duration-xs ease-in-out;
   }
 
+  &--container {
+    outline: none;
+  }
+
   &--appear {
     opacity: 0;
   }


### PR DESCRIPTION
## Summary

- `FloatingFocusManager` moves focus to the outer `.bpk-popover--container` `<div>` when a popover opens
- The inner `<section class="bpk-popover">` already had `outline: 0`, but the container `<div>` had no rule
- This caused the browser's default focus ring to appear on the container when using `@floating-ui/react` ≥ 0.27.x, which became more aggressive about moving focus to the container

## Fix

Added `&--container { outline: none; }` to `BpkPopover.module.scss`.

Issue
<img width="476" height="273" alt="image" src="https://github.com/user-attachments/assets/ee19a927-931f-4cd1-8441-67bbb88e7d23" />


## Test plan

- [ ] Open a popover — no focus outline should appear on the outer container
- [ ] Keyboard navigation still works correctly (focus moves into popover content)
- [ ] Run `npm test packages/bpk-component-popover`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)