### PR TITLE
[ST-7749][BpkComparisonTable] BpkComparisonTable improvements

### DIFF
--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable-test.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable-test.tsx
@@ -231,5 +231,28 @@ describe('BpkComparisonTable', () => {
       await userEvent.click(screen.getByLabelText('Close'));
       expect(onClose).toHaveBeenCalledTimes(1);
     });
+
+    it('fires onOpen when isOpen transitions from false to true', async () => {
+      const onOpen = jest.fn();
+      const renderTree = (isOpen: boolean) => (
+        <BpkProvider>
+          <BpkComparisonTable.Root isOpen={isOpen} onClose={noop} onOpen={onOpen}>
+            <BpkComparisonTable.Header strings={TRANSLATIONS} />
+            <BpkComparisonTable.Content
+              columns={[COLUMN_1]}
+              onRemove={noop}
+              onAddMoreClick={noop}
+              strings={TRANSLATIONS}
+            />
+          </BpkComparisonTable.Root>
+        </BpkProvider>
+      );
+
+      const { rerender } = render(renderTree(false));
+      expect(onOpen).not.toHaveBeenCalled();
+
+      rerender(renderTree(true));
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable-test.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable-test.tsx
@@ -254,5 +254,30 @@ describe('BpkComparisonTable', () => {
       rerender(renderTree(true));
       expect(onOpen).toHaveBeenCalledTimes(1);
     });
+
+    it('does not re-fire onOpen when its identity changes while isOpen stays true', async () => {
+      const onOpen = jest.fn();
+      const renderTree = (isOpen: boolean) => (
+        <BpkProvider>
+          {/* New onOpen identity on every render — simulates an inline callback in the consumer. */}
+          <BpkComparisonTable.Root isOpen={isOpen} onClose={noop} onOpen={() => onOpen()}>
+            <BpkComparisonTable.Header strings={TRANSLATIONS} />
+            <BpkComparisonTable.Content
+              columns={[COLUMN_1]}
+              onRemove={noop}
+              onAddMoreClick={noop}
+              strings={TRANSLATIONS}
+            />
+          </BpkComparisonTable.Root>
+        </BpkProvider>
+      );
+
+      const { rerender } = render(renderTree(true));
+      expect(onOpen).toHaveBeenCalledTimes(1);
+
+      rerender(renderTree(true));
+      rerender(renderTree(true));
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.module.scss
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.module.scss
@@ -112,14 +112,21 @@ $image-area-height: 83 * tokens.$bpk-one-pixel-rem;
   inset-block-start: 0;
 }
 
-// Remove button — fades and collapses its layout space so rows slide up over it.
-.bpk-comparison-table__remove-button {
+// Remove-button row — lives in the first tbody row. Fades and collapses its own
+// height in place (like the old in-header remove button), so data rows below
+// slide up into the vacated space as the user scrolls.
+// Zero the default BpkTableCell 16px padding so the row can fully collapse;
+// the inner wrapper below controls the actual spacing.
+.bpk-comparison-table__remove-cell {
+  padding: 0;
+}
+
+.bpk-comparison-table__remove-cell-inner {
+  padding: 0 tokens.bpk-spacing-base()
+    calc(tokens.bpk-spacing-sm() * var(--bpk-image-opacity, 1));
   opacity: var(--bpk-image-opacity, 1);
   overflow: clip;
-  margin-block-start: calc(
-    tokens.bpk-spacing-md() * var(--bpk-image-opacity, 1)
-  );
-  max-block-size: calc(5rem * var(--bpk-image-opacity, 1));
+  max-block-size: calc(3rem * var(--bpk-image-opacity, 1));
   overflow-clip-margin: tokens.bpk-spacing-sm();
 }
 

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.module.scss
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.module.scss
@@ -52,6 +52,7 @@ $image-area-height: 83 * tokens.$bpk-one-pixel-rem;
   table {
     border-collapse: separate;
     border-spacing: 0;
+    box-shadow: none;
 
     // min-width ensures horizontal scroll kicks in before columns become too narrow to read (e.g. inside a modal on small screens).
     min-inline-size: 3 * 180 * tokens.$bpk-one-pixel-rem;

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.module.scss
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.module.scss
@@ -119,10 +119,10 @@ $image-area-height: 83 * tokens.$bpk-one-pixel-rem;
 
 .bpk-comparison-table__remove-cell-inner {
   padding: 0 tokens.bpk-spacing-base()
-    calc(tokens.bpk-spacing-sm() * var(--bpk-image-opacity, 1));
+    calc(tokens.bpk-spacing-base() * var(--bpk-image-opacity, 1));
   opacity: var(--bpk-image-opacity, 1);
   overflow: clip;
-  max-block-size: calc(3rem * var(--bpk-image-opacity, 1));
+  max-block-size: calc(3.5rem * var(--bpk-image-opacity, 1));
   overflow-clip-margin: tokens.bpk-spacing-sm();
 }
 

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.module.scss
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.module.scss
@@ -112,11 +112,7 @@ $image-area-height: 83 * tokens.$bpk-one-pixel-rem;
   inset-block-start: 0;
 }
 
-// Remove-button row — lives in the first tbody row. Fades and collapses its own
-// height in place (like the old in-header remove button), so data rows below
-// slide up into the vacated space as the user scrolls.
-// Zero the default BpkTableCell 16px padding so the row can fully collapse;
-// the inner wrapper below controls the actual spacing.
+// Remove-button row - Fades and collapses its own height in place, so data rows below slide up into the vacated space as the user scrolls. Zero the default BpkTableCell 16px padding so the row can fully collapse; the inner wrapper below controls the actual spacing.
 .bpk-comparison-table__remove-cell {
   padding: 0;
 }

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.stories.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.stories.tsx
@@ -159,7 +159,16 @@ const StandaloneExample = () => {
         ))}
       </BpkHStack>
 
-      <BpkComparisonTable.Root isOpen={isOpen} onClose={() => setIsOpen(false)}>
+      <BpkComparisonTable.Root
+        isOpen={isOpen}
+        onClose={() => {
+          // eslint-disable-next-line no-console
+          console.log('[BpkComparisonTable] onClose fired');
+          setIsOpen(false);
+        }}
+        // eslint-disable-next-line no-console
+        onOpen={() => console.log('[BpkComparisonTable] onOpen fired')}
+      >
         <BpkComparisonTable.Header title="Modal Headline (Optional)" strings={STRINGS}>
           <BpkAiBlurb.Root>
             <BpkAiBlurb.Header title={AI_BLURB_STRINGS.aiBlurbHeadingLabel} />

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.stories.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTable.stories.tsx
@@ -159,16 +159,7 @@ const StandaloneExample = () => {
         ))}
       </BpkHStack>
 
