### PR TITLE
[NO-JIRA][BpkCheckboxV2] Allow data-testid on Root and aria-* on HiddenInput

### DIFF
--- a/packages/bpk-component-checkbox/index.ts
+++ b/packages/bpk-component-checkbox/index.ts
@@ -32,3 +32,4 @@ export type { BpkCheckboxV2RootProps, BpkCheckboxV2CheckedState } from './src/Bp
 export type { BpkCheckboxV2ControlProps } from './src/BpkCheckboxV2/BpkCheckboxV2Control';
 export type { BpkCheckboxV2LabelProps } from './src/BpkCheckboxV2/BpkCheckboxV2Label';
 export type { BpkCheckboxV2DescriptionProps } from './src/BpkCheckboxV2/BpkCheckboxV2Description';
+export type { BpkCheckboxV2HiddenInputProps } from './src/BpkCheckboxV2/BpkCheckboxV2HiddenInput';

--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2-test.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2-test.tsx
@@ -150,5 +150,63 @@ describe('BpkCheckboxV2', () => {
       const root = container.firstChild as HTMLElement;
       expect(root).toHaveAttribute('data-backpack-ds-component');
     });
+
+    it('forwards data-testid on Root to the outer label', () => {
+      render(<SimpleCheckbox data-testid="terms-checkbox" />);
+      expect(screen.getByTestId('terms-checkbox').tagName).toBe('LABEL');
+    });
+  });
+
+  describe('HiddenInput aria-* forwarding', () => {
+    it('forwards aria-label to the hidden input', () => {
+      render(
+        <BpkCheckboxV2.Root>
+          <BpkCheckboxV2.Control>
+            <BpkCheckboxV2.Indicator />
+          </BpkCheckboxV2.Control>
+          <BpkCheckboxV2.HiddenInput aria-label="Save my searches to my account" />
+        </BpkCheckboxV2.Root>,
+      );
+      expect(
+        screen.getByRole('checkbox', { name: 'Save my searches to my account' }),
+      ).toBeInTheDocument();
+    });
+
+    it('forwards aria-labelledby to the hidden input', () => {
+      render(
+        <>
+          <span id="external-label">External title</span>
+          <BpkCheckboxV2.Root>
+            <BpkCheckboxV2.Control>
+              <BpkCheckboxV2.Indicator />
+            </BpkCheckboxV2.Control>
+            <BpkCheckboxV2.HiddenInput aria-labelledby="external-label" />
+          </BpkCheckboxV2.Root>
+        </>,
+      );
+      expect(screen.getByRole('checkbox')).toHaveAttribute(
+        'aria-labelledby',
+        'external-label',
+      );
+    });
+
+    it('forwards aria-describedby to the hidden input', () => {
+      render(
+        <>
+          <span id="external-help">Helpful description</span>
+          <BpkCheckboxV2.Root>
+            <BpkCheckboxV2.Control>
+              <BpkCheckboxV2.Indicator />
+            </BpkCheckboxV2.Control>
+            <BpkCheckboxV2.Label>Accept terms</BpkCheckboxV2.Label>
+            <BpkCheckboxV2.HiddenInput aria-describedby="external-help" />
+          </BpkCheckboxV2.Root>
+        </>,
+      );
+      expect(screen.getByRole('checkbox')).toHaveAttribute(
+        'aria-describedby',
+        'external-help',
+      );
+    });
   });
 });

--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2HiddenInput.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2HiddenInput.tsx
@@ -18,8 +18,27 @@
 
 import { Checkbox } from '@ark-ui/react';
 
+export type BpkCheckboxV2HiddenInputProps = {
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+};
+
 // Renders Ark's visually hidden native <input type="checkbox">.
 // Include when the checkbox is inside a <form> for native form submission.
-const BpkCheckboxV2HiddenInput = () => <Checkbox.HiddenInput />;
+// Accepts aria-* attributes so consumers can override the screen-reader
+// announcement when the visible <BpkCheckboxV2.Label> is missing or differs
+// from the desired accessible name.
+const BpkCheckboxV2HiddenInput = ({
+  'aria-describedby': ariaDescribedby,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+}: BpkCheckboxV2HiddenInputProps = {}) => (
+  <Checkbox.HiddenInput
+    aria-describedby={ariaDescribedby}
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledby}
+  />
+);
 
 export default BpkCheckboxV2HiddenInput;

--- a/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Root.tsx
+++ b/packages/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Root.tsx
@@ -31,6 +31,7 @@ export type BpkCheckboxV2CheckedState = boolean | 'indeterminate';
 export type BpkCheckboxV2RootProps = {
   children: ReactNode;
   checked?: BpkCheckboxV2CheckedState;
+  'data-testid'?: string;
   defaultChecked?: BpkCheckboxV2CheckedState;
   disabled?: boolean;
   id?: string;
@@ -44,6 +45,7 @@ export type BpkCheckboxV2RootProps = {
 const BpkCheckboxV2Root = ({
   checked,
   children,
+  'data-testid': dataTestId,
   defaultChecked,
   disabled = false,
   id,
@@ -56,6 +58,7 @@ const BpkCheckboxV2Root = ({
   <Checkbox.Root
     className={getClassName('bpk-checkbox-v2')}
     checked={checked}
+    data-testid={dataTestId}
     defaultChecked={defaultChecked}
     disabled={disabled}
     id={id}


### PR DESCRIPTION
## Summary

Minimum-viable opening of the closed `BpkCheckboxV2` API — adds two narrowly-scoped capabilities consumers actually need today:

- **`data-testid` on `Root`** — gives tests a stable handle on the outer `<label>` (the input itself is still grabbed via `getByRole('checkbox')`).
- **`aria-label` / `aria-labelledby` / `aria-describedby` on `HiddenInput`** — lets consumers customise screen-reader announcement when the visible `<BpkCheckboxV2.Label>` is absent (e.g. icon-only checkboxes) or when the accessible name lives elsewhere on the page.

`className` and `style` remain blocked. All other rest props remain blocked, matching the closed-API style of other Ark-based Backpack components (`BpkModalV3`, `BpkCheckboxCard`, `BpkCollapsible`, `BpkSegmentedControlV2`).

This supersedes #4478, which opened up a much broader `Omit<HTMLAttributes<...>>` pass-through on every part. That scope was wider than current consumer needs and inconsistent with the rest of the codebase, so we narrowed it to what's actually required.

## What changed

- `BpkCheckboxV2Root.tsx` — added `'data-testid'?: string` to the public type and forwarded it to `Checkbox.Root`.
- `BpkCheckboxV2HiddenInput.tsx` — added `BpkCheckboxV2HiddenInputProps` with `aria-label`, `aria-labelledby`, `aria-describedby` and forwarded them to `Checkbox.HiddenInput`.
- `index.ts` — exported `BpkCheckboxV2HiddenInputProps`.
- Tests — added 4 focused tests covering the new prop forwarding.

## Test plan

- [x] `jest packages/bpk-component-checkbox/src/BpkCheckboxV2` (24/24 passing, snapshots unchanged)
- [x] ESLint clean on touched files
- [x] TypeScript clean on touched files
- [ ] Visual regression unaffected (no SCSS changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)