### PR TITLE
[CLOV-1409] Automate Figma variable sync PR creation

### DIFF
--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -145,7 +145,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_BRANCH: ${{ steps.commit.outputs.branch_name }}
         run: |
-          open_prs="$(gh pr list --state open --limit 100 --json number,headRefName,url --jq --arg new "$NEW_BRANCH" '.[] | select(.headRefName | startswith("figma-token-sync/")) | select(.headRefName != $new) | [.number, .headRefName, .url] | @tsv')"
+          open_prs="$(gh pr list --state open --limit 100 --json number,headRefName,url \
+            | jq -r --arg new "$NEW_BRANCH" '.[] | select(.headRefName | startswith("figma-token-sync/")) | select(.headRefName != $new) | [.number, .headRefName, .url] | @tsv')"
 
           if [ -z "$open_prs" ]; then
             echo "No superseded Figma token sync pull requests."

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -1,11 +1,18 @@
 name: Sync Figma variables
 
 on:
+  schedule:
+    # Weekly polling sync, every Monday at 09:00 UTC.
+    - cron: '0 9 * * 1'
   workflow_dispatch:
     inputs:
       file_key:
         description: 'Optional Figma file key override (defaults to the FIGMA_FILE_KEY repo secret).'
         required: false
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 permissions: {}
 
@@ -17,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.ref }}
           persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -32,5 +40,128 @@ jobs:
           FIGMA_FILE_KEY: ${{ github.event.inputs.file_key || secrets.FIGMA_FILE_KEY }}
         run: npm run tokens:fetch
 
