### PR TITLE
Reduce consumer bundle size via babel config + sideEffects

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -54,10 +54,7 @@ module.exports = {
           },
         ],
         'inline-react-svg',
-        [
-          '@babel/plugin-transform-runtime',
-          { useESModules: true, version: '^7.28.3' },
-        ],
+        ['@babel/plugin-transform-runtime', { useESModules: true }],
       ],
       ignore: [
         (fileName) =>

--- a/babel.config.js
+++ b/babel.config.js
@@ -28,10 +28,10 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        targets: {
-          node: 'current',
-        },
+        // `targets` intentionally omitted so preset-env picks up the
+        // root `browserslist` field (modern evergreen matrix).
         modules: false,
+        bugfixes: true,
       },
     ],
     // the option { runtime: 'automatic' } is passed to enable the new JSX transform where React is imported automatically
@@ -54,6 +54,10 @@ module.exports = {
           },
         ],
         'inline-react-svg',
+        [
+          '@babel/plugin-transform-runtime',
+          { useESModules: true, version: '^7.28.3' },
+        ],
       ],
       ignore: [
         (fileName) =>

--- a/packages/package.json
+++ b/packages/package.json
@@ -21,8 +21,13 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@ark-ui/react": "^5.34.1",
+    "@babel/runtime": "^7.28.3",
     "@chakra-ui/react": "^3.33.0",
     "@floating-ui/react": "^0.26.12",
     "@radix-ui/react-compose-refs": "^1.1.1",

--- a/packages/package.json
+++ b/packages/package.json
@@ -22,8 +22,8 @@
     "access": "public"
   },
   "sideEffects": [
-    "*.css",
-    "*.scss"
+    "**/*.css",
+    "**/*.scss"
   ],
   "dependencies": {
     "@ark-ui/react": "^5.34.1",


### PR DESCRIPTION
## Summary

Three linked changes in the publish pipeline that together reduce consumer bundle size by **~12% raw / ~9% gzipped** across the component surface.

- **`babel.config.js`** — drop `targets: { node: 'current' }` so `@babel/preset-env` honours the root `browserslist` (modern evergreen matrix). Output becomes deterministic and correctly targeted for the supported browser set rather than whichever Node version ran the CI build. Also enables `bugfixes: true` for tighter output.
- **`babel.config.js`** — enable `@babel/plugin-transform-runtime` with `useESModules: true` on the publish build, deduplicating helper functions (`_objectSpread`, `_extends`, `_defineProperty`, etc.) across the 96 component entries instead of inlining them into every file.
- **`packages/package.json`** — declare `"sideEffects": ["*.css", "*.scss"]` so consumer bundlers can tree-shake barrel imports, and add `"@babel/runtime"` as a runtime dependency to back the `transform-runtime` imports consumers will resolve.

## Measured impact

Each `dist/bpk-component-*/index.js` bundled via esbuild as ESM with `peerDependencies` + `dependencies` externalised (harness is not in this PR):

|         | raw         | gzip       |
|---------|-------------|------------|
| before  | 1882.1 KiB  | 438.9 KiB  |
| after   | 1653.9 KiB  | 399.3 KiB  |
| **delta** | **−228.2 KiB (−12.1%)** | **−39.6 KiB (−9.0%)** |

Top shrinks — no regressions:

| component | before | after | Δ raw | Δ% |
|---|---|---|---|---|
| bpk-component-comparison-table | 110.8 KiB | 77.3 KiB | −33.5 KiB | −30.3% |
| bpk-component-datepicker | 128.4 KiB | 113.6 KiB | −14.8 KiB | −11.6% |
| bpk-component-ai-blurb | 45.7 KiB | 36.3 KiB | −9.4 KiB | −20.5% |
| bpk-component-chatbot-input | 66.4 KiB | 57.4 KiB | −9.0 KiB | −13.6% |
| bpk-component-card | 39.1 KiB | 32.3 KiB | −6.7 KiB | −17.2% |

The `sideEffects` declaration gives additional consumer-side tree-shaking that isn't captured in these per-component numbers — real consumer savings will be larger when they barrel-import from `@skyscanner/backpack-web`.

## Compatibility

- **`moduleResolution: "node"` declaration emit passes.** `npx tsc -p tsconfig.declaration.json --noEmit` — exit 0. This was the stated risk; verified explicitly because the main `tsconfig.json` uses `moduleResolution: "bundler"` and can mask node-resolution failures.
- **`"sideEffects": ["*.css", "*.scss"]`** is a promise that no `.js` module in the package has import-time side effects. All 380 Jest suites / 2401 tests pass, which exercises most runtime paths — but consumers depending on module-scope side effects in a component JS file (rare) could be affected. If spotted post-merge, the allowlist can be widened.
- **`@babel/runtime`** moves from transitive to declared runtime dep; no version change.

## Test plan

- [x] `npm run transpile` — exit 0
- [x] `npx tsc -p tsconfig.declaration.json --noEmit` — exit 0
- [x] `npx jest` — 380 suites / 2401 tests pass, exit 0
- [ ] `npm test` (lint + check-react-versions + check-bpk-dependencies + jest) — run in CI
- [ ] Percy / visual regression — run in CI
- [ ] Spot-check one consumer app build to confirm `@babel/runtime` resolves correctly