### PR TITLE
[NO-JIRA] Support refs on Checkbox V2 root

### DIFF
--- a/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2-test.tsx
+++ b/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2-test.tsx
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import { createRef } from 'react';
+
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -154,6 +156,23 @@ describe('BpkCheckboxV2', () => {
     it('forwards data-testid on Root to the outer label', () => {
       render(<SimpleCheckbox data-testid="terms-checkbox" />);
       expect(screen.getByTestId('terms-checkbox').tagName).toBe('LABEL');
+    });
+
+    it('forwards refs to the root label', () => {
+      const ref = createRef<HTMLLabelElement>();
+
+      render(
+        <BpkCheckboxV2.Root ref={ref}>
+          <BpkCheckboxV2.Control>
+            <BpkCheckboxV2.Indicator />
+          </BpkCheckboxV2.Control>
+          <BpkCheckboxV2.Label>Accept terms</BpkCheckboxV2.Label>
+          <BpkCheckboxV2.HiddenInput />
+        </BpkCheckboxV2.Root>,
+      );
+
+      expect(ref.current).toBeInstanceOf(HTMLLabelElement);
+      expect(ref.current).toHaveAttribute('data-backpack-ds-component');
     });
   });
 

--- a/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2.module.scss
+++ b/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2.module.scss
@@ -104,15 +104,15 @@
     border-color: tokens.$bpk-status-danger-spot-day;
   }
 
-  // Disabled — white background, grey border (matches V1)
+  // Disabled — grey border (matches V1)
   &[data-disabled] {
     border-color: tokens.$bpk-text-disabled-day;
-    background-color: tokens.$bpk-canvas-day;
+    background-color: transparent;
 
     &[data-state='checked'],
     &[data-state='indeterminate'] {
       border-color: tokens.$bpk-text-disabled-day;
-      background-color: tokens.$bpk-canvas-day;
+      background-color: transparent;
     }
 
     // Grey checkmark for disabled+checked (same SVG as V1's :disabled override)

--- a/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Root.tsx
+++ b/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Root.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { forwardRef } from 'react';
 import type { ReactNode } from 'react';
 
 import { Checkbox } from '@ark-ui/react';
@@ -42,35 +43,43 @@ export type BpkCheckboxV2RootProps = {
   value?: string;
 };
 
-const BpkCheckboxV2Root = ({
-  checked,
-  children,
-  'data-testid': dataTestId,
-  defaultChecked,
-  disabled = false,
-  id,
-  invalid = false,
-  name,
-  onCheckedChange,
-  required = false,
-  value,
-}: BpkCheckboxV2RootProps) => (
-  <Checkbox.Root
-    className={getClassName('bpk-checkbox-v2')}
-    checked={checked}
-    data-testid={dataTestId}
-    defaultChecked={defaultChecked}
-    disabled={disabled}
-    id={id}
-    invalid={invalid}
-    name={name}
-    onCheckedChange={(details) => onCheckedChange?.(details.checked)}
-    required={required}
-    value={value}
-    {...getDataComponentAttribute('CheckboxV2')}
-  >
-    {children}
-  </Checkbox.Root>
+const BpkCheckboxV2Root = forwardRef<HTMLLabelElement, BpkCheckboxV2RootProps>(
+  (
+    {
+      checked,
+      children,
+      'data-testid': dataTestId,
+      defaultChecked,
+      disabled = false,
+      id,
+      invalid = false,
+      name,
+      onCheckedChange,
+      required = false,
+      value,
+    },
+    ref,
+  ) => (
+    <Checkbox.Root
+      ref={ref}
+      className={getClassName('bpk-checkbox-v2')}
+      checked={checked}
+      data-testid={dataTestId}
+      defaultChecked={defaultChecked}
+      disabled={disabled}
+      id={id}
+      invalid={invalid}
+      name={name}
+      onCheckedChange={(details) => onCheckedChange?.(details.checked)}
+      required={required}
+      value={value}
+      {...getDataComponentAttribute('CheckboxV2')}
+    >
+      {children}
+    </Checkbox.Root>
+  ),
 );
+
+BpkCheckboxV2Root.displayName = 'BpkCheckboxV2Root';
 
 export default BpkCheckboxV2Root;


### PR DESCRIPTION
## Summary
- Forward refs from BpkCheckboxV2.Root to Ark Checkbox.Root
- Add a unit test covering the root label ref
- Keep disabled Checkbox V2 control backgrounds transparent

## Testing
- npx eslint packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Root.tsx packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2-test.tsx
- npx jest packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2-test.tsx --runInBand --watchman=false