+      - name: Detect meaningful fetched token changes
+        id: token_changes
+        run: |
+          token_status="$(git status --porcelain --untracked-files=all -- token-sync/tokens)"
+          untracked_tokens="$(git ls-files --others --exclude-standard -- token-sync/tokens)"
+
+          if [ -z "$token_status" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No fetched token changes."
+            exit 0
+          fi
+
+          if git diff --ignore-matching-lines='^[[:space:]]*"generatedAt":' --quiet -- token-sync/tokens && [ -z "$untracked_tokens" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Only token metadata changed; skipping CSS build and PR creation."
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "Fetched token values changed."
+
+      - name: Classify token release label
+        id: release_label
+        if: steps.token_changes.outputs.changed == 'true'
+        continue-on-error: true
+        run: ./node_modules/.bin/tsx token-sync/src/classify-release-label-cli.ts
+
       - name: Stage 2 - Build CSS from DTCG tokens
+        if: steps.token_changes.outputs.changed == 'true'
         run: npm run tokens:build-css
+
+      - name: Detect generated token changes
+        id: generated_changes
+        if: steps.token_changes.outputs.changed == 'true'
+        run: |
+          changed_files="$(git status --porcelain -- token-sync/tokens token-sync/css)"
+
+          if [ -z "$changed_files" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No generated token changes after CSS build."
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "Generated token changes detected."
+
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        if: steps.generated_changes.outputs.changed == 'true'
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Close superseded Figma token sync pull requests
+        if: steps.generated_changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          open_prs="$(gh pr list --state open --limit 100 --json number,headRefName,url --jq '.[] | select(.headRefName | startswith("figma-token-sync/")) | [.number, .headRefName, .url] | @tsv')"
+
+          if [ -z "$open_prs" ]; then
+            echo "No superseded Figma token sync pull requests."
+            exit 0
+          fi
+
+          closed_count=0
+          while IFS=$'\t' read -r number _branch _url; do
+            gh pr close "$number" --comment "Closing this automated token sync PR because a newer run will open a fresh PR with the latest cumulative Figma token changes against main."
+            closed_count=$((closed_count + 1))
+          done <<< "$open_prs"
+          echo "Closed ${closed_count} superseded Figma token sync pull request(s)."
+
+      - name: Commit generated token changes
+        id: commit
+        if: steps.generated_changes.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          timestamp="$(date -u +'%Y%m%d%H%M%S')"
+          branch_name="figma-token-sync/${timestamp}-${GITHUB_RUN_ID}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch_name"
+          git add token-sync/tokens token-sync/css
+          git commit -m "Update Figma design tokens"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin "HEAD:${branch_name}"
+
+          echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        if: steps.generated_changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH_NAME: ${{ steps.commit.outputs.branch_name }}
+          RELEASE_LABEL: ${{ steps.release_label.outputs.label || 'major' }}
+          RELEASE_LABEL_OUTCOME: ${{ steps.release_label.outcome }}
+        run: |
+          {
+            echo "## Summary"
+            echo
+            echo "Automated Figma variable sync generated updates to Backpack design tokens and CSS custom properties."
+            echo
+            echo "Release label: \`${RELEASE_LABEL}\`"
+            if [ "$RELEASE_LABEL_OUTCOME" != "success" ]; then
+              echo
+              echo "> Release label classification failed, so this PR defaults to \`major\` for review."
+            fi
+            echo
+            echo "## Source"
+            echo
+            echo "- Trigger: \`${GITHUB_EVENT_NAME}\`"
+            echo "- Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > "$RUNNER_TEMP/figma-token-sync-pr.md"
+
+          pr_url="$(gh pr create \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --title "Update Figma design tokens" \
+            --body-file "$RUNNER_TEMP/figma-token-sync-pr.md" \
+            --label design-token-automation \
+            --label "$RELEASE_LABEL")"
+
+          echo "Opened pull request: $pr_url"

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.ref }}
+          ref: main
           persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -65,6 +65,8 @@ jobs:
         id: release_label
         if: steps.token_changes.outputs.changed == 'true'
         continue-on-error: true
+        env:
+          TOKEN_RELEASE_SUMMARY_PATH: ${{ runner.temp }}/token-release-summary.md
         run: ./node_modules/.bin/tsx token-sync/src/classify-release-label-cli.ts
 
       - name: Stage 2 - Build CSS from DTCG tokens
@@ -146,6 +148,10 @@ jobs:
             if [ "$RELEASE_LABEL_OUTCOME" != "success" ]; then
               echo
               echo "> Release label classification failed, so this PR defaults to \`major\` for review."
+            fi
+            if [ -s "$RUNNER_TEMP/token-release-summary.md" ]; then
+              echo
+              cat "$RUNNER_TEMP/token-release-summary.md"
             fi
             echo
             echo "## Source"

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -2,8 +2,8 @@ name: Sync Figma variables
 
 on:
   schedule:
-    # Weekly polling sync, every Monday at 09:00 UTC.
-    - cron: '0 9 * * 1'
+    # Temporarily poll every 30 minutes for validation; the production cadence will be daily at 18:00 GMT.
+    - cron: '*/30 * * * *'
   workflow_dispatch:
     inputs:
       file_key:
@@ -105,12 +105,10 @@ jobs:
             exit 0
           fi
 
-          closed_count=0
           while IFS=$'\t' read -r number _branch _url; do
             gh pr close "$number" --comment "Closing this automated token sync PR because a newer run will open a fresh PR with the latest cumulative Figma token changes against main."
-            closed_count=$((closed_count + 1))
+            echo "Closed superseded Figma token sync pull request: ${_url}"
           done <<< "$open_prs"
-          echo "Closed ${closed_count} superseded Figma token sync pull request(s)."
 
       - name: Commit generated token changes
         id: commit

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions: {}
 
@@ -44,13 +44,7 @@ jobs:
         id: token_changes
         run: |
           token_status="$(git status --porcelain --untracked-files=all -- token-sync/tokens)"
-          untracked_tokens="$(git ls-files --others --exclude-standard -- token-sync/tokens)"
-
-          if [ -z "$token_status" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No fetched token changes."
-            exit 0
-          fi
+          untracked_tokens="$(printf '%s\n' "$token_status" | grep '^?? ' || true)"
 
           if git diff --ignore-matching-lines='^[[:space:]]*"generatedAt":' --quiet -- token-sync/tokens && [ -z "$untracked_tokens" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -73,48 +67,16 @@ jobs:
         if: steps.token_changes.outputs.changed == 'true'
         run: npm run tokens:build-css
 
-      - name: Detect generated token changes
-        id: generated_changes
-        if: steps.token_changes.outputs.changed == 'true'
-        run: |
-          changed_files="$(git status --porcelain -- token-sync/tokens token-sync/css)"
-
-          if [ -z "$changed_files" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No generated token changes after CSS build."
-            exit 0
-          fi
-
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-          echo "Generated token changes detected."
-
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
-        if: steps.generated_changes.outputs.changed == 'true'
+        if: steps.token_changes.outputs.changed == 'true'
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
-      - name: Close superseded Figma token sync pull requests
-        if: steps.generated_changes.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          open_prs="$(gh pr list --state open --limit 100 --json number,headRefName,url --jq '.[] | select(.headRefName | startswith("figma-token-sync/")) | [.number, .headRefName, .url] | @tsv')"
-
-          if [ -z "$open_prs" ]; then
-            echo "No superseded Figma token sync pull requests."
-            exit 0
-          fi
-
-          while IFS=$'\t' read -r number _branch _url; do
-            gh pr close "$number" --comment "Closing this automated token sync PR because a newer run will open a fresh PR with the latest cumulative Figma token changes against main."
-            echo "Closed superseded Figma token sync pull request: ${_url}"
-          done <<< "$open_prs"
-
       - name: Commit generated token changes
         id: commit
-        if: steps.generated_changes.outputs.changed == 'true'
+        if: steps.token_changes.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -132,7 +94,7 @@ jobs:
           echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
 
       - name: Open pull request
-        if: steps.generated_changes.outputs.changed == 'true'
+        if: steps.token_changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH_NAME: ${{ steps.commit.outputs.branch_name }}
@@ -176,3 +138,21 @@ jobs:
             --label "$RELEASE_LABEL")"
 
           echo "Opened pull request: $pr_url"
+
+      - name: Close superseded Figma token sync pull requests
+        if: steps.token_changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEW_BRANCH: ${{ steps.commit.outputs.branch_name }}
+        run: |
+          open_prs="$(gh pr list --state open --limit 100 --json number,headRefName,url --jq --arg new "$NEW_BRANCH" '.[] | select(.headRefName | startswith("figma-token-sync/")) | select(.headRefName != $new) | [.number, .headRefName, .url] | @tsv')"
+
+          if [ -z "$open_prs" ]; then
+            echo "No superseded Figma token sync pull requests."
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r number _branch _url; do
+            gh pr close "$number" --comment "Closing this automated token sync PR because a newer run has opened a fresh PR with the latest cumulative Figma token changes against main."
+            echo "Closed superseded Figma token sync pull request: ${_url}"
+          done <<< "$open_prs"

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -145,9 +145,16 @@ jobs:
             echo "Automated Figma variable sync generated updates to Backpack design tokens and CSS custom properties."
             echo
             echo "Release label: \`${RELEASE_LABEL}\`"
+            echo
+            echo "**Release label rules:**"
+            echo "- \`major\` — an existing token path was removed or renamed (consumer code may break)."
+            echo "- \`minor\` — only new token paths were added, or values of existing tokens changed."
             if [ "$RELEASE_LABEL_OUTCOME" != "success" ]; then
               echo
-              echo "> Release label classification failed, so this PR defaults to \`major\` for review."
+              echo "> [!WARNING]"
+              echo "> **Release label classification threw an exception** and has fallen back to \`major\` as a safe default."
+              echo "> The automated analysis could not determine whether this change is \`major\` or \`minor\`, so a reviewer must inspect the token diff and decide manually — if \`minor\` is more appropriate, swap the label before merging."
+              echo "> See the [workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) logs for the underlying error."
             fi
             if [ -s "$RUNNER_TEMP/token-release-summary.md" ]; then
               echo

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -109,8 +109,8 @@ jobs:
             echo "Release label: \`${RELEASE_LABEL}\`"
             echo
             echo "**Release label rules:**"
-            echo "- \`major\` — an existing token path was removed or renamed (consumer code may break)."
-            echo "- \`minor\` — only new token paths were added, or values of existing tokens changed."
+            echo "- \`major\` — an existing token path was removed, renamed, or had its value changed (consumer code may break)."
+            echo "- \`minor\` — only new token paths were added."
             if [ "$RELEASE_LABEL_OUTCOME" != "success" ]; then
               echo
               echo "> [!WARNING]"

--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -101,11 +101,15 @@ When generated output changes under `token-sync/tokens/` or `token-sync/css/`, t
 any existing open `figma-token-sync/*` pull request, then creates a fresh
 `figma-token-sync/<timestamp>-<run-id>` branch and opens one pull request against `main`. Because the
 fresh branch is generated from the latest Figma state against `main`, it includes any still-unmerged
-token changes from previous sync runs. The pull request is labelled `minor` when the token diff only
-adds new tokens, and `major` when existing token paths are changed, removed, or renamed. Removed or
-renamed token paths are listed in the pull request body so reviewers can verify usage migrations. If
-release label classification fails, the pull request defaults to `major` for review. Figma API or
-Style Dictionary failures fail the workflow at the failing step.
+token changes from previous sync runs. The pull request is labelled `major` when an existing token
+path is removed or renamed (because consumer code may break), and `minor` otherwise — including when
+only token values change, since existing names keep working for consumers. Removed or renamed token
+paths are listed in the pull request body so reviewers can verify usage migrations. If release label
+classification fails, the pull request defaults to `major` for review. Figma API or Style Dictionary
+failures fail the workflow at the failing step.
+
+For human takeover (when the automated PR needs to be replaced with a hand-curated one), see the
+"Manual intervention" section in [`RUNBOOK.md`](RUNBOOK.md).
 
 ### How it works
 

--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -122,6 +122,11 @@ Style Dictionary failures fail the workflow at the failing step.
 Errors (missing env / bad token / wrong file key) exit with a hint that points to the right
 place depending on whether you're running locally or in CI.
 
+### Validation and debugging
+
+For the repeatable end-to-end validation process and basic failure triage, see
+[`RUNBOOK.md`](RUNBOOK.md).
+
 ## Stage 2 — DTCG → CSS
 
 [Style Dictionary](https://styledictionary.com/) v5 reads the DTCG files above

--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -104,9 +104,11 @@ fresh branch is generated from the latest Figma state against `main`, it include
 token changes from previous sync runs. The pull request is labelled `major` when an existing token
 path is removed, renamed, or has its value changed (because consumer code or downstream visuals may
 break), and `minor` only when the diff is purely additive (new token paths). Removed or renamed
-token paths are listed in the pull request body so reviewers can verify usage migrations. If release label
-classification fails, the pull request defaults to `major` for review. Figma API or Style Dictionary
-failures fail the workflow at the failing step.
+token paths, plus changed token values, are listed in the pull request body so reviewers can verify
+usage migrations and visual impact. Pure additions are not listed because a delete-and-add diff can
+represent a change that needs reviewer judgement. If release label classification fails, the pull
+request defaults to `major` for review. Figma API or Style Dictionary failures fail the workflow at
+the failing step.
 
 For human takeover (when the automated PR needs to be replaced with a hand-curated one), see the
 "Manual intervention" section in [`RUNBOOK.md`](RUNBOOK.md).

--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -86,9 +86,24 @@ token-sync/tokens/
 └─ manifest.json        # metadata: counts, roles, generatedAt
 ```
 
-A manually-triggered workflow at `.github/workflows/sync-figma-variables.yml` runs the same
-command in CI; trigger it from **Actions → Sync Figma variables → Run workflow**. It reads the
-two repo secrets from step 2.
+A scheduled workflow at `.github/workflows/sync-figma-variables.yml` runs the same two-stage
+sync in CI every week. It can also be triggered manually from
+**Actions → Sync Figma variables → Run workflow**, with an optional file key override for testing.
+It reads the Figma secrets from step 2, plus the `GH_APP_ID` repository variable and
+`GH_APP_PRIVATE_KEY` secret for branch and pull request automation.
+
+After fetching from Figma, the workflow checks `token-sync/tokens/` before building CSS. If there are
+no token changes, or the only change is `manifest.json`'s `generatedAt` metadata, the workflow exits
+cleanly without running the CSS build or creating a pull request.
+
+When generated output changes under `token-sync/tokens/` or `token-sync/css/`, the workflow closes
+any existing open `figma-token-sync/*` pull request, then creates a fresh
+`figma-token-sync/<timestamp>-<run-id>` branch and opens one pull request against `main`. Because the
+fresh branch is generated from the latest Figma state against `main`, it includes any still-unmerged
+token changes from previous sync runs. The pull request is labelled `minor` when the token diff only
+adds new tokens, and `major` when existing token paths are changed, removed, or renamed. If release
+label classification fails, the pull request defaults to `major` for review. Figma API or Style
+Dictionary failures fail the workflow at the failing step.
 
 ### How it works
 

--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -87,7 +87,8 @@ token-sync/tokens/
 ```
 
 A scheduled workflow at `.github/workflows/sync-figma-variables.yml` runs the same two-stage
-sync in CI every week. It can also be triggered manually from
+sync in CI. It is temporarily configured to run every 30 minutes for validation; the production
+cadence will be daily at 18:00 GMT. It can also be triggered manually from
 **Actions → Sync Figma variables → Run workflow**, with an optional file key override for testing.
 It reads the Figma secrets from step 2, plus the `GH_APP_ID` repository variable and
 `GH_APP_PRIVATE_KEY` secret for branch and pull request automation.
@@ -101,9 +102,10 @@ any existing open `figma-token-sync/*` pull request, then creates a fresh
 `figma-token-sync/<timestamp>-<run-id>` branch and opens one pull request against `main`. Because the
 fresh branch is generated from the latest Figma state against `main`, it includes any still-unmerged
 token changes from previous sync runs. The pull request is labelled `minor` when the token diff only
-adds new tokens, and `major` when existing token paths are changed, removed, or renamed. If release
-label classification fails, the pull request defaults to `major` for review. Figma API or Style
-Dictionary failures fail the workflow at the failing step.
+adds new tokens, and `major` when existing token paths are changed, removed, or renamed. Removed or
+renamed token paths are listed in the pull request body so reviewers can verify usage migrations. If
+release label classification fails, the pull request defaults to `major` for review. Figma API or
+Style Dictionary failures fail the workflow at the failing step.
 
 ### How it works
 

--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -102,9 +102,9 @@ any existing open `figma-token-sync/*` pull request, then creates a fresh
 `figma-token-sync/<timestamp>-<run-id>` branch and opens one pull request against `main`. Because the
 fresh branch is generated from the latest Figma state against `main`, it includes any still-unmerged
 token changes from previous sync runs. The pull request is labelled `major` when an existing token
-path is removed or renamed (because consumer code may break), and `minor` otherwise — including when
-only token values change, since existing names keep working for consumers. Removed or renamed token
-paths are listed in the pull request body so reviewers can verify usage migrations. If release label
+path is removed, renamed, or has its value changed (because consumer code or downstream visuals may
+break), and `minor` only when the diff is purely additive (new token paths). Removed or renamed
+token paths are listed in the pull request body so reviewers can verify usage migrations. If release label
 classification fails, the pull request defaults to `major` for review. Figma API or Style Dictionary
 failures fail the workflow at the failing step.
 

--- a/token-sync/RUNBOOK.md
+++ b/token-sync/RUNBOOK.md
@@ -33,7 +33,8 @@ to a repository output change.
    - It has a `major` label when an existing token path was removed, renamed, or had its value
      changed.
    - It has a `minor` label only when the diff is purely additive (new token paths added).
-   - Any removed or renamed token paths are listed in the pull request body, grouped by token file.
+   - Any removed, renamed, or changed token paths are listed in the pull request body, grouped by
+     token file. Pure additions are not listed.
 6. After validation, revert the controlled Figma change if it was only for testing, then rerun the
    workflow or wait for the next scheduled run to confirm the repository output returns to the
    expected state.

--- a/token-sync/RUNBOOK.md
+++ b/token-sync/RUNBOOK.md
@@ -30,12 +30,41 @@ to a repository output change.
    - It targets `main`.
    - It is opened from a `figma-token-sync/<timestamp>-<run-id>` branch.
    - It has the `design-token-automation` label.
-   - It has a `minor` label when only new token paths are added.
-   - It has a `major` label when existing token paths are changed, removed, or renamed.
+   - It has a `major` label when an existing token path was removed or renamed.
+   - It has a `minor` label otherwise — including when only token values change or new token paths
+     are added.
    - Any removed or renamed token paths are listed in the pull request body, grouped by token file.
 6. After validation, revert the controlled Figma change if it was only for testing, then rerun the
    workflow or wait for the next scheduled run to confirm the repository output returns to the
    expected state.
+
+## Manual intervention
+
+Occasionally the sync needs manual intervention — for example, to apply hand-curated edits, hold a
+controversial change for review, or run the sync earlier than the next scheduled tick. The scheduled
+workflow only auto-closes pull requests whose branch starts with `figma-token-sync/`, so use a
+different branch prefix to keep the workflow from auto-closing your PR.
+
+1. Close the current `figma-token-sync/*` pull request opened by the workflow. Closing it has no
+   side effects — the next scheduled run would close it anyway when it opens a fresh one.
+2. Run the sync locally:
+
+   ```bash
+   npm run tokens:sync
+   ```
+
+3. Create your branch using a prefix **other than** `figma-token-sync/` (e.g. `manual-token-sync/...`
+   or `<jira-key>/token-sync-fix`), commit the regenerated `token-sync/tokens/` and `token-sync/css/`
+   output, and open the pull request.
+4. Apply labels manually following the same rules the workflow uses:
+   - `design-token-automation`
+   - `major` if an existing token path was removed or renamed.
+   - `minor` if only new token paths were added or existing values changed.
+
+While your manual pull request is open the next scheduled run will still detect the same Figma
+changes and may open another `figma-token-sync/*` pull request. Either merge or close your manual
+pull request before the next scheduled tick, or close any new auto-generated `figma-token-sync/*`
+pull requests while your manual change is in flight.
 
 ## Failure triage
 

--- a/token-sync/RUNBOOK.md
+++ b/token-sync/RUNBOOK.md
@@ -30,9 +30,9 @@ to a repository output change.
    - It targets `main`.
    - It is opened from a `figma-token-sync/<timestamp>-<run-id>` branch.
    - It has the `design-token-automation` label.
-   - It has a `major` label when an existing token path was removed or renamed.
-   - It has a `minor` label otherwise — including when only token values change or new token paths
-     are added.
+   - It has a `major` label when an existing token path was removed, renamed, or had its value
+     changed.
+   - It has a `minor` label only when the diff is purely additive (new token paths added).
    - Any removed or renamed token paths are listed in the pull request body, grouped by token file.
 6. After validation, revert the controlled Figma change if it was only for testing, then rerun the
    workflow or wait for the next scheduled run to confirm the repository output returns to the
@@ -58,8 +58,8 @@ different branch prefix to keep the workflow from auto-closing your PR.
    output, and open the pull request.
 4. Apply labels manually following the same rules the workflow uses:
    - `design-token-automation`
-   - `major` if an existing token path was removed or renamed.
-   - `minor` if only new token paths were added or existing values changed.
+   - `major` if an existing token path was removed, renamed, or had its value changed.
+   - `minor` only if the diff is purely additive (new token paths added).
 
 While your manual pull request is open the next scheduled run will still detect the same Figma
 changes and may open another `figma-token-sync/*` pull request. Either merge or close your manual

--- a/token-sync/RUNBOOK.md
+++ b/token-sync/RUNBOOK.md
@@ -1,0 +1,55 @@
+# token-sync validation runbook
+
+Use this runbook to validate the end-to-end automated token pipeline from a controlled Figma change
+to a repository output change.
+
+## End-to-end validation
+
+1. Choose a low-risk token in Figma and make a controlled change. Prefer adding a temporary test
+   token, or changing a value that can be safely reverted after validation. Publish the Figma
+   variables once the change is ready.
+2. Trigger the agreed workflow mechanism:
+   - During validation, use **Actions -> Sync Figma variables -> Run workflow**.
+   - Leave `file_key` empty unless you intentionally need to test a different Figma file. Empty input
+     exercises the same `FIGMA_FILE_KEY` secret path used by scheduled runs.
+   - For production validation, wait for the scheduled run.
+3. Confirm the workflow completes successfully. The expected successful path is:
+   - `Stage 1 - Fetch tokens from Figma`
+   - `Detect meaningful fetched token changes`
+   - `Classify token release label`
+   - `Stage 2 - Build CSS from DTCG tokens`
+   - `Detect generated token changes`
+   - `Commit generated token changes`
+   - `Open pull request`
+4. Confirm the generated outputs reflect the intended change. Check the new `figma-token-sync/*`
+   pull request diff for updates under:
+   - `token-sync/tokens/*.json`
+   - `token-sync/css/*.css`
+   - `token-sync/tokens/manifest.json`
+5. Confirm the pull request is correct:
+   - It targets `main`.
+   - It is opened from a `figma-token-sync/<timestamp>-<run-id>` branch.
+   - It has the `design-token-automation` label.
+   - It has a `minor` label when only new token paths are added.
+   - It has a `major` label when existing token paths are changed, removed, or renamed.
+   - Any removed or renamed token paths are listed in the pull request body, grouped by token file.
+6. After validation, revert the controlled Figma change if it was only for testing, then rerun the
+   workflow or wait for the next scheduled run to confirm the repository output returns to the
+   expected state.
+
+## Failure triage
+
+- **Auth failures** - Check that `FIGMA_VARIABLES_SYNC_TOKEN` is present, has the
+  **Variables - Read-only** scope, is not expired, and can access the Figma file. Check that
+  `FIGMA_FILE_KEY` points to the Backpack Foundations & Components file unless testing an override.
+- **Build failures** - Read the failing step output. Stage 1 failures usually point to Figma API,
+  invalid variable names, unresolved aliases, or DTCG path collisions. Stage 2 failures usually point
+  to invalid dimensions, CSS variable name collisions, or Light/Dark token symmetry issues. Fix the
+  source token data in Figma, publish, then rerun.
+- **No-op runs** - If the workflow exits after `Detect meaningful fetched token changes`, no
+  repository output PR is expected. This means either Figma has no token value changes compared with
+  `main`, or the only fetched change was `manifest.json`'s `generatedAt` metadata.
+- **PR automation failures** - If token generation succeeds but no PR appears, check the
+  `create-github-app-token`, `Commit generated token changes`, and `Open pull request` steps. Verify
+  `GH_APP_ID` and `GH_APP_PRIVATE_KEY` are configured and that the app can push branches and open
+  pull requests.

--- a/token-sync/src/classify-release-label-cli.ts
+++ b/token-sync/src/classify-release-label-cli.ts
@@ -1,0 +1,48 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable no-console -- CLI entry: stdout/stderr output is intentional. */
+import fs from 'node:fs';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { classifyTokenReleaseLabelFromGit } from './classify-release-label';
+import { formatFatalError } from './sync-helpers';
+
+const GITHUB_OUTPUT_LABEL = 'label';
+
+function writeLabelOutput(label: string): void {
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${GITHUB_OUTPUT_LABEL}=${label}\n`);
+    return;
+  }
+
+  console.log(label);
+}
+
+function main(): void {
+  writeLabelOutput(classifyTokenReleaseLabelFromGit());
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error: unknown) {
+    console.error(formatFatalError(error));
+    process.exit(1);
+  }
+}

--- a/token-sync/src/classify-release-label-cli.ts
+++ b/token-sync/src/classify-release-label-cli.ts
@@ -21,7 +21,6 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
-  formatAddedTokensMarkdown,
   formatChangedTokenValuesMarkdown,
   formatDeletedOrRenamedTokensMarkdown,
   summariseTokenReleaseChangesFromGit,
@@ -61,7 +60,6 @@ function main(): void {
   const sections = [
     formatDeletedOrRenamedTokensMarkdown(summary.deletedOrRenamedTokens),
     formatChangedTokenValuesMarkdown(summary.changedTokens),
-    formatAddedTokensMarkdown(summary.addedTokens),
   ].filter(Boolean);
 
   writeTokenReleaseSummary(sections.join('\n\n'));

--- a/token-sync/src/classify-release-label-cli.ts
+++ b/token-sync/src/classify-release-label-cli.ts
@@ -21,6 +21,8 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
+  formatAddedTokensMarkdown,
+  formatChangedTokenValuesMarkdown,
   formatDeletedOrRenamedTokensMarkdown,
   summariseTokenReleaseChangesFromGit,
 } from './classify-release-label';
@@ -55,9 +57,14 @@ function writeTokenReleaseSummary(markdown: string): void {
 function main(): void {
   const summary = summariseTokenReleaseChangesFromGit();
   writeLabelOutput(summary.label);
-  writeTokenReleaseSummary(
+
+  const sections = [
     formatDeletedOrRenamedTokensMarkdown(summary.deletedOrRenamedTokens),
-  );
+    formatChangedTokenValuesMarkdown(summary.changedTokens),
+    formatAddedTokensMarkdown(summary.addedTokens),
+  ].filter(Boolean);
+
+  writeTokenReleaseSummary(sections.join('\n\n'));
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/token-sync/src/classify-release-label-cli.ts
+++ b/token-sync/src/classify-release-label-cli.ts
@@ -20,22 +20,44 @@ import fs from 'node:fs';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-import { classifyTokenReleaseLabelFromGit } from './classify-release-label';
+import {
+  formatDeletedOrRenamedTokensMarkdown,
+  summariseTokenReleaseChangesFromGit,
+} from './classify-release-label';
 import { formatFatalError } from './sync-helpers';
 
 const GITHUB_OUTPUT_LABEL = 'label';
 
 function writeLabelOutput(label: string): void {
   if (process.env.GITHUB_OUTPUT) {
-    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${GITHUB_OUTPUT_LABEL}=${label}\n`);
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `${GITHUB_OUTPUT_LABEL}=${label}\n`,
+    );
     return;
   }
 
   console.log(label);
 }
 
+function writeTokenReleaseSummary(markdown: string): void {
+  if (!process.env.TOKEN_RELEASE_SUMMARY_PATH) {
+    return;
+  }
+
+  fs.writeFileSync(
+    process.env.TOKEN_RELEASE_SUMMARY_PATH,
+    markdown ? `${markdown}\n` : '',
+    'utf8',
+  );
+}
+
 function main(): void {
-  writeLabelOutput(classifyTokenReleaseLabelFromGit());
+  const summary = summariseTokenReleaseChangesFromGit();
+  writeLabelOutput(summary.label);
+  writeTokenReleaseSummary(
+    formatDeletedOrRenamedTokensMarkdown(summary.deletedOrRenamedTokens),
+  );
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -21,7 +21,6 @@
 
 import {
   classifyTokenReleaseLabel,
-  formatAddedTokensMarkdown,
   formatChangedTokenValuesMarkdown,
   formatDeletedOrRenamedTokensMarkdown,
   summariseTokenReleaseChanges,
@@ -162,31 +161,6 @@ describe('classifyTokenReleaseLabel', () => {
         '### backpack.dark.json',
         '',
         '- `Spacing/Base`',
-      ].join('\n'),
-    );
-  });
-
-  it('formats added token paths for pull request bodies', () => {
-    expect(
-      formatAddedTokensMarkdown([
-        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Large' },
-        { fileName: 'backpack.light.json', tokenPath: 'Spacing/XLarge' },
-        { fileName: 'backpack.dark.json', tokenPath: 'Spacing/Large' },
-      ]),
-    ).toBe(
-      [
-        '## Added tokens',
-        '',
-        "The following token paths are new in this sync — they didn't exist in the previous commit.",
-        '',
-        '### backpack.light.json',
-        '',
-        '- `Spacing/Large`',
-        '- `Spacing/XLarge`',
-        '',
-        '### backpack.dark.json',
-        '',
-        '- `Spacing/Large`',
       ].join('\n'),
     );
   });

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -45,7 +45,7 @@ describe('classifyTokenReleaseLabel', () => {
     ).toBe('minor');
   });
 
-  it('returns minor when an existing token value changes but no token paths are removed', () => {
+  it('returns major when an existing token value changes', () => {
     expect(
       classifyTokenReleaseLabel([
         {
@@ -57,10 +57,10 @@ describe('classifyTokenReleaseLabel', () => {
           },
         },
       ]),
-    ).toBe('minor');
+    ).toBe('major');
   });
 
-  it('returns minor when token values change alongside new token paths', () => {
+  it('returns major when token values change alongside new token paths', () => {
     expect(
       classifyTokenReleaseLabel([
         {
@@ -76,7 +76,7 @@ describe('classifyTokenReleaseLabel', () => {
           },
         },
       ]),
-    ).toBe('minor');
+    ).toBe('major');
   });
 
   it('returns major when an existing token is removed or renamed', () => {

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -19,7 +19,11 @@
  * limitations under the License.
  */
 
-import { classifyTokenReleaseLabel } from './classify-release-label';
+import {
+  classifyTokenReleaseLabel,
+  formatDeletedOrRenamedTokensMarkdown,
+  summariseTokenReleaseChanges,
+} from './classify-release-label';
 
 describe('classifyTokenReleaseLabel', () => {
   it('returns minor when the diff only adds tokens', () => {
@@ -69,6 +73,42 @@ describe('classifyTokenReleaseLabel', () => {
         },
       ]),
     ).toBe('major');
+  });
+
+  it('reports token paths that were deleted or renamed', () => {
+    expect(
+      summariseTokenReleaseChanges([
+        {
+          fileName: 'token-sync/tokens/backpack.light.json',
+          previous: {
+            Spacing: {
+              $type: 'dimension',
+              Base: { $value: '8px' },
+              Default: { $value: '12px' },
+            },
+          },
+          current: {
+            Spacing: { $type: 'dimension', Default: { $value: '12px' } },
+          },
+        },
+      ]).deletedOrRenamedTokens,
+    ).toEqual([{ fileName: 'backpack.light.json', tokenPath: 'Spacing/Base' }]);
+  });
+
+  it('formats deleted or renamed token paths for pull request bodies', () => {
+    expect(
+      formatDeletedOrRenamedTokensMarkdown([
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Base' },
+      ]),
+    ).toBe(
+      [
+        '## Deleted or renamed tokens',
+        '',
+        'The following token paths existed in the previous commit but are missing from the fetched tokens. Treat them as breaking changes and verify usages have been migrated.',
+        '',
+        '- `backpack.light.json`: `Spacing/Base`',
+      ].join('\n'),
+    );
   });
 
   it('normalises object key order before comparing token values', () => {

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { classifyTokenReleaseLabel } from './classify-release-label';
+
+describe('classifyTokenReleaseLabel', () => {
+  it('returns minor when the diff only adds tokens', () => {
+    expect(
+      classifyTokenReleaseLabel([
+        {
+          previous: {
+            Spacing: { $type: 'dimension', Base: { $value: '8px' } },
+          },
+          current: {
+            Spacing: {
+              $type: 'dimension',
+              Base: { $value: '8px' },
+              Large: { $value: '16px' },
+            },
+          },
+        },
+      ]),
+    ).toBe('minor');
+  });
+
+  it('returns major when an existing token value changes', () => {
+    expect(
+      classifyTokenReleaseLabel([
+        {
+          previous: {
+            Spacing: { $type: 'dimension', Base: { $value: '8px' } },
+          },
+          current: {
+            Spacing: { $type: 'dimension', Base: { $value: '12px' } },
+          },
+        },
+      ]),
+    ).toBe('major');
+  });
+
+  it('returns major when an existing token is removed or renamed', () => {
+    expect(
+      classifyTokenReleaseLabel([
+        {
+          previous: {
+            Spacing: { $type: 'dimension', Base: { $value: '8px' } },
+          },
+          current: {
+            Spacing: { $type: 'dimension', Default: { $value: '8px' } },
+          },
+        },
+      ]),
+    ).toBe('major');
+  });
+
+  it('normalises object key order before comparing token values', () => {
+    expect(
+      classifyTokenReleaseLabel([
+        {
+          previous: {
+            Shadow: {
+              Raised: {
+                $type: 'shadow',
+                $value: { first: '1', second: '2' },
+              },
+            },
+          },
+          current: {
+            Shadow: {
+              Raised: {
+                $type: 'shadow',
+                $value: { second: '2', first: '1' },
+              },
+            },
+          },
+        },
+      ]),
+    ).toBe('minor');
+  });
+});

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -99,6 +99,8 @@ describe('classifyTokenReleaseLabel', () => {
     expect(
       formatDeletedOrRenamedTokensMarkdown([
         { fileName: 'backpack.light.json', tokenPath: 'Spacing/Base' },
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Small' },
+        { fileName: 'backpack.dark.json', tokenPath: 'Spacing/Base' },
       ]),
     ).toBe(
       [
@@ -106,7 +108,14 @@ describe('classifyTokenReleaseLabel', () => {
         '',
         'The following token paths existed in the previous commit but are missing from the fetched tokens. Treat them as breaking changes and verify usages have been migrated.',
         '',
-        '- `backpack.light.json`: `Spacing/Base`',
+        '### backpack.light.json',
+        '',
+        '- `Spacing/Base`',
+        '- `Spacing/Small`',
+        '',
+        '### backpack.dark.json',
+        '',
+        '- `Spacing/Base`',
       ].join('\n'),
     );
   });

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -45,7 +45,7 @@ describe('classifyTokenReleaseLabel', () => {
     ).toBe('minor');
   });
 
-  it('returns major when an existing token value changes', () => {
+  it('returns minor when an existing token value changes but no token paths are removed', () => {
     expect(
       classifyTokenReleaseLabel([
         {
@@ -57,7 +57,26 @@ describe('classifyTokenReleaseLabel', () => {
           },
         },
       ]),
-    ).toBe('major');
+    ).toBe('minor');
+  });
+
+  it('returns minor when token values change alongside new token paths', () => {
+    expect(
+      classifyTokenReleaseLabel([
+        {
+          previous: {
+            Spacing: { $type: 'dimension', Base: { $value: '8px' } },
+          },
+          current: {
+            Spacing: {
+              $type: 'dimension',
+              Base: { $value: '12px' },
+              Large: { $value: '16px' },
+            },
+          },
+        },
+      ]),
+    ).toBe('minor');
   });
 
   it('returns major when an existing token is removed or renamed', () => {

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -21,6 +21,8 @@
 
 import {
   classifyTokenReleaseLabel,
+  formatAddedTokensMarkdown,
+  formatChangedTokenValuesMarkdown,
   formatDeletedOrRenamedTokensMarkdown,
   summariseTokenReleaseChanges,
 } from './classify-release-label';
@@ -135,6 +137,56 @@ describe('classifyTokenReleaseLabel', () => {
         '### backpack.dark.json',
         '',
         '- `Spacing/Base`',
+      ].join('\n'),
+    );
+  });
+
+  it('formats changed token paths for pull request bodies', () => {
+    expect(
+      formatChangedTokenValuesMarkdown([
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Base' },
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Default' },
+        { fileName: 'backpack.dark.json', tokenPath: 'Spacing/Base' },
+      ]),
+    ).toBe(
+      [
+        '## Changed token values',
+        '',
+        'The following token values changed while the path stayed the same. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
+        '',
+        '### backpack.light.json',
+        '',
+        '- `Spacing/Base`',
+        '- `Spacing/Default`',
+        '',
+        '### backpack.dark.json',
+        '',
+        '- `Spacing/Base`',
+      ].join('\n'),
+    );
+  });
+
+  it('formats added token paths for pull request bodies', () => {
+    expect(
+      formatAddedTokensMarkdown([
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Large' },
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/XLarge' },
+        { fileName: 'backpack.dark.json', tokenPath: 'Spacing/Large' },
+      ]),
+    ).toBe(
+      [
+        '## Added tokens',
+        '',
+        "The following token paths are new in this sync — they didn't exist in the previous commit.",
+        '',
+        '### backpack.light.json',
+        '',
+        '- `Spacing/Large`',
+        '- `Spacing/XLarge`',
+        '',
+        '### backpack.dark.json',
+        '',
+        '- `Spacing/Large`',
       ].join('\n'),
     );
   });

--- a/token-sync/src/classify-release-label.ts
+++ b/token-sync/src/classify-release-label.ts
@@ -195,7 +195,10 @@ export function summariseTokenReleaseChanges(
   return {
     changedTokens,
     deletedOrRenamedTokens,
-    label: deletedOrRenamedTokens.length > 0 ? 'major' : 'minor',
+    label:
+      deletedOrRenamedTokens.length > 0 || changedTokens.length > 0
+        ? 'major'
+        : 'minor',
   };
 }
 

--- a/token-sync/src/classify-release-label.ts
+++ b/token-sync/src/classify-release-label.ts
@@ -217,14 +217,29 @@ export function formatDeletedOrRenamedTokensMarkdown(
   }
 
   const visibleTokens = deletedOrRenamedTokens.slice(0, limit);
+  const tokensByFile = new Map<string, string[]>();
+  visibleTokens.forEach(({ fileName, tokenPath }) => {
+    tokensByFile.set(fileName, [
+      ...(tokensByFile.get(fileName) ?? []),
+      tokenPath,
+    ]);
+  });
+
+  const tokenLines = Array.from(tokensByFile.entries()).flatMap(
+    ([fileName, tokenPaths]) => [
+      `### ${fileName}`,
+      '',
+      ...tokenPaths.map((tokenPath) => `- \`${tokenPath}\``),
+      '',
+    ],
+  );
+
   const lines = [
     '## Deleted or renamed tokens',
     '',
     'The following token paths existed in the previous commit but are missing from the fetched tokens. Treat them as breaking changes and verify usages have been migrated.',
     '',
-    ...visibleTokens.map(
-      ({ fileName, tokenPath }) => `- \`${fileName}\`: \`${tokenPath}\``,
-    ),
+    ...tokenLines.slice(0, -1),
   ];
 
   if (deletedOrRenamedTokens.length > visibleTokens.length) {

--- a/token-sync/src/classify-release-label.ts
+++ b/token-sync/src/classify-release-label.ts
@@ -195,10 +195,7 @@ export function summariseTokenReleaseChanges(
   return {
     changedTokens,
     deletedOrRenamedTokens,
-    label:
-      deletedOrRenamedTokens.length > 0 || changedTokens.length > 0
-        ? 'major'
-        : 'minor',
+    label: deletedOrRenamedTokens.length > 0 ? 'major' : 'minor',
   };
 }
 

--- a/token-sync/src/classify-release-label.ts
+++ b/token-sync/src/classify-release-label.ts
@@ -305,50 +305,6 @@ export function formatChangedTokenValuesMarkdown(
   return lines.join('\n');
 }
 
-export function formatAddedTokensMarkdown(
-  addedTokens: TokenPathChange[],
-  limit = 50,
-): string {
-  if (addedTokens.length === 0) {
-    return '';
-  }
-
-  const visibleTokens = addedTokens.slice(0, limit);
-  const tokensByFile = new Map<string, string[]>();
-  visibleTokens.forEach(({ fileName, tokenPath }) => {
-    tokensByFile.set(fileName, [
-      ...(tokensByFile.get(fileName) ?? []),
-      tokenPath,
-    ]);
-  });
-
-  const tokenLines = Array.from(tokensByFile.entries()).flatMap(
-    ([fileName, tokenPaths]) => [
-      `### ${fileName}`,
-      '',
-      ...tokenPaths.map((tokenPath) => `- \`${tokenPath}\``),
-      '',
-    ],
-  );
-
-  const lines = [
-    '## Added tokens',
-    '',
-    "The following token paths are new in this sync — they didn't exist in the previous commit.",
-    '',
-    ...tokenLines.slice(0, -1),
-  ];
-
-  if (addedTokens.length > visibleTokens.length) {
-    lines.push(
-      '',
-      `And ${addedTokens.length - visibleTokens.length} more added token path(s).`,
-    );
-  }
-
-  return lines.join('\n');
-}
-
 export function summariseTokenReleaseChangesFromGit(
   tokensDir = DEFAULT_TOKENS_DIR,
 ): TokenReleaseSummary {

--- a/token-sync/src/classify-release-label.ts
+++ b/token-sync/src/classify-release-label.ts
@@ -1,0 +1,164 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_TOKENS_DIR = 'token-sync/tokens';
+const MANIFEST_FILE_NAME = 'manifest.json';
+
+export type ReleaseLabel = 'major' | 'minor';
+
+type PlainObject = Record<string, unknown>;
+
+export interface TokenFileChange {
+  current: unknown;
+  previous: unknown;
+}
+
+function git(args: string[]): string[] {
+  return execFileSync('git', args, { encoding: 'utf8' })
+    .split('\n')
+    .filter(Boolean);
+}
+
+export function listTokenJsonFiles(tokensDir = DEFAULT_TOKENS_DIR): string[] {
+  const tracked = git(['ls-files', tokensDir]);
+  const untracked = git(['ls-files', '--others', '--exclude-standard', '--', tokensDir]);
+
+  return Array.from(new Set([...tracked, ...untracked]))
+    .filter((file) => file.endsWith('.json'))
+    .filter((file) => path.basename(file) !== MANIFEST_FILE_NAME)
+    .sort();
+}
+
+export function readCurrentJson(file: string): unknown {
+  if (!fs.existsSync(file)) {
+    return undefined;
+  }
+
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function stringifyErrorOutput(output: unknown): string {
+  if (Buffer.isBuffer(output)) {
+    return output.toString('utf8');
+  }
+
+  return typeof output === 'string' ? output : '';
+}
+
+function isMissingHeadPathError(error: unknown): boolean {
+  const gitError = error as { message?: string; status?: number; stderr?: unknown };
+  const errorText = `${stringifyErrorOutput(gitError.stderr)} ${gitError.message ?? ''}`;
+
+  return (
+    gitError.status === 128 &&
+    /does not exist in 'HEAD'|exists on disk, but not in 'HEAD'/.test(errorText)
+  );
+}
+
+export function readHeadJson(file: string): unknown {
+  let source: string;
+
+  try {
+    source = execFileSync('git', ['show', `HEAD:${file}`], { encoding: 'utf8' });
+  } catch (error: unknown) {
+    if (isMissingHeadPathError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
+
+  return JSON.parse(source);
+}
+
+function isObject(value: unknown): value is PlainObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalise(value: unknown): unknown {
+  if (!isObject(value)) {
+    return value;
+  }
+
+  const result: PlainObject = {};
+  Object.keys(value)
+    .sort()
+    .forEach((key) => {
+      result[key] = normalise(value[key]);
+    });
+
+  return result;
+}
+
+function collectTokens(
+  node: unknown,
+  prefix: string[] = [],
+  inheritedType?: unknown,
+): Map<string, string> {
+  if (!isObject(node)) {
+    return new Map();
+  }
+
+  const tokenType = node.$type ?? inheritedType;
+
+  if (Object.prototype.hasOwnProperty.call(node, '$value')) {
+    return new Map([
+      [prefix.join('/'), JSON.stringify(normalise({ ...node, $type: tokenType }))],
+    ]);
+  }
+
+  const tokens = new Map<string, string>();
+  Object.entries(node)
+    .filter(([key]) => !key.startsWith('$'))
+    .forEach(([key, value]) => {
+      collectTokens(value, [...prefix, key], tokenType).forEach((tokenValue, tokenPath) => {
+        tokens.set(tokenPath, tokenValue);
+      });
+    });
+
+  return tokens;
+}
+
+export function classifyTokenReleaseLabel(files: TokenFileChange[]): ReleaseLabel {
+  for (const file of files) {
+    const previousTokens = collectTokens(file.previous);
+    const currentTokens = collectTokens(file.current);
+
+    for (const [tokenPath, previousValue] of Array.from(previousTokens.entries())) {
+      if (!currentTokens.has(tokenPath) || currentTokens.get(tokenPath) !== previousValue) {
+        return 'major';
+      }
+    }
+  }
+
+  return 'minor';
+}
+
+export function classifyTokenReleaseLabelFromGit(
+  tokensDir = DEFAULT_TOKENS_DIR,
+): ReleaseLabel {
+  return classifyTokenReleaseLabel(
+    listTokenJsonFiles(tokensDir).map((file) => ({
+      current: readCurrentJson(file),
+      previous: readHeadJson(file),
+    })),
+  );
+}

--- a/token-sync/src/classify-release-label.ts
+++ b/token-sync/src/classify-release-label.ts
@@ -38,6 +38,7 @@ export interface TokenPathChange {
 }
 
 export interface TokenReleaseSummary {
+  addedTokens: TokenPathChange[];
   changedTokens: TokenPathChange[];
   deletedOrRenamedTokens: TokenPathChange[];
   label: ReleaseLabel;
@@ -173,6 +174,7 @@ function displayFileName(fileName?: string): string {
 export function summariseTokenReleaseChanges(
   files: TokenFileChange[],
 ): TokenReleaseSummary {
+  const addedTokens: TokenPathChange[] = [];
   const changedTokens: TokenPathChange[] = [];
   const deletedOrRenamedTokens: TokenPathChange[] = [];
 
@@ -190,9 +192,16 @@ export function summariseTokenReleaseChanges(
         changedTokens.push({ fileName, tokenPath });
       }
     }
+
+    for (const tokenPath of Array.from(currentTokens.keys())) {
+      if (!previousTokens.has(tokenPath)) {
+        addedTokens.push({ fileName, tokenPath });
+      }
+    }
   }
 
   return {
+    addedTokens,
     changedTokens,
     deletedOrRenamedTokens,
     label:
@@ -246,6 +255,94 @@ export function formatDeletedOrRenamedTokensMarkdown(
     lines.push(
       '',
       `And ${deletedOrRenamedTokens.length - visibleTokens.length} more deleted or renamed token path(s).`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+export function formatChangedTokenValuesMarkdown(
+  changedTokens: TokenPathChange[],
+  limit = 50,
+): string {
+  if (changedTokens.length === 0) {
+    return '';
+  }
+
+  const visibleTokens = changedTokens.slice(0, limit);
+  const tokensByFile = new Map<string, string[]>();
+  visibleTokens.forEach(({ fileName, tokenPath }) => {
+    tokensByFile.set(fileName, [
+      ...(tokensByFile.get(fileName) ?? []),
+      tokenPath,
+    ]);
+  });
+
+  const tokenLines = Array.from(tokensByFile.entries()).flatMap(
+    ([fileName, tokenPaths]) => [
+      `### ${fileName}`,
+      '',
+      ...tokenPaths.map((tokenPath) => `- \`${tokenPath}\``),
+      '',
+    ],
+  );
+
+  const lines = [
+    '## Changed token values',
+    '',
+    'The following token values changed while the path stayed the same. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
+    '',
+    ...tokenLines.slice(0, -1),
+  ];
+
+  if (changedTokens.length > visibleTokens.length) {
+    lines.push(
+      '',
+      `And ${changedTokens.length - visibleTokens.length} more changed token path(s).`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+export function formatAddedTokensMarkdown(
+  addedTokens: TokenPathChange[],
+  limit = 50,
+): string {
+  if (addedTokens.length === 0) {
+    return '';
+  }
+
+  const visibleTokens = addedTokens.slice(0, limit);
+  const tokensByFile = new Map<string, string[]>();
+  visibleTokens.forEach(({ fileName, tokenPath }) => {
+    tokensByFile.set(fileName, [
+      ...(tokensByFile.get(fileName) ?? []),
+      tokenPath,
+    ]);
+  });
+
+  const tokenLines = Array.from(tokensByFile.entries()).flatMap(
+    ([fileName, tokenPaths]) => [
+      `### ${fileName}`,
+      '',
+      ...tokenPaths.map((tokenPath) => `- \`${tokenPath}\``),
+      '',
+    ],
+  );
+
+  const lines = [
+    '## Added tokens',
+    '',
+    "The following token paths are new in this sync — they didn't exist in the previous commit.",
+    '',
+    ...tokenLines.slice(0, -1),
+  ];
+
+  if (addedTokens.length > visibleTokens.length) {
+    lines.push(
+      '',
+      `And ${addedTokens.length - visibleTokens.length} more added token path(s).`,
     );
   }
 

--- a/token-sync/src/classify-release-label.ts
+++ b/token-sync/src/classify-release-label.ts
@@ -28,7 +28,19 @@ type PlainObject = Record<string, unknown>;
 
 export interface TokenFileChange {
   current: unknown;
+  fileName?: string;
   previous: unknown;
+}
+
+export interface TokenPathChange {
+  fileName: string;
+  tokenPath: string;
+}
+
+export interface TokenReleaseSummary {
+  changedTokens: TokenPathChange[];
+  deletedOrRenamedTokens: TokenPathChange[];
+  label: ReleaseLabel;
 }
 
 function git(args: string[]): string[] {
@@ -39,7 +51,13 @@ function git(args: string[]): string[] {
 
 export function listTokenJsonFiles(tokensDir = DEFAULT_TOKENS_DIR): string[] {
   const tracked = git(['ls-files', tokensDir]);
-  const untracked = git(['ls-files', '--others', '--exclude-standard', '--', tokensDir]);
+  const untracked = git([
+    'ls-files',
+    '--others',
+    '--exclude-standard',
+    '--',
+    tokensDir,
+  ]);
 
   return Array.from(new Set([...tracked, ...untracked]))
     .filter((file) => file.endsWith('.json'))
@@ -64,7 +82,11 @@ function stringifyErrorOutput(output: unknown): string {
 }
 
 function isMissingHeadPathError(error: unknown): boolean {
-  const gitError = error as { message?: string; status?: number; stderr?: unknown };
+  const gitError = error as {
+    message?: string;
+    status?: number;
+    stderr?: unknown;
+  };
   const errorText = `${stringifyErrorOutput(gitError.stderr)} ${gitError.message ?? ''}`;
 
   return (
@@ -77,7 +99,9 @@ export function readHeadJson(file: string): unknown {
   let source: string;
 
   try {
-    source = execFileSync('git', ['show', `HEAD:${file}`], { encoding: 'utf8' });
+    source = execFileSync('git', ['show', `HEAD:${file}`], {
+      encoding: 'utf8',
+    });
   } catch (error: unknown) {
     if (isMissingHeadPathError(error)) {
       return undefined;
@@ -121,7 +145,10 @@ function collectTokens(
 
   if (Object.prototype.hasOwnProperty.call(node, '$value')) {
     return new Map([
-      [prefix.join('/'), JSON.stringify(normalise({ ...node, $type: tokenType }))],
+      [
+        prefix.join('/'),
+        JSON.stringify(normalise({ ...node, $type: tokenType })),
+      ],
     ]);
   }
 
@@ -129,36 +156,101 @@ function collectTokens(
   Object.entries(node)
     .filter(([key]) => !key.startsWith('$'))
     .forEach(([key, value]) => {
-      collectTokens(value, [...prefix, key], tokenType).forEach((tokenValue, tokenPath) => {
-        tokens.set(tokenPath, tokenValue);
-      });
+      collectTokens(value, [...prefix, key], tokenType).forEach(
+        (tokenValue, tokenPath) => {
+          tokens.set(tokenPath, tokenValue);
+        },
+      );
     });
 
   return tokens;
 }
 
-export function classifyTokenReleaseLabel(files: TokenFileChange[]): ReleaseLabel {
+function displayFileName(fileName?: string): string {
+  return fileName ? path.basename(fileName) : 'tokens';
+}
+
+export function summariseTokenReleaseChanges(
+  files: TokenFileChange[],
+): TokenReleaseSummary {
+  const changedTokens: TokenPathChange[] = [];
+  const deletedOrRenamedTokens: TokenPathChange[] = [];
+
   for (const file of files) {
     const previousTokens = collectTokens(file.previous);
     const currentTokens = collectTokens(file.current);
+    const fileName = displayFileName(file.fileName);
 
-    for (const [tokenPath, previousValue] of Array.from(previousTokens.entries())) {
-      if (!currentTokens.has(tokenPath) || currentTokens.get(tokenPath) !== previousValue) {
-        return 'major';
+    for (const [tokenPath, previousValue] of Array.from(
+      previousTokens.entries(),
+    )) {
+      if (!currentTokens.has(tokenPath)) {
+        deletedOrRenamedTokens.push({ fileName, tokenPath });
+      } else if (currentTokens.get(tokenPath) !== previousValue) {
+        changedTokens.push({ fileName, tokenPath });
       }
     }
   }
 
-  return 'minor';
+  return {
+    changedTokens,
+    deletedOrRenamedTokens,
+    label:
+      deletedOrRenamedTokens.length > 0 || changedTokens.length > 0
+        ? 'major'
+        : 'minor',
+  };
+}
+
+export function classifyTokenReleaseLabel(
+  files: TokenFileChange[],
+): ReleaseLabel {
+  return summariseTokenReleaseChanges(files).label;
+}
+
+export function formatDeletedOrRenamedTokensMarkdown(
+  deletedOrRenamedTokens: TokenPathChange[],
+  limit = 50,
+): string {
+  if (deletedOrRenamedTokens.length === 0) {
+    return '';
+  }
+
+  const visibleTokens = deletedOrRenamedTokens.slice(0, limit);
+  const lines = [
+    '## Deleted or renamed tokens',
+    '',
+    'The following token paths existed in the previous commit but are missing from the fetched tokens. Treat them as breaking changes and verify usages have been migrated.',
+    '',
+    ...visibleTokens.map(
+      ({ fileName, tokenPath }) => `- \`${fileName}\`: \`${tokenPath}\``,
+    ),
+  ];
+
+  if (deletedOrRenamedTokens.length > visibleTokens.length) {
+    lines.push(
+      '',
+      `And ${deletedOrRenamedTokens.length - visibleTokens.length} more deleted or renamed token path(s).`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+export function summariseTokenReleaseChangesFromGit(
+  tokensDir = DEFAULT_TOKENS_DIR,
+): TokenReleaseSummary {
+  return summariseTokenReleaseChanges(
+    listTokenJsonFiles(tokensDir).map((file) => ({
+      current: readCurrentJson(file),
+      fileName: file,
+      previous: readHeadJson(file),
+    })),
+  );
 }
 
 export function classifyTokenReleaseLabelFromGit(
   tokensDir = DEFAULT_TOKENS_DIR,
 ): ReleaseLabel {
-  return classifyTokenReleaseLabel(
-    listTokenJsonFiles(tokensDir).map((file) => ({
-      current: readCurrentJson(file),
-      previous: readHeadJson(file),
-    })),
-  );
+  return summariseTokenReleaseChangesFromGit(tokensDir).label;
 }


### PR DESCRIPTION
## Summary
- Add daily and manual Figma variable sync automation that skips runs with no meaningful token changes.
- Cancel in-flight runs when a new sync triggers (`concurrency.cancel-in-progress: true`), so an urgent token update can preempt a stale run instead of queueing behind it.
- Build CSS only when fetched token values changed, then create a fresh automated PR for generated token/CSS updates.
- Open the new automated PR before closing superseded `figma-token-sync/*` PRs, so a failed push or PR creation can't leave the repo with no open token-sync PR.
- Add a release-label classifier for generated token diffs, using `minor` only when the diff is purely additive (new token paths), and `major` when an existing token path was changed, removed, or renamed.
- Default the generated PR to `major` if label classification fails, so the sync can still reach human review.
- Document the CI credentials and sync behaviour in `token-sync/README.md`.

## Testing

### Trigger workflow manually
Set ref to current ref to trigger workflow dispatch (**would change back to main before merge**)
Manually triggered action: https://github.com/Skyscanner/backpack/actions/runs/26266827654/job/77311851919
Generated PR：https://github.com/Skyscanner/backpack/pull/4531

### Trigger workflow by schedule
Need to be tested after this PR is merged

## Notes
- Checkout currently uses `${{ github.ref }}` so this branch can be manually selected in Actions for workflow testing. We can switch it back to `main` before merge if we want the final scheduled workflow to always force a main checkout.
- The schedule cron is temporarily set to `*/30 * * * *` for validation. The production cadence will be **daily at 18:00 GMT** (`0 18 * * *`)
