### PR TITLE
[NO-JIRA][BpkCheckboxV2] Allow safe prop forwarding on atomic parts

### DIFF
--- a/packages/bpk-component-checkbox/index.ts
+++ b/packages/bpk-component-checkbox/index.ts
@@ -32,3 +32,4 @@ export type { BpkCheckboxV2RootProps, BpkCheckboxV2CheckedState } from './src/Bp
 export type { BpkCheckboxV2ControlProps } from './src/BpkCheckboxV2/BpkCheckboxV2Control';
 export type { BpkCheckboxV2LabelProps } from './src/BpkCheckboxV2/BpkCheckboxV2Label';
 export type { BpkCheckboxV2DescriptionProps } from './src/BpkCheckboxV2/BpkCheckboxV2Description';
+export type { BpkCheckboxV2HiddenInputProps } from './src/BpkCheckboxV2/BpkCheckboxV2HiddenInput';

--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2-test.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2-test.tsx
@@ -151,4 +151,120 @@ describe('BpkCheckboxV2', () => {
       expect(root).toHaveAttribute('data-backpack-ds-component');
     });
   });
+
+  describe('safe prop forwarding', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('forwards data-* and aria-* attributes on each part', () => {
+      render(
+        <BpkCheckboxV2.Root data-testid="root" aria-label="root-label">
+          <BpkCheckboxV2.Control data-testid="control">
+            <BpkCheckboxV2.Indicator />
+          </BpkCheckboxV2.Control>
+          <BpkCheckboxV2.Label data-testid="label">Label text</BpkCheckboxV2.Label>
+          <BpkCheckboxV2.Description data-testid="description">
+            Description text
+          </BpkCheckboxV2.Description>
+          <BpkCheckboxV2.HiddenInput
+            data-testid="hidden-input"
+            aria-label="hidden-input-label"
+          />
+        </BpkCheckboxV2.Root>,
+      );
+
+      expect(screen.getByTestId('root')).toHaveAttribute(
+        'aria-label',
+        'root-label',
+      );
+      expect(screen.getByTestId('control')).toBeInTheDocument();
+      expect(screen.getByTestId('label')).toBeInTheDocument();
+      expect(screen.getByTestId('description')).toBeInTheDocument();
+      expect(screen.getByTestId('hidden-input')).toHaveAttribute(
+        'aria-label',
+        'hidden-input-label',
+      );
+    });
+
+    it('strips className from each part and warns in development', () => {
+      render(
+        <BpkCheckboxV2.Root
+          data-testid="root"
+          // @ts-expect-error className is intentionally not in the public type
+          className="consumer-root"
+        >
+          <BpkCheckboxV2.Control
+            data-testid="control"
+            // @ts-expect-error className is intentionally not in the public type
+            className="consumer-control"
+          >
+            <BpkCheckboxV2.Indicator />
+          </BpkCheckboxV2.Control>
+          <BpkCheckboxV2.Label
+            data-testid="label"
+            // @ts-expect-error className is intentionally not in the public type
+            className="consumer-label"
+          >
+            Label text
+          </BpkCheckboxV2.Label>
+          <BpkCheckboxV2.Description
+            data-testid="description"
+            // @ts-expect-error className is intentionally not in the public type
+            className="consumer-description"
+          >
+            Description text
+          </BpkCheckboxV2.Description>
+          <BpkCheckboxV2.HiddenInput
+            data-testid="hidden-input"
+            // @ts-expect-error className is intentionally not in the public type
+            className="consumer-hidden-input"
+          />
+        </BpkCheckboxV2.Root>,
+      );
+
+      expect(screen.getByTestId('root').className).not.toMatch('consumer-root');
+      expect(screen.getByTestId('control').className).not.toMatch(
+        'consumer-control',
+      );
+      expect(screen.getByTestId('label').className).not.toMatch(
+        'consumer-label',
+      );
+      expect(screen.getByTestId('description').className).not.toMatch(
+        'consumer-description',
+      );
+      expect(screen.getByTestId('hidden-input').className).not.toMatch(
+        'consumer-hidden-input',
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(5);
+    });
+
+    it('strips style from each part and warns in development', () => {
+      render(
+        <BpkCheckboxV2.Root
+          data-testid="root"
+          // @ts-expect-error style is intentionally not in the public type
+          style={{ display: 'block' }}
+        >
+          <BpkCheckboxV2.Control data-testid="control">
+            <BpkCheckboxV2.Indicator />
+          </BpkCheckboxV2.Control>
+          <BpkCheckboxV2.Label data-testid="label">Label</BpkCheckboxV2.Label>
+          <BpkCheckboxV2.HiddenInput data-testid="hidden-input" />
+        </BpkCheckboxV2.Root>,
+      );
+
+      expect(screen.getByTestId('root')).not.toHaveAttribute('style');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('BpkCheckboxV2.Root'),
+      );
+    });
+  });
 });

