### PR TITLE
[NO-JIRA][ci] Ignore Nx warnings in Danger test log check

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -250,6 +250,7 @@ const invalidProps = ["for a non-boolean attribute", "Invalid ARIA attribute"]
 const actTests = ["inside a test was not wrapped in act(...)"]
 // TODO: Convert components that use CSSTransition to functional components and allow for using refs
 const findDOMNode = ["findDOMNode is deprecated and will be removed in the next major release."];
+const nxWarnings = ["nx.dev/"];
 
 const allIgnoredWarnings = linterWarnings
   .concat(invalidReactChild)
@@ -264,7 +265,8 @@ const allIgnoredWarnings = linterWarnings
   .concat(invalidCSSProperties)
   .concat(invalidProps)
   .concat(actTests)
-  .concat(findDOMNode);
+  .concat(findDOMNode)
+  .concat(nxWarnings);
 
 commonFileWarnings('logs/test.log', {
   logType: 'fail',


### PR DESCRIPTION
## Summary
Ignore Nx infrastructure messages in Danger's test log check to unblock all PRs.

## Root cause
Since Nx was adopted as the task runner (#4499), its informational messages (cache notices, update prompts, etc.) appear in test stdout. The CI command:

```yaml
npx nx affected -t test --parallel=3 |& tee 'logs/test.log'
```

pipes **all** output (Nx runtime messages + Jest test output) into `logs/test.log`. Danger's `commonFileWarnings` assumes this file contains only test output and flags any unrecognized line as a failure — blocking all PRs that run `nx affected -t test`.

## Fix
Add `nx.dev/` to Danger's ignored warnings regex. All Nx warnings reference `nx.dev/` doc URLs, so this single pattern covers the current `unknown-local-cache` warning and any future Nx informational messages.

## Follow-up
Ideally, `logs/test.log` should only contain actual test output, not Nx infrastructure messages. Possible long-term approaches:
- Explore Nx `--output-style` options to separate task output from runtime messages
- Split into two steps: use `nx show projects --affected` to get affected list, then run Jest directly
- Investigate if an env var or Nx config can suppress informational messages from stdout

For now, the Danger ignore is the pragmatic fix since Nx doesn't provide a clean way to separate its own messages from task output in the same stream.

## Test plan
- [ ] This PR's Danger check passes (self-validates)
- [ ] After merge, re-run CI on #4496 and #4539 to confirm unblock
