### PR TITLE
[NO-JIRA][nx] Module boundaries + nx affected CI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "extends": [
     "@skyscanner/eslint-config-skyscanner"
   ],
+  "plugins": ["@nx"],
   "env": {
     "browser": true,
     "jest": true
@@ -87,6 +88,23 @@
         "message": "Use '@ark-ui/react' instead of deep imports like '@ark-ui/react/dialog'. Deep imports cause transpilation errors during release."
       }]
     }],
+    "@nx/enforce-module-boundaries": [
+      "error",
+      {
+        "enforceBuildableLibDependency": true,
+        "allow": [],
+        "depConstraints": [
+          {
+            "sourceTag": "scope:publishable",
+            "onlyDependOnLibsWithTags": ["scope:publishable"]
+          },
+          {
+            "sourceTag": "scope:internal",
+            "onlyDependOnLibsWithTags": ["scope:publishable", "scope:internal"]
+          }
+        ]
+      }
+    ],
     "backpack/use-components": "off",
     "react/jsx-filename-extension": "off",
     "import/no-extraneous-dependencies": "off",
@@ -194,6 +212,23 @@
       "files": ["*test*", "*examples*", "*stories*"],
       "rules": {
         "@skyscanner/rules/forbid-component-props": ["off"]
+      }
+    },
+    {
+      // Module boundaries only apply to published source. Dev-only files (tests,
+      // stories, figma helpers, snapshots, build configs) are excluded — these
+      // match the inverse of the `production` namedInput in nx.json.
+      "files": [
+        "**/*test*",
+        "**/*stories*",
+        "**/*examples*",
+        "**/*.figma.*",
+        "**/__snapshots__/**",
+        "**/webpack.config*",
+        "**/gulpfile.js"
+      ],
+      "rules": {
+        "@nx/enforce-module-boundaries": "off"
       }
     },
     {

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash -l {0}
 
 env:
-  CACHE_NAME: node-modules-cache
+  CACHE_NAME: node-modules-cache-v2
   BUILD_CACHE_NAME: build-cache
   BUILD_LOGS: log-artifacts-build
 
@@ -19,12 +19,19 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     permissions:
+      # actions: read is mandatory for nrwl/nx-set-shas to read base/head SHAs
+      # via the GitHub Actions API. Without it, `nx affected` silently runs
+      # against the wrong baseline.
+      actions: read
+      contents: read
+      id-token: write
       statuses: write
       pull-requests: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -38,8 +45,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Restore Nx Build Cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -50,20 +56,35 @@ jobs:
             .nx/cache/
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 
+      - name: Derive Nx affected SHAs
+        uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4.3.3
+
       - name: Setup logs directory
         run: mkdir logs
 
-      - name: Build Backpack
-        run: npm run build
+      - name: Build (affected)
+        run: npx nx affected -t build --parallel=3
 
       - name: Confirm the build hasn't changed any files
         run: ./scripts/check-pristine-state package-lock.json
 
-      - name: Run typecheck
-        run: npm run typecheck
+      # TODO(Issue 6.1): replace the two checks below with
+      #   npx nx run backpack-harness:lint
+      # once the backpack-harness lib is created.
+      - name: Check React versions
+        run: npm run check-react-versions
 
-      - name: Run tests
-        run: bash -c "set -o pipefail;npm run test |& tee 'logs/test.log'"
+      - name: Check Backpack dependencies
+        run: npm run check-bpk-dependencies
+
+      - name: Lint (affected)
+        run: npx nx affected -t lint --parallel=3
+
+      - name: Typecheck (affected)
+        run: npx nx affected -t typecheck --parallel=3
+
+      - name: Tests (affected)
+        run: bash -c "set -o pipefail; npx nx affected -t test --parallel=3 |& tee 'logs/test.log'"
 
       - name: Tar and compress logs
         run: |
@@ -98,8 +119,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -147,8 +167,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Restore Cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -52,7 +52,7 @@ jobs:
         id: storybook-dist-cache
         with:
           path: |
-            dist-storybook/
+            libs/backpack-storybook-host/dist-storybook/
             .nx/cache/
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 
@@ -174,7 +174,7 @@ jobs:
         id: storybook-dist-cache
         with:
           path: |
-            dist-storybook/
+            libs/backpack-storybook-host/dist-storybook/
             .nx/cache/
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -57,7 +57,7 @@ jobs:
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 
       - name: Derive Nx affected SHAs
-        uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4.3.3
+        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
 
       - name: Setup logs directory
         run: mkdir logs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
         id: storybook-dist-cache
         with:
           path: |
-            dist-storybook/
+            libs/backpack-storybook-host/dist-storybook/
             .nx/cache/
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 
@@ -117,7 +117,7 @@ jobs:
         id: storybook-dist-cache
         with:
           path: |
-            dist-storybook/
+            libs/backpack-storybook-host/dist-storybook/
             .nx/cache/
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 
@@ -126,7 +126,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         with:
           personal_token: ${{ secrets.DEPLOY_TOKEN }}
-          publish_dir: dist-storybook/
+          publish_dir: libs/backpack-storybook-host/dist-storybook/
           keep_files: false
           external_repository: backpack/storybook
           publish_branch: main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash -l {0}
 
 env:
-  CACHE_NAME: node-modules-cache
+  CACHE_NAME: node-modules-cache-v2
   BUILD_CACHE_NAME: build-cache
 
 permissions: {}
@@ -37,8 +37,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
@@ -63,8 +62,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Upload dist-storybook to Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -83,6 +81,9 @@ jobs:
 
   Build:
     permissions:
+      actions: read
+      contents: read
+      id-token: write
       statuses: write
       pull-requests: write
     needs: [Create-NPM-Cache, Create-Build-Cache]
@@ -109,8 +110,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Restore Cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -150,8 +150,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Build Sass docs
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash -l {0}
 
 env:
-  CACHE_NAME: node-modules-cache
+  CACHE_NAME: node-modules-cache-v2
   BUILD_CACHE_NAME: build-cache
 
 permissions: {}
@@ -37,8 +37,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
@@ -63,8 +62,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Upload dist-storybook to Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -83,6 +81,9 @@ jobs:
 
   Build:
     permissions:
+      actions: read
+      contents: read
+      id-token: write
       statuses: write
       pull-requests: write
     needs: [Create-NPM-Cache, Create-Build-Cache]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,7 +69,7 @@ jobs:
         id: storybook-dist-cache
         with:
           path: |
-            dist-storybook/
+            libs/backpack-storybook-host/dist-storybook/
             .nx/cache/
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 
@@ -119,14 +119,14 @@ jobs:
       id: storybook-dist-cache
       with:
         path: |
-          dist-storybook/
+          libs/backpack-storybook-host/dist-storybook/
           .nx/cache/
         key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 
     - name: Prepare to deploy Storybook (pull request build)
       run: |
         mkdir build
-        mv dist-storybook $PR_NUMBER
+        mv libs/backpack-storybook-host/dist-storybook $PR_NUMBER
         cp -R $PR_NUMBER build/
       if: github.ref != 'refs/heads/main' && github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]'
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         id: storybook-dist-cache
         with:
           path: |