--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Control.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Control.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 
 import { Checkbox } from '@ark-ui/react';
 
@@ -26,14 +26,38 @@ import STYLES from './BpkCheckboxV2.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-export type BpkCheckboxV2ControlProps = {
+// `className` and `style` are intentionally blocked — Backpack owns the
+// visual layer.
+type BpkCheckboxV2ControlSafePassThroughProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'className' | 'style' | 'children'
+>;
+
+export type BpkCheckboxV2ControlProps = BpkCheckboxV2ControlSafePassThroughProps & {
   children: ReactNode;
 };
 
-const BpkCheckboxV2Control = ({ children }: BpkCheckboxV2ControlProps) => (
-  <Checkbox.Control className={getClassName('bpk-checkbox-v2__control')}>
-    {children}
-  </Checkbox.Control>
-);
+const BpkCheckboxV2Control = ({ children, ...rest }: BpkCheckboxV2ControlProps) => {
+  const { className, style, ...safeProps } = rest as typeof rest & {
+    className?: unknown;
+    style?: unknown;
+  };
+
+  if (process.env.NODE_ENV !== 'production' && (className || style)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[BpkCheckboxV2.Control] `className` and `style` are not supported.',
+    );
+  }
+
+  return (
+    <Checkbox.Control
+      {...safeProps}
+      className={getClassName('bpk-checkbox-v2__control')}
+    >
+      {children}
+    </Checkbox.Control>
+  );
+};
 
 export default BpkCheckboxV2Control;

--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Description.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Description.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 
 import { cssModules } from '../../../bpk-react-utils';
 
@@ -24,15 +24,45 @@ import STYLES from './BpkCheckboxV2.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-export type BpkCheckboxV2DescriptionProps = {
-  children: ReactNode;
-};
+// `className` and `style` are intentionally blocked — Backpack owns the
+// visual layer.
+type BpkCheckboxV2DescriptionSafePassThroughProps = Omit<
+  HTMLAttributes<HTMLSpanElement>,
+  'className' | 'style' | 'children'
+>;
+
+export type BpkCheckboxV2DescriptionProps =
+  BpkCheckboxV2DescriptionSafePassThroughProps & {
+    children: ReactNode;
+  };
 
 // Description renders as a <span> inside the Checkbox.Root <label>.
 // Being inside the <label> element means screen readers announce its text
 // as part of the checkbox's accessible name.
-const BpkCheckboxV2Description = ({ children }: BpkCheckboxV2DescriptionProps) => (
-  <span className={getClassName('bpk-checkbox-v2__description')}>{children}</span>
-);
+const BpkCheckboxV2Description = ({
+  children,
+  ...rest
+}: BpkCheckboxV2DescriptionProps) => {
+  const { className, style, ...safeProps } = rest as typeof rest & {
+    className?: unknown;
+    style?: unknown;
+  };
+
+  if (process.env.NODE_ENV !== 'production' && (className || style)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[BpkCheckboxV2.Description] `className` and `style` are not supported.',
+    );
+  }
+
+  return (
+    <span
+      {...safeProps}
+      className={getClassName('bpk-checkbox-v2__description')}
+    >
+      {children}
+    </span>
+  );
+};
 
 export default BpkCheckboxV2Description;

