### PR TITLE
[CLOV-1405][token-sync] Expand skipped-variable CLI output into per-variable bullets

### DIFF
--- a/token-sync/src/build-dtcg-test.ts
+++ b/token-sync/src/build-dtcg-test.ts
@@ -334,8 +334,20 @@ describe('formatBuildSummary', () => {
   it('expands into bullet list when multiple FLOAT variables share the same scope key', () => {
     const lightOutput = makeOutput(BACKPACK_MODE_LIGHT);
     lightOutput.stats.ambiguousFloatVariables = [
-      { variableName: 'Typography/Weight/Bold', variableId: 'v3', variableKey: 'k3', scopes: ['ALL_SCOPES'], inferredType: 'dimension' },
-      { variableName: 'Typography/Weight/Regular', variableId: 'v4', variableKey: 'k4', scopes: ['ALL_SCOPES'], inferredType: 'dimension' },
+      {
+        variableName: 'Typography/Weight/Bold',
+        variableId: 'v3',
+        variableKey: 'k3',
+        scopes: ['ALL_SCOPES'],
+        inferredType: 'dimension',
+      },
+      {
+        variableName: 'Typography/Weight/Regular',
+        variableId: 'v4',
+        variableKey: 'k4',
+        scopes: ['ALL_SCOPES'],
+        inferredType: 'dimension',
+      },
     ];
 
     const lines = formatBuildSummary(makeResult({ outputs: [lightOutput] }));

--- a/token-sync/src/build-dtcg-test.ts
+++ b/token-sync/src/build-dtcg-test.ts
@@ -312,6 +312,39 @@ describe('formatBuildSummary', () => {
     );
   });
 
+  it('expands into bullet list when multiple variables share the same unresolved alias id', () => {
+    const varA = makeSkipped('Component/Button/bg-default', {
+      reason: 'unresolved-alias',
+      unresolvedAliasId: 'VariableID:9999:0000',
+    });
+    const varB = makeSkipped('Component/Card/bg-default', {
+      reason: 'unresolved-alias',
+      unresolvedAliasId: 'VariableID:9999:0000',
+    });
+
+    const lines = formatBuildSummary(
+      makeResult({ outputs: [makeOutput(BACKPACK_MODE_LIGHT, [varA, varB])] }),
+    );
+
+    expect(lines).toContain('  - missing VariableID:9999:0000 (2 variable(s)):');
+    expect(lines).toContain('      • [Backpack] Component/Button/bg-default (modes: Light)');
+    expect(lines).toContain('      • [Backpack] Component/Card/bg-default (modes: Light)');
+  });
+
+  it('expands into bullet list when multiple FLOAT variables share the same scope key', () => {
+    const lightOutput = makeOutput(BACKPACK_MODE_LIGHT);
+    lightOutput.stats.ambiguousFloatVariables = [
+      { variableName: 'Typography/Weight/Bold', variableId: 'v3', variableKey: 'k3', scopes: ['ALL_SCOPES'], inferredType: 'dimension' },
+      { variableName: 'Typography/Weight/Regular', variableId: 'v4', variableKey: 'k4', scopes: ['ALL_SCOPES'], inferredType: 'dimension' },
+    ];
+
+    const lines = formatBuildSummary(makeResult({ outputs: [lightOutput] }));
+
+    expect(lines).toContain('  - scope=[ALL_SCOPES] (2 variable(s)):');
+    expect(lines).toContain('      • [Backpack] Typography/Weight/Bold (modes: Light)');
+    expect(lines).toContain('      • [Backpack] Typography/Weight/Regular (modes: Light)');
+  });
+
   it('warns about FLOAT variables with unconstrained scopes and merges Light/Dark duplicates', () => {
     const lightOutput = makeOutput(BACKPACK_MODE_LIGHT);
     lightOutput.stats.ambiguousFloatVariables = [

--- a/token-sync/src/build-dtcg.ts
+++ b/token-sync/src/build-dtcg.ts
@@ -189,6 +189,8 @@ function addToGroup(
   references.get(referenceKey)!.modes.add(modeName);
 }
 
+// Formats a SkippedByKey entry as a human-readable string, e.g.
+// "[Backpack] Canvas/Default (modes: Light, Dark)"
 function renderReferences(references: SkippedByKey): string[] {
   return sortBy(Array.from(references.values()), (r) => r.variableName).map(
     ({ collectionName, modes, variableName }) => {

--- a/token-sync/src/build-dtcg.ts
+++ b/token-sync/src/build-dtcg.ts
@@ -189,15 +189,30 @@ function addToGroup(
   references.get(referenceKey)!.modes.add(modeName);
 }
 
-// Formats a SkippedByKey entry as a human-readable string, e.g.
-// "[Backpack] Canvas/Default (modes: Light, Dark)"
-function renderReferences(references: SkippedByKey): string {
-  return sortBy(Array.from(references.values()), (r) => r.variableName)
-    .map(({ collectionName, modes, variableName }) => {
+function renderReferences(references: SkippedByKey): string[] {
+  return sortBy(Array.from(references.values()), (r) => r.variableName).map(
+    ({ collectionName, modes, variableName }) => {
       const modeLabel = Array.from(modes).sort().join(', ');
       return `[${collectionName}] ${variableName} (modes: ${modeLabel})`;
-    })
-    .join('; ');
+    },
+  );
+}
+
+// 1 ref → inline after ←; N refs → nested bullet list to avoid one giant line.
+function pushBucket(
+  lines: string[],
+  itemLabel: string,
+  references: SkippedByKey,
+): void {
+  const rendered = renderReferences(references);
+  if (rendered.length === 1) {
+    lines.push(`  - ${itemLabel} ← ${rendered[0]}`);
+    return;
+  }
+  lines.push(`  - ${itemLabel} (${rendered.length} variable(s)):`);
+  for (const ref of rendered) {
+    lines.push(`      • ${ref}`);
+  }
 }
 
 function countInstances(groups: Map<string, SkippedByKey>): number {
@@ -304,9 +319,7 @@ function appendSkippedSections(
   for (const { groups, header, itemLabel } of sections) {
     if (groups.size > 0) {
       lines.push(header(countInstances(groups), groups.size));
-      groups.forEach((refs, key) =>
-        lines.push(`  - ${itemLabel(key)} ← ${renderReferences(refs)}`),
-      );
+      groups.forEach((refs, key) => pushBucket(lines, itemLabel(key), refs));
     }
   }
 }
@@ -344,7 +357,7 @@ function appendAmbiguousFloatSection(
       `If any of these aren't dimensions (e.g. font weights), tighten the scope in Figma:`,
   );
   groups.forEach((refs, scopeLabel) =>
-    lines.push(`  - scope=[${scopeLabel}] ← ${renderReferences(refs)}`),
+    pushBucket(lines, `scope=[${scopeLabel}]`, refs),
   );
 }
 


### PR DESCRIPTION
## What

When multiple variables shared the same skip-reason bucket (e.g. two variables both aliasing the same missing ID), they were joined into one semicolon-separated line which became unreadable.

## How

- `renderReferences` returns `string[]` instead of a joined string
- New `pushBucket` helper chooses the format: 1 ref → inline `←`, N refs → nested `•` bullets
- Single-ref output is unchanged

## Tests

Added 2 unit tests covering the new multi-ref bullet path in `formatBuildSummary`.

|Before| after|
|---|---|
|<img width="300"  alt="image" src="https://github.com/user-attachments/assets/6e79342c-23f2-4cc5-a5fb-3b6ba3871af4" /> | <img width="300"  alt="image" src="https://github.com/user-attachments/assets/91e26655-39ad-45ba-8f63-b5600fe4b101" />| 