-      <BpkComparisonTable.Root
-        isOpen={isOpen}
-        onClose={() => {
-          // eslint-disable-next-line no-console
-          console.log('[BpkComparisonTable] onClose fired');
-          setIsOpen(false);
-        }}
-        // eslint-disable-next-line no-console
-        onOpen={() => console.log('[BpkComparisonTable] onOpen fired')}
-      >
+      <BpkComparisonTable.Root isOpen={isOpen} onClose={() => setIsOpen(false)}>
         <BpkComparisonTable.Header title="Modal Headline (Optional)" strings={STRINGS}>
           <BpkAiBlurb.Root>
             <BpkAiBlurb.Header title={AI_BLURB_STRINGS.aiBlurbHeadingLabel} />

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableColumnHeader.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableColumnHeader.tsx
@@ -17,7 +17,6 @@
  */
 
 import BpkBadge, { BADGE_TYPES } from '../../../bpk-component-badge';
-import BpkButton, { BUTTON_TYPES, SIZE_TYPES } from '../../../bpk-component-button';
 import { cssModules } from '../../../bpk-react-utils';
 
 import type { BpkCompareColumn } from './common-types';
@@ -26,11 +25,9 @@ import STYLES from './BpkComparisonTable.module.scss';
 
 type BpkComparisonTableColumnHeaderProps = Pick<
   BpkCompareColumn,
-  'imageSrc' | 'imageAlt' | 'headerContent' | 'itemId' | 'bestTag' | 'removeA11yLabel'
+  'imageSrc' | 'imageAlt' | 'headerContent' | 'bestTag'
 > & {
-  removeLabel: string;
   bestTagLabel: string;
-  onRemove: (itemId: string) => void;
 };
 
 const getClassName = cssModules(STYLES);