--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2HiddenInput.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2HiddenInput.tsx
@@ -16,10 +16,43 @@
  * limitations under the License.
  */
 
+import type { InputHTMLAttributes } from 'react';
+
 import { Checkbox } from '@ark-ui/react';
+
+// `className` and `style` are intentionally blocked — Backpack owns the visual
+// layer. The other props are managed by `BpkCheckboxV2.Root` to keep a single
+// source of truth.
+export type BpkCheckboxV2HiddenInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  | 'className'
+  | 'style'
+  | 'checked'
+  | 'defaultChecked'
+  | 'disabled'
+  | 'name'
+  | 'required'
+  | 'value'
+  | 'onChange'
+  | 'children'
+>;
 
 // Renders Ark's visually hidden native <input type="checkbox">.
 // Include when the checkbox is inside a <form> for native form submission.
-const BpkCheckboxV2HiddenInput = () => <Checkbox.HiddenInput />;
+const BpkCheckboxV2HiddenInput = (props: BpkCheckboxV2HiddenInputProps = {}) => {
+  const { className, style, ...safeProps } = props as BpkCheckboxV2HiddenInputProps & {
+    className?: unknown;
+    style?: unknown;
+  };
+
+  if (process.env.NODE_ENV !== 'production' && (className || style)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[BpkCheckboxV2.HiddenInput] `className` and `style` are not supported.',
+    );
+  }
+
+  return <Checkbox.HiddenInput {...safeProps} />;
+};
 
 export default BpkCheckboxV2HiddenInput;

--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Label.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Label.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 
 import { Checkbox } from '@ark-ui/react';
 
@@ -26,14 +26,38 @@ import STYLES from './BpkCheckboxV2.module.scss';
 
 const getClassName = cssModules(STYLES);
 
-export type BpkCheckboxV2LabelProps = {
+// `className` and `style` are intentionally blocked — Backpack owns the
+// visual layer.
+type BpkCheckboxV2LabelSafePassThroughProps = Omit<
+  HTMLAttributes<HTMLSpanElement>,
+  'className' | 'style' | 'children'
+>;
+
+export type BpkCheckboxV2LabelProps = BpkCheckboxV2LabelSafePassThroughProps & {
   children: ReactNode;
 };
 
-const BpkCheckboxV2Label = ({ children }: BpkCheckboxV2LabelProps) => (
-  <Checkbox.Label className={getClassName('bpk-checkbox-v2__label')}>
-    {children}
-  </Checkbox.Label>
-);
+const BpkCheckboxV2Label = ({ children, ...rest }: BpkCheckboxV2LabelProps) => {
+  const { className, style, ...safeProps } = rest as typeof rest & {
+    className?: unknown;
+    style?: unknown;
+  };
+
+  if (process.env.NODE_ENV !== 'production' && (className || style)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[BpkCheckboxV2.Label] `className` and `style` are not supported.',
+    );
+  }
+
+  return (
+    <Checkbox.Label
+      {...safeProps}
+      className={getClassName('bpk-checkbox-v2__label')}
+    >
+      {children}
+    </Checkbox.Label>
+  );
+};
 
 export default BpkCheckboxV2Label;

--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Root.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Root.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type { HTMLAttributes, LabelHTMLAttributes, ReactNode } from 'react';
 
 import { Checkbox } from '@ark-ui/react';
 
@@ -28,7 +28,17 @@ const getClassName = cssModules(STYLES);
 
 export type BpkCheckboxV2CheckedState = boolean | 'indeterminate';
 
