### PR TITLE
[CLOV-1571][BpkLayout] Fix layout component type system to enforce allowlist-only props

### DIFF
--- a/packages/backpack-web/src/bpk-component-card/src/BpkCardV2.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-card/src/BpkCardV2.stories.tsx
@@ -254,7 +254,6 @@ const FlightLeg = ({
   stops: string;
 }) => (
   <BpkGrid
-    columns={4}
     templateColumns="1fr 1fr 1fr 1fr"
     gap={BpkSpacing.Base}
     align="center"

--- a/packages/backpack-web/src/bpk-component-layout/src/types.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/types.ts
@@ -30,57 +30,7 @@ import type {
 } from '@chakra-ui/react';
 
 
-/**
- * Layout-level event props that should not be exposed on layout components.
- * onClick is handled via BpkCommonLayoutProps; onFocus/onBlur are reintroduced
- * on BpkBoxProps only.
- */
-type LayoutEventProps =
-  | 'onMouseEnter'
-  | 'onMouseLeave'
-  | 'onMouseOver'
-  | 'onMouseOut'
-  | 'onMouseDown'
-  | 'onMouseUp'
-  | 'onFocus'
-  | 'onBlur'
-  | 'onKeyDown'
-  | 'onKeyUp'
-  | 'onKeyPress';
 
-/**
- * Shorthand props from the underlying layout system that we do NOT expose on
- * Backpack layout components. These mostly mirror longer-form spacing,
- * sizing and visual props that we already model explicitly via
- * BpkCommonLayoutProps and BpkFlexGridProps.
- */
-type DisallowedShorthandProps =
-  // Spacing shorthands
-  | 'p'
-  | 'pt'
-  | 'pr'
-  | 'pb'
-  | 'pl'
-  | 'px'
-  | 'py'
-  | 'm'
-  | 'mt'
-  | 'mr'
-  | 'mb'
-  | 'ml'
-  | 'mx'
-  | 'my'
-  // Size shorthands
-  | 'w'
-  | 'h'
-  | 'minW'
-  | 'maxW'
-  | 'minH'
-  | 'maxH'
-  // Visual shorthands that map to props we have intentionally excluded
-  | 'bg'
-  | 'rounded'
-  | 'shadow';
 
 /**
  * Flexbox & grid layout props that we explicitly support on Backpack layout
@@ -162,28 +112,11 @@ type BpkBoxResponsiveLayoutProps = {
 type BpkBoxResponsiveLayoutPropKeys = keyof BpkBoxResponsiveLayoutProps;
 
 /**
- * Base type that removes common layout props, reserved props (className,
- * children) and all layout-level event props from Chakra UI props.
- *
- * These will be replaced with Backpack-specific types.
- */
-export type RemoveCommonProps<T> = Omit<
-  T,
-  | keyof BpkCommonLayoutProps
-  | 'className'
-  | 'children'
-  | LayoutEventProps
-  | FlexGridPropKeys
-  | DisallowedShorthandProps
->;
-
-/**
- * Component-specific props for BpkBox
- * Includes all Box props except those in BpkCommonLayoutProps
+ * Component-specific props for BpkBox.
+ * Explicit allowlist — does NOT inherit from Chakra BoxProps.
  */
 export interface BpkBoxSpecificProps
-  extends Omit<RemoveCommonProps<BoxProps>, BpkBoxResponsiveLayoutPropKeys>,
-    BpkBoxResponsiveLayoutProps,
+  extends BpkBoxResponsiveLayoutProps,
     Omit<BpkFlexGridProps, BpkBoxResponsiveLayoutPropKeys> {}
 
 /**
@@ -258,7 +191,7 @@ export type BpkVesselProps = {
  * Component-specific props for BpkFlex
  * Includes all Flex props except those in BpkCommonLayoutProps
  */
-export interface BpkFlexSpecificProps extends RemoveCommonProps<FlexProps> {
+export interface BpkFlexSpecificProps {
   direction?: BpkResponsiveValue<FlexProps['flexDirection']>;
   justify?: BpkResponsiveValue<FlexProps['justifyContent']>;
   align?: BpkResponsiveValue<FlexProps['alignItems']>;
@@ -281,7 +214,7 @@ export interface BpkFlexProps extends BpkCommonLayoutProps, BpkFlexSpecificProps
  * Component-specific props for BpkGrid
  * Includes all Grid props except those in BpkCommonLayoutProps
  */
-export interface BpkGridSpecificProps extends RemoveCommonProps<GridProps> {
+export interface BpkGridSpecificProps {
   justify?: BpkResponsiveValue<GridProps['justifyContent']>;
   align?: BpkResponsiveValue<GridProps['alignItems']>;
   templateColumns?: BpkResponsiveValue<GridProps['gridTemplateColumns']>;
@@ -309,7 +242,7 @@ export interface BpkGridProps extends BpkCommonLayoutProps, BpkGridSpecificProps
  * Component-specific props for BpkGridItem
  * Includes all GridItem props except those in BpkCommonLayoutProps
  */
-export interface BpkGridItemSpecificProps extends RemoveCommonProps<GridItemProps> {
+export interface BpkGridItemSpecificProps {
   area?: GridItemProps['area'];
   colEnd?: GridItemProps['colEnd'];
   colStart?: GridItemProps['colStart'];
@@ -341,14 +274,12 @@ type BpkStackOptions = {
 
 /**
  * Component-specific props for BpkStack
- * Includes all Stack props except those in BpkCommonLayoutProps
  * Overrides StackOptions to support BpkResponsiveValue.
  * `alignItems` and `justifyContent` are accepted as semantic aliases for `align` and `justify`.
  * If both are provided, `align`/`justify` take precedence.
  */
 export interface BpkStackSpecificProps
-  extends Omit<RemoveCommonProps<StackProps>, StackOptionKeysType>,
-    BpkStackOptions,
+  extends BpkStackOptions,
     Omit<BpkFlexGridProps, 'alignItems' | 'justifyContent'> {
   /** Alias for `align`. Maps to CSS `align-items`. Responsive — replaces the non-responsive BpkFlexGridProps.alignItems. */
   alignItems?: BpkStackOptions['align'];

--- a/packages/backpack-web/src/bpk-component-layout/src/types.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/types.ts
@@ -188,8 +188,8 @@ export type BpkVesselProps = {
 } & HTMLAttributes<HTMLElement>;
 
 /**
- * Component-specific props for BpkFlex
- * Includes all Flex props except those in BpkCommonLayoutProps
+ * Component-specific props for BpkFlex.
+ * Explicit allowlist — does NOT inherit from Chakra FlexProps.
  */
 export interface BpkFlexSpecificProps {
   direction?: BpkResponsiveValue<FlexProps['flexDirection']>;
@@ -211,8 +211,8 @@ export interface BpkFlexProps extends BpkCommonLayoutProps, BpkFlexSpecificProps
 }
 
 /**
- * Component-specific props for BpkGrid
- * Includes all Grid props except those in BpkCommonLayoutProps
+ * Component-specific props for BpkGrid.
+ * Explicit allowlist — does NOT inherit from Chakra GridProps.
  */
 export interface BpkGridSpecificProps {
   justify?: BpkResponsiveValue<GridProps['justifyContent']>;
@@ -239,8 +239,8 @@ export interface BpkGridProps extends BpkCommonLayoutProps, BpkGridSpecificProps
 }
 
 /**
- * Component-specific props for BpkGridItem
- * Includes all GridItem props except those in BpkCommonLayoutProps
+ * Component-specific props for BpkGridItem.
+ * Explicit allowlist — does NOT inherit from Chakra GridItemProps.
  */
 export interface BpkGridItemSpecificProps {
   area?: GridItemProps['area'];
@@ -273,10 +273,15 @@ type BpkStackOptions = {
 };
 
 /**
- * Component-specific props for BpkStack
+ * Component-specific props for BpkStack.
+ * Explicit allowlist — does NOT inherit from Chakra StackProps.
  * Overrides StackOptions to support BpkResponsiveValue.
  * `alignItems` and `justifyContent` are accepted as semantic aliases for `align` and `justify`.
  * If both are provided, `align`/`justify` take precedence.
+ *
+ * `alignItems` and `justifyContent` are explicitly omitted from `BpkFlexGridProps` here so
+ * that the responsive alias declarations below (which match BpkStackOptions) unambiguously
+ * replace the non-responsive `BoxProps` variants from `BpkFlexGridProps`.
  */
 export interface BpkStackSpecificProps
   extends BpkStackOptions,


### PR DESCRIPTION
## Summary

Fixes a type system bug where Backpack layout components silently accepted any Chakra UI prop due to a denylist-based TypeScript approach. This PR replaces the denylist with an explicit allowlist, so unsupported props now cause compile-time errors in consumer codebases — enabling teams to discover and migrate away from unsupported usage via `tsc --noEmit`.

**Depends on:** #4505 (must be merged first)

### Root cause

The previous approach used `extends Omit<RemoveCommonProps<BoxProps>, ...>` which inherited all Chakra props and only blocked specific ones. Any prop not on the denylist was silently valid TypeScript — and was also passed through to Chakra at runtime by `processBpkComponentProps`.

### Changes

**`types.ts`:**
- Removed `RemoveCommonProps<T>`, `LayoutEventProps`, `DisallowedShorthandProps` helper types
- `BpkBoxSpecificProps`, `BpkFlexSpecificProps`, `BpkGridSpecificProps`, `BpkGridItemSpecificProps`, `BpkStackSpecificProps` — all changed from `extends RemoveCommonProps<ChakraType>` to explicit allowlist-only interfaces

**`BpkCardV2.stories.tsx`:**
- Removed invalid `columns` prop (not a `BpkGrid` prop — only exists on Chakra's `SimpleGrid`)
- Changed `alignItems="end"` → `align="end"` on `BpkVStack`

### Verification

After applying this PR on top of #4505, running `tsc --noEmit` in carhire-homepage surfaces the remaining unsupported prop usages that teams need to migrate.

---

- [x] Tests
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated