### PR TITLE
[CLOV-1401][token-sync] Add authenticated Figma Variables API client

### DIFF
--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           FIGMA_VARIABLES_SYNC_TOKEN: ${{ secrets.FIGMA_VARIABLES_SYNC_TOKEN }}
           FIGMA_FILE_KEY: ${{ github.event.inputs.file_key || secrets.FIGMA_FILE_KEY }}
-        run: npm run sync-figma-variables
+        run: npm run sync

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -1,0 +1,31 @@
+name: Sync Figma variables
+
+on:
+  workflow_dispatch:
+    inputs:
+      file_key:
+        description: 'Optional Figma file key override (defaults to the FIGMA_FILE_KEY repo secret).'
+        required: false
+
+jobs:
+  sync-figma-variables:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Run sync
+        env:
+          FIGMA_VARIABLES_SYNC_TOKEN: ${{ secrets.FIGMA_VARIABLES_SYNC_TOKEN }}
+          FIGMA_FILE_KEY: ${{ github.event.inputs.file_key || secrets.FIGMA_FILE_KEY }}
+        run: npm run sync-figma-variables

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -7,6 +7,8 @@ on:
         description: 'Optional Figma file key override (defaults to the FIGMA_FILE_KEY repo secret).'
         required: false
 
+permissions: {}
+
 jobs:
   sync-figma-variables:
     runs-on: ubuntu-latest
@@ -22,7 +24,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: npm ci
 
       - name: Run sync
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/preset-typescript": "^7.28.5",
         "@babel/register": "^7.28.3",
         "@figma/code-connect": "^1.4.3",
+        "@figma/rest-api-spec": "^0.37.0",
         "@percy/cli": "^1.31.0",
         "@percy/storybook": "^9.1.0",
         "@skyscanner/bpk-foundations-web": "^24.4.1",
@@ -55,6 +56,7 @@
         "danger": "^13.0.4",
         "danger-plugin-toolbox": "^3.1.2",
         "date-fns": "^4.1.0",
+        "dotenv": "^16.4.5",
         "eslint_d": "^14.3.0",
         "glob": "^13.0.0",
         "gulp": "^5.0.0",
@@ -82,6 +84,7 @@
         "storybook": "^10.3.3",
         "style-loader": "^4.0.0",
         "ts-migrate": "^0.1.35",
+        "tsx": "^4.19.2",
         "typescript": "^5.9.2",
         "webpack": "^5.103.0",
         "wrapper-webpack-plugin": "^2.2.2"
@@ -2562,9 +2565,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -2579,9 +2582,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -2596,9 +2599,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -2613,9 +2616,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -2630,9 +2633,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -2647,9 +2650,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -2664,9 +2667,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -2681,9 +2684,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -2698,9 +2701,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -2715,9 +2718,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -2732,9 +2735,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -2749,9 +2752,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -2766,9 +2769,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -2783,9 +2786,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2800,9 +2803,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2817,9 +2820,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -2834,9 +2837,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -2851,9 +2854,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -2868,9 +2871,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -2885,9 +2888,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -2902,9 +2905,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -2918,10 +2921,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -2936,9 +2956,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -2953,9 +2973,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -2970,9 +2990,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -3642,6 +3662,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/@figma/rest-api-spec": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@figma/rest-api-spec/-/rest-api-spec-0.37.0.tgz",
+      "integrity": "sha512-KKeCgSRiO2gajT/sKCAsn48ubl8NRbYqyIvfkk5+NPK2ar+DVuLKg3fl3/cR1WharC5Dg4V5a9JzDsYv04k50g==",
+      "dev": true,
+      "license": "MIT License"
     },
     "node_modules/@gitbeaker/core": {
       "version": "38.12.1",
@@ -11949,9 +11976,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -11962,31 +11989,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -27799,6 +27827,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "start": "npm run build && npm run storybook",
     "storybook": "storybook dev -p 9001",
     "storybook:dist": "storybook build -c .storybook -o dist-storybook",
+    "sync-figma-variables": "tsx token-sync/src/sync.ts",
     "sassdoc": "sassdoc {packages/bpk-mixins/**/*,node_modules/@skyscanner/bpk-svgs/dist/*,node_modules/@skyscanner/bpk-foundations-web/tokens/base.default}.scss -d dist-sassdoc -v --strict",
     "test": "npm run lint && npm run check-react-versions && npm run check-bpk-dependencies && npm run jest",
     "typecheck": "tsc",
@@ -96,7 +97,7 @@
       "<rootDir>/scripts/jest/setup.js"
     ],
     "testEnvironment": "jsdom",
