### PR TITLE
LOOM-2442 Pt 2 React 19 Migration

### DIFF
--- a/packages/bpk-component-accordion/src/withAccordionItemState.tsx
+++ b/packages/bpk-component-accordion/src/withAccordionItemState.tsx
@@ -24,8 +24,8 @@ import { wrapDisplayName } from '../../bpk-react-utils';
 import type { BpkAccordionItemProps } from './BpkAccordionItem';
 
 type Props = {
-  initiallyExpanded: boolean;
-  expanded: boolean;
+  initiallyExpanded?: boolean;
+  expanded?: boolean;
   onClick?: () => void;
 };
 
@@ -42,17 +42,13 @@ const withAccordionItemState = <P extends BpkAccordionItemProps>(
       'withAccordionItemState',
     );
 
-    static defaultProps = {
-      initiallyExpanded: false,
-      expanded: false,
-      onClick: null,
-    };
-
     constructor(props: P & Props) {
       super(props);
 
+      const { initiallyExpanded = false } = props;
+
       this.state = {
-        expanded: props.initiallyExpanded,
+        expanded: initiallyExpanded,
       };
     }
 

--- a/packages/bpk-component-banner-alert/src/AnimateAndFade.tsx
+++ b/packages/bpk-component-banner-alert/src/AnimateAndFade.tsx
@@ -33,8 +33,8 @@ const getClassName = cssModules(STYLES);
 const ANIMATION_DURATION = parseInt(durationSm, 10);
 
 type Props = {
-  animateOnEnter: boolean;
-  animateOnLeave: boolean;
+  animateOnEnter?: boolean;
+  animateOnLeave?: boolean;
   children: ReactNode | string;
   show: boolean;
   className?: string | undefined;
@@ -51,16 +51,12 @@ type State = {
 class AnimateAndFade extends Component<Props, State> {
   toggleImmediately: boolean;
 
-  static defaultProps = {
-    animateOnEnter: false,
-    animateOnLeave: false,
-  };
-
   constructor(props: Props) {
     super(props);
 
-    this.toggleImmediately = this.props.show && this.props.animateOnEnter;
-    const initiallyShown = this.toggleImmediately ? false : this.props.show;
+    const { animateOnEnter = false, show } = props;
+    this.toggleImmediately = show && animateOnEnter;
+    const initiallyShown = this.toggleImmediately ? false : show;
 
     this.state = {
       isExpanded: initiallyShown,
@@ -127,7 +123,7 @@ class AnimateAndFade extends Component<Props, State> {
   };
 
   render() {
-    const { animateOnEnter, animateOnLeave, children, className } = this.props;
+    const { animateOnEnter = false, animateOnLeave = false, children, className } = this.props;
     const showPlaceholder =
       !this.state.visible && !this.state.hideAnimationInProgress;
     // While the expanding animation takes place, we render the child element

--- a/packages/bpk-component-banner-alert/src/withBannerAlertState.tsx
+++ b/packages/bpk-component-banner-alert/src/withBannerAlertState.tsx
@@ -48,22 +48,11 @@ const withBannerAlertState = <P extends BpkBannerAlertProps>(
 
     hideIntervalId?: ReturnType<typeof setTimeout> | null;
 
-    static defaultProps = {
-      onDismiss: null,
-      onExpandToggle: null,
-      onHide: null,
-      expanded: false,
-      show: true,
-      hideAfter: null,
-      animateOnLeave: false,
-      children: null,
-    };
-
     constructor(props: P & WithBannerAlertStateProps) {
       super(props);
 
       this.state = {
-        expanded: props.expanded,
+        expanded: props.expanded ?? false,
         show: true,
       };
 
@@ -120,8 +109,8 @@ const withBannerAlertState = <P extends BpkBannerAlertProps>(
 
     render() {
       const {
-        animateOnLeave,
-        children,
+        animateOnLeave = false,
+        children = null,
         expanded,
         hideAfter,
         onDismiss,

--- a/packages/bpk-component-barchart/src/BpkBarchart.js
+++ b/packages/bpk-component-barchart/src/BpkBarchart.js
@@ -53,6 +53,16 @@ const getClassName = cssModules(STYLES);
 const spacing = remToPx('.375rem');
 const lineHeight = remToPx(lineHeightSm);
 
+const DEFAULT_X_AXIS_MARGIN = 2 * (lineHeight + spacing);
+const DEFAULT_Y_AXIS_MARGIN = 4 * lineHeight + spacing;
+const DEFAULT_Y_AXIS_DOMAIN = [null, null];
+const DEFAULT_GET_BAR_LABEL = (
+  point: any,
+  xScaleDataKey: string,
+  yScaleDataKey: string,
+) => `${point[xScaleDataKey]} - ${point[yScaleDataKey]}`;
+const DEFAULT_GET_BAR_SELECTION = () => false;
+
 const getMaxYValue = (
   dataPoints: Array<number>,
   outlierPercentage: ?number,
@@ -108,30 +118,6 @@ class BpkBarchart extends Component<Props, State> {
 
   svgEl: ?Element;
 
-  static defaultProps = {
-    leadingScrollIndicatorClassName: null,
-    trailingScrollIndicatorClassName: null,
-    outlierPercentage: null,
-    showGridlines: false,
-    xAxisMargin: 2 * (lineHeight + spacing),
-    xAxisTickValue: identity,
-    xAxisTickOffset: 0,
-    xAxisTickEvery: 1,
-    yAxisMargin: 4 * lineHeight + spacing,
-    yAxisTickValue: identity,
-    yAxisNumTicks: null,
-    yAxisDomain: [null, null],
-    onBarClick: null,
-    onBarHover: null,
-    onBarFocus: null,
-    // Using type any here as xScaleDataKey or yScaleDataKey are strings and there is an issue that strings are not valid keys
-    getBarLabel: (point: any, xScaleDataKey: string, yScaleDataKey: string) =>
-      `${point[xScaleDataKey]} - ${point[yScaleDataKey]}`,
-    getBarSelection: () => false,
-    BarComponent: BpkBarchartBar,
-    disableDataTable: false,
-  };
-
   constructor(props: Props) {
     super(props);
 
@@ -167,31 +153,31 @@ class BpkBarchart extends Component<Props, State> {
 
   render() {
     const {
-      BarComponent,
+      BarComponent = BpkBarchartBar,
       data,
-      disableDataTable,
-      getBarLabel,
-      getBarSelection,
+      disableDataTable = false,
+      getBarLabel = DEFAULT_GET_BAR_LABEL,
+      getBarSelection = DEFAULT_GET_BAR_SELECTION,
       initialHeight,
       initialWidth,
-      leadingScrollIndicatorClassName,
-      onBarClick,
-      onBarFocus,
-      onBarHover,
-      outlierPercentage,
-      showGridlines,
-      trailingScrollIndicatorClassName,
+      leadingScrollIndicatorClassName = null,
+      onBarClick = null,
+      onBarFocus = null,
+      onBarHover = null,
+      outlierPercentage = null,
+      showGridlines = false,
+      trailingScrollIndicatorClassName = null,
       xAxisLabel,
-      xAxisMargin,
-      xAxisTickEvery,
-      xAxisTickOffset,
-      xAxisTickValue,
+      xAxisMargin = DEFAULT_X_AXIS_MARGIN,
+      xAxisTickEvery = 1,
+      xAxisTickOffset = 0,
+      xAxisTickValue = identity,
       xScaleDataKey,
-      yAxisDomain,
+      yAxisDomain = DEFAULT_Y_AXIS_DOMAIN,
       yAxisLabel,
-      yAxisMargin,
-      yAxisNumTicks,
-      yAxisTickValue,
+      yAxisMargin = DEFAULT_Y_AXIS_MARGIN,
+      yAxisNumTicks = null,
+      yAxisTickValue = identity,
       yScaleDataKey,
       ...rest
     } = this.props;

--- a/packages/bpk-component-calendar/index.ts
+++ b/packages/bpk-component-calendar/index.ts
@@ -17,6 +17,9 @@
  */
 
 import BpkCalendarContainer, {
+  DEFAULT_MARK_TODAY,
+  DEFAULT_MAX_DATE,
+  DEFAULT_MIN_DATE,
   withCalendarState,
 } from './src/BpkCalendarContainer';
 import BpkCalendarDate, {
@@ -56,6 +59,9 @@ export {
   BpkCalendarDate,
   DateUtils,
   CALENDAR_SELECTION_TYPE,
+  DEFAULT_MARK_TODAY,
+  DEFAULT_MAX_DATE,
+  DEFAULT_MIN_DATE,
   DaysOfWeek,
   ReactComponent,
   WeekDay,

--- a/packages/bpk-component-calendar/src/BpkCalendar.stories.js
+++ b/packages/bpk-component-calendar/src/BpkCalendar.stories.js
@@ -252,7 +252,6 @@ const CustomComposedCalendarExample = () => (
 
 const WeekExample = () => {
   const weekProps = {
-    ...BpkCalendarWeek.defaultProps,
     DateComponent: DummyDateComponent,
     dateModifiers: {},
     dates: [

--- a/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarContainer.tsx
@@ -42,6 +42,15 @@ import {
 
 import type { SelectionConfiguration } from './custom-proptypes';
 
+export const DEFAULT_MARK_TODAY = true;
+export const DEFAULT_MAX_DATE = addMonths(new Date(), 12);
+export const DEFAULT_MIN_DATE = new Date();
+
+const DEFAULT_SELECTION_CONFIGURATION: SelectionConfiguration = {
+  type: CALENDAR_SELECTION_TYPE.single,
+  date: null,
+};
+
 export type Props = {
   /**
    * If set to true (default), it sets a fixed width on the calendar container. This is necessary to support transitions and to create the right size for the Datepicker component.
@@ -177,38 +186,26 @@ const getRawSelectedDate = (selectionConfig: SelectionConfiguration) => {
 
 const withCalendarState = <P extends object>(Calendar: ComponentType<P>) => {
   class BpkCalendarContainer extends Component<CalendarProps<P>, State> {
-    static defaultProps = {
-      fixedWidth: true,
-      maxDate: addMonths(new Date(), 12),
-      minDate: new Date(),
-      onDateSelect: null,
-      onMonthChange: null,
-      selectionConfiguration: {
-        type: CALENDAR_SELECTION_TYPE.single,
-        date: null,
-      },
-      initiallyFocusedDate: null,
-      markToday: true,
-      markOutsideDays: true,
-    };
-
     constructor(props: CalendarProps<P>) {
       super(props);
 
-      const minDate = startOfDay(this.props.minDate!);
-      const maxDate = startOfDay(this.props.maxDate!);
+      const {
+        initiallyFocusedDate = null,
+        maxDate: maxDateProp = DEFAULT_MAX_DATE,
+        minDate: minDateProp = DEFAULT_MIN_DATE,
+        selectionConfiguration = DEFAULT_SELECTION_CONFIGURATION,
+      } = this.props;
 
-      const rawSelectedDate = getRawSelectedDate(
-        this.props.selectionConfiguration!,
-      );
+      const minDate = startOfDay(minDateProp);
+      const maxDate = startOfDay(maxDateProp);
 
-      const { initiallyFocusedDate } = this.props;
+      const rawSelectedDate = getRawSelectedDate(selectionConfiguration);
 
       this.state = {
         preventKeyboardFocus: true,
         focusedDate: determineFocusedDate(
           rawSelectedDate[0],
-          initiallyFocusedDate!,
+          initiallyFocusedDate,
           minDate,
           maxDate,
         ),
@@ -216,12 +213,16 @@ const withCalendarState = <P extends object>(Calendar: ComponentType<P>) => {
     }
 
     componentDidUpdate(prevProps: CalendarProps<P>) {
-      const rawNextSelectedDate = getRawSelectedDate(
-        this.props.selectionConfiguration!,
-      );
+      const {
+        maxDate: maxDateProp = DEFAULT_MAX_DATE,
+        minDate: minDateProp = DEFAULT_MIN_DATE,
+        selectionConfiguration = DEFAULT_SELECTION_CONFIGURATION,
+      } = this.props;
 
-      const minDate = startOfDay(this.props.minDate!);
-      const maxDate = startOfDay(this.props.maxDate!);
+      const rawNextSelectedDate = getRawSelectedDate(selectionConfiguration);
+
+      const minDate = startOfDay(minDateProp);
+      const maxDate = startOfDay(maxDateProp);
 
       if (
         focusedDateHasChanged(
@@ -243,11 +244,15 @@ const withCalendarState = <P extends object>(Calendar: ComponentType<P>) => {
       event: UIEvent,
       { date, source }: { date: Date; source: string },
     ) => {
-      const { onMonthChange } = this.props;
+      const {
+        maxDate = DEFAULT_MAX_DATE,
+        minDate = DEFAULT_MIN_DATE,
+        onMonthChange = null,
+      } = this.props;
       const focusedDate = dateToBoundaries(
         date,
-        startOfDay(this.props.minDate!),
-        startOfDay(this.props.maxDate!),
+        startOfDay(minDate),
+        startOfDay(maxDate),
       );
       const didMonthChange = !isSameMonth(this.state.focusedDate, focusedDate);
 
@@ -265,18 +270,22 @@ const withCalendarState = <P extends object>(Calendar: ComponentType<P>) => {
     };
 
     handleDateSelect = (date: Date) => {
-      const { onDateSelect, selectionConfiguration } = this.props;
+      const {
+        maxDate = DEFAULT_MAX_DATE,
+        minDate = DEFAULT_MIN_DATE,
+        onDateSelect = null,
+        selectionConfiguration = DEFAULT_SELECTION_CONFIGURATION,
+      } = this.props;
       const keyboardFocusState = { preventKeyboardFocus: false };
 
       if (onDateSelect) {
         const newDate = dateToBoundaries(
           date,
-          startOfDay(this.props.minDate!),
-          startOfDay(this.props.maxDate!),
+          startOfDay(minDate),
+          startOfDay(maxDate),
         );
 
         if (
-          selectionConfiguration &&
           selectionConfiguration.type === CALENDAR_SELECTION_TYPE.range &&
           selectionConfiguration.startDate &&
           !selectionConfiguration.endDate &&
@@ -373,16 +382,20 @@ const withCalendarState = <P extends object>(Calendar: ComponentType<P>) => {
 
     render() {
       const {
-        maxDate,
-        minDate,
+        fixedWidth = true,
+        initiallyFocusedDate = null,
+        markOutsideDays = true,
+        markToday = DEFAULT_MARK_TODAY,
+        maxDate = DEFAULT_MAX_DATE,
+        minDate = DEFAULT_MIN_DATE,
         onDateSelect,
         onMonthChange,
-        selectionConfiguration,
+        selectionConfiguration = DEFAULT_SELECTION_CONFIGURATION,
         ...calendarProps
       } = this.props;
 
-      const sanitisedMinDate = startOfDay(minDate!);
-      const sanitisedMaxDate = startOfDay(maxDate!);
+      const sanitisedMinDate = startOfDay(minDate);
+      const sanitisedMaxDate = startOfDay(maxDate);
 
       const sanitisedFocusedDate = dateToBoundaries(
         this.state.focusedDate,
@@ -399,6 +412,10 @@ const withCalendarState = <P extends object>(Calendar: ComponentType<P>) => {
           onDateKeyDown={this.handleDateKeyDown}
           preventKeyboardFocus={this.state.preventKeyboardFocus}
           focusedDate={sanitisedFocusedDate}
+          fixedWidth={fixedWidth}
+          initiallyFocusedDate={initiallyFocusedDate}
+          markOutsideDays={markOutsideDays}
+          markToday={markToday}
           {...(calendarProps as P)}
           minDate={sanitisedMinDate}
           maxDate={sanitisedMaxDate}

--- a/packages/bpk-component-calendar/src/BpkCalendarDate.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarDate.tsx
@@ -78,25 +78,14 @@ const navigatedByMonthNudger = () =>
   document?.activeElement?.id &&
   document.activeElement.id.indexOf('month_nudger') !== -1;
 
-class BpkCalendarDate extends PureComponent<Props> {
-  static defaultProps: DefaultProps = {
-    className: null,
-    isBlocked: false,
-    isFocused: false,
-    isKeyboardFocusable: true,
-    isOutside: false,
-    isSelected: false,
-    isToday: false,
-    modifiers: {},
-    onClick: null,
-    onDateKeyDown: () => {},
-    preventKeyboardFocus: true,
-    selectionType: SELECTION_TYPES.none,
-    style: {},
-  };
+const EMPTY_MODIFIERS: DateModifiers = {};
+const EMPTY_STYLE = {};
+const noopKeyDown = () => {};
 
+class BpkCalendarDate extends PureComponent<Props> {
   componentDidMount() {
-    if (!this.props.preventKeyboardFocus && this.props.isFocused) {
+    const { isFocused = false, preventKeyboardFocus = true } = this.props;
+    if (!preventKeyboardFocus && isFocused) {
       // If we got here by clicking the nudger, don't focus this date
       if (!navigatedByMonthNudger()) {
         // Giving focus after instantiation
@@ -106,30 +95,29 @@ class BpkCalendarDate extends PureComponent<Props> {
   }
 
   componentDidUpdate(prevProps: Props) {
+    const {
+      isFocused = false,
+      isKeyboardFocusable = true,
+      preventKeyboardFocus = true,
+    } = this.props;
+    const { isFocused: prevIsFocused = false, isKeyboardFocusable: prevIsKeyboardFocusable = true } = prevProps;
+
     if (
-      !this.props.isKeyboardFocusable ||
-      this.props.preventKeyboardFocus ||
+      !isKeyboardFocusable ||
+      preventKeyboardFocus ||
       navigatedByMonthNudger()
     ) {
       return;
     }
 
     // Giving focus after keyboard navigation
-    if (
-      !prevProps.isFocused &&
-      this.props.isFocused &&
-      this.props.isKeyboardFocusable
-    ) {
+    if (!prevIsFocused && isFocused && isKeyboardFocusable) {
       this.button?.focus();
       return;
     }
 
     // Giving focus after changing months with transition
-    if (
-      this.props.isFocused &&
-      !prevProps.isKeyboardFocusable &&
-      this.props.isKeyboardFocusable
-    ) {
+    if (isFocused && !prevIsKeyboardFocusable && isKeyboardFocusable) {
       this.button?.focus();
     }
   }
@@ -138,26 +126,25 @@ class BpkCalendarDate extends PureComponent<Props> {
 
   render() {
     const {
-      className,
+      className = null,
       date,
-      isBlocked,
-      isFocused,
-      isKeyboardFocusable,
-      isOutside,
-      isSelected,
-      isToday,
-      modifiers,
-      onClick,
-      onDateKeyDown,
-      selectionType,
-      style,
+      isBlocked = false,
+      isFocused = false,
+      isKeyboardFocusable = true,
+      isOutside = false,
+      isSelected = false,
+      modifiers = EMPTY_MODIFIERS,
+      onClick = null,
+      onDateKeyDown = noopKeyDown,
+      selectionType = SELECTION_TYPES.none,
+      style = EMPTY_STYLE,
       ...buttonProps
     } = this.props;
 
     const classNames = [getClassName('bpk-calendar-date')];
 
-    Object.keys(modifiers!).forEach((modifier) => {
-      if (modifiers![modifier](this.props)) {
+    Object.keys(modifiers).forEach((modifier) => {
+      if (modifiers[modifier](this.props)) {
         classNames.push(
           getClassName(`bpk-calendar-date--modifier-${modifier}`),
         );
@@ -187,6 +174,7 @@ class BpkCalendarDate extends PureComponent<Props> {
 
     delete buttonProps.preventKeyboardFocus;
     delete buttonProps.isoLabel;
+    delete buttonProps.isToday;
 
     return (
       <button

--- a/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarGrid.tsx
@@ -49,26 +49,26 @@ type DefaultProps = {
   className?: string | null;
   dateModifiers?: DateModifiers;
   focusedDate?: Date | null;
-  cellClassName: string | null;
-  isKeyboardFocusable: boolean;
-  markOutsideDays: boolean;
-  markToday: boolean;
-  maxDate: Date;
-  minDate: Date;
-  onDateClick: () => void;
-  onDateKeyDown: () => void;
+  cellClassName?: string | null;
+  isKeyboardFocusable?: boolean;
+  markOutsideDays?: boolean;
+  markToday?: boolean;
+  maxDate?: Date;
+  minDate?: Date;
+  onDateClick?: () => void;
+  onDateKeyDown?: () => void;
   /**
    * A function to format a human-readable month, for example: "January 2018":
    * If you just need to quickly prototype, use the following from [`date-fns`](https://date-fns.org/docs/format#usage)
    */
-  formatMonth: (month: Date) => string;
-  preventKeyboardFocus: boolean;
+  formatMonth?: (month: Date) => string;
+  preventKeyboardFocus?: boolean;
   /**
    * An object to indicate which configuration of the calendar is being used. Choices are `single` date selection or `range` date selection.
    */
-  selectionConfiguration: SelectionConfiguration;
-  ignoreOutsideDate: boolean;
-  dateProps: {};
+  selectionConfiguration?: SelectionConfiguration;
+  ignoreOutsideDate?: boolean;
+  dateProps?: {};
 };
 
 export type Props = DefaultProps & {
@@ -93,32 +93,23 @@ export type DateProps = {
 type State = {
   calendarMonthWeeks: DateProps[][];
 };
+
+const EMPTY_DATE_MODIFIERS: DateModifiers = {};
+const EMPTY_DATE_PROPS = {};
+const DEFAULT_MAX_DATE = addMonths(new Date(), 12);
+const DEFAULT_MIN_DATE = new Date();
+const DEFAULT_SELECTION_CONFIGURATION: SelectionConfiguration = {
+  type: CALENDAR_SELECTION_TYPE.single,
+  date: null,
+};
+const noopDateClick = () => {};
+const noopDateKeyDown = () => {};
+const defaultFormatMonth = (month: Date) => format(month, 'MMMM yyyy');
+
 /*
   BpkCalendarGrid - the grid representing a whole month
 */
 class BpkCalendarGrid extends Component<Props, State> {
-  static defaultProps: DefaultProps = {
-    className: null,
-    dateModifiers: {},
-    focusedDate: null,
-    isKeyboardFocusable: true,
-    markOutsideDays: true,
-    markToday: true,
-    maxDate: addMonths(new Date(), 12),
-    minDate: new Date(),
-    onDateClick: () => {},
-    onDateKeyDown: () => {},
-    formatMonth: (month: Date) => format(month, 'MMMM yyyy'),
-    preventKeyboardFocus: false,
-    selectionConfiguration: {
-      type: CALENDAR_SELECTION_TYPE.single,
-      date: null,
-    },
-    ignoreOutsideDate: false,
-    dateProps: {},
-    cellClassName: null,
-  };
-
   constructor(props: Props) {
     super(props);
 
@@ -160,23 +151,23 @@ class BpkCalendarGrid extends Component<Props, State> {
   render() {
     const {
       DateComponent,
-      cellClassName,
-      className,
-      dateModifiers,
-      dateProps,
-      focusedDate,
-      formatMonth,
-      ignoreOutsideDate,
-      isKeyboardFocusable,
-      markOutsideDays,
-      markToday,
-      maxDate,
-      minDate,
+      cellClassName = null,
+      className = null,
+      dateModifiers = EMPTY_DATE_MODIFIERS,
+      dateProps = EMPTY_DATE_PROPS,
+      focusedDate = null,
+      formatMonth = defaultFormatMonth,
+      ignoreOutsideDate = false,
+      isKeyboardFocusable = true,
+      markOutsideDays = true,
+      markToday = true,
+      maxDate = DEFAULT_MAX_DATE,
+      minDate = DEFAULT_MIN_DATE,
       month,
-      onDateClick,
-      onDateKeyDown,
-      preventKeyboardFocus,
-      selectionConfiguration,
+      onDateClick = noopDateClick,
+      onDateKeyDown = noopDateKeyDown,
+      preventKeyboardFocus = false,
+      selectionConfiguration = DEFAULT_SELECTION_CONFIGURATION,
       weekStartsOn,
     } = this.props;
 
@@ -201,7 +192,7 @@ class BpkCalendarGrid extends Component<Props, State> {
               onDateClick={onDateClick}
               onDateKeyDown={onDateKeyDown}
               DateComponent={DateComponent}
-              dateModifiers={dateModifiers!}
+              dateModifiers={dateModifiers}
               preventKeyboardFocus={preventKeyboardFocus}
               isKeyboardFocusable={isKeyboardFocusable}
               weekStartsOn={weekStartsOn}

--- a/packages/bpk-component-calendar/src/BpkCalendarGridHeader.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridHeader.tsx
@@ -77,13 +77,8 @@ const WeekDayComponent = ({
 );
 
 class BpkCalendarGridHeader extends PureComponent<Props> {
-  static defaultProps = {
-    className: null,
-    weekDayKey: 'nameAbbr',
-  };
-
   render() {
-    const { className, weekDayKey, weekStartsOn } = this.props;
+    const { className = null, weekDayKey = 'nameAbbr', weekStartsOn } = this.props;
 
     const daysOfWeek = orderDaysOfWeek(this.props.daysOfWeek, weekStartsOn);
 

--- a/packages/bpk-component-calendar/src/BpkCalendarGridTransition.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarGridTransition.tsx
@@ -81,12 +81,6 @@ type State = {
 class BpkCalendarGridTransition extends Component<Props, State> {
   isTransitionEndSupported: boolean;
 
-  static defaultProps = {
-    className: null,
-    month: new Date(),
-    focusedDate: null,
-  };
-
   constructor(props: Props) {
     super(props);
 

--- a/packages/bpk-component-calendar/src/BpkCalendarWeek-test.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarWeek-test.tsx
@@ -34,7 +34,6 @@ const DummyDateComponent = (props: any) => {
 };
 
 const initialProps: Props = {
-  ...BpkCalendarWeek.defaultProps,
   DateComponent: DummyDateComponent,
   dateModifiers: {},
   dates: [

--- a/packages/bpk-component-calendar/src/BpkCalendarWeek.tsx
+++ b/packages/bpk-component-calendar/src/BpkCalendarWeek.tsx
@@ -256,25 +256,17 @@ type DefaultProps = {
   selectionConfiguration?: SelectionConfiguration;
 };
 
+const DEFAULT_SELECTION_CONFIGURATION: SelectionConfiguration = {
+  type: CALENDAR_SELECTION_TYPE.single,
+  date: null,
+};
+
+const noop = () => {};
+
 /*
   BpkCalendarWeek - table row containing a week full of DateContainer components
 */
 class BpkCalendarWeek extends Component<Props> {
-  static defaultProps: DefaultProps = {
-    dateProps: {},
-    focusedDate: null,
-    ignoreOutsideDate: false,
-    maxDate: null,
-    minDate: null,
-    onDateClick: () => {},
-    onDateKeyDown: () => {},
-    selectionConfiguration: {
-      type: CALENDAR_SELECTION_TYPE.single,
-      date: null,
-    },
-    cellClassName: null,
-  };
-
   shouldComponentUpdate(nextProps: Props) {
     const shallowProps = [
       'DateComponent',
@@ -354,21 +346,21 @@ class BpkCalendarWeek extends Component<Props> {
   render() {
     const {
       DateComponent,
-      cellClassName,
+      cellClassName = null,
       dateModifiers,
-      dateProps,
-      focusedDate,
-      ignoreOutsideDate,
+      dateProps = {},
+      focusedDate = null,
+      ignoreOutsideDate = false,
       isKeyboardFocusable,
       markOutsideDays,
       markToday,
-      maxDate,
-      minDate,
+      maxDate = null,
+      minDate = null,
       month,
-      onDateClick,
-      onDateKeyDown,
+      onDateClick = noop,
+      onDateKeyDown = noop,
       preventKeyboardFocus,
-      selectionConfiguration,
+      selectionConfiguration = DEFAULT_SELECTION_CONFIGURATION,
       weekStartsOn,
     } = this.props;
 
@@ -398,16 +390,16 @@ class BpkCalendarWeek extends Component<Props> {
 
           const dateSelectionType = getSelectionType(
             date.val,
-            selectionConfiguration!,
+            selectionConfiguration,
             month,
             weekStartsOn,
-            ignoreOutsideDate!,
+            ignoreOutsideDate,
           );
 
           return (
             <DateContainer
               className={cellClassName}
-              isEmptyCell={!isSameMonth(date.val, month) && ignoreOutsideDate!}
+              isEmptyCell={!isSameMonth(date.val, month) && ignoreOutsideDate}
               key={date.val.getDate()}
               selectionType={dateSelectionType}
             >
@@ -420,7 +412,7 @@ class BpkCalendarWeek extends Component<Props> {
                 preventKeyboardFocus={preventKeyboardFocus}
                 isKeyboardFocusable={isKeyboardFocusable}
                 isFocused={focusedDate && isSameDay(date.val, focusedDate)}
-                isSelected={getSelectedDate(date.val, selectionConfiguration!)}
+                isSelected={getSelectedDate(date.val, selectionConfiguration)}
                 isBlocked={isBlocked}
                 isOutside={markOutsideDays && !isSameMonth(date.val, month)}
                 isToday={markToday && isToday(date.val)}

--- a/packages/bpk-component-datepicker/src/BpkDatepicker.tsx
+++ b/packages/bpk-component-datepicker/src/BpkDatepicker.tsx
@@ -27,6 +27,9 @@ import {
   BpkCalendarDate,
   withCalendarState,
   CALENDAR_SELECTION_TYPE,
+  DEFAULT_MARK_TODAY,
+  DEFAULT_MAX_DATE,
+  DEFAULT_MIN_DATE,
   DateUtils,
   BpkCalendarNav,
 } from '../../bpk-component-calendar';
@@ -70,15 +73,15 @@ type Props = {
    * The "pagewrap" element id is a convention we use internally at Skyscanner. In most cases it should "just work".
    */
   getApplicationElement: () => HTMLElement | null;
-  nextMonthLabel: string;
-  previousMonthLabel: string;
   weekStartsOn: number;
   // Optional
-  calendarComponent: ReactComponent;
+  nextMonthLabel?: string | null;
+  previousMonthLabel?: string | null;
+  calendarComponent?: ReactComponent;
   /**
    * By default BpkInput. If passed, it should be a DOM node with a ref attached to it.
    */
-  inputComponent: ReactElement<any> | null;
+  inputComponent?: ReactElement<any> | null;
   dateModifiers?: {};
   fixedWidth?: boolean;
   inputProps?: {};
@@ -108,6 +111,11 @@ type State = {
   isOpen: boolean;
 };
 
+const DEFAULT_SELECTION_CONFIGURATION: SelectionConfiguration = {
+  type: CALENDAR_SELECTION_TYPE.single,
+  date: null,
+};
+
 class BpkDatepicker extends Component<Props, State> {
   inputRef: (ref:HTMLInputElement) => void;
 
@@ -115,36 +123,13 @@ class BpkDatepicker extends Component<Props, State> {
 
   focusRef?: Ref<HTMLDivElement>;
 
-  static defaultProps = {
-    calendarComponent: DefaultCalendar,
-    inputComponent: null,
-    dateModifiers: {},
-    inputProps: {},
-    fixedWidth: true,
-    markOutsideDays: true,
-    markToday: DefaultCalendar.defaultProps.markToday,
-    maxDate: DefaultCalendar.defaultProps.maxDate,
-    minDate: DefaultCalendar.defaultProps.minDate,
-    nextMonthLabel: null,
-    onDateSelect: null,
-    onOpenChange: null,
-    onMonthChange: null,
-    previousMonthLabel: null,
-    selectionConfiguration: {
-      type: CALENDAR_SELECTION_TYPE.single,
-      date: null,
-    },
-    initiallyFocusedDate: null,
-    renderTarget: null,
-    isOpen: false,
-    valid: null,
-  };
-
   constructor(props: Props) {
     super(props);
 
+    const { isOpen = false } = props;
+
     this.state = {
-      isOpen: props.isOpen!,
+      isOpen,
     };
     this.focusRef = createRef();
     this.inputRef = (ref) => {
@@ -165,20 +150,22 @@ class BpkDatepicker extends Component<Props, State> {
   }
 
   onOpen = () => {
+    const { onOpenChange = null } = this.props;
     this.setState({
       isOpen: true,
     });
-    if (this.props.onOpenChange) {
-      this.props.onOpenChange(true);
+    if (onOpenChange) {
+      onOpenChange(true);
     }
   };
 
   onClose = () => {
+    const { onOpenChange = null } = this.props;
     this.setState({
       isOpen: false,
     });
-    if (this.props.onOpenChange) {
-      this.props.onOpenChange(false);
+    if (onOpenChange) {
+      onOpenChange(false);
     }
   };
 
@@ -241,14 +228,18 @@ class BpkDatepicker extends Component<Props, State> {
   };
 
   handleDateSelect = (startDate: Date, endDate: Date | null = null) => {
-    const { maxDate, minDate, onClose, onDateSelect, selectionConfiguration } =
-      this.props;
+    const {
+      maxDate = DEFAULT_MAX_DATE,
+      minDate = DEFAULT_MIN_DATE,
+      onClose,
+      onDateSelect = null,
+      selectionConfiguration = DEFAULT_SELECTION_CONFIGURATION,
+    } = this.props;
 
     // When the calendar is a single date we always want to close it when a date is selected
     // or if its a range calendar we only want to close the calendar when a range is selected.
     // If a custom onClose function is provided then we don't want to run the internal version.
     if (
-      selectionConfiguration &&
       (selectionConfiguration.type === CALENDAR_SELECTION_TYPE.single ||
         (selectionConfiguration.type === CALENDAR_SELECTION_TYPE.range &&
           endDate)) &&
@@ -260,17 +251,16 @@ class BpkDatepicker extends Component<Props, State> {
     if (onDateSelect) {
       const newStartDate = DateUtils.dateToBoundaries(
         startDate,
-        DateUtils.startOfDay(minDate!),
-        DateUtils.startOfDay(maxDate!),
+        DateUtils.startOfDay(minDate),
+        DateUtils.startOfDay(maxDate),
       );
       const newEndDate = DateUtils.dateToBoundaries(
         endDate,
-        DateUtils.startOfDay(minDate!),
-        DateUtils.startOfDay(maxDate!),
+        DateUtils.startOfDay(minDate),
+        DateUtils.startOfDay(maxDate),
       );
 
       if (
-        selectionConfiguration &&
         selectionConfiguration.type === CALENDAR_SELECTION_TYPE.range &&
         selectionConfiguration.startDate &&
         !selectionConfiguration.endDate &&
@@ -288,34 +278,35 @@ class BpkDatepicker extends Component<Props, State> {
 
   render() {
     const {
-      calendarComponent: Calendar,
+      calendarComponent,
       changeMonthLabel,
       closeButtonText,
-      dateModifiers,
+      dateModifiers = {},
       daysOfWeek,
-      fixedWidth,
+      fixedWidth = true,
       formatDate,
       formatDateFull,
       formatMonth,
       getApplicationElement,
       id,
-      initiallyFocusedDate,
-      inputComponent,
-      inputProps,
-      markOutsideDays,
-      markToday,
-      maxDate,
-      minDate,
-      nextMonthLabel,
-      onMonthChange,
-      previousMonthLabel,
-      renderTarget,
-      selectionConfiguration,
+      initiallyFocusedDate = null,
+      inputComponent = null,
+      inputProps = {},
+      markOutsideDays = true,
+      markToday = DEFAULT_MARK_TODAY,
+      maxDate = DEFAULT_MAX_DATE,
+      minDate = DEFAULT_MIN_DATE,
+      nextMonthLabel = null,
+      onMonthChange = null,
+      previousMonthLabel = null,
+      renderTarget = null,
+      selectionConfiguration = DEFAULT_SELECTION_CONFIGURATION,
       title,
       valid,
       weekStartsOn,
       ...rest
     } = this.props;
+    const Calendar: ReactComponent = calendarComponent || (DefaultCalendar as unknown as ReactComponent);
 
     // The following props are not used in render
     delete rest.onDateSelect;
@@ -328,10 +319,10 @@ class BpkDatepicker extends Component<Props, State> {
           inputRef={this.inputRef}
           id={id}
           name={`${id}_input`}
-          value={this.getValue(selectionConfiguration!, formatDate)}
+          value={this.getValue(selectionConfiguration, formatDate)}
           aria-live="polite"
           aria-atomic="true"
-          aria-label={this.getLabel(selectionConfiguration!, formatDateFull)}
+          aria-label={this.getLabel(selectionConfiguration, formatDateFull)}
           onChange={() => null}
           onOpen={this.onOpen}
           isOpen={this.state.isOpen}

--- a/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
+++ b/packages/bpk-component-grid-toggle/src/BpkGridToggle.js
@@ -42,8 +42,9 @@ class BpkGridToggle extends Component {
   }
 
   componentWillUnmount() {
+    const { targetContainer = 'body' } = this.props;
     document
-      .querySelector(this.props.targetContainer)
+      .querySelector(targetContainer)
       .classList.remove(GRID_CLASS_NAME);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
@@ -55,10 +56,11 @@ class BpkGridToggle extends Component {
   };
 
   toggleGrid = (e) => {
+    const { targetContainer = 'body' } = this.props;
     e.preventDefault();
 
     document
-      .querySelector(this.props.targetContainer)
+      .querySelector(targetContainer)
       .classList.toggle(GRID_CLASS_NAME);
 
     this.setState((state) => ({
@@ -67,7 +69,7 @@ class BpkGridToggle extends Component {
   };
 
   render() {
-    const { className } = this.props;
+    const { className = null } = this.props;
     const { gridEnabled } = this.state;
     const onOrOff = gridEnabled ? 'off' : 'on';
 
@@ -88,11 +90,6 @@ class BpkGridToggle extends Component {
 BpkGridToggle.propTypes = {
   targetContainer: PropTypes.string,
   className: PropTypes.string,
-};
-
-BpkGridToggle.defaultProps = {
-  targetContainer: 'body',
-  className: null,
 };
 
 export default BpkGridToggle;

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -75,8 +75,9 @@ class BpkHorizontalNav extends Component<Props> {
   }
 
   scrollSelectedIntoView = (useSmoothScroll: boolean) => {
+    const { autoScrollToSelected = false } = this.props;
     if (
-      !this.props.autoScrollToSelected ||
+      !autoScrollToSelected ||
       !this.scrollRef ||
       !this.selectedItemRef
     ) {
@@ -125,14 +126,14 @@ class BpkHorizontalNav extends Component<Props> {
 
   render() {
     const {
-      ariaLabel,
-      autoScrollToSelected,
+      ariaLabel = null,
+      autoScrollToSelected = false,
       children: rawChildren,
-      className,
-      leadingScrollIndicatorClassName,
-      showUnderline,
-      trailingScrollIndicatorClassName,
-      type,
+      className = null,
+      leadingScrollIndicatorClassName = null,
+      showUnderline = true,
+      trailingScrollIndicatorClassName = null,
+      type = HORIZONTAL_NAV_TYPES.default,
       ...rest
     } = this.props;
 
@@ -208,16 +209,6 @@ BpkHorizontalNav.propTypes = {
   trailingScrollIndicatorClassName: PropTypes.string,
   type: PropTypes.oneOf(Object.keys(HORIZONTAL_NAV_TYPES)),
 }
-
-BpkHorizontalNav.defaultProps = {
-  ariaLabel: null,
-  autoScrollToSelected: false,
-  className: null,
-  leadingScrollIndicatorClassName: null,
-  showUnderline: true,
-  trailingScrollIndicatorClassName: null,
-  type: HORIZONTAL_NAV_TYPES.default,
-};
 
 export default BpkHorizontalNav;
 export { HORIZONTAL_NAV_TYPES };

--- a/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/packages/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -46,12 +46,12 @@ class BpkHorizontalNavItem extends Component<Props> {
   render() {
     const {
       children,
-      className,
-      disabled,
-      href,
-      selected,
-      spaceAround,
-      type,
+      className = null,
+      disabled = false,
+      href = null,
+      selected = false,
+      spaceAround = false,
+      type = HORIZONTAL_NAV_TYPES.default,
       ...rest
     } = this.props;
 
@@ -113,15 +113,6 @@ BpkHorizontalNavItem.propTypes = {
   selected: PropTypes.bool,
   spaceAround: PropTypes.bool,
   type: PropTypes.oneOf(Object.keys(HORIZONTAL_NAV_TYPES)),
-};
-
-BpkHorizontalNavItem.defaultProps = {
-  className: null,
-  disabled: false,
-  href: null,
-  selected: false,
-  spaceAround: false,
-  type: HORIZONTAL_NAV_TYPES.default,
 };
 
 const themeAttributes = [

--- a/packages/bpk-component-image/src/BpkBackgroundImage.tsx
+++ b/packages/bpk-component-image/src/BpkBackgroundImage.tsx
@@ -46,31 +46,23 @@ export type BpkBackgroundImageProps = {
 class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
   trackImg?: HTMLImageElement | null;
 
-  static defaultProps = {
-    className: '',
-    inView: true,
-    loading: false,
-    onLoad: null,
-    onError: null,
-    style: {},
-    imageStyle: {},
-  };
-
   constructor(props: BpkBackgroundImageProps) {
     super(props);
     this.trackImg = null;
   }
 
   componentDidMount() {
-    if (this.props.inView) {
+    const { inView = true } = this.props;
+    if (inView) {
       this.startImageLoad();
     }
   }
 
   componentDidUpdate(prevProps: BpkBackgroundImageProps) {
-    const { inView, src } = this.props;
+    const { inView = true, src } = this.props;
+    const { inView: prevInView = true } = prevProps;
 
-    if (prevProps.src !== src || (inView && !prevProps.inView)) {
+    if (prevProps.src !== src || (inView && !prevInView)) {
       this.startImageLoad();
     }
   }
@@ -103,8 +95,15 @@ class BpkBackgroundImage extends Component<BpkBackgroundImageProps> {
   };
 
   render() {
-    const { children, className, imageStyle, inView, loading, src, style } =
-      this.props;
+    const {
+      children,
+      className = '',
+      imageStyle = {},
+      inView = true,
+      loading = false,
+      src,
+      style = {},
+    } = this.props;
 
     const calculatedAspectRatio = this.getAspectRatio();
     const aspectRatioPc = `${100 / calculatedAspectRatio}%`;

--- a/packages/bpk-component-image/src/BpkImage.tsx
+++ b/packages/bpk-component-image/src/BpkImage.tsx
@@ -41,10 +41,6 @@ type ImageProps = {
 class Image extends Component<ImageProps> {
   img?: HTMLImageElement | null;
 
-  static defaultProps = {
-    hidden: false,
-  };
-
   constructor(props: ImageProps) {
     super(props);
     this.img = null;
@@ -63,7 +59,7 @@ class Image extends Component<ImageProps> {
   };
 
   render() {
-    const { altText, hidden, onImageLoad, ...rest } = this.props;
+    const { altText, hidden = false, onImageLoad, ...rest } = this.props;
 
     const imgClassNames = [getClassName('bpk-image__img')];
 
@@ -103,15 +99,6 @@ type BpkImageProps = {
 class BpkImage extends Component<BpkImageProps> {
   placeholder?: HTMLElement | null;
 
-  static defaultProps = {
-    borderRadiusStyle: BORDER_RADIUS_STYLES.none,
-    inView: true,
-    loading: false,
-    onLoad: null,
-    style: {},
-    suppressHydrationWarning: false,
-  };
-
   onImageLoad = (): void => {
     if (this.props.onLoad) {
       this.props.onLoad();
@@ -129,12 +116,12 @@ class BpkImage extends Component<BpkImageProps> {
     const {
       altText,
       aspectRatio,
-      borderRadiusStyle,
+      borderRadiusStyle = BORDER_RADIUS_STYLES.none,
       className,
-      inView,
-      loading,
+      inView = true,
+      loading = false,
       onLoad,
-      style,
+      style = {},
       ...rest
     } = this.props;
 

--- a/packages/bpk-component-image/src/withLazyLoading.tsx
+++ b/packages/bpk-component-image/src/withLazyLoading.tsx
@@ -47,11 +47,6 @@ export default function withLazyLoading<P extends object>(
 
     placeholderReference?: string;
 
-    static defaultProps = {
-      style: {},
-      className: '',
-    };
-
     constructor(props: Omit<P, 'inView'> & WithLazyLoadingProps) {
       super(props);
 
@@ -144,7 +139,7 @@ export default function withLazyLoading<P extends object>(
     };
 
     render() {
-      const { className, style, ...rest } = this.props;
+      const { className = '', style = {}, ...rest } = this.props;
 
       return (
         <div

--- a/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
+++ b/packages/bpk-component-infinite-scroll/src/withInfiniteScroll.js
@@ -114,8 +114,6 @@ const withInfiniteScroll = <T: ExtendedProps>(
 
     static propTypes = { ...propTypes };
 
-    static defaultProps = { ...defaultProps };
-
     constructor(props: Props) {
       super(props);
 
@@ -140,7 +138,8 @@ const withInfiniteScroll = <T: ExtendedProps>(
     componentDidMount() {
       this.props.dataSource.onDataChange(this.updateData);
       this.fetchItems({
-        elementsPerScroll: this.props.initiallyLoadedElements,
+        elementsPerScroll:
+          this.props.initiallyLoadedElements ?? defaultProps.initiallyLoadedElements,
       }).then((newState) => {
         this.setState(newState);
       });
@@ -156,7 +155,8 @@ const withInfiniteScroll = <T: ExtendedProps>(
         this.props.dataSource.onDataChange(this.updateData);
         this.fetchItems({
           index: 0,
-          elementsPerScroll: this.props.elementsPerScroll,
+          elementsPerScroll:
+            this.props.elementsPerScroll ?? defaultProps.elementsPerScroll,
           elementsToRender: [],
         }).then((newState) => this.setStateAfterDsUpdate(newState));
       }
@@ -185,14 +185,16 @@ const withInfiniteScroll = <T: ExtendedProps>(
 
     updateData = () => {
       const { index } = this.state;
+      const elementsPerScroll =
+        this.props.elementsPerScroll ?? defaultProps.elementsPerScroll;
       // This means updateData was called before any data was loaded, e.g.
       // An ArrayDataSource initialized empty and then changed latter on via `updateData`
       // In this case we want to load new data and not just replace the old one.
       // "See More After" should also be computed again in this case.
-      const isFirstLoad = index < this.props.elementsPerScroll;
+      const isFirstLoad = index < elementsPerScroll;
       this.fetchItems({
         index: 0,
-        elementsPerScroll: isFirstLoad ? this.props.elementsPerScroll : index,
+        elementsPerScroll: isFirstLoad ? elementsPerScroll : index,
         elementsToRender: [],
         computeShowSeeMore: isFirstLoad,
       }).then((newState) => this.setStateAfterDsUpdate(newState));
@@ -204,7 +206,8 @@ const withInfiniteScroll = <T: ExtendedProps>(
         extend(
           {
             index: this.state.index,
-            elementsPerScroll: this.props.elementsPerScroll,
+            elementsPerScroll:
+              this.props.elementsPerScroll ?? defaultProps.elementsPerScroll,
             elementsToRender: this.state.elementsToRender,
             computeShowSeeMore: true,
           },

--- a/packages/bpk-component-info-banner/src/AnimateAndFade.tsx
+++ b/packages/bpk-component-info-banner/src/AnimateAndFade.tsx
@@ -33,8 +33,8 @@ const getClassName = cssModules(STYLES);
 const ANIMATION_DURATION = parseInt(durationSm, 10);
 
 type Props = {
-  animateOnEnter: boolean;
-  animateOnLeave: boolean;
+  animateOnEnter?: boolean;
+  animateOnLeave?: boolean;
   children: ReactNode | string;
   show: boolean;
   className?: string | undefined;
@@ -51,16 +51,12 @@ type State = {
 class AnimateAndFade extends Component<Props, State> {
   toggleImmediately: boolean;
 
-  static defaultProps = {
-    animateOnEnter: false,
-    animateOnLeave: false,
-  };
-
   constructor(props: Props) {
     super(props);
 
-    this.toggleImmediately = this.props.show && this.props.animateOnEnter;
-    const initiallyShown = this.toggleImmediately ? false : this.props.show;
+    const { animateOnEnter = false, show } = props;
+    this.toggleImmediately = show && animateOnEnter;
+    const initiallyShown = this.toggleImmediately ? false : show;
 
     this.state = {
       isExpanded: initiallyShown,
@@ -127,7 +123,7 @@ class AnimateAndFade extends Component<Props, State> {
   };
 
   render() {
-    const { animateOnEnter, animateOnLeave, children, className } = this.props;
+    const { animateOnEnter = false, animateOnLeave = false, children, className } = this.props;
     const showPlaceholder =
       !this.state.visible && !this.state.hideAnimationInProgress;
     // While the expanding animation takes place, we render the child element

--- a/packages/bpk-component-info-banner/src/withBannerAlertState.tsx
+++ b/packages/bpk-component-info-banner/src/withBannerAlertState.tsx
@@ -48,22 +48,11 @@ const withBannerAlertState = <P extends BpkInfoBannerProps>(
 
     hideIntervalId?: ReturnType<typeof setTimeout> | null;
 
-    static defaultProps = {
-      onDismiss: null,
-      onExpandToggle: null,
-      onHide: null,
-      expanded: false,
-      show: true,
-      hideAfter: null,
-      animateOnLeave: false,
-      children: null,
-    };
-
     constructor(props: P & WithBannerAlertStateProps) {
       super(props);
 
       this.state = {
-        expanded: props.expanded,
+        expanded: props.expanded ?? false,
         show: true,
       };
 
@@ -120,8 +109,8 @@ const withBannerAlertState = <P extends BpkInfoBannerProps>(
 
     render() {
       const {
-        animateOnLeave,
-        children,
+        animateOnLeave = false,
+        children = null,
         expanded,
         hideAfter,
         onDismiss,

--- a/packages/bpk-component-input/src/BpkInput.tsx
+++ b/packages/bpk-component-input/src/BpkInput.tsx
@@ -22,7 +22,7 @@ import { withButtonAlignment } from '../../bpk-component-icon';
 import ClearIcon from '../../bpk-component-icon/sm/close-circle';
 import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
-import { CLEAR_BUTTON_MODES, defaultProps } from './common-types';
+import { CLEAR_BUTTON_MODES, INPUT_TYPES } from './common-types';
 
 import type { Props } from './common-types';
 
@@ -36,8 +36,6 @@ const getClassName = cssModules(STYLES);
 
 const ClearButtonIcon = withButtonAlignment(ClearIcon);
 class BpkInput extends Component<Props, State> {
-  static defaultProps = defaultProps;
-
   constructor(props: Props) {
     super(props);
 
@@ -50,17 +48,18 @@ class BpkInput extends Component<Props, State> {
     const clearButtonClassNames = [getClassName('bpk-input__clear-button')];
     const {
       className,
-      clearButtonLabel,
-      clearButtonMode,
-      docked,
-      dockedFirst,
-      dockedLast,
-      dockedMiddle,
-      inputRef,
-      large,
+      clearButtonLabel = null,
+      clearButtonMode = CLEAR_BUTTON_MODES.never,
+      docked = false,
+      dockedFirst = false,
+      dockedLast = false,
+      dockedMiddle = false,
+      inputRef = null,
+      large = false,
       name,
-      onClear,
-      valid,
+      onClear = null,
+      type = INPUT_TYPES.text,
+      valid = null,
       value,
       ...rest
     } = this.props;
@@ -130,6 +129,7 @@ class BpkInput extends Component<Props, State> {
           }
         }}
         aria-invalid={isInvalid}
+        type={type}
         value={value}
         name={name}
         {...getDataComponentAttribute('Input')}

--- a/packages/bpk-component-input/src/withOpenEvents.tsx
+++ b/packages/bpk-component-input/src/withOpenEvents.tsx
@@ -31,6 +31,10 @@ const KEYCODES = {
   SPACEBAR: 'Space',
 } as const;
 
+const HAS_TOUCH_SUPPORT = !!(
+  typeof window !== 'undefined' && 'ontouchstart' in window
+);
+
 export type WithOpenEventsProps = {
   /**
    * It is important you pass the `isOpen` prop, as it is necessary to work around an IE bug.
@@ -95,22 +99,6 @@ const withOpenEvents = <P extends object>(WithOpenEventsInputComponent: Componen
 
     focusCanOpen: boolean;
 
-    static defaultProps = {
-      // Custom props
-      isOpen: false,
-      hasTouchSupport: !!(
-        typeof window !== 'undefined' && 'ontouchstart' in window
-      ),
-      onOpen: null,
-      // Input props
-      onClick: null,
-      onFocus: null,
-      onBlur: null,
-      onTouchEnd: null,
-      onKeyDown: null,
-      onKeyUp: null,
-    };
-
     constructor(props: P & WithOpenEventsProps & InputProps) {
       super(props);
 
@@ -150,7 +138,7 @@ const withOpenEvents = <P extends object>(WithOpenEventsInputComponent: Componen
     render(): ReactElement<any> {
       const {
         className,
-        hasTouchSupport,
+        hasTouchSupport = HAS_TOUCH_SUPPORT,
         isOpen,
         onBlur,
         onClick,

--- a/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
+++ b/packages/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.tsx
@@ -89,11 +89,6 @@ type State = {
 class BpkMobileScrollContainer extends Component<Props, State> {
   debouncedResize: DebouncedFunc<() => void>;
 
-  static defaultProps: Partial<Props> = {
-    innerContainerTagName: 'div',
-    showScrollbar: false,
-  };
-
   constructor(props: Props) {
     super(props);
 
@@ -168,7 +163,7 @@ class BpkMobileScrollContainer extends Component<Props, State> {
       leadingIndicatorClassName,
       onScroll,
       scrollerRef,
-      showScrollbar,
+      showScrollbar = false,
       style,
       trailingIndicatorClassName,
       ...rest

--- a/packages/bpk-component-progress/src/BpkProgress.js
+++ b/packages/bpk-component-progress/src/BpkProgress.js
@@ -73,27 +73,19 @@ const propTypes = {
   tabIndex: PropTypes.number,
 };
 
-const defaultProps = {
-  className: null,
-  stepped: false,
-  small: false,
-  onComplete: () => null,
-  onCompleteTransitionEnd: () => null,
-  getValueText: null,
-}
-
 class BpkProgress extends Component<Props> {
   componentDidUpdate(previousProps: Props) {
-    const { max, value } = this.props;
-    if (
-      value >= max &&
-      value !== previousProps.value &&
-      this.props.onComplete
-    ) {
-      this.props.onComplete();
+    const {
+      max,
+      onComplete = () => null,
+      onCompleteTransitionEnd,
+      value,
+    } = this.props;
+    if (value >= max && value !== previousProps.value) {
+      onComplete();
 
-      if (!isTransitionEndSupported() && this.props.onCompleteTransitionEnd) {
-        this.props.onCompleteTransitionEnd();
+      if (!isTransitionEndSupported() && onCompleteTransitionEnd) {
+        onCompleteTransitionEnd();
       }
     }
   }
@@ -107,12 +99,12 @@ class BpkProgress extends Component<Props> {
 
   render() {
     const {
-      className,
-      getValueText,
+      className = null,
+      getValueText = null,
       max,
       min,
-      small,
-      stepped,
+      small = false,
+      stepped = false,
       value,
       ...rest
     } = this.props;
@@ -160,10 +152,6 @@ class BpkProgress extends Component<Props> {
 
 BpkProgress.propTypes = {
   ...propTypes,
-}
-
-BpkProgress.defaultProps = {
-  ...defaultProps,
 }
 
 export default BpkProgress;

--- a/packages/bpk-component-split-input/src/BpkInputField.tsx
+++ b/packages/bpk-component-split-input/src/BpkInputField.tsx
@@ -30,19 +30,14 @@ export type Props = DefaultProps;
 type DefaultProps = {
   id: string;
   label: string;
-  value: string | number;
+  value?: string | number;
   focus: boolean;
   index: number;
-  name: string;
+  name?: string;
   [key: string]: any;
 }
 
 class BpkInputField extends PureComponent<Props> {
-  static defaultProps = {
-    value: '',
-    name: ''
-  };
-
   componentDidUpdate(prevProps: Props) {
     const { focus } = this.props;
     if (prevProps.focus !== focus && this.input && focus) {
@@ -54,7 +49,7 @@ class BpkInputField extends PureComponent<Props> {
   private input: HTMLInputElement | null = null;
 
   render() {
-    const { focus, id, index, label, name, value, ...rest } = this.props;
+    const { focus, id, index, label, name = '', value = '', ...rest } = this.props;
     return (
       <div key={index} className={getClassName('bpk-input-field')} {...getDataComponentAttribute('InputField')}>
         <BpkInput

--- a/packages/bpk-component-split-input/src/BpkSplitInput.tsx
+++ b/packages/bpk-component-split-input/src/BpkSplitInput.tsx
@@ -46,13 +46,6 @@ interface State {
 }
 
 class BpkSplitInput extends Component<Props, State> {
-  static defaultProps = {
-    type: INPUT_TYPES.number,
-    inputLength: 4,
-    large: true,
-    placeholder: '',
-  };
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -94,7 +87,7 @@ class BpkSplitInput extends Component<Props, State> {
     return true;
   };
 
-  isNumeric = () => this.props.type === INPUT_TYPES.number;
+  isNumeric = () => (this.props.type ?? INPUT_TYPES.number) === INPUT_TYPES.number;
 
   isInputValid = (value: string | number) => {
     const isTypeValid = this.isNumeric() ? /^\d$/.test(`${value}`) : typeof value === 'string';
@@ -102,8 +95,8 @@ class BpkSplitInput extends Component<Props, State> {
   };
 
   focusInput = (inputIndex: number) => {
-    const { inputLength } = this.props;
-    const focusedInput = Math.max(Math.min(inputLength! - 1, inputIndex), 0);
+    const { inputLength = 4 } = this.props;
+    const focusedInput = Math.max(Math.min(inputLength - 1, inputIndex), 0);
     this.setState({ focusedInput });
   };
 
@@ -119,12 +112,12 @@ class BpkSplitInput extends Component<Props, State> {
 
   handleOnPaste = (e: ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault();
-    const { inputLength } = this.props;
+    const { inputLength = 4 } = this.props;
     const { focusedInput, inputValue } = this.state;
 
     const pastedData = e.clipboardData
       .getData('text/plain')
-      .slice(0, inputLength! - focusedInput)
+      .slice(0, inputLength - focusedInput)
   .split('');
     const charsReceived = pastedData.length;
 
@@ -193,9 +186,18 @@ class BpkSplitInput extends Component<Props, State> {
 
   renderInputs = () => {
     const { focusedInput, inputValue } = this.state;
-    const { id, inputLength, label, large, name, placeholder, type, ...rest } = this.props;
+    const {
+      id,
+      inputLength = 4,
+      label,
+      large = true,
+      name,
+      placeholder = '',
+      type = INPUT_TYPES.number,
+      ...rest
+    } = this.props;
     const inputs = [];
-    for (let index = 0; index < inputLength!; index += 1) {
+    for (let index = 0; index < inputLength; index += 1) {
       inputs.push(
         <InputField
           key={index}

--- a/packages/bpk-component-star-rating/src/withInteractiveStarRatingState.js
+++ b/packages/bpk-component-star-rating/src/withInteractiveStarRatingState.js
@@ -28,7 +28,7 @@ const withInteractiveStarRatingState = (
   InteractiveStarRating: ComponentType<any>,
 ) => {
   type Props = {
-    onRatingSelect: (number, Function) => mixed,
+    onRatingSelect?: (number, Function) => mixed,
   };
 
   type State = {
@@ -39,10 +39,6 @@ const withInteractiveStarRatingState = (
   class EnhancedComponent extends Component<Props, State> {
     static propTypes = {
       onRatingSelect: PropTypes.func,
-    };
-
-    static defaultProps = {
-      onRatingSelect: () => null,
     };
 
     constructor() {

--- a/packages/bpk-react-utils/src/Portal.tsx
+++ b/packages/bpk-react-utils/src/Portal.tsx
@@ -27,6 +27,8 @@ const KEYCODES = {
   ESCAPE: 'Escape',
 } as const;
 
+const noop = () => null;
+
 type InteractionEvents = TouchEvent | MouseEvent | KeyboardEvent;
 
 type JSXElementWithRefProps = JSX.Element & {
@@ -36,24 +38,24 @@ type JSXElementWithRefProps = JSX.Element & {
 type Props = {
   children: string | ReactNode;
   isOpen: boolean;
-  beforeClose: ((arg0: () => void) => void) | null | undefined;
-  className: string | null | undefined;
-  onClose: (
+  beforeClose?: ((arg0: () => void) => void) | null | undefined;
+  className?: string | null | undefined;
+  onClose?: (
     arg0: InteractionEvents,
     arg1: {
       source: 'ESCAPE' | 'DOCUMENT_CLICK';
     },
   ) => void;
-  onOpen: (arg0: HTMLElement, arg1?: HTMLElement | null | undefined) => void;
-  onRender: (
+  onOpen?: (arg0: HTMLElement, arg1?: HTMLElement | null | undefined) => void;
+  onRender?: (
     arg0: HTMLElement | null | undefined,
     arg1: HTMLElement | null | undefined,
   ) => void;
-  style: {} | null | undefined;
-  renderTarget: null | HTMLElement | (() => null | HTMLElement);
-  target: null | HTMLElement | JSX.Element | (() => HTMLElement);
-  targetRef: ((arg0: null | Element | undefined) => void) | null | undefined;
-  closeOnEscPressed: boolean;
+  style?: {} | null | undefined;
+  renderTarget?: null | HTMLElement | (() => null | HTMLElement);
+  target?: null | HTMLElement | JSX.Element | (() => HTMLElement);
+  targetRef?: ((arg0: null | Element | undefined) => void) | null | undefined;
+  closeOnEscPressed?: boolean;
 };
 
 type State = {
@@ -64,19 +66,6 @@ class Portal extends Component<Props, State> {
   portalElement: null | HTMLDivElement;
 
   shouldClose: boolean;
-
-  static defaultProps = {
-    beforeClose: null,
-    className: null,
-    onClose: () => null,
-    onOpen: () => null,
-    onRender: () => null,
-    style: null,
-    renderTarget: null,
-    target: null,
-    targetRef: null,
-    closeOnEscPressed: true,
-  };
 
   constructor(props: Props) {
     super(props);
@@ -114,15 +103,16 @@ class Portal extends Component<Props, State> {
   // call their beforeClose function so that they can trigger the close.
   // If they don't provide `beforeClose` we just call `close` directly.
   componentDidUpdate(prevProps: Props) {
+    const { beforeClose, onRender = noop } = this.props;
     if (this.props.isOpen) {
       if (!prevProps.isOpen) {
         this.open();
       } else {
-        this.props.onRender(this.portalElement, this.getTargetElement());
+        onRender(this.portalElement, this.getTargetElement());
       }
     } else if (prevProps.isOpen) {
-      if (this.props.beforeClose) {
-        this.props.beforeClose(this.close);
+      if (beforeClose) {
+        beforeClose(this.close);
       } else {
         this.close();
       }
@@ -148,6 +138,7 @@ class Portal extends Component<Props, State> {
   }
 
   onDocumentMouseUp(event: MouseEvent | TouchEvent) {
+    const { onClose = noop } = this.props;
     const clickEventProperties = this.getClickEventProperties(event);
 
     if (
@@ -162,19 +153,20 @@ class Portal extends Component<Props, State> {
     if (this.shouldClose) {
       // `onClose` tells the consumer that they should change `isOpen` to false.
       // Once the consumer has responded to `onClose`, `beforeClose` and `close` will be called.
-      this.props.onClose(event, { source: 'DOCUMENT_CLICK' });
+      onClose(event, { source: 'DOCUMENT_CLICK' });
     }
   }
 
   onDocumentKeyDown(event: KeyboardEvent) {
+    const { closeOnEscPressed = true, onClose = noop } = this.props;
     if (
       event.key === KEYCODES.ESCAPE &&
       this.props.isOpen &&
-      this.props.closeOnEscPressed
+      closeOnEscPressed
     ) {
       // `onClose` tells the consumer that they should change `isOpen` to false.
       // Once the consumer has responded to `onClose`, `beforeClose` and `close` will be called.
-      this.props.onClose(event, { source: 'ESCAPE' });
+      onClose(event, { source: 'ESCAPE' });
     }
   }
 
@@ -261,9 +253,10 @@ class Portal extends Component<Props, State> {
       portalElement.className = this.props.className;
     }
 
+    const { onOpen = noop } = this.props;
     this.portalElement = portalElement;
     this.setState({ isVisible: true }, () =>
-      this.props.onOpen(portalElement, this.getTargetElement()),
+      onOpen(portalElement, this.getTargetElement()),
     );
   }
 

--- a/packages/bpk-scrim-utils/src/withScrim.tsx
+++ b/packages/bpk-scrim-utils/src/withScrim.tsx
@@ -44,6 +44,9 @@ import STYLES from './bpk-scrim-content.module.scss';
 
 const getClassName = cssModules(STYLES);
 
+const DEFAULT_IS_IPHONE = isDeviceIphone();
+const DEFAULT_IS_IPAD = isDeviceIpad();
+
 export type Props = {
   /**
    * The `pagewrap` element id is a convention we use internally at Skyscanner. In most cases it should "just work".
@@ -74,16 +77,12 @@ const withScrim = <P extends object>(
 
     public static displayName: string;
 
-    static defaultProps = {
-      onClose: null,
-      isIphone: isDeviceIphone(),
-      isIpad: isDeviceIpad(),
-      containerClassName: null,
-      closeOnScrimClick: true,
-    };
-
     componentDidMount() {
-      const { getApplicationElement, isIpad, isIphone } = this.props;
+      const {
+        getApplicationElement,
+        isIpad = DEFAULT_IS_IPAD,
+        isIphone = DEFAULT_IS_IPHONE,
+      } = this.props;
       const applicationElement = getApplicationElement();
 
       /**
@@ -117,7 +116,11 @@ const withScrim = <P extends object>(
     }
 
     componentWillUnmount() {
-      const { getApplicationElement, isIpad, isIphone } = this.props;
+      const {
+        getApplicationElement,
+        isIpad = DEFAULT_IS_IPAD,
+        isIphone = DEFAULT_IS_IPHONE,
+      } = this.props;
       const applicationElement = getApplicationElement();
 
       if (isIphone || isIpad) {
@@ -143,11 +146,11 @@ const withScrim = <P extends object>(
 
     render() {
       const {
-        closeOnScrimClick,
-        containerClassName,
+        closeOnScrimClick = true,
+        containerClassName = null,
         getApplicationElement,
-        isIpad,
-        isIphone,
+        isIpad = DEFAULT_IS_IPAD,
+        isIphone = DEFAULT_IS_IPHONE,
         onClose,
         ...rest
       } = this.props;


### PR DESCRIPTION
Part 2 of React 19 migration, split by commit 

 Verification matrix (R18 + R19, with TZ=Etc/UTC matching CI):
  - typecheck: clean on both
  - jest: 382 suites / 2420 tests / 825 snapshots passing on both R18.3.1 and R19.2.5
  - lint: clean on touched files (only pre-existing browser-feature warnings remain repo-wide)
  - audit: only out-of-scope *.stories.{js,tsx} and withInfiniteScroll-test.flow.js retain defaultProps

  Per-commit summary:
  1. aa4ae8e0c — Coupled calendar pair: extracted DEFAULT_MARK_TODAY/MAX_DATE/MIN_DATE constants in BpkCalendarContainer and shared with BpkDatepicker; migrated BpkCalendarWeek and dropped the two
  ...BpkCalendarWeek.defaultProps spreads in test/story.
  2. 0e4abae3d — Render-only batch (8 files) — accordion, calendar-date, calendar-grid-header, lazy-load HOC, BpkInput, split-input pair, star-rating HOC.
  3. c68861307 — Twin-pair (4 files) — banner-alert + info-banner symmetric AnimateAndFade + withBannerAlertState.
  4. da8ee50bc — Remaining multi-method (13 files): BpkBarchart, BpkCalendarGrid/Transition, BpkBackgroundImage/BpkImage, withInfiniteScroll, withOpenEvents, BpkMobileScrollContainer, withScrim, plus the 4 Flow
  external-assignment files (BpkGridToggle, BpkHorizontalNav/Item, BpkProgress).
  5. d31a22768 — Portal.tsx (largest single migration).

  Notable callouts:
  - BpkProgress caught a real bug from the existing test suite — static defaultProps had onComplete: () => null, and componentDidUpdate truthy-checked it before calling onCompleteTransitionEnd. Without the default,
  onCompleteTransitionEnd never fired. Restructured to call destructure-defaulted onComplete unconditionally.
  - BpkCalendarGrid can't import DEFAULT_MAX_DATE/MIN_DATE from BpkCalendarContainer (cycle via BpkCalendarGridWithTransition); uses local module-level constants instead.
  - The 5 composeCalendar-test snapshot diffs locally are pre-existing system-locale drift (Coordinated Universal Time vs Greenwich Mean Time); pass under TZ=Etc/UTC (= CI).

  Workspace left at R18.3.1 in both module trees.



Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