-            dist-storybook/
+            libs/backpack-storybook-host/dist-storybook/
             .nx/cache/
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ defaults:
     shell: bash -l {0}
 
 env:
-  CACHE_NAME: node-modules-cache
+  CACHE_NAME: node-modules-cache-v2
   BUILD_CACHE_NAME: build-cache
 
 permissions: {}
@@ -33,8 +33,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
@@ -59,8 +58,7 @@ jobs:
         with:
           path: |
             node_modules/
-            packages/backpack-web/node_modules/
-          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
       - name: Upload dist-storybook to Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -79,6 +77,9 @@ jobs:
 
   Build:
     permissions:
+      actions: read
+      contents: read
+      id-token: write
       statuses: write
       pull-requests: write
     needs: [Create-NPM-Cache, Create-Build-Cache]
@@ -109,8 +110,7 @@ jobs:
       with:
         path: |
           node_modules/
-          packages/backpack-web/node_modules/
-        key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json', 'packages/backpack-web/package-lock.json') }}
+        key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
     - run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /dist
 /packages/backpack-web/dist
 /dist-sassdoc
-/dist-storybook
+/libs/backpack-storybook-host/dist-storybook
 /coverage
 /packages/backpack-web/src/bpk-component-icon/*/
 /packages/backpack-web/src/bpk-component-spinner/src/spinners

--- a/libs/backpack-storybook-host/project.json
+++ b/libs/backpack-storybook-host/project.json
@@ -52,8 +52,8 @@
       "dependsOn": ["^build"],
       "options": {
         "commands": [
-          "nx run backpack-storybook-host:build-storybook -- -o ../../dist-storybook",
-          "percy storybook dist-storybook -i '/Visual\\stest\\s?([a-z]*)?/i'"
+          "nx run backpack-storybook-host:build-storybook -- -o dist-storybook",
+          "percy storybook libs/backpack-storybook-host/dist-storybook -i '/Visual\\stest\\s?([a-z]*)?/i'"
         ],
         "parallel": false,
         "cwd": "{workspaceRoot}"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier": "prettier --config .prettierrc --write \"**/*.(js|ts|tsx)\"",
     "start": "npm run build && npm run storybook",
     "storybook": "nx run backpack-storybook-host:serve-storybook -- -p 9001",
