### PR TITLE
[NO-JIRA] Track Figma metadata for token release labels

### DIFF
--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: main
+          ref: ${{ github.ref }}
           persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -109,8 +109,8 @@ jobs:
             echo "Release label: \`${RELEASE_LABEL}\`"
             echo
             echo "**Release label rules:**"
-            echo "- \`major\` — an existing token path was removed, renamed, or had its value changed (consumer code may break)."
-            echo "- \`minor\` — only new token paths were added."
+            echo "- \`major\` — an existing Figma variable key was removed, renamed, or had its emitted token value changed (consumer code may break)."
+            echo "- \`minor\` — only new Figma variable keys were added."
             if [ "$RELEASE_LABEL_OUTCOME" != "success" ]; then
               echo
               echo "> [!WARNING]"

--- a/token-sync/README.md
+++ b/token-sync/README.md
@@ -56,7 +56,7 @@ The token is never committed. There are two places it needs to live:
 - **CI** — add two repository secrets at **Settings → Secrets and variables → Actions**:
 
   | Secret name                  | Value                                      |
-  |------------------------------|--------------------------------------------|
+  | ---------------------------- | ------------------------------------------ |
   | `FIGMA_VARIABLES_SYNC_TOKEN` | Same token as above                        |
   | `FIGMA_FILE_KEY`             | Backpack Foundations & Components file key |
 
@@ -101,14 +101,14 @@ When generated output changes under `token-sync/tokens/` or `token-sync/css/`, t
 any existing open `figma-token-sync/*` pull request, then creates a fresh
 `figma-token-sync/<timestamp>-<run-id>` branch and opens one pull request against `main`. Because the
 fresh branch is generated from the latest Figma state against `main`, it includes any still-unmerged
-token changes from previous sync runs. The pull request is labelled `major` when an existing token
-path is removed, renamed, or has its value changed (because consumer code or downstream visuals may
-break), and `minor` only when the diff is purely additive (new token paths). Removed or renamed
-token paths, plus changed token values, are listed in the pull request body so reviewers can verify
-usage migrations and visual impact. Pure additions are not listed because a delete-and-add diff can
-represent a change that needs reviewer judgement. If release label classification fails, the pull
-request defaults to `major` for review. Figma API or Style Dictionary failures fail the workflow at
-the failing step.
+token changes from previous sync runs. Generated DTCG tokens include Figma variable metadata under
+`$extensions.figma`, allowing the workflow to compare stable Figma variable keys across runs. The
+pull request is labelled `major` when an existing Figma variable key is removed, renamed, or has its
+emitted token value changed (because consumer code or downstream visuals may break), and `minor`
+only when the diff is purely additive (new Figma variable keys). Deleted, renamed, changed, and added
+token paths are listed in the pull request body so reviewers can verify usage migrations and visual
+impact. If release label classification fails, the pull request defaults to `major` for review.
+Figma API or Style Dictionary failures fail the workflow at the failing step.
 
 For human takeover (when the automated PR needs to be replaced with a hand-curated one), see the
 "Manual intervention" section in [`RUNBOOK.md`](RUNBOOK.md).

--- a/token-sync/RUNBOOK.md
+++ b/token-sync/RUNBOOK.md
@@ -30,11 +30,11 @@ to a repository output change.
    - It targets `main`.
    - It is opened from a `figma-token-sync/<timestamp>-<run-id>` branch.
    - It has the `design-token-automation` label.
-   - It has a `major` label when an existing token path was removed, renamed, or had its value
-     changed.
-   - It has a `minor` label only when the diff is purely additive (new token paths added).
-   - Any removed, renamed, or changed token paths are listed in the pull request body, grouped by
-     token file. Pure additions are not listed.
+   - It has a `major` label when an existing Figma variable key was removed, renamed, or had its
+     emitted token value changed.
+   - It has a `minor` label only when the diff is purely additive (new Figma variable keys added).
+   - Any removed, renamed, changed, or added token paths are listed in the pull request body,
+     grouped by token file.
 6. After validation, revert the controlled Figma change if it was only for testing, then rerun the
    workflow or wait for the next scheduled run to confirm the repository output returns to the
    expected state.
@@ -59,8 +59,9 @@ different branch prefix to keep the workflow from auto-closing your PR.
    output, and open the pull request.
 4. Apply labels manually following the same rules the workflow uses:
    - `design-token-automation`
-   - `major` if an existing token path was removed, renamed, or had its value changed.
-   - `minor` only if the diff is purely additive (new token paths added).
+   - `major` if an existing Figma variable key was removed, renamed, or had its emitted token value
+     changed.
+   - `minor` only if the diff is purely additive (new Figma variable keys added).
 
 While your manual pull request is open the next scheduled run will still detect the same Figma
 changes and may open another `figma-token-sync/*` pull request. Either merge or close your manual

--- a/token-sync/RUNBOOK.md
+++ b/token-sync/RUNBOOK.md
@@ -80,6 +80,10 @@ pull requests while your manual change is in flight.
 - **No-op runs** - If the workflow exits after `Detect meaningful fetched token changes`, no
   repository output PR is expected. This means either Figma has no token value changes compared with
   `main`, or the only fetched change was `manifest.json`'s `generatedAt` metadata.
+  - **Caveat**: when the run is a no-op, the "Close superseded Figma token sync pull requests"
+    step is also skipped. If a stale `figma-token-sync/*` pull request is still open while `main`
+    and Figma are now in sync, it will not be auto-closed — close it manually, or wait until the
+    next real Figma change triggers a run that closes it.
 - **PR automation failures** - If token generation succeeds but no PR appears, check the
   `create-github-app-token`, `Commit generated token changes`, and `Open pull request` steps. Verify
   `GH_APP_ID` and `GH_APP_PRIVATE_KEY` are configured and that the app can push branches and open

--- a/token-sync/src/build-dtcg-test.ts
+++ b/token-sync/src/build-dtcg-test.ts
@@ -26,13 +26,11 @@ import path from 'node:path';
 import {
   BACKPACK_MODE_DARK,
   BACKPACK_MODE_LIGHT,
+  KEY_SEM_CANVAS_CONTRAST,
+  KEY_SEM_CANVAS_DEFAULT,
   buildFixtureResponse,
 } from './__fixtures__/figma-variable';
-import {
-  buildDTCG,
-  buildDTCGOutputs,
-  formatBuildSummary,
-} from './build-dtcg';
+import { buildDTCG, buildDTCGOutputs, formatBuildSummary } from './build-dtcg';
 import { FigmaApi } from './figma-api';
 import { TARGET_COLLECTION_NAMES } from './sync-helpers';
 
