### PR TITLE
Bump @skyscanner/bpk-foundations-web to 24.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@figma/rest-api-spec": "^0.37.0",
         "@percy/cli": "^1.31.0",
         "@percy/storybook": "^9.1.0",
-        "@skyscanner/bpk-foundations-web": "^24.5.0",
+        "@skyscanner/bpk-foundations-web": "^24.6.0",
         "@skyscanner/bpk-svgs": "^20.11.0",
         "@skyscanner/eslint-config-skyscanner": "^22.6.0",
         "@skyscanner/stylelint-config-skyscanner": "^14.2.0",
@@ -5815,20 +5815,20 @@
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "24.5.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-24.5.0.tgz",
-      "integrity": "sha512-Lft06khFD3XGOvENnmrNeJLm0nIjAy6lW1wyNGzVS947EU3hrLFTM7pAz5jO69lpPvjgorpiA9MrX+80IVg05A==",
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-24.6.0.tgz",
+      "integrity": "sha512-wd6wrh/ri3Jp/ejMp9DpUICumyEj5GDFmVbtyVTWLsuVwIsO+PxTwV7njrwJfAoyirtorbMr93zhQO5xYGwvnA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@skyscanner/bpk-foundations-common": "^24.5.0",
+        "@skyscanner/bpk-foundations-common": "^24.6.0",
         "color": "^5.0.0"
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web/node_modules/@skyscanner/bpk-foundations-common": {
-      "version": "24.5.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-24.5.0.tgz",
-      "integrity": "sha512-08NIg5Z8ZKZIRHujjXKyahiJAS64bq0mDSG4ITdBxIRcy0wMAxizhXNpLw8TmSPdluTaYYwxKYCJ2gOF2cngAA==",
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-24.6.0.tgz",
+      "integrity": "sha512-sgzuBYZG1xw+poB379SFca8i6/ulGBICdGbq8KyQHXToOmXkU/L4KJPK2C2KeWIV4jPzCaHSUie0+bSLE623qw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@figma/rest-api-spec": "^0.37.0",
     "@percy/cli": "^1.31.0",
     "@percy/storybook": "^9.1.0",
-    "@skyscanner/bpk-foundations-web": "^24.5.0",
+    "@skyscanner/bpk-foundations-web": "^24.6.0",
     "@skyscanner/bpk-svgs": "^20.11.0",
     "@skyscanner/eslint-config-skyscanner": "^22.6.0",
     "@skyscanner/stylelint-config-skyscanner": "^14.2.0",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -15,7 +15,7 @@
         "@radix-ui/react-compose-refs": "^1.1.1",
         "@radix-ui/react-slider": "1.3.5",
         "@react-google-maps/api": "^2.19.3",
-        "@skyscanner/bpk-foundations-web": "^24.5.0",
+        "@skyscanner/bpk-foundations-web": "^24.6.0",
         "@skyscanner/bpk-svgs": "^20.11.0",
         "d3-path": "^3.1.0",
         "d3-scale": "^4.0.2",
@@ -829,21 +829,21 @@
       "license": "MIT"
     },
     "node_modules/@skyscanner/bpk-foundations-common": {
-      "version": "24.5.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-24.5.0.tgz",
-      "integrity": "sha512-08NIg5Z8ZKZIRHujjXKyahiJAS64bq0mDSG4ITdBxIRcy0wMAxizhXNpLw8TmSPdluTaYYwxKYCJ2gOF2cngAA==",
+      "version": "24.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-24.6.0.tgz",
+      "integrity": "sha512-sgzuBYZG1xw+poB379SFca8i6/ulGBICdGbq8KyQHXToOmXkU/L4KJPK2C2KeWIV4jPzCaHSUie0+bSLE623qw==",
       "license": "Apache-2.0",
       "dependencies": {
         "color": "^5.0.0"
       }
     },
     "node_modules/@skyscanner/bpk-foundations-web": {
-      "version": "24.5.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-24.5.0.tgz",
-      "integrity": "sha512-Lft06khFD3XGOvENnmrNeJLm0nIjAy6lW1wyNGzVS947EU3hrLFTM7pAz5jO69lpPvjgorpiA9MrX+80IVg05A==",
+      "version": "24.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-24.6.0.tgz",
+      "integrity": "sha512-wd6wrh/ri3Jp/ejMp9DpUICumyEj5GDFmVbtyVTWLsuVwIsO+PxTwV7njrwJfAoyirtorbMr93zhQO5xYGwvnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@skyscanner/bpk-foundations-common": "^24.5.0",
+        "@skyscanner/bpk-foundations-common": "^24.6.0",
         "color": "^5.0.0"
       }
     },

--- a/packages/package.json
+++ b/packages/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-compose-refs": "^1.1.1",
     "@radix-ui/react-slider": "1.3.5",
     "@react-google-maps/api": "^2.19.3",
-    "@skyscanner/bpk-foundations-web": "^24.5.0",
+    "@skyscanner/bpk-foundations-web": "^24.6.0",
     "@skyscanner/bpk-svgs": "^20.11.0",
     "tabbable": "^6.4.0",
     "d3-path": "^3.1.0",


### PR DESCRIPTION
## Summary
- Bumps `@skyscanner/bpk-foundations-web` from `^24.5.0` to `^24.6.0` in both root and `packages/` to pick up the new `PRIVATE_SWITCH_ON_CONTRAST_OFF` token.
- Release notes: https://github.com/Skyscanner/backpack-foundations/releases/tag/24.6.0

## Test plan
- [ ] CI is green
- [ ] No visual regressions in Percy

🤖 Generated with [Claude Code](https://claude.com/claude-code)