-export type BpkCheckboxV2RootProps = {
+// `className` and `style` are blocked — Backpack owns the visual layer.
+// `role` is blocked because Ark UI sets it.
+// `id`, `children` are managed below; `defaultChecked` is overridden because
+// Ark's HTMLAttributes value is a `boolean` whereas V2 also supports
+// `'indeterminate'`.
+type BpkCheckboxV2RootSafePassThroughProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'className' | 'style' | 'role' | 'id' | 'children' | 'defaultChecked'
+>;
+
+export type BpkCheckboxV2RootProps = BpkCheckboxV2RootSafePassThroughProps & {
   children: ReactNode;
   checked?: BpkCheckboxV2CheckedState;
   defaultChecked?: BpkCheckboxV2CheckedState;
@@ -52,22 +62,43 @@ const BpkCheckboxV2Root = ({
   onCheckedChange,
   required = false,
   value,
-}: BpkCheckboxV2RootProps) => (
-  <Checkbox.Root
-    className={getClassName('bpk-checkbox-v2')}
-    checked={checked}
-    defaultChecked={defaultChecked}
-    disabled={disabled}
-    id={id}
-    invalid={invalid}
-    name={name}
-    onCheckedChange={(details) => onCheckedChange?.(details.checked)}
-    required={required}
-    value={value}
-    {...getDataComponentAttribute('CheckboxV2')}
-  >
-    {children}
-  </Checkbox.Root>
-);
+  ...rest
+}: BpkCheckboxV2RootProps) => {
+  const { className, style, ...safeProps } = rest as typeof rest & {
+    className?: unknown;
+    style?: unknown;
+  };
+
+  if (process.env.NODE_ENV !== 'production' && (className || style)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[BpkCheckboxV2.Root] `className` and `style` are not supported.',
+    );
+  }
+
+  // Public type is `HTMLAttributes<HTMLDivElement>` for ergonomics, but
+  // Checkbox.Root renders a <label>; the event-handler element types differ
+  // only in label-specific properties consumers are unlikely to use.
+  const labelSafeProps = safeProps as LabelHTMLAttributes<HTMLLabelElement>;
+
+  return (
+    <Checkbox.Root
+      {...labelSafeProps}
+      className={getClassName('bpk-checkbox-v2')}
+      checked={checked}
+      defaultChecked={defaultChecked}
+      disabled={disabled}
+      id={id}
+      invalid={invalid}
+      name={name}
+      onCheckedChange={(details) => onCheckedChange?.(details.checked)}
+      required={required}
+      value={value}
+      {...getDataComponentAttribute('CheckboxV2')}
+    >
+      {children}
+    </Checkbox.Root>
+  );
+};
 
 export default BpkCheckboxV2Root;


### PR DESCRIPTION
## Summary

Open up safe prop forwarding on `BpkCheckboxV2`'s atomic parts (`Root`, `Control`, `Label`, `Description`, `HiddenInput`) so consumers can wire up `data-testid`, `aria-label`/`aria-labelledby`/`aria-describedby`, `id`, and other native HTML attributes — while keeping `className` and `style` strictly locked down so Backpack retains ownership of the visual layer.

## What changed

- Each part's prop type is now built on the matching `HTMLAttributes` / `InputHTMLAttributes` interface with `className` and `style` (and the props the V2 wrapper already manages) removed via `Omit`.
- A defensive runtime strip + dev-only `console.warn` catches any `as any` bypass that smuggles `className` / `style` through.
- `BpkCheckboxV2HiddenInputProps` is now exported from the package index alongside the existing part types.
- `Indicator` is unchanged — it returns `null`, so there is no element to forward props to.
- No shorthand `<BpkCheckboxV2 label="..." />` API in this PR — tracked separately.
- V1 `BpkCheckbox` is untouched.

## Test plan

- [x] `jest packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2-test.tsx` — 15/15 pass, including 3 new tests covering forwarding + className/style stripping
- [x] `eslint packages/bpk-component-checkbox/src/BpkCheckboxV2 --ext .ts,.tsx` clean
- [x] `tsc --noEmit` clean for the checkbox package
- [ ] Reviewer to sanity-check that consumer-facing types disallow `className` / `style` (the test file exercises this with `@ts-expect-error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)