@@ -50,7 +48,10 @@ describe('buildDTCGOutputs (end-to-end on fixtures)', () => {
     );
 
     expect(classified).toEqual([
-      { collection: expect.objectContaining({ name: 'Backpack' }), role: 'semantic' },
+      {
+        collection: expect.objectContaining({ name: 'Backpack' }),
+        role: 'semantic',
+      },
       {
         collection: expect.objectContaining({ name: 'Primitives' }),
         role: 'primitive',
@@ -72,8 +73,18 @@ describe('buildDTCGOutputs (end-to-end on fixtures)', () => {
     expect(backpackLight.tree).toEqual({
       Canvas: {
         $type: 'color',
-        Contrast: { $value: '{Colour.Pink}' },
-        Default: { $value: '{Colour.Pink}' },
+        Contrast: {
+          $value: '{Colour.Pink}',
+          $extensions: {
+            figma: expect.objectContaining({ key: KEY_SEM_CANVAS_CONTRAST }),
+          },
+        },
+        Default: {
+          $value: '{Colour.Pink}',
+          $extensions: {
+            figma: expect.objectContaining({ key: KEY_SEM_CANVAS_DEFAULT }),
+          },
+        },
       },
     });
     expect(backpackLight.stats).toMatchObject({
@@ -113,9 +124,17 @@ describe('buildDTCGOutputs (end-to-end on fixtures)', () => {
       modeNameMap: { Light: 'LightSky', Dark: 'DarkSky' },
     });
 
-    expect(outputs.filter((o) => o.collectionName === 'Backpack')).toMatchObject([
-      { modeName: 'DarkSky', tree: { Canvas: { Default: { $value: '{Colour.Berry}' } } } },
-      { modeName: 'LightSky', tree: { Canvas: { Default: { $value: '{Colour.Pink}' } } } },
+    expect(
+      outputs.filter((o) => o.collectionName === 'Backpack'),
+    ).toMatchObject([
+      {
+        modeName: 'DarkSky',
+        tree: { Canvas: { Default: { $value: '{Colour.Berry}' } } },
+      },
+      {
+        modeName: 'LightSky',
+        tree: { Canvas: { Default: { $value: '{Colour.Pink}' } } },
+      },
     ]);
   });
 });
@@ -199,15 +218,21 @@ describe('formatBuildSummary', () => {
   }
 
   // Minimal fake — we only exercise the formatter, not the writer.
-  function makeResult(overrides: Partial<BuildDTCGResult> = {}): BuildDTCGResult {
+  function makeResult(
+    overrides: Partial<BuildDTCGResult> = {},
+  ): BuildDTCGResult {
     return {
       classified: [
         {
-          collection: { name: 'Backpack' } as BuildDTCGResult['classified'][number]['collection'],
+          collection: {
+            name: 'Backpack',
+          } as BuildDTCGResult['classified'][number]['collection'],
           role: 'semantic',
         },
         {
-          collection: { name: 'Primitives' } as BuildDTCGResult['classified'][number]['collection'],
+          collection: {
+            name: 'Primitives',
+          } as BuildDTCGResult['classified'][number]['collection'],
           role: 'primitive',
         },
       ],
@@ -244,7 +269,9 @@ describe('formatBuildSummary', () => {
 
   it('includes a warning when target collections are missing', () => {
     const lines = formatBuildSummary(makeResult({ missingNames: ['VDL'] }));
-    expect(lines.some((l) => l.includes('Warning') && l.includes('VDL'))).toBe(true);
+    expect(lines.some((l) => l.includes('Warning') && l.includes('VDL'))).toBe(
+      true,
+    );
   });
 
   it('groups unresolved aliases by missing alias id and merges Light/Dark duplicates', () => {
@@ -326,9 +353,15 @@ describe('formatBuildSummary', () => {
       makeResult({ outputs: [makeOutput(BACKPACK_MODE_LIGHT, [varA, varB])] }),
     );
 
-    expect(lines).toContain('  - missing VariableID:9999:0000 (2 variable(s)):');
-    expect(lines).toContain('      • [Backpack] Component/Button/bg-default (modes: Light)');
-    expect(lines).toContain('      • [Backpack] Component/Card/bg-default (modes: Light)');
+    expect(lines).toContain(
+      '  - missing VariableID:9999:0000 (2 variable(s)):',
+    );
+    expect(lines).toContain(
+      '      • [Backpack] Component/Button/bg-default (modes: Light)',
+    );
+    expect(lines).toContain(
+      '      • [Backpack] Component/Card/bg-default (modes: Light)',
+    );
   });
 
   it('expands into bullet list when multiple FLOAT variables share the same scope key', () => {
@@ -353,8 +386,12 @@ describe('formatBuildSummary', () => {
     const lines = formatBuildSummary(makeResult({ outputs: [lightOutput] }));
 
     expect(lines).toContain('  - scope=[ALL_SCOPES] (2 variable(s)):');
-    expect(lines).toContain('      • [Backpack] Typography/Weight/Bold (modes: Light)');
-    expect(lines).toContain('      • [Backpack] Typography/Weight/Regular (modes: Light)');
+    expect(lines).toContain(
+      '      • [Backpack] Typography/Weight/Bold (modes: Light)',
+    );
+    expect(lines).toContain(
+      '      • [Backpack] Typography/Weight/Regular (modes: Light)',
+    );
   });
 
   it('warns about FLOAT variables with unconstrained scopes and merges Light/Dark duplicates', () => {

--- a/token-sync/src/classify-release-label-cli.ts
+++ b/token-sync/src/classify-release-label-cli.ts
@@ -24,7 +24,6 @@ import {
   formatAddedTokensMarkdown,
   formatChangedTokenValuesMarkdown,
   formatDeletedTokensMarkdown,
-  formatDeletedOrRenamedTokensMarkdown,
   formatRenamedTokensMarkdown,
   summariseTokenReleaseChangesFromGit,
 } from './classify-release-label';
@@ -60,19 +59,12 @@ function main(): void {
   const summary = summariseTokenReleaseChangesFromGit();
   writeLabelOutput(summary.label);
 
-  const sections =
-    summary.classificationMethod === 'figma-key'
-      ? [
-          formatDeletedTokensMarkdown(summary.deletedTokens),
-          formatRenamedTokensMarkdown(summary.renamedTokens),
-          formatChangedTokenValuesMarkdown(summary.changedTokens),
-          formatAddedTokensMarkdown(summary.addedTokens),
-        ].filter(Boolean)
-      : [
-          formatDeletedOrRenamedTokensMarkdown(summary.deletedOrRenamedTokens),
-          formatChangedTokenValuesMarkdown(summary.changedTokens),
-          formatAddedTokensMarkdown(summary.addedTokens),
-        ].filter(Boolean);
+  const sections = [
+    formatRenamedTokensMarkdown(summary.renamedTokens),
+    formatChangedTokenValuesMarkdown(summary.changedTokens),
+    formatDeletedTokensMarkdown(summary.deletedTokens),
+    formatAddedTokensMarkdown(summary.addedTokens),
+  ].filter(Boolean);
 
   writeTokenReleaseSummary(sections.join('\n\n'));
 }

--- a/token-sync/src/classify-release-label-cli.ts
+++ b/token-sync/src/classify-release-label-cli.ts
@@ -21,8 +21,11 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
+  formatAddedTokensMarkdown,
   formatChangedTokenValuesMarkdown,
+  formatDeletedTokensMarkdown,
   formatDeletedOrRenamedTokensMarkdown,
+  formatRenamedTokensMarkdown,
   summariseTokenReleaseChangesFromGit,
 } from './classify-release-label';
 import { formatFatalError } from './sync-helpers';
@@ -57,10 +60,19 @@ function main(): void {
   const summary = summariseTokenReleaseChangesFromGit();
   writeLabelOutput(summary.label);
 
-  const sections = [
-    formatDeletedOrRenamedTokensMarkdown(summary.deletedOrRenamedTokens),
-    formatChangedTokenValuesMarkdown(summary.changedTokens),
-  ].filter(Boolean);
+  const sections =
+    summary.classificationMethod === 'figma-key'
+      ? [
+          formatDeletedTokensMarkdown(summary.deletedTokens),
+          formatRenamedTokensMarkdown(summary.renamedTokens),
+          formatChangedTokenValuesMarkdown(summary.changedTokens),
+          formatAddedTokensMarkdown(summary.addedTokens),
+        ].filter(Boolean)
+      : [
+          formatDeletedOrRenamedTokensMarkdown(summary.deletedOrRenamedTokens),
+          formatChangedTokenValuesMarkdown(summary.changedTokens),
+          formatAddedTokensMarkdown(summary.addedTokens),
+        ].filter(Boolean);
 
   writeTokenReleaseSummary(sections.join('\n\n'));
 }

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -36,7 +36,6 @@ function token(value: unknown, key: string) {
       figma: {
         id: `id-${key}`,
         key,
-        name: key,
       },
     },
   };
@@ -219,7 +218,6 @@ describe('classifyTokenReleaseLabel', () => {
                   figma: {
                     id: 'new-id',
                     key: 'spacing-base',
-                    name: 'Spacing/Base',
                   },
                 },
               },

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -21,10 +21,26 @@
 
 import {
   classifyTokenReleaseLabel,
+  formatAddedTokensMarkdown,
   formatChangedTokenValuesMarkdown,
+  formatDeletedTokensMarkdown,
   formatDeletedOrRenamedTokensMarkdown,
+  formatRenamedTokensMarkdown,
   summariseTokenReleaseChanges,
 } from './classify-release-label';
+
+function token(value: unknown, key: string) {
+  return {
+    $value: value,
+    $extensions: {
+      figma: {
+        id: `id-${key}`,
+        key,
+        name: key,
+      },
+    },
+  };
+}
 
 describe('classifyTokenReleaseLabel', () => {
   it('returns minor when the diff only adds tokens', () => {
@@ -115,6 +131,105 @@ describe('classifyTokenReleaseLabel', () => {
     ).toEqual([{ fileName: 'backpack.light.json', tokenPath: 'Spacing/Base' }]);
   });
 
+  it('uses Figma keys to distinguish renamed tokens from deletes and adds', () => {
+    const summary = summariseTokenReleaseChanges([
+      {
+        fileName: 'token-sync/tokens/backpack.light.json',
+        previous: {
+          Spacing: {
+            $type: 'dimension',
+            Base: token('8px', 'spacing-base'),
+          },
+        },
+        current: {
+          Spacing: {
+            $type: 'dimension',
+            Default: token('8px', 'spacing-base'),
+          },
+        },
+      },
+    ]);
+
+    expect(summary).toMatchObject({
+      addedTokens: [],
+      changedTokens: [],
+      classificationMethod: 'figma-key',
+      deletedTokens: [],
+      label: 'major',
+      renamedTokens: [
+        {
+          currentTokenPath: 'Spacing/Default',
+          fileName: 'backpack.light.json',
+          previousTokenPath: 'Spacing/Base',
+        },
+      ],
+    });
+  });
+
+  it('uses Figma keys to report added, deleted, and changed tokens', () => {
+    const summary = summariseTokenReleaseChanges([
+      {
+        fileName: 'token-sync/tokens/backpack.light.json',
+        previous: {
+          Spacing: {
+            $type: 'dimension',
+            Base: token('8px', 'spacing-base'),
+            Removed: token('4px', 'spacing-removed'),
+          },
+        },
+        current: {
+          Spacing: {
+            $type: 'dimension',
+            Base: token('12px', 'spacing-base'),
+            Large: token('16px', 'spacing-large'),
+          },
+        },
+      },
+    ]);
+
+    expect(summary).toMatchObject({
+      addedTokens: [
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Large' },
+      ],
+      changedTokens: [
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Base' },
+      ],
+      classificationMethod: 'figma-key',
+      deletedTokens: [
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Removed' },
+      ],
+      label: 'major',
+      renamedTokens: [],
+    });
+  });
+
+  it('ignores Figma metadata when comparing token values', () => {
+    expect(
+      summariseTokenReleaseChanges([
+        {
+          previous: {
+            Spacing: { $type: 'dimension', Base: token('8px', 'spacing-base') },
+          },
+          current: {
+            Spacing: {
+              $type: 'dimension',
+              Base: {
+                ...token('8px', 'spacing-base'),
+                $extensions: {
+                  figma: {
+                    id: 'new-id',
+                    key: 'spacing-base',
+                    name: 'Spacing/Base',
+                  },
+                },
+              },
+            },
+          },
+        },
+      ]).label,
+    ).toBe('minor');
+  });
+
   it('formats deleted or renamed token paths for pull request bodies', () => {
     expect(
       formatDeletedOrRenamedTokensMarkdown([
@@ -140,6 +255,60 @@ describe('classifyTokenReleaseLabel', () => {
     );
   });
 
+  it('formats deleted token paths for pull request bodies', () => {
+    expect(
+      formatDeletedTokensMarkdown([
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Base' },
+        { fileName: 'backpack.dark.json', tokenPath: 'Spacing/Base' },
+      ]),
+    ).toBe(
+      [
+        '## Deleted tokens',
+        '',
+        'The following Figma variable keys existed in the previous commit but are missing from the fetched tokens. Treat them as breaking changes and verify usages have been migrated.',
+        '',
+        '### backpack.light.json',
+        '',
+        '- `Spacing/Base`',
+        '',
+        '### backpack.dark.json',
+        '',
+        '- `Spacing/Base`',
+      ].join('\n'),
+    );
+  });
+
+  it('formats renamed token paths for pull request bodies', () => {
+    expect(
+      formatRenamedTokensMarkdown([
+        {
+          currentTokenPath: 'Spacing/Default',
+          fileName: 'backpack.light.json',
+          previousTokenPath: 'Spacing/Base',
+        },
+        {
+          currentTokenPath: 'Spacing/Default',
+          fileName: 'backpack.dark.json',
+          previousTokenPath: 'Spacing/Base',
+        },
+      ]),
+    ).toBe(
+      [
+        '## Renamed tokens',
+        '',
+        'The following token paths changed while the Figma variable key stayed the same. Treat them as breaking changes and verify usages have been migrated.',
+        '',
+        '### backpack.light.json',
+        '',
+        '- `Spacing/Base` -> `Spacing/Default`',
+        '',
+        '### backpack.dark.json',
+        '',
+        '- `Spacing/Base` -> `Spacing/Default`',
+      ].join('\n'),
+    );
+  });
+
   it('formats changed token paths for pull request bodies', () => {
     expect(
       formatChangedTokenValuesMarkdown([
@@ -151,7 +320,7 @@ describe('classifyTokenReleaseLabel', () => {
       [
         '## Changed token values',
         '',
-        'The following token values changed while the path stayed the same. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
+        'The following token values changed for an existing token. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
         '',
         '### backpack.light.json',
         '',
@@ -161,6 +330,31 @@ describe('classifyTokenReleaseLabel', () => {
         '### backpack.dark.json',
         '',
         '- `Spacing/Base`',
+      ].join('\n'),
+    );
+  });
+
+  it('formats added token paths for pull request bodies', () => {
+    expect(
+      formatAddedTokensMarkdown([
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/Large' },
+        { fileName: 'backpack.light.json', tokenPath: 'Spacing/XLarge' },
+        { fileName: 'backpack.dark.json', tokenPath: 'Spacing/Large' },
+      ]),
+    ).toBe(
+      [
+        '## Added tokens',
+        '',
+        'The following token paths are new in this sync. When Figma key metadata is available, these are variables whose keys were not present in the previous generated tokens.',
+        '',
+        '### backpack.light.json',
+        '',
+        '- `Spacing/Large`',
+        '- `Spacing/XLarge`',
+        '',
+        '### backpack.dark.json',
+        '',
+        '- `Spacing/Large`',
       ].join('\n'),
     );
   });

--- a/token-sync/src/classify-release-label-test.ts
+++ b/token-sync/src/classify-release-label-test.ts
@@ -165,6 +165,39 @@ describe('classifyTokenReleaseLabel', () => {
     });
   });
 
+  it('does not report renamed tokens as value changes', () => {
+    const summary = summariseTokenReleaseChanges([
+      {
+        fileName: 'token-sync/tokens/backpack.light.json',
+        previous: {
+          Spacing: {
+            $type: 'dimension',
+            Base: token('8px', 'spacing-base'),
+          },
+        },
+        current: {
+          Spacing: {
+            $type: 'dimension',
+            Default: token('12px', 'spacing-base'),
+          },
+        },
+      },
+    ]);
+
+    expect(summary).toMatchObject({
+      addedTokens: [],
+      changedTokens: [],
+      deletedTokens: [],
+      renamedTokens: [
+        {
+          currentTokenPath: 'Spacing/Default',
+          fileName: 'backpack.light.json',
+          previousTokenPath: 'Spacing/Base',
+        },
+      ],
+    });
+  });
+
   it('uses Figma keys to report added, deleted, and changed tokens', () => {
     const summary = summariseTokenReleaseChanges([
       {
@@ -318,7 +351,7 @@ describe('classifyTokenReleaseLabel', () => {
       [
         '## Changed token values',
         '',
-        'The following token values changed for an existing token. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
+        'The following token values changed while the token path stayed the same. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
         '',
         '### backpack.light.json',
         '',

--- a/token-sync/src/classify-release-label.ts
+++ b/token-sync/src/classify-release-label.ts
@@ -37,11 +37,20 @@ export interface TokenPathChange {
   tokenPath: string;
 }
 
+export interface TokenRenameChange {
+  currentTokenPath: string;
+  fileName: string;
+  previousTokenPath: string;
+}
+
 export interface TokenReleaseSummary {
   addedTokens: TokenPathChange[];
   changedTokens: TokenPathChange[];
+  classificationMethod: 'figma-key' | 'token-path';
+  deletedTokens: TokenPathChange[];
   deletedOrRenamedTokens: TokenPathChange[];
   label: ReleaseLabel;
+  renamedTokens: TokenRenameChange[];
 }
 
 function git(args: string[]): string[] {
@@ -133,6 +142,19 @@ function normalise(value: unknown): unknown {
   return result;
 }
 
+function tokenFingerprint(node: PlainObject, tokenType: unknown): string {
+  const tokenWithoutExtensions: PlainObject = {};
+  Object.entries(node).forEach(([key, value]) => {
+    if (key !== '$extensions') {
+      tokenWithoutExtensions[key] = value;
+    }
+  });
+
+  return JSON.stringify(
+    normalise({ ...tokenWithoutExtensions, $type: tokenType }),
+  );
+}
+
 function collectTokens(
   node: unknown,
   prefix: string[] = [],
@@ -145,12 +167,7 @@ function collectTokens(
   const tokenType = node.$type ?? inheritedType;
 
   if (Object.prototype.hasOwnProperty.call(node, '$value')) {
-    return new Map([
-      [
-        prefix.join('/'),
-        JSON.stringify(normalise({ ...node, $type: tokenType })),
-      ],
-    ]);
+    return new Map([[prefix.join('/'), tokenFingerprint(node, tokenType)]]);
   }
 
   const tokens = new Map<string, string>();
@@ -167,16 +184,211 @@ function collectTokens(
   return tokens;
 }
 
+interface FigmaTokenRecord extends TokenPathChange {
+  figmaId: string;
+  figmaKey: string;
+  value: string;
+}
+
+interface CollectedFigmaTokens {
+  tokenCount: number;
+  tokens: FigmaTokenRecord[];
+}
+
+function readFigmaMetadata(
+  node: PlainObject,
+): { id: string; key: string } | undefined {
+  if (!isObject(node.$extensions)) {
+    return undefined;
+  }
+
+  const { figma } = node.$extensions;
+  if (
+    !isObject(figma) ||
+    typeof figma.id !== 'string' ||
+    typeof figma.key !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return { id: figma.id, key: figma.key };
+}
+
+function collectFigmaTokens(
+  node: unknown,
+  fileName: string,
+  prefix: string[] = [],
+  inheritedType?: unknown,
+): CollectedFigmaTokens {
+  if (!isObject(node)) {
+    return { tokenCount: 0, tokens: [] };
+  }
+
+  const tokenType = node.$type ?? inheritedType;
+
+  if (Object.prototype.hasOwnProperty.call(node, '$value')) {
+    const metadata = readFigmaMetadata(node);
+    if (!metadata) {
+      return { tokenCount: 1, tokens: [] };
+    }
+
+    return {
+      tokenCount: 1,
+      tokens: [
+        {
+          figmaId: metadata.id,
+          figmaKey: metadata.key,
+          fileName,
+          tokenPath: prefix.join('/'),
+          value: tokenFingerprint(node, tokenType),
+        },
+      ],
+    };
+  }
+
+  return Object.entries(node)
+    .filter(([key]) => !key.startsWith('$'))
+    .reduce<CollectedFigmaTokens>(
+      (result, [key, value]) => {
+        const child = collectFigmaTokens(
+          value,
+          fileName,
+          [...prefix, key],
+          tokenType,
+        );
+        return {
+          tokenCount: result.tokenCount + child.tokenCount,
+          tokens: [...result.tokens, ...child.tokens],
+        };
+      },
+      { tokenCount: 0, tokens: [] },
+    );
+}
+
 function displayFileName(fileName?: string): string {
   return fileName ? path.basename(fileName) : 'tokens';
 }
 
-export function summariseTokenReleaseChanges(
+function tokenIdentity(token: FigmaTokenRecord): string {
+  return `${token.fileName}:${token.figmaKey}`;
+}
+
+function mapFigmaTokens(
+  tokens: FigmaTokenRecord[],
+): Map<string, FigmaTokenRecord> {
+  const mapped = new Map<string, FigmaTokenRecord>();
+
+  tokens.forEach((token) => {
+    const identity = tokenIdentity(token);
+    if (mapped.has(identity)) {
+      throw new Error(
+        `Duplicate Figma variable key "${token.figmaKey}" in ${token.fileName}.`,
+      );
+    }
+    mapped.set(identity, token);
+  });
+
+  return mapped;
+}
+
+function buildSummary({
+  addedTokens,
+  changedTokens,
+  classificationMethod,
+  deletedTokens,
+  renamedTokens,
+}: {
+  addedTokens: TokenPathChange[];
+  changedTokens: TokenPathChange[];
+  classificationMethod: TokenReleaseSummary['classificationMethod'];
+  deletedTokens: TokenPathChange[];
+  renamedTokens: TokenRenameChange[];
+}): TokenReleaseSummary {
+  const deletedOrRenamedTokens = [
+    ...deletedTokens,
+    ...renamedTokens.map(({ fileName, previousTokenPath }) => ({
+      fileName,
+      tokenPath: previousTokenPath,
+    })),
+  ];
+
+  return {
+    addedTokens,
+    changedTokens,
+    classificationMethod,
+    deletedTokens,
+    deletedOrRenamedTokens,
+    label:
+      deletedTokens.length > 0 ||
+      renamedTokens.length > 0 ||
+      changedTokens.length > 0
+        ? 'major'
+        : 'minor',
+    renamedTokens,
+  };
+}
+
+function summariseFigmaTokenReleaseChanges(
+  previousTokens: FigmaTokenRecord[],
+  currentTokens: FigmaTokenRecord[],
+): TokenReleaseSummary {
+  const addedTokens: TokenPathChange[] = [];
+  const changedTokens: TokenPathChange[] = [];
+  const deletedTokens: TokenPathChange[] = [];
+  const renamedTokens: TokenRenameChange[] = [];
+  const previousByIdentity = mapFigmaTokens(previousTokens);
+  const currentByIdentity = mapFigmaTokens(currentTokens);
+
+  previousByIdentity.forEach((previousToken, identity) => {
+    const currentToken = currentByIdentity.get(identity);
+    if (!currentToken) {
+      deletedTokens.push({
+        fileName: previousToken.fileName,
+        tokenPath: previousToken.tokenPath,
+      });
+      return;
+    }
+
+    if (previousToken.tokenPath !== currentToken.tokenPath) {
+      renamedTokens.push({
+        currentTokenPath: currentToken.tokenPath,
+        fileName: currentToken.fileName,
+        previousTokenPath: previousToken.tokenPath,
+      });
+    }
+
+    if (previousToken.value !== currentToken.value) {
+      changedTokens.push({
+        fileName: currentToken.fileName,
+        tokenPath: currentToken.tokenPath,
+      });
+    }
+  });
+
+  currentByIdentity.forEach((currentToken, identity) => {
+    if (!previousByIdentity.has(identity)) {
+      addedTokens.push({
+        fileName: currentToken.fileName,
+        tokenPath: currentToken.tokenPath,
+      });
+    }
+  });
+
+  return buildSummary({
+    addedTokens,
+    changedTokens,
+    classificationMethod: 'figma-key',
+    deletedTokens,
+    renamedTokens,
+  });
+}
+
+function summariseTokenPathReleaseChanges(
   files: TokenFileChange[],
 ): TokenReleaseSummary {
   const addedTokens: TokenPathChange[] = [];
   const changedTokens: TokenPathChange[] = [];
-  const deletedOrRenamedTokens: TokenPathChange[] = [];
+  const deletedTokens: TokenPathChange[] = [];
 
   for (const file of files) {
     const previousTokens = collectTokens(file.previous);
@@ -187,7 +399,7 @@ export function summariseTokenReleaseChanges(
       previousTokens.entries(),
     )) {
       if (!currentTokens.has(tokenPath)) {
-        deletedOrRenamedTokens.push({ fileName, tokenPath });
+        deletedTokens.push({ fileName, tokenPath });
       } else if (currentTokens.get(tokenPath) !== previousValue) {
         changedTokens.push({ fileName, tokenPath });
       }
@@ -200,21 +412,95 @@ export function summariseTokenReleaseChanges(
     }
   }
 
-  return {
+  return buildSummary({
     addedTokens,
     changedTokens,
-    deletedOrRenamedTokens,
-    label:
-      deletedOrRenamedTokens.length > 0 || changedTokens.length > 0
-        ? 'major'
-        : 'minor',
-  };
+    classificationMethod: 'token-path',
+    deletedTokens,
+    renamedTokens: [],
+  });
+}
+
+export function summariseTokenReleaseChanges(
+  files: TokenFileChange[],
+): TokenReleaseSummary {
+  const figmaFiles = files.map((file) => {
+    const fileName = displayFileName(file.fileName);
+    return {
+      current: collectFigmaTokens(file.current, fileName),
+      previous: collectFigmaTokens(file.previous, fileName),
+    };
+  });
+
+  const canUseFigmaMetadata =
+    figmaFiles.some(
+      ({ current, previous }) =>
+        current.tokenCount > 0 || previous.tokenCount > 0,
+    ) &&
+    figmaFiles.every(
+      ({ current, previous }) =>
+        current.tokenCount === current.tokens.length &&
+        previous.tokenCount === previous.tokens.length,
+    );
+
+  if (canUseFigmaMetadata) {
+    return summariseFigmaTokenReleaseChanges(
+      figmaFiles.flatMap(({ previous }) => previous.tokens),
+      figmaFiles.flatMap(({ current }) => current.tokens),
+    );
+  }
+
+  return summariseTokenPathReleaseChanges(files);
 }
 
 export function classifyTokenReleaseLabel(
   files: TokenFileChange[],
 ): ReleaseLabel {
   return summariseTokenReleaseChanges(files).label;
+}
+
+export function formatDeletedTokensMarkdown(
+  deletedTokens: TokenPathChange[],
+  limit = 50,
+): string {
+  if (deletedTokens.length === 0) {
+    return '';
+  }
+
+  const visibleTokens = deletedTokens.slice(0, limit);
+  const tokensByFile = new Map<string, string[]>();
+  visibleTokens.forEach(({ fileName, tokenPath }) => {
+    tokensByFile.set(fileName, [
+      ...(tokensByFile.get(fileName) ?? []),
+      tokenPath,
+    ]);
+  });
+
+  const tokenLines = Array.from(tokensByFile.entries()).flatMap(
+    ([fileName, tokenPaths]) => [
+      `### ${fileName}`,
+      '',
+      ...tokenPaths.map((tokenPath) => `- \`${tokenPath}\``),
+      '',
+    ],
+  );
+
+  const lines = [
+    '## Deleted tokens',
+    '',
+    'The following Figma variable keys existed in the previous commit but are missing from the fetched tokens. Treat them as breaking changes and verify usages have been migrated.',
+    '',
+    ...tokenLines.slice(0, -1),
+  ];
+
+  if (deletedTokens.length > visibleTokens.length) {
+    lines.push(
+      '',
+      `And ${deletedTokens.length - visibleTokens.length} more deleted token path(s).`,
+    );
+  }
+
+  return lines.join('\n');
 }
 
 export function formatDeletedOrRenamedTokensMarkdown(
@@ -261,6 +547,50 @@ export function formatDeletedOrRenamedTokensMarkdown(
   return lines.join('\n');
 }
 
+export function formatRenamedTokensMarkdown(
+  renamedTokens: TokenRenameChange[],
+  limit = 50,
+): string {
+  if (renamedTokens.length === 0) {
+    return '';
+  }
+
+  const visibleTokens = renamedTokens.slice(0, limit);
+  const tokensByFile = new Map<string, string[]>();
+  visibleTokens.forEach(({ currentTokenPath, fileName, previousTokenPath }) => {
+    tokensByFile.set(fileName, [
+      ...(tokensByFile.get(fileName) ?? []),
+      `\`${previousTokenPath}\` -> \`${currentTokenPath}\``,
+    ]);
+  });
+
+  const tokenLines = Array.from(tokensByFile.entries()).flatMap(
+    ([fileName, tokenPaths]) => [
+      `### ${fileName}`,
+      '',
+      ...tokenPaths.map((tokenPath) => `- ${tokenPath}`),
+      '',
+    ],
+  );
+
+  const lines = [
+    '## Renamed tokens',
+    '',
+    'The following token paths changed while the Figma variable key stayed the same. Treat them as breaking changes and verify usages have been migrated.',
+    '',
+    ...tokenLines.slice(0, -1),
+  ];
+
+  if (renamedTokens.length > visibleTokens.length) {
+    lines.push(
+      '',
+      `And ${renamedTokens.length - visibleTokens.length} more renamed token path(s).`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
 export function formatChangedTokenValuesMarkdown(
   changedTokens: TokenPathChange[],
   limit = 50,
@@ -290,7 +620,7 @@ export function formatChangedTokenValuesMarkdown(
   const lines = [
     '## Changed token values',
     '',
-    'The following token values changed while the path stayed the same. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
+    'The following token values changed for an existing token. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
     '',
     ...tokenLines.slice(0, -1),
   ];
@@ -299,6 +629,50 @@ export function formatChangedTokenValuesMarkdown(
     lines.push(
       '',
       `And ${changedTokens.length - visibleTokens.length} more changed token path(s).`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+export function formatAddedTokensMarkdown(
+  addedTokens: TokenPathChange[],
+  limit = 50,
+): string {
+  if (addedTokens.length === 0) {
+    return '';
+  }
+
+  const visibleTokens = addedTokens.slice(0, limit);
+  const tokensByFile = new Map<string, string[]>();
+  visibleTokens.forEach(({ fileName, tokenPath }) => {
+    tokensByFile.set(fileName, [
+      ...(tokensByFile.get(fileName) ?? []),
+      tokenPath,
+    ]);
+  });
+
+  const tokenLines = Array.from(tokensByFile.entries()).flatMap(
+    ([fileName, tokenPaths]) => [
+      `### ${fileName}`,
+      '',
+      ...tokenPaths.map((tokenPath) => `- \`${tokenPath}\``),
+      '',
+    ],
+  );
+
+  const lines = [
+    '## Added tokens',
+    '',
+    'The following token paths are new in this sync. When Figma key metadata is available, these are variables whose keys were not present in the previous generated tokens.',
+    '',
+    ...tokenLines.slice(0, -1),
+  ];
+
+  if (addedTokens.length > visibleTokens.length) {
+    lines.push(
+      '',
+      `And ${addedTokens.length - visibleTokens.length} more added token path(s).`,
     );
   }
 

--- a/token-sync/src/classify-release-label.ts
+++ b/token-sync/src/classify-release-label.ts
@@ -355,6 +355,7 @@ function summariseFigmaTokenReleaseChanges(
         fileName: currentToken.fileName,
         previousTokenPath: previousToken.tokenPath,
       });
+      return;
     }
 
     if (previousToken.value !== currentToken.value) {
@@ -620,7 +621,7 @@ export function formatChangedTokenValuesMarkdown(
   const lines = [
     '## Changed token values',
     '',
-    'The following token values changed for an existing token. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
+    'The following token values changed while the token path stayed the same. Treat them as potentially breaking — visuals or behaviour driven by these tokens may shift.',
     '',
     ...tokenLines.slice(0, -1),
   ];

--- a/token-sync/src/dtcg-transformer-test.ts
+++ b/token-sync/src/dtcg-transformer-test.ts
@@ -65,7 +65,6 @@ function figmaExtensions(variable: LocalVariable) {
     figma: {
       id: variable.id,
       key: variable.key,
-      name: variable.name,
     },
   };
 }

--- a/token-sync/src/dtcg-transformer-test.ts
+++ b/token-sync/src/dtcg-transformer-test.ts
@@ -60,6 +60,16 @@ import {
 import type { LocalVariable } from './figma-api';
 import type { DTCGTree, ResolveContext } from './types';
 
+function figmaExtensions(variable: LocalVariable) {
+  return {
+    figma: {
+      id: variable.id,
+      key: variable.key,
+      name: variable.name,
+    },
+  };
+}
+
 function makeContext(
   options: {
     includeCycle?: boolean;
@@ -245,10 +255,14 @@ describe('resolveAliasTarget', () => {
 describe('resolveVariableValue', () => {
   it('returns the correct literal value for non-alias variables', () => {
     const context = makeContext();
-    expect(resolveVariableValue(primitiveColourPink, PRIMITIVES_MODE_HEX, context)).toEqual({
+    expect(
+      resolveVariableValue(primitiveColourPink, PRIMITIVES_MODE_HEX, context),
+    ).toEqual({
       value: '#ff66b3',
     });
-    expect(resolveVariableValue(primitiveSpacingMd, PRIMITIVES_MODE_HEX, context)).toEqual({
+    expect(
+      resolveVariableValue(primitiveSpacingMd, PRIMITIVES_MODE_HEX, context),
+    ).toEqual({
       value: '8px',
     });
   });
@@ -257,14 +271,15 @@ describe('resolveVariableValue', () => {
     const context = makeContext({
       preservedKeys: new Set([KEY_COLOUR_PINK, KEY_COLOUR_BERRY]),
     });
-    expect(resolveVariableValue(semanticCanvasDefault, BACKPACK_MODE_LIGHT, context)).toEqual(
-      {
-        value: '{Colour.Pink}',
-        preservedAliasTo: 'Colour.Pink',
-      },
-    );
     expect(
-      resolveVariableValue(semanticCanvasDefault, BACKPACK_MODE_DARK, context).value,
+      resolveVariableValue(semanticCanvasDefault, BACKPACK_MODE_LIGHT, context),
+    ).toEqual({
+      value: '{Colour.Pink}',
+      preservedAliasTo: 'Colour.Pink',
+    });
+    expect(
+      resolveVariableValue(semanticCanvasDefault, BACKPACK_MODE_DARK, context)
+        .value,
     ).toBe('{Colour.Berry}');
   });
 
@@ -273,7 +288,11 @@ describe('resolveVariableValue', () => {
     // Canvas/Contrast -> Canvas/Default -> primitive Colour/Pink (preserved).
     // Since the intermediate target is NOT preserved, we walk through it;
     // the terminal target IS preserved, so we end on a {Colour.Pink} ref.
-    const result = resolveVariableValue(semanticCanvasContrast, BACKPACK_MODE_LIGHT, context);
+    const result = resolveVariableValue(
+      semanticCanvasContrast,
+      BACKPACK_MODE_LIGHT,
+      context,
+    );
     expect(result.value).toBe('{Colour.Pink}');
     expect(result.inlinedFrom).toBe('Canvas.Default');
   });
@@ -287,22 +306,22 @@ describe('resolveVariableValue', () => {
       preservedReferenceKeys: new Set(),
     };
     const broken = response.meta.variables['variable-semantic-broken'];
-    expect(() => resolveVariableValue(broken, BACKPACK_MODE_LIGHT, context)).toThrow(
-      DTCGTransformError,
-    );
-    expect(() => resolveVariableValue(broken, BACKPACK_MODE_LIGHT, context)).toThrow(
-      /Could not resolve alias target/,
-    );
+    expect(() =>
+      resolveVariableValue(broken, BACKPACK_MODE_LIGHT, context),
+    ).toThrow(DTCGTransformError);
+    expect(() =>
+      resolveVariableValue(broken, BACKPACK_MODE_LIGHT, context),
+    ).toThrow(/Could not resolve alias target/);
   });
 
   it('throws an alias-cycle DTCGTransformError when variables alias each other', () => {
     const context = makeContext({ includeCycle: true });
-    expect(() => resolveVariableValue(semanticCycleA, BACKPACK_MODE_LIGHT, context)).toThrow(
-      DTCGTransformError,
-    );
-    expect(() => resolveVariableValue(semanticCycleA, BACKPACK_MODE_LIGHT, context)).toThrow(
-      /Alias cycle detected/,
-    );
+    expect(() =>
+      resolveVariableValue(semanticCycleA, BACKPACK_MODE_LIGHT, context),
+    ).toThrow(DTCGTransformError);
+    expect(() =>
+      resolveVariableValue(semanticCycleA, BACKPACK_MODE_LIGHT, context),
+    ).toThrow(/Alias cycle detected/);
   });
 
   it('throws when the collection is missing', () => {
@@ -322,12 +341,12 @@ describe('resolveVariableValue', () => {
       ...primitiveColourPink,
       valuesByMode: {},
     } as LocalVariable;
-    expect(() => resolveVariableValue(emptyModes, PRIMITIVES_MODE_HEX, context)).toThrow(
-      DTCGTransformError,
-    );
-    expect(() => resolveVariableValue(emptyModes, PRIMITIVES_MODE_HEX, context)).toThrow(
-      /has no value for mode/,
-    );
+    expect(() =>
+      resolveVariableValue(emptyModes, PRIMITIVES_MODE_HEX, context),
+    ).toThrow(DTCGTransformError);
+    expect(() =>
+      resolveVariableValue(emptyModes, PRIMITIVES_MODE_HEX, context),
+    ).toThrow(/has no value for mode/);
   });
 });
 
@@ -472,8 +491,14 @@ describe('buildDTCGTreeForMode', () => {
     expect(output.tree).toEqual({
       Colour: {
         $type: 'color',
-        Berry: { $value: 'rgba(0, 0, 0, 0.5)' },
-        Pink: { $value: '#ff66b3' },
+        Berry: {
+          $value: 'rgba(0, 0, 0, 0.5)',
+          $extensions: figmaExtensions(primitiveColourBerry),
+        },
+        Pink: {
+          $value: '#ff66b3',
+          $extensions: figmaExtensions(primitiveColourPink),
+        },
       },
     });
     expect(output.stats).toEqual({
@@ -532,7 +557,10 @@ describe('buildDTCGTreeForMode', () => {
     expect(lightOutput.tree).toEqual({
       Canvas: {
         $type: 'color',
-        Default: { $value: '{Colour.Pink}' },
+        Default: {
+          $value: '{Colour.Pink}',
+          $extensions: figmaExtensions(semanticCanvasDefault),
+        },
       },
     });
     expect(lightOutput.stats.preservedAliasCount).toBe(1);
@@ -547,7 +575,10 @@ describe('buildDTCGTreeForMode', () => {
     expect(darkOutput.tree).toEqual({
       Canvas: {
         $type: 'color',
-        Default: { $value: '{Colour.Berry}' },
+        Default: {
+          $value: '{Colour.Berry}',
+          $extensions: figmaExtensions(semanticCanvasDefault),
+        },
       },
     });
   });
@@ -566,7 +597,10 @@ describe('buildDTCGTreeForMode', () => {
     expect(output.tree).toEqual({
       Surface: {
         $type: 'color',
-        Default: { $value: '{Colour.Pink}' },
+        Default: {
+          $value: '{Colour.Pink}',
+          $extensions: figmaExtensions(semanticSurface),
+        },
       },
     });
   });
@@ -684,7 +718,9 @@ describe('buildDTCGTreeForMode', () => {
       id: 'variable-collide-child',
       key: 'key-collide-child',
       name: 'Colour/Brand/Pink',
-      valuesByMode: { [PRIMITIVES_MODE_HEX_ID]: { r: 1, g: 0.4, b: 0.7, a: 1 } },
+      valuesByMode: {
+        [PRIMITIVES_MODE_HEX_ID]: { r: 1, g: 0.4, b: 0.7, a: 1 },
+      },
     } as unknown as LocalVariable;
     // Parent writes first (sorted: "Colour/Brand" < "Colour/Brand/Pink"); child collides.
     const { skipped, skippedCount, throwingCall } = setupSkipOrThrow(

--- a/token-sync/src/dtcg-transformer.ts
+++ b/token-sync/src/dtcg-transformer.ts
@@ -665,7 +665,6 @@ export function buildDTCGTreeForMode(
           figma: {
             id: variable.id,
             key: variable.key,
-            name: variable.name,
           },
         },
       });

--- a/token-sync/src/dtcg-transformer.ts
+++ b/token-sync/src/dtcg-transformer.ts
@@ -295,7 +295,8 @@ export function resolveVariableValue(
   context: ResolveContext,
   seen: ReadonlySet<string> = new Set<string>(),
 ): ResolveValueResult {
-  const collection = context.localCollectionsById[variable.variableCollectionId];
+  const collection =
+    context.localCollectionsById[variable.variableCollectionId];
   if (!collection) {
     throw new Error(
       `Missing local collection "${variable.variableCollectionId}" for variable "${variable.name}"`,
@@ -342,7 +343,12 @@ export function resolveVariableValue(
   const nextSeen = new Set(seen);
   nextSeen.add(seenKey);
 
-  const resolved = resolveVariableValue(target, sourceModeName, context, nextSeen);
+  const resolved = resolveVariableValue(
+    target,
+    sourceModeName,
+    context,
+    nextSeen,
+  );
   return {
     value: resolved.value,
     // Report the immediate target path so stats reflect which var we inlined
@@ -497,7 +503,10 @@ export function setTokenAtPath(
 
 // Walk the variable list and assign a group-level $type when every descendant
 // of that group shares a single DTCG type. Reduces verbosity in output files.
-export function addGroupTypes(tree: DTCGTree, variables: LocalVariable[]): void {
+export function addGroupTypes(
+  tree: DTCGTree,
+  variables: LocalVariable[],
+): void {
   const groupTypes = new Map<string, Set<DTCGTokenType>>();
 
   for (const variable of variables) {
@@ -548,7 +557,9 @@ export function stripRedundantTypes(
 
   const record = node as Record<string, unknown>;
   const ownType =
-    typeof record.$type === 'string' ? (record.$type as DTCGTokenType) : undefined;
+    typeof record.$type === 'string'
+      ? (record.$type as DTCGTokenType)
+      : undefined;
   const isLeaf = '$value' in record;
 
   if (ownType && inheritedType && ownType === inheritedType) {
@@ -600,17 +611,26 @@ export function buildDTCGTreeForMode(
     const invalidNameReason = describeInvalidVariableName(variable.name);
     if (invalidNameReason) {
       if (options.skipUnresolvedAliases) {
-        skippedVariables.push({ ...baseRecord, reason: SKIPPED_VARIABLE_REASONS.invalidName, invalidNameReason });
+        skippedVariables.push({
+          ...baseRecord,
+          reason: SKIPPED_VARIABLE_REASONS.invalidName,
+          invalidNameReason,
+        });
         return;
       }
-      throw new Error(`Invalid variable name "${variable.name}": ${invalidNameReason}`);
+      throw new Error(
+        `Invalid variable name "${variable.name}": ${invalidNameReason}`,
+      );
     }
 
     let resolved: ResolveValueResult;
     try {
       resolved = resolveVariableValue(variable, modeName, context);
     } catch (error: unknown) {
-      if (options.skipUnresolvedAliases && error instanceof DTCGTransformError) {
+      if (
+        options.skipUnresolvedAliases &&
+        error instanceof DTCGTransformError
+      ) {
         if (error.reason === TRANSFORM_ERROR_REASONS.unresolvedAlias) {
           skippedVariables.push({
             ...baseRecord,
@@ -618,10 +638,16 @@ export function buildDTCGTreeForMode(
             unresolvedAliasId: error.aliasId,
             // When the chain broke at a different variable (X → M → missing),
             // remember M so the diagnostic can point at it.
-            ...(error.variableName !== variable.name ? { unresolvedAt: error.variableName } : {}),
+            ...(error.variableName !== variable.name
+              ? { unresolvedAt: error.variableName }
+              : {}),
           });
         } else if (error.reason === TRANSFORM_ERROR_REASONS.missingModeValue) {
-          skippedVariables.push({ ...baseRecord, reason: SKIPPED_VARIABLE_REASONS.missingModeValue, missingModeName: error.modeName });
+          skippedVariables.push({
+            ...baseRecord,
+            reason: SKIPPED_VARIABLE_REASONS.missingModeValue,
+            missingModeName: error.modeName,
+          });
         } else {
           throw error;
         }
@@ -635,6 +661,13 @@ export function buildDTCGTreeForMode(
       setTokenAtPath(tree, variable.name, {
         $value: resolved.value,
         $type: tokenType,
+        $extensions: {
+          figma: {
+            id: variable.id,
+            key: variable.key,
+            name: variable.name,
+          },
+        },
       });
     } catch (error: unknown) {
       if (
@@ -642,7 +675,11 @@ export function buildDTCGTreeForMode(
         error instanceof DTCGTransformError &&
         error.reason === TRANSFORM_ERROR_REASONS.pathCollision
       ) {
-        skippedVariables.push({ ...baseRecord, reason: SKIPPED_VARIABLE_REASONS.pathCollision, collidingVariableName: error.collidingVariableName });
+        skippedVariables.push({
+          ...baseRecord,
+          reason: SKIPPED_VARIABLE_REASONS.pathCollision,
+          collidingVariableName: error.collidingVariableName,
+        });
         return;
       }
       throw error;

--- a/token-sync/src/types.ts
+++ b/token-sync/src/types.ts
@@ -38,7 +38,6 @@ export type DTCGScalar = boolean | number | string;
 export interface DTCGFigmaMetadata {
   id: string;
   key: string;
-  name: string;
 }
 
 export interface DTCGTokenExtensions {

--- a/token-sync/src/types.ts
+++ b/token-sync/src/types.ts
@@ -16,10 +16,7 @@
  * limitations under the License.
  */
 
-import type {
-  LocalVariable,
-  LocalVariableCollection,
-} from './figma-api';
+import type { LocalVariable, LocalVariableCollection } from './figma-api';
 
 // DTCG token types we emit. Narrower than the full DTCG spec — only the types
 // Backpack's Figma variables actually produce today. `'number'` is used for
@@ -38,9 +35,20 @@ export type DTCGTokenType =
 // types (e.g. typography) but Backpack variables only emit primitives.
 export type DTCGScalar = boolean | number | string;
 
+export interface DTCGFigmaMetadata {
+  id: string;
+  key: string;
+  name: string;
+}
+
+export interface DTCGTokenExtensions {
+  figma?: DTCGFigmaMetadata;
+}
+
 export interface DTCGToken {
   $value: DTCGScalar;
   $type?: DTCGTokenType;
+  $extensions?: DTCGTokenExtensions;
 }
 
 // Recursive DTCG group: a node is either a token (has $value) or another group


### PR DESCRIPTION
## Summary

This PR upgrades the Figma token sync release-label classifier from a **token-path-based diff** to a **Figma-key-based diff**, so renames in Figma show up as renames (one event) rather than as a delete + add (two events). It also splits the auto-generated PR summary into separate sections for renamed, changed, deleted, and added tokens so reviewers can scan the impact at a glance.

## Why

Today the classifier compares two snapshots of `token-sync/tokens/*.json` by token path (the `/`-joined position in the JSON tree).

That's fine for value changes, but it has two real problems:

1. **Renames look like delete + add.** If a designer renames a Figma variable from `core/primary` to `core/brand-primary`, the classifier sees the old path disappear and a new path appear. The release is correctly labelled `major` — but the PR body says "deleted/renamed: `core/primary`" and "added: `core/brand-primary`" with no link between the two. Reviewers have to manually figure out it's the same token.
2. **Group-level renames look like mass deletes.** Renaming a Figma group (e.g. `semantic` → `semantic-color`) currently shows up as N deletes + N adds, which buries any actually deleted token in the noise.

The fix is to track the Figma-side identity of each variable (`id` + `key`, both stable across renames) inside the emitted DTCG token, and key the diff off that identity instead of the path.

## Changes

### 1. Emit Figma metadata into the DTCG output

[`token-sync/src/dtcg-transformer.ts`](token-sync/src/dtcg-transformer.ts) and [`types.ts`](token-sync/src/types.ts) now write a `$extensions.figma` block on every emitted leaf:

```jsonc
{
  "$value": "#0770e3",
  "$type": "color",
  "$extensions": {
    "figma": {
      "id": "VariableID:1234:5678",
      "key": "abc123def456..."
    }
  }
}
```

`key` is the persistent published key Figma assigns to a variable; it does not change when the variable is renamed or moved between groups. `id` is included for traceability back to the Figma file.

### 2. Classify by Figma key, fall back to token path

[`classify-release-label.ts`](token-sync/src/classify-release-label.ts) now has two diff paths:

- **`figma-key` mode** — used when every leaf in both snapshots carries `$extensions.figma`. Builds an identity map keyed by `${fileName}:${figmaKey}` and produces:
  - `renamedTokens` — same key, different `tokenPath`
  - `changedTokens` — same key, same path, different value fingerprint
  - `deletedTokens` — key in previous, missing in current
  - `addedTokens` — key in current, missing in previous
  - Each token lands in **exactly one** bucket — no double-counting.
- **`token-path` mode** (fallback) — preserves the existing path-based behaviour for older generated JSON that hasn't been re-fetched yet.

The chosen mode is exposed as `summary.classificationMethod` so callers/tests can assert on it.

The `major` vs `minor` rule is unchanged in spirit: any rename, value change, or deletion → `major`; pure additions → `minor`.

### 3. Value fingerprint ignores `$extensions`

[`tokenFingerprint`](token-sync/src/classify-release-label.ts) strips `$extensions` before serialising the leaf for comparison. This means a metadata-only churn (e.g. Figma reassigns an internal `id` but the variable's value is unchanged) is **not** flagged as a value change.

### 4. Separate PR body sections

Previously the auto-generated PR body had a single "Deleted or renamed tokens" section. It now renders four distinct sections in this order:

1. Renamed tokens — with `before → after` paths
2. Changed token values
3. Deleted tokens
4. Added tokens

Each token appears in only one section. Empty sections are omitted.

### 5. Workflow + docs

- [`sync-figma-variables.yml`](.github/workflows/sync-figma-variables.yml): updated the in-PR-body release-label rules text to refer to "Figma variable keys" instead of "token paths". Also switches `actions/checkout` to use `${{ github.ref }}` so the workflow can be tested from a feature branch via `workflow_dispatch`.
- [`token-sync/README.md`](token-sync/README.md) and [`RUNBOOK.md`](token-sync/RUNBOOK.md): describe the key-based classification and the new PR body sections.

## Backwards compatibility

- Old generated tokens without `$extensions.figma` continue to work — the classifier falls back to path-based diffing for that file set. The first run after this PR merges will write the metadata, and from then on key-based diffing applies.
- `summary.deletedOrRenamedTokens` is retained as a derived field (concat of `deletedTokens` + previous paths from `renamedTokens`) for any existing consumers.

## Out of scope

- The classifier still flags `$description`-only changes as `changed`. That can be tightened later if it proves noisy in practice.
- No change to the `major`/`minor` boundary itself — only to how each bucket is computed and presented.