### PR TITLE
[NO-JIRA][BpkChatbotInput] Add sm box-shadow to COMPOSER input type

### DIFF
--- a/packages/bpk-component-chatbot-input/src/BpkChatbotInput.module.scss
+++ b/packages/bpk-component-chatbot-input/src/BpkChatbotInput.module.scss
@@ -85,6 +85,8 @@
     );
 
     &--with-shadow {
+      box-shadow: tokens.$bpk-box-shadow-sm;
+
       &:focus-within {
         box-shadow: tokens.$bpk-box-shadow-lg;
       }


### PR DESCRIPTION
Adds `box-shadow: tokens.$bpk-box-shadow-sm` to the chatbot input at rest when `inputType` is `COMPOSER`. `CARS_COMPOSER` keeps its existing non-shadow behaviour because the `--with-shadow` modifier class is only applied for the `COMPOSER` type. The existing `lg` shadow on `:focus-within` is preserved.

Align with Figma:

| Code | Figma |
| --- | --- |
| <img width="399" height="113" alt="image" src="https://github.com/user-attachments/assets/9083dce9-b4f9-41ae-8968-6bedba51b859" /> | <img width="689" height="140" alt="image" src="https://github.com/user-attachments/assets/f111d785-56a8-4396-806f-0075deb67982" /> |


- [x] Component SCSS updated
- [x] No API changes; existing tests cover the type-based class application