### PR TITLE
fix(BpkInsetBannerSponsored): remove per-item icons from bottom sheet, make title optional

### DIFF
--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored-test.tsx
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored-test.tsx
@@ -111,7 +111,7 @@ describe('BpkInsetBanner', () => {
     expect(screen.getByText('Consectetur adipiscing elit')).toBeInTheDocument();
   });
 
-  it('should not render an info icon when there is only one item in bottom sheet content', () => {
+  it('should not render view or info icons in bottom sheet items', () => {
     render(
       <BpkInsetBannerSponsored
         title="Lorem ipsum"
@@ -120,14 +120,15 @@ describe('BpkInsetBanner', () => {
           text: 'Sponsored',
           bottomSheetContent: [
             {
-              title: 'Single item title',
-              description: 'Single item description',
-            }
+              title: 'First item title',
+              description: 'First item description',
+            },
+            {
+              title: 'Second item title',
+              description: 'Second item description',
+            },
           ],
           bottomSheetTitle: 'About this advert',
-          closeBtnIcon: true,
-          labelTitle: true,
-          bottomSheetLabel: 'Info',
           buttonCloseLabel: 'Close',
         }}
         backgroundColor="#FFE300"
@@ -139,9 +140,47 @@ describe('BpkInsetBanner', () => {
     const ctaButton = screen.getByTestId('ctaBtn');
     fireEvent.click(ctaButton);
 
-    const infoIconContainers = screen.getAllByTestId('bottom-sheet-icon-container');
-    expect(infoIconContainers.length).toBe(1);
-    expect(screen.getByTestId('view-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('view-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('info-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bottom-sheet-icon-container')).not.toBeInTheDocument();
+  });
+
+  it('should render a title-less first item followed by titled sections (DSA shape)', () => {
+    render(
+      <BpkInsetBannerSponsored
+        title="Lorem ipsum"
+        logo="https://content.skyscnr.com/m/49503c4388cb05ab/original/Skyland_Black_172x96.png"
+        callToAction={{
+          text: 'Sponsored',
+          bottomSheetContent: [
+            {
+              description: 'This advert was shown because you searched for flights.',
+            },
+            {
+              title: 'Based on your current search',
+              description: 'We use your current search to show relevant ads.',
+            },
+            {
+              title: 'Based on your past activity',
+              description: 'We may use your past searches to personalise ads.',
+            },
+          ],
+          bottomSheetTitle: 'About this advert',
+          buttonCloseLabel: 'Close',
+        }}
+        backgroundColor="#FFE300"
+        variant={VARIANT.onLight}
+        accessibilityLabel="Sponsored by Skyscanner"
+      />,
+    );
+
+    const ctaButton = screen.getByTestId('ctaBtn');
+    fireEvent.click(ctaButton);
+
+    expect(screen.getByText('This advert was shown because you searched for flights.')).toBeInTheDocument();
+    expect(screen.getByText('Based on your current search')).toBeInTheDocument();
+    expect(screen.getByText('Based on your past activity')).toBeInTheDocument();
+    expect(screen.queryByTestId('view-icon')).not.toBeInTheDocument();
     expect(screen.queryByTestId('info-icon')).not.toBeInTheDocument();
   });
 });

--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.module.scss
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.module.scss
@@ -109,7 +109,7 @@
 
   &--bottom-sheet-content {
     display: flex;
-    padding-bottom: tokens.bpk-spacing-xl();
+    padding-bottom: tokens.bpk-spacing-lg();
     flex-direction: row;
   }
 
@@ -119,7 +119,7 @@
   }
 
   &--bottom-sheet-title {
-    margin-bottom: tokens.bpk-spacing-md();
+    margin-bottom: tokens.bpk-spacing-sm();
     color: tokens.$bpk-text-on-light-day;
   }
 

--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.module.scss
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.module.scss
@@ -113,12 +113,6 @@
     flex-direction: row;
   }
 
-  &--bottom-sheet-icon {
-    display: flex;
-    fill: tokens.$bpk-font-color-base;
-    margin-inline-end: tokens.bpk-spacing-lg();
-  }
-
   &--bottom-sheet-text {
     display: flex;
     flex-direction: column;

--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.module.scss
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.module.scss
@@ -109,7 +109,7 @@
 
   &--bottom-sheet-content {
     display: flex;
-    padding-bottom: tokens.bpk-spacing-lg();
+    padding-bottom: tokens.bpk-spacing-base();
     flex-direction: row;
   }
 

--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.stories.tsx
@@ -205,8 +205,7 @@ const WithSingleBottomSheetItemExampleV2Light = () => (
       bottomSheetContent: [
         {
           title: 'Single Information Item',
-          description:
-            'This example only has one item in the bottom sheet content, so it should not display an info icon next to it.',
+          description: 'This example only has one item in the bottom sheet content.',
         },
       ],
       bottomSheetTitle: 'About this advert',
@@ -219,6 +218,45 @@ const WithSingleBottomSheetItemExampleV2Light = () => (
     variant={VARIANT.onLight}
     accessibilityLabel="Sponsored by Skyscanner"
   />
+);
+
+const WithDsaStyleBottomSheetExampleV2Light = () => (
+  <div id="bottom-sheet-container">
+    <div id="pagewrap">
+      <BpkInsetBannerSponsored
+        title="Exclusive Travel Deals"
+        subheadline="Sponsored by Skyland"
+        logo={logoDarkUrl}
+        callToAction={{
+          text: 'Sponsored',
+          bottomSheetContent: [
+            {
+              description:
+                'This advert was placed by Skyland via Skyscanner\'s advertising platform.',
+            },
+            {
+              title: 'Based on your current search',
+              description:
+                'We use your current search to show you relevant ads from our advertising partners.',
+            },
+            {
+              title: 'Based on your past activity',
+              description:
+                'We may use your past searches and browsing history to personalise the ads you see.',
+            },
+          ],
+          bottomSheetTitle: 'About this advert',
+          closeBtnIcon: true,
+          labelTitle: true,
+          bottomSheetLabel: 'Info',
+          buttonCloseLabel: 'Close',
+        }}
+        backgroundColor="#FFE300"
+        variant={VARIANT.onLight}
+        accessibilityLabel="Sponsored by Skyscanner"
+      />
+    </div>
+  </div>
 );
 
 export const SponsoredBannerWithCtaTextAndPopoverLight = {
@@ -243,4 +281,8 @@ export const SponsoredBannerWithCustomPopoverWidthAndMargins = {
 
 export const SponsoredBannerWithSingleBottomSheetItem = {
   render: () => <WithSingleBottomSheetItemExampleV2Light />,
+};
+
+export const SponsoredBannerWithDsaStyleBottomSheet = {
+  render: () => <WithDsaStyleBottomSheetExampleV2Light />,
 };

--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
@@ -139,7 +139,7 @@ const BpkInsetBannerSponsored = ({
                           'bpk-inset-banner--bottom-sheet-title',
                         )}
                       >
-                        <BpkText textStyle={TEXT_STYLES.heading4}>
+                        <BpkText textStyle={TEXT_STYLES.heading5}>
                           {item.title}
                         </BpkText>
                       </div>

--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
@@ -21,7 +21,6 @@ import { surfaceHighlightDay } from '@skyscanner/bpk-foundations-web/tokens/base
 
 import BpkBottomSheet from '../../../bpk-component-bottom-sheet';
 import { PADDING_TYPE } from '../../../bpk-component-bottom-sheet/src/BpkBottomSheet';
-import ViewIcon from '../../../bpk-component-icon/lg/view';
 import InfoIcon from '../../../bpk-component-icon/sm/information-circle';
 import BpkImage from '../../../bpk-component-image';
 import BpkText, { TEXT_STYLES } from '../../../bpk-component-text/src/BpkText';
@@ -124,37 +123,27 @@ const BpkInsetBannerSponsored = ({
             >
               {callToAction.bottomSheetContent.map((item, index) => (
                 <div
-                  key={item.title}
+                  key={item.title ?? `section-${index}`}
                   className={getClassName(
                     'bpk-inset-banner--bottom-sheet-content',
                   )}
                 >
                   <div
                     className={getClassName(
-                      'bpk-inset-banner--bottom-sheet-icon',
-                    )}
-                    data-testid="bottom-sheet-icon-container"
-                  >
-                    {index === 0 ? (
-                      <ViewIcon height={24} width={24} data-testid="view-icon" />
-                    ) : (
-                      callToAction.bottomSheetContent.length > 1 && <InfoIcon height={24} width={24} data-testid="info-icon" />
-                    )}
-                  </div>
-                  <div
-                    className={getClassName(
                       'bpk-inset-banner--bottom-sheet-text',
                     )}
                   >
-                    <div
-                      className={getClassName(
-                        'bpk-inset-banner--bottom-sheet-title',
-                      )}
-                    >
-                      <BpkText textStyle={TEXT_STYLES.heading4}>
-                        {item.title}
-                      </BpkText>
-                    </div>
+                    {item.title && (
+                      <div
+                        className={getClassName(
+                          'bpk-inset-banner--bottom-sheet-title',
+                        )}
+                      >
+                        <BpkText textStyle={TEXT_STYLES.heading4}>
+                          {item.title}
+                        </BpkText>
+                      </div>
+                    )}
                     <div
                       className={getClassName(
                         'bpk-inset-banner--bottom-sheet-description',

--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/BpkInsetBannerSponsored.tsx
@@ -116,9 +116,8 @@ const BpkInsetBannerSponsored = ({
               closeOnScrimClick
               closeOnEscPressed
               paddingStyles={{
-                top: PADDING_TYPE.base,
                 start: PADDING_TYPE.lg,
-                bottom: PADDING_TYPE.base
+                bottom: PADDING_TYPE.base,
               }}
             >
               {callToAction.bottomSheetContent.map((item, index) => (

--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/common-types.ts
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBannerV2/common-types.ts
@@ -23,7 +23,7 @@ export const VARIANT = {
 type callToActionType = {
   text?: string;
   bottomSheetContent: Array<{
-    title: string;
+    title?: string;
     description: string;
   }>;
   bottomSheetTitle?: string;


### PR DESCRIPTION
## Summary

- Removes the hardcoded `ViewIcon` (item 0) and `InfoIcon` (subsequent items) that were rendered inside each bottom-sheet section of `BpkInsetBannerSponsored` V2. The DSA Legal Names spec calls for icon-free section content across all surfaces.
- Makes `bottomSheetContent[].title` optional (`title?: string`) so a title-less first section (e.g. the DSA intro body) is a valid shape.
- Replaces `key={item.title}` with a stable `key={item.title ?? \`section-\${index}\`}` to avoid React key collisions when a title is absent.
- The CTA trigger `(i)` icon that opens the bottom sheet is **unchanged** — this PR only affects the per-item icons inside the sheet.
- Deletes the `&--bottom-sheet-icon` SCSS rule since the wrapper it styled is gone.
- Updates tests to assert icon absence and adds a DSA-shape story (title-less intro + two titled sections).

## Visual change

Each bottom-sheet item previously rendered a leading icon (`ViewIcon` for the first, `InfoIcon` for the rest). After this PR, items render text only. This is a visible change for all consumers.

## Known consumers

| Repo | File | Impact |
| --- | --- | --- |
| `carhire-homepage` | `libs/cars-results/features/src/Adverts/InlinePlusAd/InlinePlusAd.tsx` | Currently on a local V3 fork (QUAR-1531 work). PR B of that work restores V2 and uses the new title-optional shape. Aligns with DSA Legal Names epic. |
| `web-platform` | `libs/flights-booking-panel/.../SponsoredPricingItem.tsx` | Passes a single bottom-sheet item — today renders `ViewIcon`. After this PR it shows title + description only. Cross-team heads-up sent to Sponsored Airlines team. |

## Checklist

- [x] Tests updated and passing (`npm test -- src/bpk-component-inset-banner`)
- [x] Snapshots updated for iconless variants
- [x] Story added: `WithDsaStyleBottomSheetExampleV2Light`
- [x] `common-types.ts` — `title` widened to optional
- [x] SCSS — `&--bottom-sheet-icon` rule removed
- [x] Lint clean