### PR TITLE
[NO-JIRA][ci] Use static-IP runner for Build job

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-2cores-tools-public
     permissions:
       # actions: read is mandatory for nrwl/nx-set-shas to read base/head SHAs
       # via the GitHub Actions API. Without it, `nx affected` silently runs


### PR DESCRIPTION
## Summary

- Fix CI failure in Build job caused by `nrwl/nx-set-shas` being blocked by the org IP allowlist
- Switch Build job runner from `ubuntu-latest` to `ubuntu-24.04-2cores-tools-public` (static IP, already in Skyscanner's allowlist)

## Context

PR #4525 introduced `nrwl/nx-set-shas` which calls the GitHub Actions API to find the last successful workflow run. With the Skyscanner org IP allowlist enabled, standard `ubuntu-latest` runners get a 403:

> Although you appear to have the correct authorization credentials, the `Skyscanner` organization has an IP allow list enabled, and your IP address is not permitted to access this resource.

The `ubuntu-24.04-2cores-tools-public` runner has a static IP registered in the org allowlist (same runner already used by `zizmor.yml` in this repo).

## Test plan

- [ ] CI Build job passes without IP allowlist errors
- [ ] `nx affected` correctly derives base/head SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)