### PR TITLE
[NO-JIRA][BpkPageIndicator] Add carousel variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@figma/code-connect": "^1.4.3",
         "@percy/cli": "^1.31.0",
         "@percy/storybook": "^9.1.0",
-        "@skyscanner/bpk-foundations-web": "^24.4.1",
+        "@skyscanner/bpk-foundations-web": "^24.5.0",
         "@skyscanner/bpk-svgs": "^20.11.0",
         "@skyscanner/eslint-config-skyscanner": "^22.6.0",
         "@skyscanner/stylelint-config-skyscanner": "^14.2.0",
@@ -5788,20 +5788,20 @@
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "24.4.1",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-24.4.1.tgz",
-      "integrity": "sha512-o0YBuWNzntVhKte2sjcLQNV09e8BXsqJE71ip8N/RdcPqOBlkQ3YgoVP20ViVKg46RnL9u3ykltrYirb433cbg==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-24.5.0.tgz",
+      "integrity": "sha512-Lft06khFD3XGOvENnmrNeJLm0nIjAy6lW1wyNGzVS947EU3hrLFTM7pAz5jO69lpPvjgorpiA9MrX+80IVg05A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@skyscanner/bpk-foundations-common": "^24.4.1",
+        "@skyscanner/bpk-foundations-common": "^24.5.0",
         "color": "^5.0.0"
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web/node_modules/@skyscanner/bpk-foundations-common": {
-      "version": "24.4.1",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-24.4.1.tgz",
-      "integrity": "sha512-d4ECD/c1Z7QebGeKruXKaUR93IIbrVdgJdGuFLq0tdEM7FC7NNSH/kbiH0eJv4/ENaZlU3VU2rIl5a+YWtHhmQ==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-24.5.0.tgz",
+      "integrity": "sha512-08NIg5Z8ZKZIRHujjXKyahiJAS64bq0mDSG4ITdBxIRcy0wMAxizhXNpLw8TmSPdluTaYYwxKYCJ2gOF2cngAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@figma/code-connect": "^1.4.3",
     "@percy/cli": "^1.31.0",
     "@percy/storybook": "^9.1.0",
-    "@skyscanner/bpk-foundations-web": "^24.4.1",
+    "@skyscanner/bpk-foundations-web": "^24.5.0",
     "@skyscanner/bpk-svgs": "^20.11.0",
     "@skyscanner/eslint-config-skyscanner": "^22.6.0",
     "@skyscanner/stylelint-config-skyscanner": "^14.2.0",

--- a/packages/bpk-component-carousel/src/BpkCarousel.module.scss
+++ b/packages/bpk-component-carousel/src/BpkCarousel.module.scss
@@ -35,4 +35,8 @@
     justify-content: center;
     overflow: clip;
   }
+
+  &__page-indicator-over-image--carousel {
+    bottom: tokens.bpk-spacing-base();
+  }
 }

--- a/packages/bpk-component-carousel/src/BpkCarousel.module.scss
+++ b/packages/bpk-component-carousel/src/BpkCarousel.module.scss
@@ -35,8 +35,4 @@
     justify-content: center;
     overflow: clip;
   }
-
-  &__page-indicator-over-image--carousel {
-    bottom: tokens.bpk-spacing-base();
-  }
 }

--- a/packages/bpk-component-carousel/src/BpkCarousel.module.scss
+++ b/packages/bpk-component-carousel/src/BpkCarousel.module.scss
@@ -33,6 +33,5 @@
     display: flex;
     margin: auto tokens.bpk-spacing-base();
     justify-content: center;
-    overflow: clip;
   }
 }

