### PR TITLE
[BpkSwitch] Add onContrast variant

### DIFF
--- a/packages/bpk-component-switch/index.ts
+++ b/packages/bpk-component-switch/index.ts
@@ -18,12 +18,12 @@
 /* @flow strict */
 
 import BpkSwitch, {
-  SWITCH_TYPES,
+  SWITCH_VARIANTS,
   type Props as BpkSwitchProps,
-  type SwitchType,
+  type SwitchVariant,
 } from './src/BpkSwitch';
 import themeAttributes from './src/themeAttributes';
 
-export type { BpkSwitchProps, SwitchType };
-export { SWITCH_TYPES, themeAttributes };
+export type { BpkSwitchProps, SwitchVariant };
+export { SWITCH_VARIANTS, themeAttributes };
 export default BpkSwitch;

--- a/packages/bpk-component-switch/index.ts
+++ b/packages/bpk-component-switch/index.ts
@@ -17,9 +17,13 @@
  */
 /* @flow strict */
 
-import BpkSwitch, { type Props as BpkSwitchProps } from './src/BpkSwitch';
+import BpkSwitch, {
+  SWITCH_TYPES,
+  type Props as BpkSwitchProps,
+  type SwitchType,
+} from './src/BpkSwitch';
 import themeAttributes from './src/themeAttributes';
 
-export type { BpkSwitchProps };
-export { themeAttributes };
+export type { BpkSwitchProps, SwitchType };
+export { SWITCH_TYPES, themeAttributes };
 export default BpkSwitch;

--- a/packages/bpk-component-switch/src/BpkSwitch-test.tsx
+++ b/packages/bpk-component-switch/src/BpkSwitch-test.tsx
@@ -18,7 +18,7 @@
 
 import { render, screen } from '@testing-library/react';
 
