### PR TITLE
[NO-JIRA][BpkCheckboxCard] Fix cars variant disabled label color

### DIFF
--- a/packages/backpack-web/src/bpk-component-checkbox-card/src/BpkCheckboxCard.module.scss
+++ b/packages/backpack-web/src/bpk-component-checkbox-card/src/BpkCheckboxCard.module.scss
@@ -203,6 +203,7 @@
     // half-opacity so a checked-and-disabled chip doesn't show an orphaned
     // full-opacity navy tick.
     &[data-disabled]:not([data-loading]) {
+      color: tokens.$bpk-text-primary-day;
       box-shadow: inset 0 0 0 tokens.$bpk-border-size-sm
         var(--bpk-checkbox-card-disabled-border-color, #{tokens.$bpk-line-day});
       opacity: 0.5;

--- a/packages/backpack-web/src/bpk-component-checkbox-card/src/BpkCheckboxCard.module.scss
+++ b/packages/backpack-web/src/bpk-component-checkbox-card/src/BpkCheckboxCard.module.scss
@@ -299,6 +299,10 @@
     );
   }
 
+  .bpk-checkbox-card-root--cars[data-disabled]:not([data-loading]) & {
+    color: tokens.$bpk-text-disabled-day;
+  }
+
   // Keep nested content centered without using !important.
   > * {
     text-align: inherit;


### PR DESCRIPTION
## Summary
- Fix incorrect text color hierarchy in BpkCheckboxCard `cars` variant when disabled

## Problem
Not fixed
<img width="204" height="60" alt="image" src="https://github.com/user-attachments/assets/47c3c82e-f57c-4a30-9261-b335c488c9c4" />
Origin
<img width="315" height="150" alt="image" src="https://github.com/user-attachments/assets/b97bcbba-726f-4f89-8cc9-8e1ecbb9cc55" />


When a `cars` variant checkbox card is disabled (`not available`), the **label** (title) appears lighter than the **description** (subtitle), which inverts the expected visual hierarchy.

| Current (broken) | Expected (origin behavior) |
|---|---|
| Title: very light (disabled color + opacity) | Title: medium-dim (primary color + opacity) |
| Subtitle: medium-dark (secondary color + opacity) | Subtitle: very light (disabled color + opacity in consumer) |

**Root cause**: The base `.bpk-checkbox-card-root[data-disabled]` rule sets `color: $bpk-text-disabled-day`. The `cars` variant disabled rule only applied `opacity: 0.5` without overriding this color. Since `.bpk-checkbox-card-label` uses `color: inherit`, the label inherited the very faint disabled color — while the description kept its hardcoded `$bpk-text-secondary-day` (which is darker).

The original `BpkPanel`-based implementation in carhire-homepage used `color={TEXT_COLORS.textPrimary}` on the title element directly, so the label stayed in primary color and was only dimmed by the container's `opacity: 0.5`.

## Fix
<img width="634" height="210" alt="image" src="https://github.com/user-attachments/assets/eb18d77e-f5f2-4552-bea8-ae721d6aa396" />

Add `color: tokens.$bpk-text-primary-day` to the cars variant disabled rule so the label stays in primary color, matching the original BpkPanel behavior. The `opacity: 0.5` alone handles the disabled visual treatment for this variant.

## Test plan

- [x] stylelint passes
- [ ] Visual check: cars variant disabled state shows title darker than subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)