-    "storybook:dist": "nx run backpack-storybook-host:build-storybook -- -o ../../dist-storybook",
+    "storybook:dist": "nx run backpack-storybook-host:build-storybook -- -o dist-storybook",
     "tokens:fetch": "tsx token-sync/src/index.ts",
     "tokens:build-css": "tsx token-sync/src/build-css-cli.ts",
     "tokens:sync": "npm run tokens:fetch && npm run tokens:build-css",
@@ -54,7 +54,7 @@
     "test": "npm run lint && npm run check-react-versions && npm run check-bpk-dependencies && npm run jest",
     "typecheck": "tsc && nx run backpack-storybook-host:typecheck",
     "prepare": "husky",
-    "percy-test": "percy storybook ./dist-storybook -i '/Visual\\stest\\s?([a-z]*)?/i'",
+    "percy-test": "percy storybook ./libs/backpack-storybook-host/dist-storybook -i '/Visual\\stest\\s?([a-z]*)?/i'",
     "ts-migrate": "ts-migrate"
   },
   "lint-staged": {

--- a/packages/backpack-web/package.json
+++ b/packages/backpack-web/package.json
@@ -22,6 +22,7 @@
     "access": "public"
   },
   "exports": {
+    "./package.json": "./package.json",
     "./bpk-stylesheets": "./src/bpk-stylesheets/index.js",
     "./bpk-stylesheets/*": "./src/bpk-stylesheets/*.js",
     "./bpk-component-autosuggest": "./src/bpk-component-autosuggest/index.js",


### PR DESCRIPTION
## Summary

- Register `@nx/enforce-module-boundaries` in `.eslintrc` so `scope:publishable` (`backpack-web`) can only depend on other publishable libs and `scope:internal` (`backpack-storybook-utils`, `backpack-storybook-host`) can depend on either; dev-only files (tests, stories, figma helpers, snapshots, webpack/gulp configs) are exempt via an overrides block.
- Switch the CI Build job to `nx affected` for build/lint/typecheck/test, add `nrwl/nx-set-shas@v4.3.3` with the required `actions: read` permission, and propagate that permission through the `pr.yml` / `main.yml` / `release.yml` callers.
- Drop the obsolete `packages/backpack-web/{node_modules,package-lock.json}` cache paths (npm workspaces hoists) and bump `CACHE_NAME` to `node-modules-cache-v2` across all four workflows.

This implements Issues 4.1 and 5.1 of the Nx adoption plan. The `backpack-harness:lint` / `check-pristine` consolidation is gated behind Issue 6.1 — the legacy `check-react-versions` / `check-bpk-dependencies` / `check-pristine-state` steps remain in `_build.yml` with a `TODO(Issue 6.1)` marker.

## Test plan

- [x] `nx run backpack-web:lint-js`, `backpack-storybook-utils:lint-js`, `backpack-storybook-host:lint-js` — all pass with the new rule active (0 errors).
- [x] `nx show projects --affected` correctly resolves projects from `.eslintrc` edits.
- [ ] CI Build job picks up base/head SHAs from `nx-set-shas` and runs `nx affected` against the right baseline.
- [ ] Touching one component should rebuild only the affected chain in CI.