-    "testRegex": "packages/.*-test\\.[jt]sx?$",
+    "testRegex": "(?:packages|token-sync)/.*-test\\.[jt]sx?$",
     "transformIgnorePatterns": [
       "node_modules/(?!bpk|@skyscanner|d3-.*|internmap)"
     ],
@@ -121,6 +122,7 @@
     "@babel/preset-typescript": "^7.28.5",
     "@babel/register": "^7.28.3",
     "@figma/code-connect": "^1.4.3",
+    "@figma/rest-api-spec": "^0.37.0",
     "@percy/cli": "^1.31.0",
     "@percy/storybook": "^9.1.0",
     "@skyscanner/bpk-foundations-web": "^24.4.1",
@@ -155,6 +157,7 @@
     "danger": "^13.0.4",
     "danger-plugin-toolbox": "^3.1.2",
     "date-fns": "^4.1.0",
+    "dotenv": "^16.4.5",
     "eslint_d": "^14.3.0",
     "glob": "^13.0.0",
     "gulp": "^5.0.0",
@@ -182,6 +185,7 @@
     "storybook": "^10.3.3",
     "style-loader": "^4.0.0",
     "ts-migrate": "^0.1.35",
+    "tsx": "^4.19.2",
     "typescript": "^5.9.2",
     "webpack": "^5.103.0",
     "wrapper-webpack-plugin": "^2.2.2"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "start": "npm run build && npm run storybook",
     "storybook": "storybook dev -p 9001",
     "storybook:dist": "storybook build -c .storybook -o dist-storybook",
-    "sync-figma-variables": "tsx token-sync/src/sync.ts",
+    "sync": "tsx token-sync/src/index.ts",
     "sassdoc": "sassdoc {packages/bpk-mixins/**/*,node_modules/@skyscanner/bpk-svgs/dist/*,node_modules/@skyscanner/bpk-foundations-web/tokens/base.default}.scss -d dist-sassdoc -v --strict",
     "test": "npm run lint && npm run check-react-versions && npm run check-bpk-dependencies && npm run jest",
     "typecheck": "tsc",

--- a/token-sync/.env.example
+++ b/token-sync/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to `.env` and fill in real values.
+# `.env` is git-ignored; never commit it.
+
+# Figma personal access token with at least "Variables read-only" scope.
+# Generate from: https://www.figma.com/settings -> Security -> Personal access tokens.
+FIGMA_VARIABLES_SYNC_TOKEN=FIGMA_VARIABLES_SYNC_TOKEN
+
+# File key of the Backpack Foundations Figma file.
+# Found in the Figma URL: https://www.figma.com/design/<FILE_KEY>/<title>
+FIGMA_FILE_KEY=FIGMA_FILE_KEY

--- a/token-sync/.env.example
+++ b/token-sync/.env.example
@@ -3,8 +3,8 @@
 
 # Figma personal access token with at least "Variables read-only" scope.
 # Generate from: https://www.figma.com/settings -> Security -> Personal access tokens.
-FIGMA_VARIABLES_SYNC_TOKEN=FIGMA_VARIABLES_SYNC_TOKEN
+FIGMA_VARIABLES_SYNC_TOKEN=
 
-# File key of the Backpack Foundations Figma file.
+# File key of the Backpack Foundations & Components Figma file.
 # Found in the Figma URL: https://www.figma.com/design/<FILE_KEY>/<title>
-FIGMA_FILE_KEY=FIGMA_FILE_KEY
+FIGMA_FILE_KEY=

--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -41,7 +41,7 @@ From the repo root:
 
 ```bash
 npm install
-npm run sync-figma-variables
+npm run sync
 ```
 
 Expected output (shape; counts may differ):

