### PR TITLE
[NO-JIRA] Switch Figma sync workflow to daily 18:00 GMT cadence

### DIFF
--- a/.github/workflows/sync-figma-variables.yml
+++ b/.github/workflows/sync-figma-variables.yml
@@ -2,8 +2,8 @@ name: Sync Figma variables
 
 on:
   schedule:
-    # Temporarily poll every 30 minutes for validation; the production cadence will be daily at 18:00 GMT.
-    - cron: '*/30 * * * *'
+    # Daily at 18:00 GMT.
+    - cron: '0 18 * * *'
   workflow_dispatch:
     inputs:
       file_key:


### PR DESCRIPTION
## Summary
- Validation phase complete — workflow has been polling every 30 minutes successfully (creates new sync PR + closes prior one cleanly).
- Switch cron from `*/30 * * * *` to `0 18 * * *` (daily at 18:00 GMT) to match the originally documented production cadence.
- Drop the temporary "validation" comment.

## Test plan
- [ ] CI passes
- [ ] After merge, confirm next scheduled run fires at 18:00 GMT (not on the next 30-min boundary)