--- a/packages/bpk-component-carousel/src/BpkCarousel.stories.js
+++ b/packages/bpk-component-carousel/src/BpkCarousel.stories.js
@@ -57,7 +57,6 @@ const WithCarouselPageIndicatorExample = () => (
   >
     <BpkCarousel
       images={imagesList}
-      bottom={24}
       pageIndicatorVariant={VARIANT.carousel}
     />
   </div>

--- a/packages/bpk-component-carousel/src/BpkCarousel.stories.js
+++ b/packages/bpk-component-carousel/src/BpkCarousel.stories.js
@@ -33,9 +33,7 @@ const imagesList = imageUrls.map((url) => (
   </div>
 ));
 
-const DefaultExample = () => <BpkCarousel images={imagesList} bottom={16} />;
-
-const WithNavDesktopExample = () => (
+const DefaultExample = () => (
   <div
     style={{
       maxWidth: '800px',
@@ -67,8 +65,6 @@ const MixedExample = () => (
   <div>
     <DefaultExample />
     <br />
-    <WithNavDesktopExample />
-    <br />
     <WithCarouselPageIndicatorExample />
   </div>
 );
@@ -82,10 +78,6 @@ export default meta;
 
 export const Default = {
   render: () => <DefaultExample />,
-};
-
-export const WithNavDesktop = {
-  render: () => <WithNavDesktopExample />,
 };
 
 export const WithCarouselPageIndicator = {

--- a/packages/bpk-component-carousel/src/BpkCarousel.stories.js
+++ b/packages/bpk-component-carousel/src/BpkCarousel.stories.js
@@ -58,6 +58,7 @@ const WithCarouselPageIndicatorExample = () => (
     <BpkCarousel
       images={imagesList}
       pageIndicatorVariant={VARIANT.carousel}
+      bottom={16}
     />
   </div>
 );

--- a/packages/bpk-component-carousel/src/BpkCarousel.stories.js
+++ b/packages/bpk-component-carousel/src/BpkCarousel.stories.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import { VARIANT } from '../../bpk-component-page-indicator';
+
 import BpkCarousel from './BpkCarousel';
 
 const imageUrls = [
@@ -45,11 +47,29 @@ const WithNavDesktopExample = () => (
   </div>
 );
 
+const WithCarouselPageIndicatorExample = () => (
+  <div
+    style={{
+      maxWidth: '800px',
+      width: '100%',
+      margin: 'auto',
+    }}
+  >
+    <BpkCarousel
+      images={imagesList}
+      bottom={16}
+      pageIndicatorVariant={VARIANT.carousel}
+    />
+  </div>
+);
+
 const MixedExample = () => (
   <div>
     <DefaultExample />
     <br />
     <WithNavDesktopExample />
+    <br />
+    <WithCarouselPageIndicatorExample />
   </div>
 );
 
@@ -66,6 +86,10 @@ export const Default = {
 
 export const WithNavDesktop = {
   render: () => <WithNavDesktopExample />,
+};
+
+export const WithCarouselPageIndicator = {
+  render: () => <WithCarouselPageIndicatorExample />,
 };
 
 export const VisualTest = {

--- a/packages/bpk-component-carousel/src/BpkCarousel.stories.js
+++ b/packages/bpk-component-carousel/src/BpkCarousel.stories.js
@@ -57,7 +57,7 @@ const WithCarouselPageIndicatorExample = () => (
   >
     <BpkCarousel
       images={imagesList}
-      bottom={16}
+      bottom={24}
       pageIndicatorVariant={VARIANT.carousel}
     />
   </div>

--- a/packages/bpk-component-carousel/src/BpkCarousel.tsx
+++ b/packages/bpk-component-carousel/src/BpkCarousel.tsx
@@ -69,10 +69,7 @@ const BpkCarousel = ({
         onImageChanged={onImageChanged}
       />
       <div
-        className={getClassName(
-          'bpk-carousel__page-indicator-over-image',
-          pageIndicatorVariant === VARIANT.carousel && 'bpk-carousel__page-indicator-over-image--carousel',
-        )}
+        className={getClassName('bpk-carousel__page-indicator-over-image')}
         style={bottom ? {
           bottom
         } : undefined}

--- a/packages/bpk-component-carousel/src/BpkCarousel.tsx
+++ b/packages/bpk-component-carousel/src/BpkCarousel.tsx
@@ -69,7 +69,10 @@ const BpkCarousel = ({
         onImageChanged={onImageChanged}
       />
       <div
-        className={getClassName('bpk-carousel__page-indicator-over-image')}
+        className={getClassName(
+          'bpk-carousel__page-indicator-over-image',
+          pageIndicatorVariant === VARIANT.carousel && 'bpk-carousel__page-indicator-over-image--carousel',
+        )}
         style={bottom ? {
           bottom
         } : undefined}

--- a/packages/bpk-component-carousel/src/BpkCarousel.tsx
+++ b/packages/bpk-component-carousel/src/BpkCarousel.tsx
@@ -37,6 +37,7 @@ const BpkCarousel = ({
   images,
   initialImageIndex = 0,
   onImageChanged = null,
+  pageIndicatorVariant = VARIANT.overImageSpaced,
   }: Props) => {
   const [shownImageIndex, updateShownImageIndex] = useState(initialImageIndex);
   const imagesRef = useRef<Array<HTMLElement | null>>([]);
@@ -77,7 +78,7 @@ const BpkCarousel = ({
         <BpkPageIndicator
           currentIndex={shownImageIndex}
           totalIndicators={images.length}
-          variant={VARIANT.overImageSpaced}
+          variant={pageIndicatorVariant}
           indicatorLabel={accessibilityLabels.indicatorLabel ?? "Go to slide"}
           prevNavLabel={accessibilityLabels.prevNavLabel ?? "Previous slide"}
           nextNavLabel={accessibilityLabels.nextNavLabel ?? "Next slide"}

--- a/packages/bpk-component-carousel/src/BpkCarousel.tsx
+++ b/packages/bpk-component-carousel/src/BpkCarousel.tsx
@@ -38,10 +38,12 @@ const BpkCarousel = ({
   initialImageIndex = 0,
   onImageChanged = null,
   pageIndicatorVariant = VARIANT.overImageSpaced,
+  showPageIndicatorNav,
   }: Props) => {
   const [shownImageIndex, updateShownImageIndex] = useState(initialImageIndex);
   const imagesRef = useRef<Array<HTMLElement | null>>([]);
   const isDesktop = useMediaQuery(BREAKPOINTS.ABOVE_TABLET);
+  const showNav = showPageIndicatorNav ?? isDesktop;
 
   const handleIndicatorClick = (
     e: MouseEvent<HTMLButtonElement>,
@@ -82,8 +84,8 @@ const BpkCarousel = ({
           indicatorLabel={accessibilityLabels.indicatorLabel ?? "Go to slide"}
           prevNavLabel={accessibilityLabels.prevNavLabel ?? "Previous slide"}
           nextNavLabel={accessibilityLabels.nextNavLabel ?? "Next slide"}
-          showNav={isDesktop}
-          onClick={isDesktop ? handleIndicatorClick : () => {}}
+          showNav={showNav}
+          onClick={showNav ? handleIndicatorClick : () => {}}
         />
       </div>
     </div>

--- a/packages/bpk-component-carousel/src/BpkCarouselImage.module.scss
+++ b/packages/bpk-component-carousel/src/BpkCarouselImage.module.scss
@@ -31,6 +31,7 @@
   isolation: isolate;
 
   img {
+    display: block;
     max-width: 100%;
     max-height: 100%;
     object-fit: initial;

--- a/packages/bpk-component-carousel/src/types.ts
+++ b/packages/bpk-component-carousel/src/types.ts
@@ -18,6 +18,8 @@
 
 import type { ReactNode } from "react";
 
+import type { VARIANT } from '../../bpk-component-page-indicator';
+
 export type OnImageChangedHandler = ((shownImageIndex: number) => void) | null | undefined;
 
 export type AccessibilityLabels = {
@@ -25,6 +27,8 @@ export type AccessibilityLabels = {
   prevNavLabel?: string;
   nextNavLabel?: string;
 };
+
+export type PageIndicatorVariant = typeof VARIANT.overImageSpaced | typeof VARIANT.carousel;
 
 export type Props = {
   images: ReactNode[]
@@ -35,4 +39,5 @@ export type Props = {
   */
   bottom?: number;
   accessibilityLabels?: AccessibilityLabels;
+  pageIndicatorVariant?: PageIndicatorVariant;
 };

--- a/packages/bpk-component-carousel/src/types.ts
+++ b/packages/bpk-component-carousel/src/types.ts
@@ -40,4 +40,9 @@ export type Props = {
   bottom?: number;
   accessibilityLabels?: AccessibilityLabels;
   pageIndicatorVariant?: PageIndicatorVariant;
+  /**
+   * Force the page indicator's nav buttons on or off.
+   * When omitted, the nav buttons are shown on desktop breakpoints only.
+   */
+  showPageIndicatorNav?: boolean;
 };

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator-test.tsx
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator-test.tsx
@@ -19,7 +19,7 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import BpkPageIndicator from './BpkPageIndicator';
+import BpkPageIndicator, { VARIANT } from './BpkPageIndicator';
 
 import type { Props } from './BpkPageIndicator';
 
@@ -54,5 +54,17 @@ describe('BpkPageIndicator', () => {
 
     expect(screen.getByLabelText('Previous slide')).toBeTruthy();
     expect(screen.getByLabelText('Next slide')).toBeTruthy();
+  });
+
+  it('renders the carousel variant with enabled nav at the bounds and a full-width container', () => {
+    render(
+      <BpkPageIndicator {...props} variant={VARIANT.carousel} showNav />,
+    );
+
+    expect(screen.getByLabelText('Previous slide')).toBeEnabled();
+    expect(screen.getByLabelText('Next slide')).toBeEnabled();
+    expect(
+      document.querySelector('.bpk-page-indicator-fullWidth__container'),
+    ).toBeTruthy();
   });
 });

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -121,11 +121,5 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
     --bpk-button-secondary-on-dark-text-color: #{tokens.$bpk-text-primary-day};
     --bpk-button-secondary-on-dark-hover-text-color: #{tokens.$bpk-text-primary-day};
     --bpk-button-secondary-on-dark-active-text-color: #{tokens.$bpk-text-primary-day};
-
-    .bpk-button {
-      width: tokens.bpk-spacing-xxl();
-      min-height: tokens.bpk-spacing-xxl();
-      padding: tokens.bpk-spacing-md();
-    }
   }
 }

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -105,14 +105,14 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
 
   &__nav-carousel {
     --bpk-button-border-radius: 50%;
-    --bpk-button-secondary-on-dark-background-color: #{rgb(255, 255, 255, 0.5)};
-    --bpk-button-secondary-on-dark-hover-background-color: #{rgb(
+    --bpk-button-secondary-on-dark-background-color: #{rgba(255, 255, 255, 0.5)};
+    --bpk-button-secondary-on-dark-hover-background-color: #{rgba(
         255,
         255,
         255,
         0.8
       )};
-    --bpk-button-secondary-on-dark-active-background-color: #{rgb(
+    --bpk-button-secondary-on-dark-active-background-color: #{rgba(
         255,
         255,
         255,

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -121,5 +121,11 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
     --bpk-button-secondary-on-dark-text-color: #{tokens.$bpk-text-primary-day};
     --bpk-button-secondary-on-dark-hover-text-color: #{tokens.$bpk-text-primary-day};
     --bpk-button-secondary-on-dark-active-text-color: #{tokens.$bpk-text-primary-day};
+
+    .bpk-button {
+      width: tokens.bpk-spacing-xxl();
+      min-height: tokens.bpk-spacing-xxl();
+      padding: tokens.bpk-spacing-md();
+    }
   }
 }

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -105,19 +105,9 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
 
   &__nav-carousel {
     --bpk-button-border-radius: 50%;
-    --bpk-button-secondary-on-dark-background-color: #{rgba(255, 255, 255, 0.5)};
-    --bpk-button-secondary-on-dark-hover-background-color: #{rgba(
-        255,
-        255,
-        255,
-        0.8
-      )};
-    --bpk-button-secondary-on-dark-active-background-color: #{rgba(
-        255,
-        255,
-        255,
-        0.8
-      )};
+    --bpk-button-secondary-on-dark-background-color: #{tokens.$bpk-private-page-indicator-button-carousel-normal-background-day};
+    --bpk-button-secondary-on-dark-hover-background-color: #{tokens.$bpk-private-page-indicator-button-carousel-pressed-background-day};
+    --bpk-button-secondary-on-dark-active-background-color: #{tokens.$bpk-private-page-indicator-button-carousel-pressed-background-day};
     --bpk-button-secondary-on-dark-text-color: #{tokens.$bpk-text-primary-day};
     --bpk-button-secondary-on-dark-hover-text-color: #{tokens.$bpk-text-primary-day};
     --bpk-button-secondary-on-dark-active-text-color: #{tokens.$bpk-text-primary-day};

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -83,7 +83,8 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
     }
 
     &--overImage,
-    &--overImageSpaced {
+    &--overImageSpaced,
+    &--carousel {
       background-color: tokens.$bpk-line-on-dark-day;
     }
 
@@ -94,10 +95,31 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
       }
 
       &-overImage,
-      &-overImageSpaced {
+      &-overImageSpaced,
+      &-carousel {
         background-color: tokens.$bpk-text-on-dark-day;
         pointer-events: none;
       }
     }
+  }
+
+  &__nav-carousel {
+    --bpk-button-border-radius: 50%;
+    --bpk-button-secondary-on-dark-background-color: #{rgb(255, 255, 255, 0.5)};
+    --bpk-button-secondary-on-dark-hover-background-color: #{rgb(
+        255,
+        255,
+        255,
+        0.8
+      )};
+    --bpk-button-secondary-on-dark-active-background-color: #{rgb(
+        255,
+        255,
+        255,
+        0.8
+      )};
+    --bpk-button-secondary-on-dark-text-color: #{tokens.$bpk-text-primary-day};
+    --bpk-button-secondary-on-dark-hover-text-color: #{tokens.$bpk-text-primary-day};
+    --bpk-button-secondary-on-dark-active-text-color: #{tokens.$bpk-text-primary-day};
   }
 }

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -124,9 +124,13 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
   }
 
   &__nav-carousel-button {
+    display: inline-flex;
     width: tokens.bpk-spacing-xl();
+    height: tokens.bpk-spacing-xl();
     min-height: tokens.bpk-spacing-xl();
-    padding: tokens.bpk-spacing-md();
+    padding: 0;
+    justify-content: center;
+    align-items: center;
   }
 
   &--carousel {

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -122,4 +122,10 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
     --bpk-button-secondary-on-dark-hover-text-color: #{tokens.$bpk-text-primary-day};
     --bpk-button-secondary-on-dark-active-text-color: #{tokens.$bpk-text-primary-day};
   }
+
+  &__nav-carousel-button {
+    width: tokens.bpk-spacing-xxl();
+    min-height: tokens.bpk-spacing-xxl();
+    padding: tokens.bpk-spacing-md();
+  }
 }

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -124,8 +124,12 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
   }
 
   &__nav-carousel-button {
-    width: tokens.bpk-spacing-xxl();
-    min-height: tokens.bpk-spacing-xxl();
+    width: tokens.bpk-spacing-xl();
+    min-height: tokens.bpk-spacing-xl();
     padding: tokens.bpk-spacing-md();
+  }
+
+  &--carousel {
+    padding: tokens.bpk-spacing-base();
   }
 }

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -132,8 +132,4 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
     justify-content: center;
     align-items: center;
   }
-
-  &--carousel {
-    padding: tokens.bpk-spacing-base();
-  }
 }

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.stories.module.scss
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.stories.module.scss
@@ -22,6 +22,7 @@
     display: flex;
     width: 100%;
     height: 80 * tokens.$bpk-one-pixel-rem;
+    padding: tokens.bpk-spacing-base();
     justify-content: center;
     align-items: flex-end;
   }

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.stories.tsx
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.stories.tsx
@@ -103,26 +103,39 @@ const ThreePagesWithNavExample = () => (
   <PageIndicatorContainer totalIndicators={3} showNav />
 );
 
