### PR TITLE
[CLOV-1406][token-sync] Add manifest.json to pipeline diagram

### DIFF
--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -16,9 +16,8 @@ flowchart LR
     end
 
     subgraph tokens["token-sync/tokens/"]
-        pj["primitives.json"]
-        bl["backpack.light.json"]
-        bd["backpack.dark.json"]
+        pj["primitives.json"] ~~~ mf["manifest.json"]
+        bl["backpack.light.json"] ~~~ bd["backpack.dark.json"]
     end
 
     subgraph css["token-sync/css/"]


### PR DESCRIPTION
Small follow-up to #4487 — adds `manifest.json` to the tokens directory in the pipeline diagram, so it matches the actual Stage 1 output.
<img width="2215" height="290" alt="image" src="https://github.com/user-attachments/assets/03295dc1-4800-4521-9ab5-e3204494284f" />

CLOV-1406