--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -1,0 +1,72 @@
+# token-sync
+
+A small CLI that authenticates against Figma's [Variables REST API](https://www.figma.com/developers/api#variables)
+and fetches variable collections from the Backpack Foundations & Components file. It prints the matched
+collection names and modes — a minimal, verifiable foundation for downstream design-token sync.
+
+> Requires a Figma **Enterprise** org. Non-Enterprise accounts get `403` even with a valid token.
+
+## Setup
+
+### 1. Generate a Figma access token
+
+Open <https://www.figma.com/settings> → **Security** → **Personal access tokens**, generate a new
+token with the **Variables — Read-only** scope, and copy it (Figma only shows it once).
+
+### 2. Store the token
+
+The token is never committed. There are two places it needs to live:
+
+- **Local dev** — copy `token-sync/.env.example` to `token-sync/.env` and fill in:
+
+  ```
+  FIGMA_VARIABLES_SYNC_TOKEN=<token from step 1>
+  FIGMA_FILE_KEY=<Backpack Foundations & Components file key>
+  ```
+
+  `.env` is git-ignored.
+
+- **CI** — add two repository secrets at **Settings → Secrets and variables → Actions**:
+
+  | Secret name                  | Value                                                      |
+  | ---------------------------- | ---------------------------------------------------------- |
+  | `FIGMA_VARIABLES_SYNC_TOKEN` | Same token as above                                        |
+  | `FIGMA_FILE_KEY`             | Backpack Foundations & Components file key                 |
+
+  Requires repo admin; only needs to be done once.
+
+## Running it
+
+From the repo root:
+
+```bash
+npm install
+npm run sync-figma-variables
+```
+
+Expected output (shape; counts may differ):
+
+```
+Fetching variable collections from file...
+Found 2 variable collection(s):
+- Backpack
+    modes: Day, Night
+- Primitives
+    modes: Hex
+Done.
+```
+
+Errors (missing env / bad token / wrong file key) exit with a hint that points to the right
+place depending on whether you're running locally or in CI.
+
+A manually-triggered workflow at `.github/workflows/sync-figma-variables.yml` runs the same
+command in CI; trigger it from **Actions → Sync Figma variables → Run workflow**. It reads the
+two repo secrets from step 2.
+
+## How it works
+
+- Calls `GET /v1/files/{file_key}/variables/local` with the `X-Figma-Token` header.
+- Filters the response to the two target collections: `Primitives` and `Backpack`.
+- Keeps only locally-authored collections (drops any `remote: true` Library-subscription copies
+  — those are read-only snapshots of the last publish and would duplicate the working state).
+- Logs the matched collections with their modes.

