### PR TITLE
[NO-JIRA][BpkChatbotInput] Reorder WithToolbar story below ComposerOver500

### DIFF
--- a/packages/bpk-component-chatbot-input/src/BpkChatbotInput.stories.tsx
+++ b/packages/bpk-component-chatbot-input/src/BpkChatbotInput.stories.tsx
@@ -403,6 +403,10 @@ export const ComposerOver500 = {
   render: () => <ComposerOver500Example />,
 };
 
+export const WithToolbar = {
+  render: () => <WithToolbarExample />,
+};
+
 export const Cars = {
   render: () => <CarsExample />,
 };
@@ -452,10 +456,6 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
-};
-
-export const WithToolbar = {
-  render: () => <WithToolbarExample />,
 };
 
 export const WithCustomSendButton = {


### PR DESCRIPTION
## Summary
- Move the `WithToolbar` story to sit directly below `ComposerOver500` in `BpkChatbotInput.stories.tsx` so that the Composer-family stories stay grouped together in the Storybook sidebar, ahead of the Cars variants.
<img width="335" height="340" alt="image" src="https://github.com/user-attachments/assets/8ae820f1-39b2-4c5a-b089-097fc42a00f8" />

## Test plan
- [x] Open Storybook and verify the `bpk-component-chatbot-input` sidebar order: Composer → Composer With Value → Composer Sending → Composer Over 500 → With Toolbar → Cars → ...