### PR TITLE
[NO-JIRA][BpkCarousel] Always show page indicator nav in stories

### DIFF
--- a/packages/bpk-component-carousel/src/BpkCarousel.stories.js
+++ b/packages/bpk-component-carousel/src/BpkCarousel.stories.js
@@ -41,7 +41,7 @@ const DefaultExample = () => (
       margin: 'auto',
     }}
   >
-    <BpkCarousel images={imagesList} bottom={16} />
+    <BpkCarousel images={imagesList} bottom={16} showPageIndicatorNav />
   </div>
 );
 
@@ -57,6 +57,7 @@ const WithCarouselPageIndicatorExample = () => (
       images={imagesList}
       pageIndicatorVariant={VARIANT.carousel}
       bottom={16}
+      showPageIndicatorNav
     />
   </div>
 );


### PR DESCRIPTION
Adds `showPageIndicatorNav` to the `Default` and `WithCarouselPageIndicator` story examples so the previous/next navigation buttons always render regardless of viewport size, making the stories (and the `VisualTest`/`VisualTestWithZoom` variants that reuse them) cover the nav UI consistently.

- [x] Storybook examples updated

Label: `skip-changelog` (stories-only change).