--- a/token-sync/src/figma-api-test.ts
+++ b/token-sync/src/figma-api-test.ts
@@ -30,7 +30,7 @@ describe('FigmaApi', () => {
   });
 
   describe('getLocalVariables', () => {
-    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    const fetchSpy = jest.spyOn(global, 'fetch');
 
     afterEach(() => {
       fetchSpy.mockReset();

--- a/token-sync/src/figma-api-test.ts
+++ b/token-sync/src/figma-api-test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FigmaApi, FigmaApiError } from './figma-api';
+
+describe('FigmaApi', () => {
+  describe('constructor', () => {
+    it('throws when token is empty or whitespace', () => {
+      expect(() => new FigmaApi('')).toThrow('token is required');
+      expect(() => new FigmaApi('   ')).toThrow('token is required');
+    });
+  });
+
+  describe('getLocalVariables', () => {
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+
+    afterEach(() => {
+      fetchSpy.mockReset();
+    });
+
+    it('rejects without calling fetch when fileKey is empty', async () => {
+      const api = new FigmaApi('valid-token');
+      await expect(api.getLocalVariables('')).rejects.toThrow(
+        'fileKey is required',
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('sends X-Figma-Token header and returns parsed JSON on 2xx', async () => {
+      const payload = {
+        status: 200,
+        error: false,
+        meta: { variables: {}, variableCollections: {} },
+      };
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+
+      const api = new FigmaApi('secret-token');
+      const result = await api.getLocalVariables('file-123');
+
+      expect(result).toEqual(payload);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/file-123/variables/local',
+        {
+          headers: {
+            Accept: '*/*',
+            'X-Figma-Token': 'secret-token',
+          },
+        },
+      );
+    });
+
+    it('throws FigmaApiError carrying status, endpoint and body on non-2xx', async () => {
+      fetchSpy.mockResolvedValue(new Response('forbidden', { status: 403 }));
+      const api = new FigmaApi('bad-token');
+
+      const error = await api.getLocalVariables('file-xyz').catch((e) => e);
+      expect(error).toBeInstanceOf(FigmaApiError);
+      expect(error).toMatchObject({
+        name: 'FigmaApiError',
+        status: 403,
+        endpoint: '/files/file-xyz/variables/local',
+        body: 'forbidden',
+      });
+    });
+  });
+});

--- a/token-sync/src/figma-api-test.ts
+++ b/token-sync/src/figma-api-test.ts
@@ -69,6 +69,21 @@ describe('FigmaApi', () => {
       );
     });
 
+    it('URL-encodes the fileKey so stray special characters cannot break the URL', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({ status: 200, error: false, meta: { variables: {}, variableCollections: {} } }),
+          { status: 200 },
+        ),
+      );
+      const api = new FigmaApi('valid-token');
+      await api.getLocalVariables('weird key/with?stuff');
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/weird%20key%2Fwith%3Fstuff/variables/local',
+        expect.any(Object),
+      );
+    });
+
     it('throws FigmaApiError carrying status, endpoint and body on non-2xx', async () => {
       fetchSpy.mockResolvedValue(new Response('forbidden', { status: 403 }));
       const api = new FigmaApi('bad-token');

--- a/token-sync/src/figma-api.ts
+++ b/token-sync/src/figma-api.ts
@@ -59,8 +59,10 @@ export class FigmaApi {
     if (!fileKey || !fileKey.trim()) {
       throw new Error('FigmaApi: fileKey is required');
     }
+    // Figma file keys are alphanumeric in practice; encode anyway so a value
+    // with stray whitespace or special characters can't break the URL.
     return this.request<GetLocalVariablesResponse>(
-      `/files/${fileKey}/variables/local`,
+      `/files/${encodeURIComponent(fileKey)}/variables/local`,
     );
   }
 

--- a/token-sync/src/figma-api.ts
+++ b/token-sync/src/figma-api.ts
@@ -1,0 +1,62 @@
+import type {
+  GetLocalVariablesResponse,
+  LocalVariableCollection,
+  LocalVariable,
+} from '@figma/rest-api-spec';
+
+const FIGMA_API_BASE = 'https://api.figma.com/v1';
+
+export type { GetLocalVariablesResponse, LocalVariableCollection, LocalVariable };
+
+export class FigmaApiError extends Error {
+  readonly status: number;
+  readonly endpoint: string;
+  readonly body: string;
+
+  constructor(status: number, endpoint: string, body: string) {
+    super(`Figma API ${status} (${endpoint}): ${body}`);
+    this.name = 'FigmaApiError';
+    this.status = status;
+    this.endpoint = endpoint;
+    this.body = body;
+  }
+}
+
+export class FigmaApi {
+  private readonly token: string;
+  private readonly baseUrl: string;
+
+  constructor(token: string, baseUrl: string = FIGMA_API_BASE) {
+    if (!token || !token.trim()) {
+      throw new Error('FigmaApi: token is required');
+    }
+    this.token = token;
+    this.baseUrl = baseUrl;
+  }
+
+  async getLocalVariables(fileKey: string): Promise<GetLocalVariablesResponse> {
+    if (!fileKey || !fileKey.trim()) {
+      throw new Error('FigmaApi: fileKey is required');
+    }
+    return this.request<GetLocalVariablesResponse>(
+      `/files/${fileKey}/variables/local`,
+    );
+  }
+
+  private async request<T>(endpoint: string): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: '*/*',
+        'X-Figma-Token': this.token,
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new FigmaApiError(response.status, endpoint, body);
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/token-sync/src/figma-api.ts
+++ b/token-sync/src/figma-api.ts
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type {
   GetLocalVariablesResponse,
   LocalVariableCollection,
@@ -10,7 +28,9 @@ export type { GetLocalVariablesResponse, LocalVariableCollection, LocalVariable 
 
 export class FigmaApiError extends Error {
   readonly status: number;
+
   readonly endpoint: string;
+
   readonly body: string;
 
   constructor(status: number, endpoint: string, body: string) {
@@ -24,6 +44,7 @@ export class FigmaApiError extends Error {
 
 export class FigmaApi {
   private readonly token: string;
+
   private readonly baseUrl: string;
 
   constructor(token: string, baseUrl: string = FIGMA_API_BASE) {

--- a/token-sync/src/index.ts
+++ b/token-sync/src/index.ts
@@ -33,14 +33,10 @@ import {
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 loadDotenv({ path: path.resolve(scriptDir, '../.env') });
 
-function sortByName<T extends { name: string }>(items: T[]): T[] {
-  return [...items].sort((left, right) => left.name.localeCompare(right.name));
-}
-
 function logCollections(collections: LocalVariableCollection[]) {
   console.log(`Found ${collections.length} variable collection(s):`);
-  for (const collection of sortByName(collections)) {
-    const modeNames = sortByName(collection.modes).map((mode) => mode.name);
+  for (const collection of collections) {
+    const modeNames = collection.modes.map((mode) => mode.name);
     console.log(`- ${collection.name}`);
     console.log(`    modes: ${modeNames.join(', ') || '(none)'}`);
   }

--- a/token-sync/src/sync-helpers-test.ts
+++ b/token-sync/src/sync-helpers-test.ts
@@ -1,0 +1,192 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FigmaApiError, type LocalVariableCollection } from './figma-api';
+import {
+  credentialLocation,
+  filterLocalTargets,
+  formatFatalError,
+  isCI,
+  requireEnv,
+} from './sync-helpers';
+
+/**
+ * The real shape has many required fields we don't care about for filter logic.
+ * Cast through `unknown` to keep the test data minimal.
+ */
+function makeCollection(
+  name: string,
+  remote = false,
+): LocalVariableCollection {
+  return { name, remote, modes: [] } as unknown as LocalVariableCollection;
+}
+
+describe('isCI / credentialLocation', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.CI;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('isCI returns false by default, true when GITHUB_ACTIONS or CI is "true"', () => {
+    expect(isCI()).toBe(false);
+
+    process.env.GITHUB_ACTIONS = 'true';
+    expect(isCI()).toBe(true);
+
+    delete process.env.GITHUB_ACTIONS;
+    process.env.CI = 'true';
+    expect(isCI()).toBe(true);
+  });
+
+  it('credentialLocation points to the .env file locally and to the repo secret in CI', () => {
+    expect(credentialLocation('FOO')).toBe(
+      'FOO in token-sync/.env (see token-sync/.env.example)',
+    );
+
+    process.env.GITHUB_ACTIONS = 'true';
+    expect(credentialLocation('FOO')).toBe(
+      'the "FOO" repository secret (Settings → Secrets and variables → Actions)',
+    );
+  });
+});
+
+describe('requireEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.CI;
+    delete process.env.TEST_TOKEN_SYNC_REQUIRE_ENV;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns the trimmed value when the env var is set', () => {
+    process.env.TEST_TOKEN_SYNC_REQUIRE_ENV = '  hello  ';
+    expect(requireEnv('TEST_TOKEN_SYNC_REQUIRE_ENV')).toBe('hello');
+  });
+
+  it('throws a CI-aware message when the env var is missing', () => {
+    expect(() => requireEnv('TEST_TOKEN_SYNC_REQUIRE_ENV')).toThrow(
+      'Missing required environment variable: TEST_TOKEN_SYNC_REQUIRE_ENV. Set TEST_TOKEN_SYNC_REQUIRE_ENV in token-sync/.env (see token-sync/.env.example).',
+    );
+  });
+});
+
+describe('filterLocalTargets', () => {
+  const backpackLocal = makeCollection('Backpack', false);
+  const backpackRemote = makeCollection('Backpack', true);
+  const primitives = makeCollection('Primitives', false);
+  const vdl = makeCollection('VDL', false);
+
+  it('keeps only non-remote collections matching a target name, with no missing', () => {
+    const result = filterLocalTargets(
+      [backpackLocal, backpackRemote, primitives, vdl],
+      ['Backpack', 'Primitives'],
+    );
+
+    expect(result.matched).toEqual([backpackLocal, primitives]);
+    expect(result.missingNames).toEqual([]);
+    expect(result.availableLocalNames).toEqual([
+      'Backpack',
+      'Primitives',
+      'VDL',
+    ]);
+  });
+
+  it('reports missingNames when a target has only a remote variant, not local', () => {
+    const result = filterLocalTargets(
+      [primitives, backpackRemote],
+      ['Backpack', 'Primitives'],
+    );
+
+    expect(result.matched).toEqual([primitives]);
+    expect(result.missingNames).toEqual(['Backpack']);
+    expect(result.availableLocalNames).toEqual(['Primitives']);
+  });
+
+  it('returns no matches plus a full availableLocalNames list when nothing matches', () => {
+    const result = filterLocalTargets(
+      [vdl, backpackRemote],
+      ['Backpack', 'Primitives'],
+    );
+
+    expect(result.matched).toEqual([]);
+    expect(result.missingNames).toEqual(['Backpack', 'Primitives']);
+    expect(result.availableLocalNames).toEqual(['VDL']);
+  });
+});
+
+describe('formatFatalError', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.CI;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it.each([401, 403])(
+    'returns an auth-failure message pointing at FIGMA_VARIABLES_SYNC_TOKEN for FigmaApiError status %s',
+    (status) => {
+      const message = formatFatalError(
+        new FigmaApiError(status, '/files/x/variables/local', 'denied'),
+      );
+      expect(message).toContain(`Authentication failed (${status})`);
+      expect(message).toMatch(
+        /FIGMA_VARIABLES_SYNC_TOKEN[\s\S]*(\.env|repository secret)/,
+      );
+    },
+  );
+
+  it('returns a file-not-found message pointing at FIGMA_FILE_KEY for FigmaApiError 404', () => {
+    const message = formatFatalError(
+      new FigmaApiError(404, '/files/bad/variables/local', 'not found'),
+    );
+    expect(message).toContain('File not found (404)');
+    expect(message).toContain('FIGMA_FILE_KEY');
+  });
+
+  it('falls back to FigmaApiError.message for other status codes', () => {
+    const error = new FigmaApiError(500, '/files/x/variables/local', 'boom');
+    expect(formatFatalError(error)).toBe(error.message);
+  });
+
+  it('returns the message of a non-FigmaApiError Error', () => {
+    expect(formatFatalError(new Error('regular error'))).toBe('regular error');
+  });
+
+  it('wraps unknown non-Error throws in an "Unknown error:" prefix', () => {
+    expect(formatFatalError('oops')).toBe('Unknown error: oops');
+    expect(formatFatalError(42)).toBe('Unknown error: 42');
+  });
+});

--- a/token-sync/src/sync-helpers-test.ts
+++ b/token-sync/src/sync-helpers-test.ts
@@ -25,10 +25,8 @@ import {
   requireEnv,
 } from './sync-helpers';
 
-/**
- * The real shape has many required fields we don't care about for filter logic.
- * Cast through `unknown` to keep the test data minimal.
- */
+// The real shape has many required fields we don't care about for filter logic.
+// Cast through `unknown` to keep the test data minimal.
 function makeCollection(
   name: string,
   remote = false,
@@ -49,7 +47,11 @@ describe('isCI / credentialLocation', () => {
     process.env = originalEnv;
   });
 
-  it('isCI returns false by default, true when GITHUB_ACTIONS or CI is "true"', () => {
+  it('isCI returns false by default, true for any non-empty GITHUB_ACTIONS / CI value', () => {
+    expect(isCI()).toBe(false);
+
+    // Empty string should still be treated as "not CI".
+    process.env.CI = '';
     expect(isCI()).toBe(false);
 
     process.env.GITHUB_ACTIONS = 'true';
@@ -57,6 +59,10 @@ describe('isCI / credentialLocation', () => {
 
     delete process.env.GITHUB_ACTIONS;
     process.env.CI = 'true';
+    expect(isCI()).toBe(true);
+
+    // Other truthy values some CI providers use.
+    process.env.CI = '1';
     expect(isCI()).toBe(true);
   });
 

--- a/token-sync/src/sync-helpers.ts
+++ b/token-sync/src/sync-helpers.ts
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import process from 'node:process';
 
 import { FigmaApiError, type LocalVariableCollection } from './figma-api';
@@ -5,8 +23,11 @@ import { FigmaApiError, type LocalVariableCollection } from './figma-api';
 export const TARGET_COLLECTION_NAMES = ['Primitives', 'Backpack'] as const;
 
 export function isCI(): boolean {
+  // Most CIs set GITHUB_ACTIONS / CI to the string "true", but some use "1" or
+  // another truthy value. Treat any non-empty trimmed value as CI.
   return (
-    process.env.GITHUB_ACTIONS === 'true' || process.env.CI === 'true'
+    (process.env.GITHUB_ACTIONS?.trim() ?? '') !== '' ||
+    (process.env.CI?.trim() ?? '') !== ''
   );
 }
 
@@ -34,12 +55,10 @@ export interface LocalTargetFilterResult {
   availableLocalNames: string[];
 }
 
-/**
- * Keep only collections that are (a) defined locally in this file (not subscribed
- * back from a Library as `remote: true`) and (b) whose names are in `targetNames`.
- * Returns the match plus `missingNames` (targets with no local match) and
- * `availableLocalNames` (every local collection name, for error messaging).
- */
+// Keep only collections that are (a) defined locally in this file (not subscribed
+// back from a Library as `remote: true`) and (b) whose names are in `targetNames`.
+// Returns the match plus `missingNames` (targets with no local match) and
+// `availableLocalNames` (every local collection name, for error messaging).
 export function filterLocalTargets(
   allCollections: LocalVariableCollection[],
   targetNames: readonly string[],
@@ -56,11 +75,9 @@ export function filterLocalTargets(
   return { matched, missingNames, availableLocalNames };
 }
 
-/**
- * Turn any thrown value into a single user-facing error string. Keeps the
- * CI-vs-local hint consistent via `credentialLocation`. Pure — no logging,
- * no `process.exit` — so the caller (sync.ts) decides how to surface it.
- */
+// Turn any thrown value into a single user-facing error string. Keeps the
+// CI-vs-local hint consistent via `credentialLocation`. Pure — no logging,
+// no `process.exit` — so the caller (sync.ts) decides how to surface it.
 export function formatFatalError(error: unknown): string {
   if (error instanceof FigmaApiError) {
     if (error.status === 403 || error.status === 401) {

--- a/token-sync/src/sync-helpers.ts
+++ b/token-sync/src/sync-helpers.ts
@@ -1,0 +1,87 @@
+import process from 'node:process';
+
+import { FigmaApiError, type LocalVariableCollection } from './figma-api';
+
+export const TARGET_COLLECTION_NAMES = ['Primitives', 'Backpack'] as const;
+
+export function isCI(): boolean {
+  return (
+    process.env.GITHUB_ACTIONS === 'true' || process.env.CI === 'true'
+  );
+}
+
+export function credentialLocation(name: string): string {
+  if (isCI()) {
+    return `the "${name}" repository secret (Settings → Secrets and variables → Actions)`;
+  }
+  return `${name} in token-sync/.env (see token-sync/.env.example)`;
+}
+
+export function requireEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(
+      `Missing required environment variable: ${name}. ` +
+        `Set ${credentialLocation(name)}.`,
+    );
+  }
+  return value;
+}
+
+export interface LocalTargetFilterResult {
+  matched: LocalVariableCollection[];
+  missingNames: string[];
+  availableLocalNames: string[];
+}
+
+/**
+ * Keep only collections that are (a) defined locally in this file (not subscribed
+ * back from a Library as `remote: true`) and (b) whose names are in `targetNames`.
+ * Returns the match plus `missingNames` (targets with no local match) and
+ * `availableLocalNames` (every local collection name, for error messaging).
+ */
+export function filterLocalTargets(
+  allCollections: LocalVariableCollection[],
+  targetNames: readonly string[],
+): LocalTargetFilterResult {
+  const matched = allCollections.filter(
+    (collection) =>
+      !collection.remote && targetNames.includes(collection.name),
+  );
+  const foundNames = new Set(matched.map((collection) => collection.name));
+  const missingNames = targetNames.filter((name) => !foundNames.has(name));
+  const availableLocalNames = allCollections
+    .filter((collection) => !collection.remote)
+    .map((collection) => collection.name);
+  return { matched, missingNames, availableLocalNames };
+}
+
+/**
+ * Turn any thrown value into a single user-facing error string. Keeps the
+ * CI-vs-local hint consistent via `credentialLocation`. Pure — no logging,
+ * no `process.exit` — so the caller (sync.ts) decides how to surface it.
+ */
+export function formatFatalError(error: unknown): string {
+  if (error instanceof FigmaApiError) {
+    if (error.status === 403 || error.status === 401) {
+      return (
+        `Authentication failed (${error.status}). ` +
+        `The Figma access token is invalid, expired, or missing the "Variables — Read-only" scope; ` +
+        `or the account has no access to the file. ` +
+        `Regenerate at https://www.figma.com/settings → Security → Personal access tokens, ` +
+        `then update ${credentialLocation('FIGMA_VARIABLES_SYNC_TOKEN')}.`
+      );
+    }
+    if (error.status === 404) {
+      return (
+        `File not found (404). ` +
+        `Check ${credentialLocation('FIGMA_FILE_KEY')} points to a file the account can access.`
+      );
+    }
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return `Unknown error: ${String(error)}`;
+}

--- a/token-sync/src/sync-helpers.ts
+++ b/token-sync/src/sync-helpers.ts
@@ -77,7 +77,7 @@ export function filterLocalTargets(
 
 // Turn any thrown value into a single user-facing error string. Keeps the
 // CI-vs-local hint consistent via `credentialLocation`. Pure — no logging,
-// no `process.exit` — so the caller (sync.ts) decides how to surface it.
+// no `process.exit` — so the caller (index.ts) decides how to surface it.
 export function formatFatalError(error: unknown): string {
   if (error instanceof FigmaApiError) {
     if (error.status === 403 || error.status === 401) {

--- a/token-sync/src/sync.ts
+++ b/token-sync/src/sync.ts
@@ -1,0 +1,66 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { config as loadDotenv } from 'dotenv';
+
+import { FigmaApi, type LocalVariableCollection } from './figma-api';
+import {
+  TARGET_COLLECTION_NAMES,
+  filterLocalTargets,
+  formatFatalError,
+  requireEnv,
+} from './sync-helpers';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+loadDotenv({ path: path.resolve(scriptDir, '../.env') });
+
+function sortByName<T extends { name: string }>(items: T[]): T[] {
+  return [...items].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function logCollections(collections: LocalVariableCollection[]) {
+  console.log(`Found ${collections.length} variable collection(s):`);
+  for (const collection of sortByName(collections)) {
+    const modeNames = sortByName(collection.modes).map((mode) => mode.name);
+    console.log(`- ${collection.name}`);
+    console.log(`    modes: ${modeNames.join(', ') || '(none)'}`);
+  }
+}
+
+async function main() {
+  const token = requireEnv('FIGMA_VARIABLES_SYNC_TOKEN');
+  const fileKey = requireEnv('FIGMA_FILE_KEY');
+
+  const api = new FigmaApi(token);
+
+  console.log('Fetching variable collections from file...');
+  const response = await api.getLocalVariables(fileKey);
+
+  const allCollections = Object.values(response.meta.variableCollections);
+  const { matched, missingNames, availableLocalNames } = filterLocalTargets(
+    allCollections,
+    TARGET_COLLECTION_NAMES,
+  );
+
+  if (matched.length === 0) {
+    throw new Error(
+      `None of the target collections [${TARGET_COLLECTION_NAMES.join(', ')}] were found as local collections in the file. ` +
+        `Available local collections: ${availableLocalNames.join(', ') || '(none)'}.`,
+    );
+  }
+
+  if (missingNames.length > 0) {
+    console.warn(
+      `Warning: these target collections were not found as local collections and will be skipped: ${missingNames.join(', ')}.`,
+    );
+  }
+
+  logCollections(matched);
+  console.log('Done.');
+}
+
+main().catch((error: unknown) => {
+  console.error(formatFatalError(error));
+  process.exit(1);
+});

--- a/token-sync/src/sync.ts
+++ b/token-sync/src/sync.ts
@@ -1,3 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable no-console -- CLI entry: stdout/stderr output is intentional. */
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -38,7 +56,7 @@ async function main() {
   const response = await api.getLocalVariables(fileKey);
 
   const allCollections = Object.values(response.meta.variableCollections);
-  const { matched, missingNames, availableLocalNames } = filterLocalTargets(
+  const { availableLocalNames, matched, missingNames } = filterLocalTargets(
     allCollections,
     TARGET_COLLECTION_NAMES,
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
   "include": [
     "packages",
     "@types",
-    "examples"
+    "examples",
+    "token-sync"
   ],
   "exclude": ["**/**/*.figma.tsx"]
 }


### PR DESCRIPTION
## Summary

Adds a small TypeScript CLI that authenticates against Figma's Variables REST API and fetches the `Primitives` and `Backpack` collections from the Backpack Foundations & Components file. Infrastructure only — the DTCG → CSS transform and full end-to-end sync land in a follow-up.

## What's included

- `token-sync/` CLI:
  - `figma-api.ts` — Figma API client with `X-Figma-Token` auth, typed via `@figma/rest-api-spec`
  - `sync-helpers.ts` — pure helpers: env loading, target filter, CI-aware error formatting
  - `sync.ts` — entry script (fetch → filter → log)
- 17 unit tests (`*-test.ts`) covering every branch in `sync-helpers` + the API client's happy/error paths
- Manually-triggered workflow at `.github/workflows/sync-figma-variables.yml`
- Root wiring: `dotenv` / `tsx` / `@figma/rest-api-spec` added to devDependencies; `sync-figma-variables` npm script; `token-sync/` included in root `tsconfig.json` and jest `testRegex`

## How it works

- Calls `GET /v1/files/{file_key}/variables/local` and filters to the two target collections, keeping only locally-authored ones (`remote: false` — drops the duplicate subscribed-back Library snapshot).
- Error paths exit with a hint that switches between "set `.env`" (local) and "set the repo secret" (CI) based on `GITHUB_ACTIONS` / `CI`.

## Configuration required before the CI workflow can run

Repo admin needs to create two repository secrets at **Settings → Secrets and variables → Actions**:

| Secret name                  | Value                                                      |
| ---------------------------- | ---------------------------------------------------------- |
| `FIGMA_VARIABLES_SYNC_TOKEN` | Figma PAT with `Variables — Read-only` scope               |
| `FIGMA_FILE_KEY`             | File key of the Backpack Foundations & Components file     |

## Test plan

- [x] \`npm run jest -- token-sync\` — 17 tests pass
- [ ] \`npm run typecheck\` — no new errors
- [ ] Local: with \`token-sync/.env\` filled in, \`npm run sync-figma-variables\` prints the two collections
- [x] CI: after secrets are set, trigger via **Actions → Sync Figma variables → Run workflow** and confirm the same output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLOV-1401]: https://skyscanner.atlassian.net/browse/CLOV-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