### PR TITLE
LOOM-2442 Pt 2 React 19 migration

### DIFF
--- a/packages/bpk-component-banner-alert/src/AnimateAndFade.tsx
+++ b/packages/bpk-component-banner-alert/src/AnimateAndFade.tsx
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-import { Component } from 'react';
-import type { ReactNode } from 'react';
+import { Component, cloneElement, createRef, isValidElement } from 'react';
+import type { ReactElement, ReactNode, RefObject } from 'react';
 
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
@@ -110,6 +110,8 @@ class AnimateAndFade extends Component<Props, State> {
     }
   };
 
+  nodeRef = createRef<HTMLElement>();
+
   toggle = () => {
     if (this.state.visible && this.state.isExpanded) {
       this.setState({
@@ -147,6 +149,7 @@ class AnimateAndFade extends Component<Props, State> {
           >
             {this.state.visible && (
               <CSSTransition
+                nodeRef={this.nodeRef}
                 classNames={{
                   exit: getClassName('bpk-animate-and-fade--leave'),
                   exitActive: getClassName('bpk-animate-and-fade--leave-active'),
@@ -162,7 +165,9 @@ class AnimateAndFade extends Component<Props, State> {
                   exit: ANIMATION_DURATION * 2,
                 }}
               >
-                {children}
+                {isValidElement(children)
+                  ? cloneElement(children as ReactElement<{ ref?: RefObject<HTMLElement | null> }>, { ref: this.nodeRef })
+                  : children}
               </CSSTransition>
             )}
           </TransitionGroup>

--- a/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
+++ b/packages/bpk-component-drawer/src/BpkDrawerContent.tsx
@@ -16,7 +16,8 @@
  * limitations under the License.
  */
 
-import type { CSSProperties, ReactNode, Ref } from 'react';
+import type { CSSProperties, MutableRefObject, ReactNode, Ref } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { Transition } from 'react-transition-group';
 
@@ -96,8 +97,23 @@ const BpkDrawerContent = ({
 
   const headingId = `bpk-drawer-heading-${id}`;
 
+  const nodeRef = useRef<HTMLElement | null>(null);
+  const setRefs = useCallback(
+    (el: HTMLElement | null) => {
+      nodeRef.current = el;
+      const consumerRef = dialogRef;
+      if (typeof consumerRef === 'function') {
+        consumerRef(el);
+      } else if (consumerRef) {
+        (consumerRef as MutableRefObject<HTMLElement | null>).current = el;
+      }
+    },
+    [dialogRef],
+  );
+
   return (
     <Transition
+      nodeRef={nodeRef}
       timeout={{
         enter: 0,
         exit: parseInt(animations.durationSm, 10),
@@ -124,7 +140,7 @@ const BpkDrawerContent = ({
             drawerClassNames.join(' '),
             getClassName(`bpk-drawer--${status}`, mobileModalDisplay ? `bpk-drawer__modal-mobile-view--${status}` : undefined),
           ].join(' ')}
-          ref={dialogRef}
+          ref={setRefs}
           {...rest}
         >
           <header className={getClassName('bpk-drawer__header')}>

--- a/packages/bpk-component-floating-notification/src/BpkFloatingNotification.tsx
+++ b/packages/bpk-component-floating-notification/src/BpkFloatingNotification.tsx
@@ -17,7 +17,7 @@
  */
 
 import type { MouseEvent, FunctionComponent } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { CSSTransition } from 'react-transition-group';
 
@@ -58,6 +58,7 @@ export type Props = {
 
 const BpkFloatingNotification = (props: Props) => {
   const [showMessage, setShowMessage] = useState(true);
+  const nodeRef = useRef<HTMLDivElement>(null);
 
   const {
     animateOnEnter = true,
@@ -91,6 +92,7 @@ const BpkFloatingNotification = (props: Props) => {
   return (
     <CSSTransition
       in={showMessage}
+      nodeRef={nodeRef}
       classNames={{
         exit: getClassName('bpk-floating-notification--leave'),
         exitActive: getClassName('bpk-floating-notification--leave-active'),
@@ -104,6 +106,7 @@ const BpkFloatingNotification = (props: Props) => {
       onExited={onExit}
     >
       <div
+        ref={nodeRef}
         className={classNames}
         {...getDataComponentAttribute('FloatingNotification')}
         {...rest}

--- a/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
+++ b/packages/bpk-component-infinite-scroll/src/__snapshots__/withInfiniteScroll-test.js.snap
@@ -44,25 +44,6 @@ exports[`withInfiniteScroll should finish the list when array changes to empty 1
   <div>
     <div
       id="list"
-    >
-      <div>
-        Element 0
-      </div>
-      <div>
-        Element 1
-      </div>
-      <div>
-        Element 2
-      </div>
-      <div>
-        Element 3
-      </div>
-      <div>
-        Element 4
-      </div>
-    </div>
-    <div
-      class="bpk-sentinel"
     />
   </div>
 </DocumentFragment>
@@ -88,24 +69,15 @@ exports[`withInfiniteScroll should refresh data when data changes 1`] = `
       id="list"
     >
       <div>
-        Element 0
+        1
       </div>
       <div>
-        Element 1
+        2
       </div>
       <div>
-        Element 2
-      </div>
-      <div>
-        Element 3
-      </div>
-      <div>
-        Element 4
+        3
       </div>
     </div>
-    <div
-      class="bpk-sentinel"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -117,24 +89,15 @@ exports[`withInfiniteScroll should refresh data when data changes from an empty 
       id="list"
     >
       <div>
-        Element 0
+        1
       </div>
       <div>
-        Element 1
+        2
       </div>
       <div>
-        Element 2
-      </div>
-      <div>
-        Element 3
-      </div>
-      <div>
-        Element 4
+        3
       </div>
     </div>
-    <div
-      class="bpk-sentinel"
-    />
   </div>
 </DocumentFragment>
 `;

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll-test.js
@@ -18,7 +18,7 @@
 
 import PropTypes from 'prop-types';
 
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ArrayDataSource } from './DataSource';
@@ -280,8 +280,9 @@ describe('withInfiniteScroll', () => {
     const { asFragment } = render(<InfiniteList dataSource={myDs} />);
     await nextTick();
 
-    myDs.updateData([1, 2, 3]);
-    await nextTick();
+    await act(async () => {
+      myDs.updateData([1, 2, 3]);
+    });
 
     expect(myDs.fetchItems).toHaveBeenCalledTimes(2);
     expect(asFragment()).toMatchSnapshot();
@@ -293,8 +294,9 @@ describe('withInfiniteScroll', () => {
     const { asFragment } = render(<InfiniteList dataSource={myDs} />);
     await nextTick();
 
-    myDs.updateData([1, 2, 3]);
-    await nextTick();
+    await act(async () => {
+      myDs.updateData([1, 2, 3]);
+    });
 
     expect(myDs.fetchItems).toHaveBeenCalledTimes(2);
     expect(asFragment()).toMatchSnapshot();
@@ -315,8 +317,9 @@ describe('withInfiniteScroll', () => {
     );
     await nextTick();
 
-    myDs.updateData([]);
-    await nextTick();
+    await act(async () => {
+      myDs.updateData([]);
+    });
 
     expect(myDs.fetchItems).toHaveBeenCalledTimes(2);
     expect(onFinished).toHaveBeenCalled();
@@ -401,9 +404,15 @@ describe('withInfiniteScroll', () => {
         onScrollFinished={onFinished}
       />,
     );
-    await nextTick();
-    await intersect();
-    await intersect();
+    await act(async () => {
+      await nextTick();
+    });
+    await act(async () => {
+      await intersect();
+    });
+    await act(async () => {
+      await intersect();
+    });
 
     expect(myDs.fetchItems).toHaveBeenCalledTimes(3);
     expect(onFinished).toHaveBeenCalled();

--- a/packages/bpk-component-info-banner/src/AnimateAndFade.tsx
+++ b/packages/bpk-component-info-banner/src/AnimateAndFade.tsx
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-import { Component } from 'react';
-import type { ReactNode } from 'react';
+import { Component, cloneElement, createRef, isValidElement } from 'react';
+import type { ReactElement, ReactNode, RefObject } from 'react';
 
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
@@ -110,6 +110,8 @@ class AnimateAndFade extends Component<Props, State> {
     }
   };
 
+  nodeRef = createRef<HTMLElement>();
+
   toggle = () => {
     if (this.state.visible && this.state.isExpanded) {
       this.setState({
@@ -147,6 +149,7 @@ class AnimateAndFade extends Component<Props, State> {
           >
             {this.state.visible && (
               <CSSTransition
+                nodeRef={this.nodeRef}
                 classNames={{
                   exit: getClassName('bpk-animate-and-fade--leave'),
                   exitActive: getClassName('bpk-animate-and-fade--leave-active'),
@@ -162,7 +165,9 @@ class AnimateAndFade extends Component<Props, State> {
                   exit: ANIMATION_DURATION * 2,
                 }}
               >
-                {children}
+                {isValidElement(children)
+                  ? cloneElement(children as ReactElement<{ ref?: RefObject<HTMLElement | null> }>, { ref: this.nodeRef })
+                  : children}
               </CSSTransition>
             )}
           </TransitionGroup>


### PR DESCRIPTION
LOOM-2442

Finishes making the React 19 jest matrix green so it can be flipped to required.

  - react-transition-group nodeRef migration — R19 removed findDOMNode, which <Transition>/<CSSTransition> fall back to without nodeRef. Added refs in 4 components:
    - BpkFloatingNotification — useRef on the wrapping <div>
    - BpkDrawerContent — local nodeRef plus a setRefs callback that also forwards to the existing dialogRef prop
    - AnimateAndFade (banner-alert + info-banner) — class-field nodeRef injected onto the single-element child via cloneElement
  - withInfiniteScroll test stabilisation — wrapped updateData(...) and intersect() calls in act(async () => …) so state flushes deterministically across both React versions. Regenerated 3 snapshots that were
  latently stale on R18 (they were captured before the data refresh actually applied — the test name said "should refresh data" but the snapshot showed pre-refresh DOM).

All tests passing, snapshots working

  npm run lint and npm run typecheck clean on both versions.

  Follow-ups (not in this PR)

  - Flip the React19 CI job from continue-on-error: true to required after this lands and stays green on main for a run or two.
  - Remaining deferred items from #4455 (class-component defaultProps, Flow prop-types removal, @types/react@19 bump) are independent threads.

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
