### PR TITLE
[NO-JIRA][BpkCheckboxV2] Add position: relative to Root

### DIFF
--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2.module.scss
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2.module.scss
@@ -23,6 +23,11 @@
 
 // Root — flex row container (renders as <label> via Ark)
 .bpk-checkbox-v2 {
+  // Anchor Ark's visually-hidden <input position:absolute> to the Root.
+  // Without this, the hidden input climbs the DOM to the nearest positioned
+  // ancestor (e.g. a fixed BpkDrawer), inflating that ancestor's scrollHeight
+  // by the cumulative offsets of every checkbox inside it.
+  position: relative;
   display: inline-flex;
   align-items: flex-start;
   cursor: pointer;


### PR DESCRIPTION
## Summary

- Adds `position: relative` to `.bpk-checkbox-v2` Root in `BpkCheckboxV2.module.scss`
- Fixes a layout bug where Ark UI's `Checkbox.HiddenInput` (rendered with `position: absolute` internally) escapes the checkbox and anchors to the nearest positioned ancestor

## Why

Ark UI's `Checkbox.HiddenInput` renders a visually-hidden native `<input>` with `position: absolute`. Because `BpkCheckboxV2`'s Root doesn't establish a containing block, the hidden input climbs the DOM looking for the nearest positioned ancestor.

In a real consumer (~30 supplier checkboxes inside `BpkDrawer`, which is `position: fixed`), every hidden input anchored to the drawer itself, inflating `.bpk-drawer.scrollHeight` to ~5000px and producing a double-scroller inside the mobile filter drawer.

## Fix

One-line addition: `position: relative` on the Root, so the hidden input is anchored to its own checkbox rather than escaping the component.

- Zero visual impact — the input is already visually hidden (1×1px, clipped, off-screen)
- Fully backwards compatible — Root previously had no `position`, so no consumer is relying on a static positioning context
- Snapshot test unchanged — the snapshot captures inline styles from Ark's hidden input, not computed CSS from the module

## Test plan

- [ ] CI passes (lint + typecheck + jest)
- [ ] Storybook stories for `BpkCheckboxV2` render unchanged (visual diff)
- [ ] Manual repro in a fixed-position container with many checkboxes — `scrollHeight` no longer inflates