### PR TITLE
[BpkChatbotInput] Fix Storybook args table not auto-generating

### DIFF
--- a/packages/bpk-component-chatbot-input/src/BpkChatbotInput.stories.tsx
+++ b/packages/bpk-component-chatbot-input/src/BpkChatbotInput.stories.tsx
@@ -376,6 +376,7 @@ const WithCustomSendButtonExample = () => {
 
 const meta = {
   title: 'bpk-component-chatbot-input',
+  component: BpkChatbotInput.Input,
   decorators: [
     (Story: any) => (
       <BpkProvider>


### PR DESCRIPTION
## Summary
- The `bpk-component-chatbot-input` Storybook docs panel was showing the placeholder *"Args table with interactive controls couldn't be auto-generated"* instead of the props/controls table.
- Root cause: the story `meta` was missing the `component` field, so Storybook had no React component to introspect for prop types.
- Fix: set `component: BpkChatbotInput.Input` on the meta — `Input` is the main interactive subcomponent that carries the prop surface. This mirrors the pattern in `BpkCheckboxV2.stories.tsx` (`component: BpkCheckboxV2.Root`), which is the existing convention for namespace-style components.


Before
<img width="1192" height="568" alt="image" src="https://github.com/user-attachments/assets/0d54a3d3-cb4f-454f-ba03-b9df668d44f7" />
After
<img width="1183" height="686" alt="image" src="https://github.com/user-attachments/assets/a9ac45ba-ca28-4424-8117-9acb60a790ef" />


## Test plan
- [ ] Run `npm run storybook` and open `bpk-component-chatbot-input` → confirm the docs panel now renders the auto-generated args / controls table.
- [ ] Confirm existing stories (Composer, Cars, CarsComposer, Themed, WithToolbar, etc.) still render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)