-const CarouselExample = () => (
-  <BpkBackgroundImage
-    aspectRatio={imageWidth / imageHeight}
-    style={{ width: imageWidth, height: imageHeight }}
-    imageStyle={{
-      backgroundRepeat: 'no-repeat',
-      backgroundSize: 'cover',
-      backgroundPosition: '50% 50%',
-    }}
-    src={image}
-  >
-    <div className={getClassName('bpk-page-indicator-examples__container')}>
-      <PageIndicatorContainer
-        totalIndicators={5}
-        variant={VARIANT.carousel}
-        showNav
-      />
-    </div>
-  </BpkBackgroundImage>
-);
+const CarouselExample = () => {
+  const totalIndicators = 5;
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  return (
+    <BpkBackgroundImage
+      aspectRatio={imageWidth / imageHeight}
+      style={{ width: imageWidth, height: imageHeight }}
+      imageStyle={{
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: 'cover',
+        backgroundPosition: '50% 50%',
+      }}
+      src={image}
+    >
+      <div className={getClassName('bpk-page-indicator-examples__container')}>
+        <BpkPageIndicator
+          currentIndex={currentIndex}
+          totalIndicators={totalIndicators}
+          variant={VARIANT.carousel}
+          showNav
+          indicatorLabel="Go to slide"
+          prevNavLabel="Previous slide"
+          nextNavLabel="Next slide"
+          onClick={(_e, index) => {
+            const wrapped = (index + totalIndicators) % totalIndicators;
+            setCurrentIndex(wrapped);
+          }}
+        />
+      </div>
+    </BpkBackgroundImage>
+  );
+};
 
 const VisualTestExample = () => (
   <>

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.stories.tsx
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.stories.tsx
@@ -103,6 +103,27 @@ const ThreePagesWithNavExample = () => (
   <PageIndicatorContainer totalIndicators={3} showNav />
 );
 
+const CarouselExample = () => (
+  <BpkBackgroundImage
+    aspectRatio={imageWidth / imageHeight}
+    style={{ width: imageWidth, height: imageHeight }}
+    imageStyle={{
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'cover',
+      backgroundPosition: '50% 50%',
+    }}
+    src={image}
+  >
+    <div className={getClassName('bpk-page-indicator-examples__container')}>
+      <PageIndicatorContainer
+        totalIndicators={5}
+        variant={VARIANT.carousel}
+        showNav
+      />
+    </div>
+  </BpkBackgroundImage>
+);
+
 const VisualTestExample = () => (
   <>
     <DefaultExample />
@@ -111,6 +132,7 @@ const VisualTestExample = () => (
     <WithNavExample />
     <WithNavOverImageSpacedExample />
     <ThreePagesWithNavExample />
+    <CarouselExample />
     <div style={{ width: '50%' }}>
       <WithNavExample />
     </div>
@@ -142,6 +164,10 @@ export const WithNav = {
 
 export const WithNavOverImageSpaced = {
   render: () => <WithNavOverImageSpacedExample />,
+};
+
+export const Carousel = {
+  render: () => <CarouselExample />,
 };
 
 export const VisualTest = {

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.tsx
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.tsx
@@ -96,6 +96,7 @@ const BpkPageIndicator = ({
         className={getClassName(
           'bpk-page-indicator',
           showNav && 'bpk-page-indicator__showNav',
+          variant === VARIANT.carousel && 'bpk-page-indicator--carousel',
         )} {...getDataComponentAttribute('PageIndicator')}
       >
         {showNav && (

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.tsx
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.tsx
@@ -33,7 +33,8 @@ const START_SCROLL_INDEX = Math.floor(DISPLAYED_TOTAL / 2);
 export const VARIANT = {
   default: 'default',
   overImage: 'overImage',
-  overImageSpaced: 'overImageSpaced'
+  overImageSpaced: 'overImageSpaced',
+  carousel: 'carousel',
 } as const;
 
 type Variant = (typeof VARIANT)[keyof typeof VARIANT];
@@ -89,7 +90,7 @@ const BpkPageIndicator = ({
 
   return (
     <div
-      className={variant === VARIANT.overImageSpaced ? getClassName('bpk-page-indicator-fullWidth__container') : className}
+      className={variant === VARIANT.overImageSpaced || variant === VARIANT.carousel ? getClassName('bpk-page-indicator-fullWidth__container') : className}
       aria-hidden={isInteractive ? 'false' : 'true'}
       data-testid="indicator-container"
     >
@@ -103,10 +104,11 @@ const BpkPageIndicator = ({
           <NavButton
             currentIndex={currentIndex}
             onClick={onClick}
-            disabled={variant === VARIANT.overImageSpaced ? totalIndicators <= 1 : currentIndex === 0 || totalIndicators <= 1}
+            disabled={variant === VARIANT.overImageSpaced || variant === VARIANT.carousel ? totalIndicators <= 1 : currentIndex === 0 || totalIndicators <= 1}
             direction={DIRECTIONS.PREV}
             ariaLabel={prevNavLabel}
-            type={variant === VARIANT.overImageSpaced ? BUTTON_TYPES.secondaryOnDark : BUTTON_TYPES.link}
+            variant={variant}
+            type={variant === VARIANT.overImageSpaced || variant === VARIANT.carousel ? BUTTON_TYPES.secondaryOnDark : BUTTON_TYPES.link}
           />
         )}
         <div className={getClassName('bpk-page-indicator__container')}>
@@ -151,10 +153,11 @@ const BpkPageIndicator = ({
           <NavButton
             currentIndex={currentIndex}
             onClick={onClick}
-            disabled={variant === VARIANT.overImageSpaced ? totalIndicators <= 1 : currentIndex === totalIndicators - 1 || totalIndicators <= 1 }
+            disabled={variant === VARIANT.overImageSpaced || variant === VARIANT.carousel ? totalIndicators <= 1 : currentIndex === totalIndicators - 1 || totalIndicators <= 1 }
             ariaLabel={nextNavLabel}
             direction={DIRECTIONS.NEXT}
-            type={variant === VARIANT.overImageSpaced ? BUTTON_TYPES.secondaryOnDark : BUTTON_TYPES.link}
+            variant={variant}
+            type={variant === VARIANT.overImageSpaced || variant === VARIANT.carousel ? BUTTON_TYPES.secondaryOnDark : BUTTON_TYPES.link}
           />
         )}
       </div>

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.tsx
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.tsx
@@ -22,6 +22,9 @@ import { BUTTON_TYPES } from '../../bpk-component-button';
 import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
 import NavButton, { DIRECTIONS } from './NavButton';
+import { VARIANT } from './common-types';
+
+import type { Variant } from './common-types';
 
 import STYLES from './BpkPageIndicator.module.scss';
 
@@ -30,14 +33,9 @@ const getClassName = cssModules(STYLES);
 const DISPLAYED_TOTAL = 5;
 const START_SCROLL_INDEX = Math.floor(DISPLAYED_TOTAL / 2);
 
-export const VARIANT = {
-  default: 'default',
-  overImage: 'overImage',
-  overImageSpaced: 'overImageSpaced',
-  carousel: 'carousel',
-} as const;
+export { VARIANT };
+export type { Variant };
 
-type Variant = (typeof VARIANT)[keyof typeof VARIANT];
 type Direction = (typeof DIRECTIONS)[keyof typeof DIRECTIONS];
 
 export type Props = {

--- a/packages/bpk-component-page-indicator/src/BpkPageIndicator.tsx
+++ b/packages/bpk-component-page-indicator/src/BpkPageIndicator.tsx
@@ -96,7 +96,6 @@ const BpkPageIndicator = ({
         className={getClassName(
           'bpk-page-indicator',
           showNav && 'bpk-page-indicator__showNav',
-          variant === VARIANT.carousel && 'bpk-page-indicator--carousel',
         )} {...getDataComponentAttribute('PageIndicator')}
       >
         {showNav && (

--- a/packages/bpk-component-page-indicator/src/NavButton.tsx
+++ b/packages/bpk-component-page-indicator/src/NavButton.tsx
@@ -19,7 +19,7 @@
 import type { MouseEvent } from 'react';
 
 import BpkButton, { BUTTON_TYPES } from '../../bpk-component-button';
-import { withButtonAlignment, withLargeButtonAlignment, withRtlSupport } from '../../bpk-component-icon';
+import { withLargeButtonAlignment, withRtlSupport } from '../../bpk-component-icon';
 import LeftArrowIcon from '../../bpk-component-icon/lg/chevron-left';
 import RightArrowIcon from '../../bpk-component-icon/lg/chevron-right';
 import SmallLeftArrowIcon from '../../bpk-component-icon/sm/chevron-left';
@@ -59,8 +59,8 @@ type Props = {
 
 const AlignedLeftArrowIcon = withLargeButtonAlignment(withRtlSupport(LeftArrowIcon));
 const AlignedRightArrowIcon = withLargeButtonAlignment(withRtlSupport(RightArrowIcon));
-const AlignedSmallLeftArrowIcon = withButtonAlignment(withRtlSupport(SmallLeftArrowIcon));
-const AlignedSmallRightArrowIcon = withButtonAlignment(withRtlSupport(SmallRightArrowIcon));
+const RtlSmallLeftArrowIcon = withRtlSupport(SmallLeftArrowIcon);
+const RtlSmallRightArrowIcon = withRtlSupport(SmallRightArrowIcon);
 
 const NavButton = ({
   ariaLabel,
@@ -72,8 +72,8 @@ const NavButton = ({
   variant,
 }: Props) => {
   const isCarousel = variant === VARIANT.carousel;
-  const PrevIcon = isCarousel ? AlignedSmallLeftArrowIcon : AlignedLeftArrowIcon;
-  const NextIcon = isCarousel ? AlignedSmallRightArrowIcon : AlignedRightArrowIcon;
+  const PrevIcon = isCarousel ? RtlSmallLeftArrowIcon : AlignedLeftArrowIcon;
+  const NextIcon = isCarousel ? RtlSmallRightArrowIcon : AlignedRightArrowIcon;
   const button = (
     <BpkButton
       iconOnly

--- a/packages/bpk-component-page-indicator/src/NavButton.tsx
+++ b/packages/bpk-component-page-indicator/src/NavButton.tsx
@@ -19,9 +19,11 @@
 import type { MouseEvent } from 'react';
 
 import BpkButton, { BUTTON_TYPES } from '../../bpk-component-button';
-import { withLargeButtonAlignment, withRtlSupport } from '../../bpk-component-icon';
+import { withButtonAlignment, withLargeButtonAlignment, withRtlSupport } from '../../bpk-component-icon';
 import LeftArrowIcon from '../../bpk-component-icon/lg/chevron-left';
 import RightArrowIcon from '../../bpk-component-icon/lg/chevron-right';
+import SmallLeftArrowIcon from '../../bpk-component-icon/sm/chevron-left';
+import SmallRightArrowIcon from '../../bpk-component-icon/sm/chevron-right';
 import { cssModules } from '../../bpk-react-utils';
 
 import { VARIANT } from './common-types';
@@ -57,6 +59,8 @@ type Props = {
 
 const AlignedLeftArrowIcon = withLargeButtonAlignment(withRtlSupport(LeftArrowIcon));
 const AlignedRightArrowIcon = withLargeButtonAlignment(withRtlSupport(RightArrowIcon));
+const AlignedSmallLeftArrowIcon = withButtonAlignment(withRtlSupport(SmallLeftArrowIcon));
+const AlignedSmallRightArrowIcon = withButtonAlignment(withRtlSupport(SmallRightArrowIcon));
 
 const NavButton = ({
   ariaLabel,
@@ -68,6 +72,8 @@ const NavButton = ({
   variant,
 }: Props) => {
   const isCarousel = variant === VARIANT.carousel;
+  const PrevIcon = isCarousel ? AlignedSmallLeftArrowIcon : AlignedLeftArrowIcon;
+  const NextIcon = isCarousel ? AlignedSmallRightArrowIcon : AlignedRightArrowIcon;
   const button = (
     <BpkButton
       iconOnly
@@ -85,9 +91,9 @@ const NavButton = ({
       disabled={disabled}
     >
       {direction === DIRECTIONS.PREV ? (
-        <AlignedLeftArrowIcon />
+        <PrevIcon />
       ) : (
-        <AlignedRightArrowIcon />
+        <NextIcon />
       )}
     </BpkButton>
   );

--- a/packages/bpk-component-page-indicator/src/NavButton.tsx
+++ b/packages/bpk-component-page-indicator/src/NavButton.tsx
@@ -19,9 +19,7 @@
 import type { MouseEvent } from 'react';
 
 import BpkButton, { BUTTON_TYPES } from '../../bpk-component-button';
-import { withLargeButtonAlignment, withRtlSupport } from '../../bpk-component-icon';
-import LeftArrowIcon from '../../bpk-component-icon/lg/chevron-left';
-import RightArrowIcon from '../../bpk-component-icon/lg/chevron-right';
+import { withButtonAlignment, withRtlSupport } from '../../bpk-component-icon';
 import SmallLeftArrowIcon from '../../bpk-component-icon/sm/chevron-left';
 import SmallRightArrowIcon from '../../bpk-component-icon/sm/chevron-right';
 import { cssModules } from '../../bpk-react-utils';
@@ -57,8 +55,8 @@ type Props = {
   variant?: Variant;
 };
 
-const AlignedLeftArrowIcon = withLargeButtonAlignment(withRtlSupport(LeftArrowIcon));
-const AlignedRightArrowIcon = withLargeButtonAlignment(withRtlSupport(RightArrowIcon));
+const AlignedLeftArrowIcon = withButtonAlignment(withRtlSupport(SmallLeftArrowIcon));
+const AlignedRightArrowIcon = withButtonAlignment(withRtlSupport(SmallRightArrowIcon));
 const RtlSmallLeftArrowIcon = withRtlSupport(SmallLeftArrowIcon);
 const RtlSmallRightArrowIcon = withRtlSupport(SmallRightArrowIcon);
 

--- a/packages/bpk-component-page-indicator/src/NavButton.tsx
+++ b/packages/bpk-component-page-indicator/src/NavButton.tsx
@@ -18,7 +18,7 @@
 
 import type { MouseEvent } from 'react';
 
-import BpkButton, { BUTTON_TYPES, SIZE_TYPES } from '../../bpk-component-button';
+import BpkButton, { BUTTON_TYPES } from '../../bpk-component-button';
 import { withLargeButtonAlignment, withRtlSupport } from '../../bpk-component-icon';
 import LeftArrowIcon from '../../bpk-component-icon/lg/chevron-left';
 import RightArrowIcon from '../../bpk-component-icon/lg/chevron-right';
@@ -67,7 +67,6 @@ const NavButton = ({
     <BpkButton
       iconOnly
       type={type}
-      size={SIZE_TYPES.large}
       onClick={(e) => {
         if (direction === DIRECTIONS.PREV) {
           onClick(e, currentIndex - 1, direction);

--- a/packages/bpk-component-page-indicator/src/NavButton.tsx
+++ b/packages/bpk-component-page-indicator/src/NavButton.tsx
@@ -24,6 +24,10 @@ import LeftArrowIcon from '../../bpk-component-icon/lg/chevron-left';
 import RightArrowIcon from '../../bpk-component-icon/lg/chevron-right';
 import { cssModules } from '../../bpk-react-utils';
 
+import { VARIANT } from './common-types';
+
+import type { Variant } from './common-types';
+
 import STYLES from './BpkPageIndicator.module.scss';
 
 const getClassName = cssModules(STYLES);
@@ -48,7 +52,7 @@ type Props = {
     direction: Direction,
   ) => void;
   type?: ButtonType;
-  variant?: string;
+  variant?: Variant;
 };
 
 const AlignedLeftArrowIcon = withLargeButtonAlignment(withRtlSupport(LeftArrowIcon));
@@ -63,7 +67,7 @@ const NavButton = ({
   type = BUTTON_TYPES.link,
   variant,
 }: Props) => {
-  const isCarousel = variant === 'carousel';
+  const isCarousel = variant === VARIANT.carousel;
   const button = (
     <BpkButton
       iconOnly

--- a/packages/bpk-component-page-indicator/src/NavButton.tsx
+++ b/packages/bpk-component-page-indicator/src/NavButton.tsx
@@ -63,10 +63,13 @@ const NavButton = ({
   type = BUTTON_TYPES.link,
   variant,
 }: Props) => {
+  const isCarousel = variant === 'carousel';
   const button = (
     <BpkButton
       iconOnly
       type={type}
+      // eslint-disable-next-line @skyscanner/rules/forbid-component-props
+      className={isCarousel ? getClassName('bpk-page-indicator__nav-carousel-button') : undefined}
       onClick={(e) => {
         if (direction === DIRECTIONS.PREV) {
           onClick(e, currentIndex - 1, direction);
@@ -85,7 +88,7 @@ const NavButton = ({
     </BpkButton>
   );
 
-  if (variant === 'carousel') {
+  if (isCarousel) {
     return (
       <span className={getClassName('bpk-page-indicator__nav-carousel')}>
         {button}

--- a/packages/bpk-component-page-indicator/src/NavButton.tsx
+++ b/packages/bpk-component-page-indicator/src/NavButton.tsx
@@ -18,10 +18,15 @@
 
 import type { MouseEvent } from 'react';
 
-import BpkButton, { BUTTON_TYPES } from '../../bpk-component-button';
+import BpkButton, { BUTTON_TYPES, SIZE_TYPES } from '../../bpk-component-button';
 import { withLargeButtonAlignment, withRtlSupport } from '../../bpk-component-icon';
 import LeftArrowIcon from '../../bpk-component-icon/lg/chevron-left';
 import RightArrowIcon from '../../bpk-component-icon/lg/chevron-right';
+import { cssModules } from '../../bpk-react-utils';
+
+import STYLES from './BpkPageIndicator.module.scss';
+
+const getClassName = cssModules(STYLES);
 
 export const DIRECTIONS = {
   PREV: 'PREV',
@@ -43,6 +48,7 @@ type Props = {
     direction: Direction,
   ) => void;
   type?: ButtonType;
+  variant?: string;
 };
 
 const AlignedLeftArrowIcon = withLargeButtonAlignment(withRtlSupport(LeftArrowIcon));
@@ -55,26 +61,40 @@ const NavButton = ({
   disabled = false,
   onClick = () => {},
   type = BUTTON_TYPES.link,
-}: Props) => (
-  <BpkButton
-    iconOnly
-    type={type}
-    onClick={(e) => {
-      if (direction === DIRECTIONS.PREV) {
-        onClick(e, currentIndex - 1, direction);
-      } else {
-        onClick(e, currentIndex + 1, direction);
-      }
-    }}
-    aria-label={ariaLabel}
-    disabled={disabled}
-  >
-    {direction === DIRECTIONS.PREV ? (
-      <AlignedLeftArrowIcon />
-    ) : (
-      <AlignedRightArrowIcon />
-    )}
-  </BpkButton>
-);
+  variant,
+}: Props) => {
+  const button = (
+    <BpkButton
+      iconOnly
+      type={type}
+      size={SIZE_TYPES.large}
+      onClick={(e) => {
+        if (direction === DIRECTIONS.PREV) {
+          onClick(e, currentIndex - 1, direction);
+        } else {
+          onClick(e, currentIndex + 1, direction);
+        }
+      }}
+      aria-label={ariaLabel}
+      disabled={disabled}
+    >
+      {direction === DIRECTIONS.PREV ? (
+        <AlignedLeftArrowIcon />
+      ) : (
+        <AlignedRightArrowIcon />
+      )}
+    </BpkButton>
+  );
+
+  if (variant === 'carousel') {
+    return (
+      <span className={getClassName('bpk-page-indicator__nav-carousel')}>
+        {button}
+      </span>
+    );
+  }
+
+  return button;
+};
 
 export default NavButton;

--- a/packages/bpk-component-page-indicator/src/common-types.ts
+++ b/packages/bpk-component-page-indicator/src/common-types.ts
@@ -1,0 +1,26 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const VARIANT = {
+  default: 'default',
+  overImage: 'overImage',
+  overImageSpaced: 'overImageSpaced',
+  carousel: 'carousel',
+} as const;
+
+export type Variant = (typeof VARIANT)[keyof typeof VARIANT];

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -15,7 +15,7 @@
         "@radix-ui/react-compose-refs": "^1.1.1",
         "@radix-ui/react-slider": "1.3.5",
         "@react-google-maps/api": "^2.19.3",
-        "@skyscanner/bpk-foundations-web": "^24.4.1",
+        "@skyscanner/bpk-foundations-web": "^24.5.0",
         "@skyscanner/bpk-svgs": "^20.11.0",
         "d3-path": "^3.1.0",
         "d3-scale": "^4.0.2",
@@ -829,21 +829,21 @@
       "license": "MIT"
     },
     "node_modules/@skyscanner/bpk-foundations-common": {
-      "version": "24.4.1",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-24.4.1.tgz",
-      "integrity": "sha512-d4ECD/c1Z7QebGeKruXKaUR93IIbrVdgJdGuFLq0tdEM7FC7NNSH/kbiH0eJv4/ENaZlU3VU2rIl5a+YWtHhmQ==",
+      "version": "24.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-24.5.0.tgz",
+      "integrity": "sha512-08NIg5Z8ZKZIRHujjXKyahiJAS64bq0mDSG4ITdBxIRcy0wMAxizhXNpLw8TmSPdluTaYYwxKYCJ2gOF2cngAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "color": "^5.0.0"
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "24.4.1",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-24.4.1.tgz",
-      "integrity": "sha512-o0YBuWNzntVhKte2sjcLQNV09e8BXsqJE71ip8N/RdcPqOBlkQ3YgoVP20ViVKg46RnL9u3ykltrYirb433cbg==",
+      "version": "24.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-24.5.0.tgz",
+      "integrity": "sha512-Lft06khFD3XGOvENnmrNeJLm0nIjAy6lW1wyNGzVS947EU3hrLFTM7pAz5jO69lpPvjgorpiA9MrX+80IVg05A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@skyscanner/bpk-foundations-common": "^24.4.1",
+        "@skyscanner/bpk-foundations-common": "^24.5.0",
         "color": "^5.0.0"
       }
     },
@@ -1831,7 +1831,7 @@
     },
     "node_modules/color": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color/-/color-5.0.3.tgz",
       "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
       "license": "MIT",
       "dependencies": {
@@ -1844,7 +1844,7 @@
     },
     "node_modules/color-convert": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-3.1.3.tgz",
       "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
       "license": "MIT",
       "dependencies": {
@@ -1856,7 +1856,7 @@
     },
     "node_modules/color-name": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-2.1.0.tgz",
       "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
       "license": "MIT",
       "engines": {
@@ -1865,7 +1865,7 @@
     },
     "node_modules/color-string": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-string/-/color-string-2.1.4.tgz",
       "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
       "license": "MIT",
       "dependencies": {

--- a/packages/package.json
+++ b/packages/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-compose-refs": "^1.1.1",
     "@radix-ui/react-slider": "1.3.5",
     "@react-google-maps/api": "^2.19.3",
-    "@skyscanner/bpk-foundations-web": "^24.4.1",
+    "@skyscanner/bpk-foundations-web": "^24.5.0",
     "@skyscanner/bpk-svgs": "^20.11.0",
     "tabbable": "^6.4.0",
     "d3-path": "^3.1.0",


### PR DESCRIPTION
## Summary

Adds a new \`carousel\` variant to \`BpkPageIndicator\`. The nav buttons render as fully circular large icon-only buttons with a white alpha-50 background (alpha-80 on hover) and \`text-primary-day\` chevrons. Layout follows the \`overImageSpaced\` variant (full-width, space-between). Implemented by reusing \`BpkButton\` with \`type=secondaryOnDark\` and overriding its theming CSS variables (\`--bpk-button-border-radius\` and \`--bpk-button-secondary-on-dark-*\`) via a wrapper span.

- [x] Component \`README.md\` — not applicable (no doc changes needed)
- [x] Tests — existing tests pass
- [x] Storybook examples created/updated — added \`Carousel\` story over a background image

Add a \`minor\` label (new variant, non-breaking).