-import BpkSwitch, { SWITCH_TYPES } from './BpkSwitch';
+import BpkSwitch, { SWITCH_VARIANTS } from './BpkSwitch';
 
 describe('BpkSwitch', () => {
   it('should render correctly', () => {
@@ -59,14 +59,14 @@ describe('BpkSwitch', () => {
 
   it('should render the on-contrast variant', () => {
     const { container } = render(
-      <BpkSwitch ariaLabel="Switch" type={SWITCH_TYPES.onContrast} />,
+      <BpkSwitch ariaLabel="Switch" variant={SWITCH_VARIANTS.onContrast} />,
     );
     expect(container.querySelectorAll('.bpk-switch__switch--on-contrast')[0].className).toBe(
       'bpk-switch__switch bpk-switch__switch--on-contrast',
     );
   });
 
-  it('should not apply the on-contrast modifier for the default type', () => {
+  it('should not apply the on-contrast modifier for the default variant', () => {
     const { container } = render(<BpkSwitch ariaLabel="Switch" />);
     expect(
       container.querySelectorAll('.bpk-switch__switch--on-contrast'),

--- a/packages/bpk-component-switch/src/BpkSwitch-test.tsx
+++ b/packages/bpk-component-switch/src/BpkSwitch-test.tsx
@@ -18,7 +18,7 @@
 
 import { render, screen } from '@testing-library/react';
 
-import BpkSwitch from './BpkSwitch';
+import BpkSwitch, { SWITCH_TYPES } from './BpkSwitch';
 
 describe('BpkSwitch', () => {
   it('should render correctly', () => {
@@ -55,5 +55,21 @@ describe('BpkSwitch', () => {
     render(<BpkSwitch ariaLabel="Switch" data-testid="my-switch" />);
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
     expect(screen.getAllByTestId('my-switch')).toHaveLength(1);
+  });
+
+  it('should render the on-contrast variant', () => {
+    const { container } = render(
+      <BpkSwitch ariaLabel="Switch" type={SWITCH_TYPES.onContrast} />,
+    );
+    expect(container.querySelectorAll('.bpk-switch__switch--on-contrast')[0].className).toBe(
+      'bpk-switch__switch bpk-switch__switch--on-contrast',
+    );
+  });
+
+  it('should not apply the on-contrast modifier for the default type', () => {
+    const { container } = render(<BpkSwitch ariaLabel="Switch" />);
+    expect(
+      container.querySelectorAll('.bpk-switch__switch--on-contrast'),
+    ).toHaveLength(0);
   });
 });

--- a/packages/bpk-component-switch/src/BpkSwitch.module.scss
+++ b/packages/bpk-component-switch/src/BpkSwitch.module.scss
@@ -90,5 +90,9 @@ $border-width: tokens.$bpk-one-pixel-rem * 2;
         height: tokens.bpk-spacing-base();
       }
     }
+
+    &--on-contrast {
+      background: tokens.$bpk-private-switch-on-contrast-off-day;
+    }
   }
 }

--- a/packages/bpk-component-switch/src/BpkSwitch.stories.tsx
+++ b/packages/bpk-component-switch/src/BpkSwitch.stories.tsx
@@ -18,7 +18,14 @@
 
 import { ArgTypes, Title, Markdown } from '@storybook/addon-docs/blocks';
 
-import BpkSwitch from './BpkSwitch';
+import {
+  BACKGROUND_COLORS,
+  BpkFlex,
+  BpkProvider,
+  BpkSpacing,
+} from '../../bpk-component-layout';
+
+import BpkSwitch, { SWITCH_TYPES } from './BpkSwitch';
 
 import type { Meta } from '@storybook/react';
 
@@ -33,6 +40,22 @@ const DefaultExample = ({ ...rest }: Props) => (
 
 const SmallExample = ({ ...rest }: Props) => (
   <BpkSwitch small {...rest} ariaLabel="Activate Backpack" />
+);
+
+const OnContrastExample = () => (
+  <BpkProvider>
+    <BpkFlex
+      direction="column"
+      padding={BpkSpacing.Base}
+      gap={BpkSpacing.Base}
+      backgroundColor={BACKGROUND_COLORS.surfaceContrast}
+    >
+      <BpkSwitch type={SWITCH_TYPES.onContrast} checked ariaLabel="Activate Backpack" />
+      <BpkSwitch type={SWITCH_TYPES.onContrast} ariaLabel="Activate Backpack" />
+      <BpkSwitch type={SWITCH_TYPES.onContrast} small checked ariaLabel="Activate Backpack" />
+      <BpkSwitch type={SWITCH_TYPES.onContrast} small ariaLabel="Activate Backpack" />
+    </BpkFlex>
+  </BpkProvider>
 );
 
 const ReducedSpaceExample = ({ ...rest }: Props) => (
@@ -85,6 +108,10 @@ export const Small = {
 
 export const ReducedSpace = {
   render: () => <ReducedSpaceExample />,
+};
+
+export const OnContrast = {
+  render: () => <OnContrastExample />,
 };
 
 export const VisualTest = {

--- a/packages/bpk-component-switch/src/BpkSwitch.stories.tsx
+++ b/packages/bpk-component-switch/src/BpkSwitch.stories.tsx
@@ -73,6 +73,7 @@ const MixedExample = () => (
     <DefaultExample checked />
     <SmallExample checked />
     <ReducedSpaceExample checked />
+    <OnContrastExample />
   </div>
 );
 

--- a/packages/bpk-component-switch/src/BpkSwitch.stories.tsx
+++ b/packages/bpk-component-switch/src/BpkSwitch.stories.tsx
@@ -50,9 +50,9 @@ const OnContrastExample = () => (
       gap={BpkSpacing.Base}
       backgroundColor={BACKGROUND_COLORS.surfaceContrast}
     >
-      <BpkSwitch variant={SWITCH_VARIANTS.onContrast} checked ariaLabel="Activate Backpack" />
+      <BpkSwitch variant={SWITCH_VARIANTS.onContrast} defaultChecked ariaLabel="Activate Backpack" />
       <BpkSwitch variant={SWITCH_VARIANTS.onContrast} ariaLabel="Activate Backpack" />
-      <BpkSwitch variant={SWITCH_VARIANTS.onContrast} small checked ariaLabel="Activate Backpack" />
+      <BpkSwitch variant={SWITCH_VARIANTS.onContrast} small defaultChecked ariaLabel="Activate Backpack" />
       <BpkSwitch variant={SWITCH_VARIANTS.onContrast} small ariaLabel="Activate Backpack" />
     </BpkFlex>
   </BpkProvider>

--- a/packages/bpk-component-switch/src/BpkSwitch.stories.tsx
+++ b/packages/bpk-component-switch/src/BpkSwitch.stories.tsx
@@ -25,7 +25,7 @@ import {
   BpkSpacing,
 } from '../../bpk-component-layout';
 
-import BpkSwitch, { SWITCH_TYPES } from './BpkSwitch';
+import BpkSwitch, { SWITCH_VARIANTS } from './BpkSwitch';
 
 import type { Meta } from '@storybook/react';
 
@@ -50,10 +50,10 @@ const OnContrastExample = () => (
       gap={BpkSpacing.Base}
       backgroundColor={BACKGROUND_COLORS.surfaceContrast}
     >
-      <BpkSwitch type={SWITCH_TYPES.onContrast} checked ariaLabel="Activate Backpack" />
-      <BpkSwitch type={SWITCH_TYPES.onContrast} ariaLabel="Activate Backpack" />
-      <BpkSwitch type={SWITCH_TYPES.onContrast} small checked ariaLabel="Activate Backpack" />
-      <BpkSwitch type={SWITCH_TYPES.onContrast} small ariaLabel="Activate Backpack" />
+      <BpkSwitch variant={SWITCH_VARIANTS.onContrast} checked ariaLabel="Activate Backpack" />
+      <BpkSwitch variant={SWITCH_VARIANTS.onContrast} ariaLabel="Activate Backpack" />
+      <BpkSwitch variant={SWITCH_VARIANTS.onContrast} small checked ariaLabel="Activate Backpack" />
+      <BpkSwitch variant={SWITCH_VARIANTS.onContrast} small ariaLabel="Activate Backpack" />
     </BpkFlex>
   </BpkProvider>
 );

--- a/packages/bpk-component-switch/src/BpkSwitch.tsx
+++ b/packages/bpk-component-switch/src/BpkSwitch.tsx
@@ -20,25 +20,26 @@ import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
 import STYLES from './BpkSwitch.module.scss';
 
-export const SWITCH_TYPES = {
+export const SWITCH_VARIANTS = {
   default: 'default',
   onContrast: 'onContrast',
 } as const;
 
-export type SwitchType = (typeof SWITCH_TYPES)[keyof typeof SWITCH_TYPES];
+export type SwitchVariant =
+  (typeof SWITCH_VARIANTS)[keyof typeof SWITCH_VARIANTS];
 
 const getClassName = cssModules(STYLES);
 
-const switchTypeClassNames = {
-  [SWITCH_TYPES.default]: null,
-  [SWITCH_TYPES.onContrast]: getClassName('bpk-switch__switch--on-contrast'),
+const switchVariantClassNames = {
+  [SWITCH_VARIANTS.default]: null,
+  [SWITCH_VARIANTS.onContrast]: getClassName('bpk-switch__switch--on-contrast'),
 };
 
 export type Props = {
   ariaLabel: string;
   className?: string | null;
   small?: boolean;
-  type?: SwitchType;
+  variant?: SwitchVariant;
   [rest: string]: any;
 };
 
@@ -46,13 +47,13 @@ const BpkSwitch = ({
   ariaLabel,
   className = null,
   small = false,
-  type = SWITCH_TYPES.default,
+  variant = SWITCH_VARIANTS.default,
   ...rest
 }: Props) => {
   const switchClassNames = getClassName(
     'bpk-switch__switch',
     small && 'bpk-switch__switch--small',
-    switchTypeClassNames[type],
+    switchVariantClassNames[variant],
   );
 
   return (

--- a/packages/bpk-component-switch/src/BpkSwitch.tsx
+++ b/packages/bpk-component-switch/src/BpkSwitch.tsx
@@ -20,12 +20,25 @@ import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
 import STYLES from './BpkSwitch.module.scss';
 
+export const SWITCH_TYPES = {
+  default: 'default',
+  onContrast: 'onContrast',
+} as const;
+
+export type SwitchType = (typeof SWITCH_TYPES)[keyof typeof SWITCH_TYPES];
+
 const getClassName = cssModules(STYLES);
+
+const switchTypeClassNames = {
+  [SWITCH_TYPES.default]: null,
+  [SWITCH_TYPES.onContrast]: getClassName('bpk-switch__switch--on-contrast'),
+};
 
 export type Props = {
   ariaLabel: string;
   className?: string | null;
   small?: boolean;
+  type?: SwitchType;
   [rest: string]: any;
 };
 
@@ -33,11 +46,13 @@ const BpkSwitch = ({
   ariaLabel,
   className = null,
   small = false,
+  type = SWITCH_TYPES.default,
   ...rest
 }: Props) => {
   const switchClassNames = getClassName(
     'bpk-switch__switch',
     small && 'bpk-switch__switch--small',
+    switchTypeClassNames[type],
   );
 
   return (


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
-->

## Summary

Adds an `onContrast` value to a new `variant` prop on `BpkSwitch`, for use on dark/contrast surfaces. The off-state track uses the dedicated `$bpk-private-switch-on-contrast-off-day` foundations token introduced in `bpk-foundations-web@24.6.0`. The default appearance is unchanged.

The prop is named `variant` (not `type`) to avoid colliding with the native `<input>` `type` attribute, since `BpkSwitch` forwards arbitrary input props via `...rest`. Using `type` would have been a breaking change for JS consumers forwarding it and would have made the props incompatible with `InputHTMLAttributes<HTMLInputElement>`.

```tsx
import BpkSwitch, { SWITCH_VARIANTS } from '@skyscanner/backpack-web/bpk-component-switch';

<BpkSwitch variant={SWITCH_VARIANTS.onContrast} ariaLabel="…" />
```

A new `OnContrast` Storybook story renders the four state/size combinations on a contrast surface via `BpkFlex` / `BpkProvider`.

## Checklist

- [x] PR title includes the component name
- [ ] `README.md` (If you have created a new component) — n/a
- [ ] Component `README.md` — not updated; happy to add a section if reviewers want one
- [x] Tests — existing 9/9 plus 2 new `onContrast` tests pass (11/11)
- [x] Accessibility tests
    - [x] Keyboard-only navigation (unchanged from default variant)
    - [x] Zoom 200%/400% (unchanged from default variant)
    - [x] Screen reader (uses the same hidden `input[type=checkbox]` as the default)
- [x] Storybook examples created/updated (`OnContrast` story)
- [ ] Breaking change — n/a (additive `variant` prop, default `'default'` preserves existing behaviour)