### PR TITLE
[NO-JIRA][ci] Forward PERCY_TOKEN to reusable build workflow

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -5,6 +5,8 @@ on:
     secrets:
       GH_APP_PRIVATE_KEY:
         required: true
+      PERCY_TOKEN:
+        required: false
 
 defaults:
   run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
   StorybookDeploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,6 +89,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
 
   StorybookDeploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
   ReleaseWeb:
     name: Release @skyscanner/backpack-web to NPM


### PR DESCRIPTION
## Summary

`_build.yml` is a reusable workflow (`workflow_call`). Reusable workflows do **not** automatically inherit secrets from their caller — secrets must be declared under `workflow_call.secrets` *and* explicitly forwarded by every caller. `PERCY_TOKEN` was neither declared nor forwarded, so `${{ secrets.PERCY_TOKEN }}` inside `_build.yml` always evaluated to an empty string, regardless of how the repository secret was configured. Percy CLI then printed `Missing Percy token` / `Build not created` and exited 0 — silent failure.

This was confirmed by inspecting the rendered job env in CI: `PERCY_TOKEN:` was empty, while `NODE_AUTH_TOKEN` (set by `actions/setup-node`, not via reusable-workflow secret plumbing) carried its masked value.

## Why did this break?

`git log -S "secrets: inherit"` traces the regression to **#4124 (`COPP-8605: Deploy zizmor to open source repos`, merged 2026-01-19)**. Before that PR, the callers used `secrets: inherit`, which forwards every caller-side secret automatically — including `PERCY_TOKEN`.

`zizmor` is a GitHub Actions security linter, and its `secrets-inherit` rule (correctly) flags `secrets: inherit` as a security smell: it leaks more secrets than the called workflow actually needs, widening the blast radius if the called workflow is ever compromised.

The PR's commit message shows the author working through these warnings:
> * Address warnings[excessive-permissions,secrets-inherit]
> * Attempt to fix secrets passing for shared workflow
> * Attempt to pass envvar via string interpolation

When converting from `secrets: inherit` to explicit forwarding, `GH_APP_PRIVATE_KEY` was listed but `PERCY_TOKEN` was missed. From that day on, every PR/main build silently no-op'd visual regression — and because `@percy/cli` exits 0 on missing-token, the `PercyTests` step kept showing green, so nobody noticed for ~4 months. The companion PR #4541 (turn Percy silent failures into hard CI errors) is what finally made this visible.

## Changes

- `_build.yml`: declare `PERCY_TOKEN` under `workflow_call.secrets` (`required: false` so fork PRs without secret access don't fail the schema check).
- `pr.yml`, `main.yml`, `release.yml`: forward `PERCY_TOKEN: \${{ secrets.PERCY_TOKEN }}` alongside the existing `GH_APP_PRIVATE_KEY`.

## Verification

This branch's CI run confirms the fix end-to-end. The current commit produces:

\`\`\`
[percy] Finalized build #3766: https://percy.io/09e69e44/web/backpack/builds/50085364
\`\`\`

A new \`percy/backpack\` status check (Percy → GitHub) also appears, which is impossible to receive without a valid token. The two prior commits on this branch (token-only attempts, before this fix) produced \`[percy] Error: Missing Percy token\` even though \`PERCY_TOKEN\` was correctly configured at the repo level — proving the issue was secret plumbing in the workflow, not the secret value.

## Related

- #4541 — Surface Percy silent failures as CI errors. That PR is the safety net that prevents this class of bug from going unnoticed again; this PR (#4632) fixes the underlying root cause. Recommend merging this one first so #4541 doesn't immediately turn every build red.

## Test plan

- [x] Token-only attempt (no workflow change) still fails with \`Missing Percy token\` — confirms secret plumbing is the root cause
- [x] After secret forwarding fix, Percy authenticates and finalizes build #3766
- [x] \`percy/backpack\` status check arrives from Percy's side (only possible with valid token)
- [ ] After merge, next \`main\` build creates a Percy build visible in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)