@@ -41,10 +38,6 @@ const BpkComparisonTableColumnHeader = ({
   headerContent,
   imageAlt = '',
   imageSrc,
-  itemId,
-  onRemove,
-  removeA11yLabel,
-  removeLabel,
 }: BpkComparisonTableColumnHeaderProps) => (
   <div
     className={getClassName('bpk-comparison-table__header-content')}
@@ -64,17 +57,6 @@ const BpkComparisonTableColumnHeader = ({
 
     <div className={getClassName('bpk-comparison-table__header-id-section')}>
       {headerContent}
-    </div>
-
-    <div className={getClassName('bpk-comparison-table__remove-button')}>
-      <BpkButton
-        type={BUTTON_TYPES.link}
-        size={SIZE_TYPES.small}
-        onClick={() => onRemove(itemId)}
-        aria-label={removeA11yLabel}
-      >
-        {removeLabel}
-      </BpkButton>
     </div>
   </div>
 );

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableContent.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableContent.tsx
@@ -18,6 +18,7 @@
 
 import { useEffect, useRef } from 'react';
 
+import BpkButton, { BUTTON_TYPES, SIZE_TYPES } from '../../../bpk-component-button';
 import {
   BpkTable,
   BpkTableBody,
@@ -97,12 +98,36 @@ const BpkComparisonTableContent = ({
       <BpkTable>
         <BpkComparisonTableHeaderRow
           displayColumns={displayColumns}
-          onRemove={onRemove}
           onAddMoreClick={onAddMoreClick}
           strings={strings}
         />
 
         <BpkTableBody type={TABLE_BODY_TYPES.striped}>
+          {/* Remove-button row — fades and collapses in place so data rows below slide up into its space. */}
+          <BpkTableRow>
+            {displayColumns.map((column, index) => (
+              <BpkTableCell
+                key={column ? `remove-${column.itemId}` : `remove-placeholder-${index}`}
+                // Zero padding needed for row collapse animation — no BpkTableCell prop.
+                // eslint-disable-next-line @skyscanner/rules/forbid-component-props
+                className={getClassName('bpk-comparison-table__remove-cell')}
+              >
+                {column && (
+                  <div className={getClassName('bpk-comparison-table__remove-cell-inner')}>
+                    <BpkButton
+                      type={BUTTON_TYPES.link}
+                      size={SIZE_TYPES.small}
+                      onClick={() => onRemove(column.itemId)}
+                      aria-label={column.removeA11yLabel}
+                    >
+                      {strings.removeLabel}
+                    </BpkButton>
+                  </div>
+                )}
+              </BpkTableCell>
+            ))}
+          </BpkTableRow>
+
           {rowIds.map((rowId) => (
             <BpkTableRow key={rowId}>
               {displayColumns.map((column, index) => (

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableContent.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableContent.tsx
@@ -103,7 +103,8 @@ const BpkComparisonTableContent = ({
         />
 
         <BpkTableBody type={TABLE_BODY_TYPES.striped}>
-          {/* Remove-button row — fades and collapses in place so data rows below slide up into its space. */}
+          {/* Remove-button row — only when there's at least one real column to remove. Fades and collapses in place so data rows below slide up into its space. */}
+          {columns.length > 0 && (
           <BpkTableRow>
             {displayColumns.map((column, index) => (
               <BpkTableCell
@@ -127,6 +128,7 @@ const BpkComparisonTableContent = ({
               </BpkTableCell>
             ))}
           </BpkTableRow>
+          )}
 
           {rowIds.map((rowId) => (
             <BpkTableRow key={rowId}>

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableHeaderRow.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableHeaderRow.tsx
@@ -32,7 +32,6 @@ import type {
 
 type BpkComparisonTableHeaderRowProps = {
   displayColumns: Array<BpkCompareColumn | null>;
-  onRemove: (itemId: string) => void;
   onAddMoreClick: () => void;
   strings: BpkComparisonTableStrings;
 };
@@ -40,10 +39,9 @@ type BpkComparisonTableHeaderRowProps = {
 const BpkComparisonTableHeaderRow = ({
   displayColumns,
   onAddMoreClick,
-  onRemove,
   strings,
 }: BpkComparisonTableHeaderRowProps) => {
-  const { addMoreDescription, addMoreLinkText, bestTagLabel, removeLabel } = strings;
+  const { addMoreDescription, addMoreLinkText, bestTagLabel } = strings;
 
   return (
     <BpkTableHead>
@@ -55,8 +53,6 @@ const BpkComparisonTableHeaderRow = ({
             {column ? (
               <BpkComparisonTableColumnHeader
                 {...column}
-                removeLabel={removeLabel}
-                onRemove={onRemove}
                 bestTagLabel={bestTagLabel}
               />
             ) : (

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableRoot.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableRoot.tsx
@@ -16,26 +16,36 @@
  * limitations under the License.
  */
 
+import { useEffect } from 'react';
+
 import { BpkModalV3 } from '../../../bpk-component-modal';
 
 import type { BpkComparisonTableRootProps } from './common-types';
 
-const BpkComparisonTableRoot = ({ children, isOpen, onClose }: BpkComparisonTableRootProps) => (
-  <BpkModalV3.Root
-    open={isOpen}
-    onOpenChange={(details) => {
-      if (!details.open) {
-        onClose();
-      }
-    }}
-  >
-    <BpkModalV3.Portal>
-      <BpkModalV3.Scrim />
-      <BpkModalV3.Content>
-        {children}
-      </BpkModalV3.Content>
-    </BpkModalV3.Portal>
-  </BpkModalV3.Root>
-);
+const BpkComparisonTableRoot = ({ children, isOpen, onClose, onOpen }: BpkComparisonTableRootProps) => {
+  useEffect(() => {
+    if (isOpen) {
+      onOpen?.();
+    }
+  }, [isOpen, onOpen]);
+
+  return (
+    <BpkModalV3.Root
+      open={isOpen}
+      onOpenChange={(details) => {
+        if (!details.open) {
+          onClose();
+        }
+      }}
+    >
+      <BpkModalV3.Portal>
+        <BpkModalV3.Scrim />
+        <BpkModalV3.Content>
+          {children}
+        </BpkModalV3.Content>
+      </BpkModalV3.Portal>
+    </BpkModalV3.Root>
+  );
+};
 
 export default BpkComparisonTableRoot;

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableRoot.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableRoot.tsx
@@ -16,18 +16,23 @@
  * limitations under the License.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { BpkModalV3 } from '../../../bpk-component-modal';
 
 import type { BpkComparisonTableRootProps } from './common-types';
 
 const BpkComparisonTableRoot = ({ children, isOpen, onClose, onOpen }: BpkComparisonTableRootProps) => {
+  // Hold onOpen in a ref so inline callbacks (new identity each render) don't
+  // re-trigger the effect and double-fire while the modal stays open.
+  const onOpenRef = useRef(onOpen);
+  onOpenRef.current = onOpen;
+
   useEffect(() => {
     if (isOpen) {
-      onOpen?.();
+      onOpenRef.current?.();
     }
-  }, [isOpen, onOpen]);
+  }, [isOpen]);
 
   return (
     <BpkModalV3.Root

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableRoot.tsx
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/BpkComparisonTableRoot.tsx
@@ -23,8 +23,7 @@ import { BpkModalV3 } from '../../../bpk-component-modal';
 import type { BpkComparisonTableRootProps } from './common-types';
 
 const BpkComparisonTableRoot = ({ children, isOpen, onClose, onOpen }: BpkComparisonTableRootProps) => {
-  // Hold onOpen in a ref so inline callbacks (new identity each render) don't
-  // re-trigger the effect and double-fire while the modal stays open.
+  // Hold onOpen in a ref so inline callbacks (new identity each render) don't re-trigger the effect and double-fire while the modal stays open.
   const onOpenRef = useRef(onOpen);
   onOpenRef.current = onOpen;
 

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/README.md
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/README.md
@@ -14,7 +14,7 @@ import type { BpkCompareColumn, BpkComparisonTableStrings } from '@skyscanner/ba
 - **Manage the columns array.** The table is stateless — it renders whatever you pass to `columns`.
 - **Cap the array at 3 columns.** If you pass more than 3, only the first 3 are rendered.
 - **Ensure rowId sequences match across all columns.** Every column must declare the same `rowId` values in the same order. `rowId` is the shared key that aligns rows across columns — think of it as the row label (e.g. `'cancellation'`, `'rating'`). Mismatches will cause rows to misalign.
-- **Control open/close state.** Pass `isOpen` and call `setIsOpen(false)` inside `onClose`.
+- **Control open/close state.** Pass `isOpen` and call `setIsOpen(false)` inside `onClose`. Optionally pass `onOpen` to run side effects (analytics, logging, data fetches) once per open.
 - **Handle removal.** When `onRemove(itemId)` fires, remove that item from your columns array. If fewer than 1 item remains you should also close the modal.
 - **Compose BpkAiBlurb when needed.** Pass a `BpkAiBlurb.Root` as children of `BpkComparisonTable.Header`. The component does not render AI content automatically — you own the composition.
 
@@ -114,9 +114,10 @@ If you don't need the AI Blurb, omit the children from `BpkComparisonTable.Heade
 
 | Property | PropType    | Required | Default Value |
 | -------- | ----------- | -------- | ------------- |
-| isOpen   | boolean     | true     | -             |
-| onClose  | `() => void` | true    | -             |
-| children | ReactNode   | true     | -             |
+| isOpen   | boolean       | true     | -             |
+| onClose  | `() => void`  | true     | -             |
+| onOpen   | `() => void`  | false    | -             |
+| children | ReactNode     | true     | -             |
 
 ### `BpkComparisonTable.Header`
 

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/common-types.ts
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/common-types.ts
@@ -66,6 +66,8 @@ export type BpkComparisonTableRootProps = {
   isOpen: boolean;
   /** Called when the modal close trigger is activated or Escape is pressed. */
   onClose: () => void;
+  /** Optional — called once per open, when `isOpen` transitions from false to true. Useful for analytics, logging, or fetching data on open. */
+  onOpen?: () => void;
   /** BpkComparisonTable.Header and BpkComparisonTable.Content. */
   children: ReactNode;
 };

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTable/common-types.ts
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTable/common-types.ts
@@ -66,7 +66,7 @@ export type BpkComparisonTableRootProps = {
   isOpen: boolean;
   /** Called when the modal close trigger is activated or Escape is pressed. */
   onClose: () => void;
-  /** Optional — called once per open, when `isOpen` transitions from false to true. Useful for analytics, logging, or fetching data on open. */
+  /** Optional — called each time the modal opens: on mount if `isOpen` is `true`, and whenever `isOpen` transitions from `false` to `true`. Useful for analytics, logging, or fetching data on open. */
   onOpen?: () => void;
   /** BpkComparisonTable.Header and BpkComparisonTable.Content. */
   children: ReactNode;

--- a/packages/bpk-component-comparison-table/src/BpkComparisonTray/BpkComparisonTray.module.scss
+++ b/packages/bpk-component-comparison-table/src/BpkComparisonTray/BpkComparisonTray.module.scss
@@ -33,6 +33,11 @@
     min-width: 0;
     flex: 1;
   }
+
+  button {
+    min-height: 0;
+    padding-block: 0;
+  }
 }
 
 // Filled item — relative for close button positioning.


### PR DESCRIPTION
## Description

**Layout change — Remove button moves from sticky column header into the first `<tbody>` row.**

Previously the Remove button lived inside each column's sticky `<th>`, fading and collapsing on scroll. It now lives in the first body row, with matching fade + collapse animation (opacity + `max-block-size` tied to `--bpk-image-opacity`). Data rows slide up into the vacated space as the row collapses. The sticky header now contains only image + `headerContent`, which frees consumers to place price/CTA inside `headerContent` without crowding.

**New optional `onOpen` prop on `BpkComparisonTable.Root`.**

Fires once when `isOpen` transitions from `false → true`. Useful for analytics, logging, or open-time data fetches. Implemented via `useEffect` on `isOpen` — Ark UI's `Dialog.onOpenChange` (used by `BpkModalV3`) only fires on user-initiated state changes (close button, Escape, backdrop), so it can't detect programmatic opens. `onClose` remains unchanged.

**Minor: `BpkComparisonTray` height reduced to 60px per design.**

---

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [x] Component `README.md`
- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [x] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [x] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [x] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [x] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
