### PR TITLE
[NO-JIRA][CI] Run Figma Code Connect with --dry-run on PRs

### DIFF
--- a/.github/workflows/sync-figma-code-connect.yml
+++ b/.github/workflows/sync-figma-code-connect.yml
@@ -3,6 +3,10 @@ on:
     paths:
       - packages/**/*.figma.tsx
     branches: [main]
+  pull_request:
+    paths:
+      - packages/**/*.figma.tsx
+    branches: [main]
 
 permissions: {}
 
@@ -10,10 +14,19 @@ jobs:
   code-connect:
     name: Code Connect
     runs-on: ubuntu-latest
+    # Skip on PRs from forks where FIGMA_TOKEN is unavailable.
+    if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - run: npx --package @figma/code-connect figma connect publish
+      - name: Validate Code Connect (dry run)
+        if: github.event_name == 'pull_request'
+        run: npx --package @figma/code-connect figma connect publish --dry-run
+        env:
+          FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+      - name: Publish Code Connect
+        if: github.event_name == 'push'
+        run: npx --package @figma/code-connect figma connect publish
         env:
           FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,7 +319,7 @@ Releases are managed by the Backpack design system team. If you have contributed
 
 ## Figma Code Connect
 
-Backpack uses [Figma Code Connect](https://github.com/figma/code-connect) to link React components to their Figma designs. When `.figma.tsx` files are merged to `main`, a GitHub Actions workflow automatically publishes the mappings to Figma.
+Backpack uses [Figma Code Connect](https://github.com/figma/code-connect) to link React components to their Figma designs. Pull requests that touch `.figma.tsx` files are validated with `figma connect publish --dry-run`, and once merged to `main` a GitHub Actions workflow automatically publishes the mappings to Figma.
 
 ### Regenerating all Figma assets
 
@@ -346,9 +346,14 @@ Icon Code Connect mappings are auto-generated. Do not edit `packages/bpk-compone
 
 For non-icon components, Code Connect mappings are written manually. Each component's mapping lives alongside its source code as `BpkComponentName.figma.tsx`. See existing `.figma.tsx` files for examples. After adding a new `.figma.tsx` file, run `npm run figma:generate-config` to update the import path mappings.
 
-### Publishing
+### Publishing and validation
 
-The `sync-figma-code-connect` workflow (`.github/workflows/sync-figma-code-connect.yml`) runs on pushes to `main` when `packages/**/*.figma.tsx` files change. It requires the `FIGMA_TOKEN` secret to be configured in the repository.
+The `sync-figma-code-connect` workflow (`.github/workflows/sync-figma-code-connect.yml`) runs whenever `packages/**/*.figma.tsx` files change:
+
+- On **pull requests** to `main`, it runs `figma connect publish --dry-run` to validate the mappings without publishing, surfacing parsing or schema issues as a PR check.
+- On **pushes** to `main`, it runs `figma connect publish` to publish the mappings to Figma.
+
+It requires the `FIGMA_TOKEN` secret to be configured in the repository. Pull requests from forks are skipped because forked workflows don't have access to repository secrets.
 
 ## And finally..
 


### PR DESCRIPTION
## Summary

Extends `.github/workflows/sync-figma-code-connect.yml` to also trigger on pull requests that touch `packages/**/*.figma.tsx`, running `figma connect publish --dry-run` so Code Connect issues surface as a PR check before merge. The existing publish-on-push-to-main behaviour is preserved, and fork PRs are skipped at the job level because `FIGMA_TOKEN` isn't exposed to them.

## Checklist

- [x] Tests — N/A (CI workflow change)
- [x] Accessibility tests — N/A
- [x] Storybook examples created/updated — N/A

Add the `skip-changelog` label since this is a CI-only change.