### PR TITLE
[CLOV-1606][BpkModalV3] Fix infinite focus redirect loop when BpkModalV3 and BpkDrawer coexist

### DIFF
--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
@@ -136,6 +136,7 @@ describe('BpkModalV3', () => {
     });
 
     it('should call focusScope.resumeFocus when modal transitions from open to closed', () => {
+      jest.useFakeTimers();
       const { rerender } = render(
         <BpkModalV3.Root open onOpenChange={jest.fn()}>
           <BpkModalV3.Content>
@@ -152,7 +153,12 @@ describe('BpkModalV3', () => {
           </BpkModalV3.Content>
         </BpkModalV3.Root>,
       );
+      // Lock stays active during the exit animation — not released yet.
+      expect(focusScope.resumeFocus).not.toHaveBeenCalled();
+
+      act(() => { jest.runAllTimers(); });
       expect(focusScope.resumeFocus).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
     });
 
     it('should not call focusScope.resumeFocus when the modal is initially open', () => {
@@ -171,6 +177,7 @@ describe('BpkModalV3', () => {
     });
 
     it('should call portalLock.unlock when modal transitions from open to closed', () => {
+      jest.useFakeTimers();
       const { rerender } = render(
         <BpkModalV3.Root open onOpenChange={jest.fn()}>
           <BpkModalV3.Content>
@@ -187,7 +194,12 @@ describe('BpkModalV3', () => {
           </BpkModalV3.Content>
         </BpkModalV3.Root>,
       );
+      // Lock stays active during the exit animation — not released yet.
+      expect(portalLock.unlock).not.toHaveBeenCalled();
+
+      act(() => { jest.runAllTimers(); });
       expect(portalLock.unlock).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
     });
 
     it('should call portalLock.unlock on unmount while open', () => {

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
@@ -27,8 +27,10 @@ import BpkModalV3 from './BpkModalV3';
 jest.mock('../../../bpk-scrim-utils/src/focusScope', () => ({
   __esModule: true,
   default: {
-    unscopeFocus: jest.fn(),
     scopeFocus: jest.fn(),
+    unscopeFocus: jest.fn(),
+    pauseFocus: jest.fn(),
+    resumeFocus: jest.fn(),
   },
 }));
 
@@ -86,20 +88,22 @@ describe('BpkModalV3', () => {
 
   describe('Root', () => {
     beforeEach(() => {
-      (focusScope.unscopeFocus as jest.Mock).mockClear();
+      (focusScope.pauseFocus as jest.Mock).mockClear();
+      (focusScope.resumeFocus as jest.Mock).mockClear();
+      (focusScope.scopeFocus as jest.Mock).mockClear();
     });
 
-    it('should call focusScope.unscopeFocus when the modal opens', () => {
+    it('should call focusScope.pauseFocus when the modal opens', () => {
       renderModal({ open: true });
-      expect(focusScope.unscopeFocus).toHaveBeenCalledTimes(1);
+      expect(focusScope.pauseFocus).toHaveBeenCalledTimes(1);
     });
 
-    it('should not call focusScope.unscopeFocus when the modal is closed', () => {
+    it('should not call focusScope.pauseFocus when the modal is closed', () => {
       renderModal({ open: false });
-      expect(focusScope.unscopeFocus).not.toHaveBeenCalled();
+      expect(focusScope.pauseFocus).not.toHaveBeenCalled();
     });
 
-    it('should call focusScope.unscopeFocus when modal transitions from closed to open', () => {
+    it('should call focusScope.pauseFocus when modal transitions from closed to open', () => {
       const { rerender } = render(
         <BpkModalV3.Root open={false} onOpenChange={jest.fn()}>
           <BpkModalV3.Content>
@@ -107,7 +111,7 @@ describe('BpkModalV3', () => {
           </BpkModalV3.Content>
         </BpkModalV3.Root>,
       );
-      expect(focusScope.unscopeFocus).not.toHaveBeenCalled();
+      expect(focusScope.pauseFocus).not.toHaveBeenCalled();
 
       rerender(
         <BpkModalV3.Root open onOpenChange={jest.fn()}>
@@ -116,7 +120,32 @@ describe('BpkModalV3', () => {
           </BpkModalV3.Content>
         </BpkModalV3.Root>,
       );
-      expect(focusScope.unscopeFocus).toHaveBeenCalledTimes(1);
+      expect(focusScope.pauseFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call focusScope.resumeFocus when modal transitions from open to closed', () => {
+      const { rerender } = render(
+        <BpkModalV3.Root open onOpenChange={jest.fn()}>
+          <BpkModalV3.Content>
+            <BpkModalV3.Title>Test</BpkModalV3.Title>
+          </BpkModalV3.Content>
+        </BpkModalV3.Root>,
+      );
+      expect(focusScope.resumeFocus).not.toHaveBeenCalled();
+
+      rerender(
+        <BpkModalV3.Root open={false} onOpenChange={jest.fn()}>
+          <BpkModalV3.Content>
+            <BpkModalV3.Title>Test</BpkModalV3.Title>
+          </BpkModalV3.Content>
+        </BpkModalV3.Root>,
+      );
+      expect(focusScope.resumeFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call focusScope.resumeFocus when the modal is initially open', () => {
+      renderModal({ open: true });
+      expect(focusScope.resumeFocus).not.toHaveBeenCalled();
     });
 
     it('should render wrapper div with default type', () => {

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
@@ -20,13 +20,13 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
-import focusScope from '../../../bpk-scrim-utils/src/focusScope';
+import { focusScope } from '../../../bpk-scrim-utils';
 
 import BpkModalV3 from './BpkModalV3';
 
-jest.mock('../../../bpk-scrim-utils/src/focusScope', () => ({
+jest.mock('../../../bpk-scrim-utils', () => ({
   __esModule: true,
-  default: {
+  focusScope: {
     scopeFocus: jest.fn(),
     unscopeFocus: jest.fn(),
     pauseFocus: jest.fn(),

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
@@ -20,9 +20,19 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
+import { portalLock } from '../../../bpk-react-utils';
 import { focusScope } from '../../../bpk-scrim-utils';
 
 import BpkModalV3 from './BpkModalV3';
+
+jest.mock('../../../bpk-react-utils', () => ({
+  ...jest.requireActual('../../../bpk-react-utils'),
+  portalLock: {
+    lock: jest.fn(),
+    unlock: jest.fn(),
+    isLocked: jest.fn(() => false),
+  },
+}));
 
 jest.mock('../../../bpk-scrim-utils', () => ({
   __esModule: true,
@@ -91,6 +101,8 @@ describe('BpkModalV3', () => {
       (focusScope.pauseFocus as jest.Mock).mockClear();
       (focusScope.resumeFocus as jest.Mock).mockClear();
       (focusScope.scopeFocus as jest.Mock).mockClear();
+      (portalLock.lock as jest.Mock).mockClear();
+      (portalLock.unlock as jest.Mock).mockClear();
     });
 
     it('should call focusScope.pauseFocus when the modal opens', () => {
@@ -146,6 +158,43 @@ describe('BpkModalV3', () => {
     it('should not call focusScope.resumeFocus when the modal is initially open', () => {
       renderModal({ open: true });
       expect(focusScope.resumeFocus).not.toHaveBeenCalled();
+    });
+
+    it('should call portalLock.lock when the modal opens', () => {
+      renderModal({ open: true });
+      expect(portalLock.lock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call portalLock.lock when the modal is closed', () => {
+      renderModal({ open: false });
+      expect(portalLock.lock).not.toHaveBeenCalled();
+    });
+
+    it('should call portalLock.unlock when modal transitions from open to closed', () => {
+      const { rerender } = render(
+        <BpkModalV3.Root open onOpenChange={jest.fn()}>
+          <BpkModalV3.Content>
+            <BpkModalV3.Title>Test</BpkModalV3.Title>
+          </BpkModalV3.Content>
+        </BpkModalV3.Root>,
+      );
+      expect(portalLock.unlock).not.toHaveBeenCalled();
+
+      rerender(
+        <BpkModalV3.Root open={false} onOpenChange={jest.fn()}>
+          <BpkModalV3.Content>
+            <BpkModalV3.Title>Test</BpkModalV3.Title>
+          </BpkModalV3.Content>
+        </BpkModalV3.Root>,
+      );
+      expect(portalLock.unlock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call portalLock.unlock on unmount while open', () => {
+      const { unmount } = renderModal({ open: true });
+      expect(portalLock.unlock).not.toHaveBeenCalled();
+      unmount();
+      expect(portalLock.unlock).toHaveBeenCalledTimes(1);
     });
 
     it('should render wrapper div with default type', () => {

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3-test.tsx
@@ -20,7 +20,17 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
+import focusScope from '../../../bpk-scrim-utils/src/focusScope';
+
 import BpkModalV3 from './BpkModalV3';
+
+jest.mock('../../../bpk-scrim-utils/src/focusScope', () => ({
+  __esModule: true,
+  default: {
+    unscopeFocus: jest.fn(),
+    scopeFocus: jest.fn(),
+  },
+}));
 
 // ResizeObserver mock required for Ark UI / Zag.js
 window.ResizeObserver =
@@ -75,6 +85,40 @@ describe('BpkModalV3', () => {
   });
 
   describe('Root', () => {
+    beforeEach(() => {
+      (focusScope.unscopeFocus as jest.Mock).mockClear();
+    });
+
+    it('should call focusScope.unscopeFocus when the modal opens', () => {
+      renderModal({ open: true });
+      expect(focusScope.unscopeFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call focusScope.unscopeFocus when the modal is closed', () => {
+      renderModal({ open: false });
+      expect(focusScope.unscopeFocus).not.toHaveBeenCalled();
+    });
+
+    it('should call focusScope.unscopeFocus when modal transitions from closed to open', () => {
+      const { rerender } = render(
+        <BpkModalV3.Root open={false} onOpenChange={jest.fn()}>
+          <BpkModalV3.Content>
+            <BpkModalV3.Title>Test</BpkModalV3.Title>
+          </BpkModalV3.Content>
+        </BpkModalV3.Root>,
+      );
+      expect(focusScope.unscopeFocus).not.toHaveBeenCalled();
+
+      rerender(
+        <BpkModalV3.Root open onOpenChange={jest.fn()}>
+          <BpkModalV3.Content>
+            <BpkModalV3.Title>Test</BpkModalV3.Title>
+          </BpkModalV3.Content>
+        </BpkModalV3.Root>,
+      );
+      expect(focusScope.unscopeFocus).toHaveBeenCalledTimes(1);
+    });
+
     it('should render wrapper div with default type', () => {
       const { container } = renderModal();
       const wrapper = container.querySelector('[data-type]');

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
@@ -748,11 +748,18 @@ const WithDrawerExample = () => {
             </BpkModalV3.Header>
             <BpkModalV3.Body>
               <BpkBox paddingInline={BpkSpacing.LG} paddingBottom={BpkSpacing.LG}>
-                <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
-                  This modal was opened while a BpkDrawer was active. Focus
-                  management has transitioned from the drawer&apos;s focusScope
-                  to the modal&apos;s ark-ui focus trap without conflict.
-                </BpkText>
+                <BpkVStack gap={BpkSpacing.Base}>
+                  <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
+                    This modal was opened while a BpkDrawer was active. Focus
+                    management has transitioned from the drawer&apos;s focusScope
+                    to the modal&apos;s ark-ui focus trap without conflict.
+                  </BpkText>
+                  <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
+                    <strong>To verify:</strong> close this modal (click &ldquo;Close&rdquo;
+                    or press Esc), then press Tab inside the drawer. Focus should
+                    remain trapped within the drawer and not escape to the page.
+                  </BpkText>
+                </BpkVStack>
               </BpkBox>
             </BpkModalV3.Body>
           </BpkModalV3.Content>

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
@@ -20,7 +20,6 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import BpkButton from '../../../bpk-component-button';
-import BpkDrawer from '../../../bpk-component-drawer';
 import {
   BpkBox,
   BpkBreakpoint,
@@ -692,83 +691,6 @@ const LogoExample = () => (
   </ModalContainer>
 );
 
-const WithDrawerExample = () => {
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  return (
-    <BpkProvider>
-      <div id="modal-with-drawer-pagewrap">
-        <BpkVStack gap={BpkSpacing.Base} padding={BpkSpacing.LG}>
-          <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
-            Open the drawer first, then open the modal from within it.
-            BpkDrawer uses the legacy focusScope system; BpkModalV3 uses
-            ark-ui. Both coexist without causing a focus redirect loop.
-          </BpkText>
-          <BpkButton onClick={() => setIsDrawerOpen(true)}>
-            Open drawer
-          </BpkButton>
-        </BpkVStack>
-      </div>
-
-      <BpkDrawer
-        id="modal-with-drawer-drawer"
-        isOpen={isDrawerOpen}
-        onClose={() => setIsDrawerOpen(false)}
-        title="Filters"
-        closeLabel="Close drawer"
-        getApplicationElement={() =>
-          document.getElementById('modal-with-drawer-pagewrap')
-        }
-      >
-        <BpkVStack gap={BpkSpacing.Base}>
-          <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
-            The drawer is open. Click below to open a BpkModalV3 on top.
-          </BpkText>
-          <BpkButton onClick={() => setIsModalOpen(true)}>
-            Open modal
-          </BpkButton>
-        </BpkVStack>
-      </BpkDrawer>
-
-      <BpkModalV3.Root
-        open={isModalOpen}
-        onOpenChange={({ open }) => setIsModalOpen(open)}
-      >
-        <BpkModalV3.Portal>
-          <BpkModalV3.Scrim />
-          <BpkModalV3.Content>
-            <BpkModalV3.Header>
-              <BpkModalV3.Title>
-                <BpkText textStyle={TEXT_STYLES.label1} tagName="span">
-                  Modal opened from drawer
-                </BpkText>
-              </BpkModalV3.Title>
-              <BpkModalV3.CloseTrigger label="Close" />
-            </BpkModalV3.Header>
-            <BpkModalV3.Body>
-              <BpkBox paddingInline={BpkSpacing.LG} paddingBottom={BpkSpacing.LG}>
-                <BpkVStack gap={BpkSpacing.Base}>
-                  <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
-                    This modal was opened while a BpkDrawer was active. Focus
-                    management has transitioned from the drawer&apos;s focusScope
-                    to the modal&apos;s ark-ui focus trap without conflict.
-                  </BpkText>
-                  <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
-                    <strong>To verify:</strong> close this modal (click &ldquo;Close&rdquo;
-                    or press Esc), then press Tab inside the drawer. Focus should
-                    remain trapped within the drawer and not escape to the page.
-                  </BpkText>
-                </BpkVStack>
-              </BpkBox>
-            </BpkModalV3.Body>
-          </BpkModalV3.Content>
-        </BpkModalV3.Portal>
-      </BpkModalV3.Root>
-    </BpkProvider>
-  );
-};
-
 const meta = {
   title: 'bpk-component-modal-v3',
   component: BpkModalV3.Root,
@@ -839,10 +761,6 @@ export const Trigger = {
 
 export const Logo = {
   render: () => <LogoExample />,
-};
-
-export const WithDrawer = {
-  render: () => <WithDrawerExample />,
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
@@ -20,6 +20,7 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import BpkButton from '../../../bpk-component-button';
+import BpkDrawer from '../../../bpk-component-drawer';
 import {
   BpkBox,
   BpkBreakpoint,
@@ -691,6 +692,76 @@ const LogoExample = () => (
   </ModalContainer>
 );
 
+const WithDrawerExample = () => {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <BpkProvider>
+      <div id="modal-with-drawer-pagewrap">
+        <BpkVStack gap={BpkSpacing.Base} padding={BpkSpacing.LG}>
+          <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
+            Open the drawer first, then open the modal from within it.
+            BpkDrawer uses the legacy focusScope system; BpkModalV3 uses
+            ark-ui. Both coexist without causing a focus redirect loop.
+          </BpkText>
+          <BpkButton onClick={() => setIsDrawerOpen(true)}>
+            Open drawer
+          </BpkButton>
+        </BpkVStack>
+      </div>
+
+      <BpkDrawer
+        id="modal-with-drawer-drawer"
+        isOpen={isDrawerOpen}
+        onClose={() => setIsDrawerOpen(false)}
+        title="Filters"
+        closeLabel="Close drawer"
+        getApplicationElement={() =>
+          document.getElementById('modal-with-drawer-pagewrap')
+        }
+      >
+        <BpkVStack gap={BpkSpacing.Base}>
+          <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
+            The drawer is open. Click below to open a BpkModalV3 on top.
+          </BpkText>
+          <BpkButton onClick={() => setIsModalOpen(true)}>
+            Open modal
+          </BpkButton>
+        </BpkVStack>
+      </BpkDrawer>
+
+      <BpkModalV3.Root
+        open={isModalOpen}
+        onOpenChange={({ open }) => setIsModalOpen(open)}
+      >
+        <BpkModalV3.Portal>
+          <BpkModalV3.Scrim />
+          <BpkModalV3.Content>
+            <BpkModalV3.Header>
+              <BpkModalV3.Title>
+                <BpkText textStyle={TEXT_STYLES.label1} tagName="span">
+                  Modal opened from drawer
+                </BpkText>
+              </BpkModalV3.Title>
+              <BpkModalV3.CloseTrigger label="Close" />
+            </BpkModalV3.Header>
+            <BpkModalV3.Body>
+              <BpkBox paddingInline={BpkSpacing.LG} paddingBottom={BpkSpacing.LG}>
+                <BpkText textStyle={TEXT_STYLES.bodyDefault} tagName="p">
+                  This modal was opened while a BpkDrawer was active. Focus
+                  management has transitioned from the drawer&apos;s focusScope
+                  to the modal&apos;s ark-ui focus trap without conflict.
+                </BpkText>
+              </BpkBox>
+            </BpkModalV3.Body>
+          </BpkModalV3.Content>
+        </BpkModalV3.Portal>
+      </BpkModalV3.Root>
+    </BpkProvider>
+  );
+};
+
 const meta = {
   title: 'bpk-component-modal-v3',
   component: BpkModalV3.Root,
@@ -761,6 +832,10 @@ export const Trigger = {
 
 export const Logo = {
   render: () => <LogoExample />,
+};
+
+export const WithDrawer = {
+  render: () => <WithDrawerExample />,
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
@@ -23,7 +23,7 @@ import { Dialog } from '@ark-ui/react';
 import { durationBase } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 import { getDataComponentAttribute, useBodyLock } from '../../../../bpk-react-utils';
-import focusScope from '../../../../bpk-scrim-utils/src/focusScope';
+import { focusScope } from '../../../../bpk-scrim-utils';
 import { ModalTypeProvider } from '../BpkModalV3Context';
 import { MODAL_V3_TYPES, type BpkModalV3Type } from '../common-types';
 

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
@@ -58,13 +58,17 @@ const BpkModalV3Root = ({
 
   useBodyLock(type === MODAL_V3_TYPES.chatbot && bodyLockOpen);
 
-  // When this modal opens, deactivate any active focusScope (used by legacy
+  // When this modal opens, pause any active focusScope (used by legacy
   // withScrim components such as BpkDrawer). Both systems listen to 'focusin'
   // on document, and their simultaneous presence causes an infinite focus
-  // redirect loop that overflows the call stack.
+  // redirect loop that overflows the call stack. The scope is resumed without
+  // stealing focus when the modal closes, restoring the drawer's focus trap.
+  // TODO: Remove once BpkDrawer is migrated to ark-ui.
   useEffect(() => {
     if (isOpen) {
-      focusScope.unscopeFocus();
+      focusScope.pauseFocus();
+    } else {
+      focusScope.resumeFocus();
     }
   }, [isOpen]);
 

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
@@ -70,7 +70,7 @@ const BpkModalV3Root = ({
   // The cleanup function runs both on isOpen→false AND on unmount-while-open,
   // ensuring the locks are always released.
   //
-  // TODO: Remove once BpkDrawer, BpkModal, BpkDialog are deprecated. (CLOV-1643)
+  // TODO: CLOV-1643 Remove once BpkDrawer, BpkModal, BpkDialog are deprecated.
   useEffect(() => {
     if (!isOpen) return undefined;
     focusScope.pauseFocus();

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
@@ -22,7 +22,7 @@ import { Dialog } from '@ark-ui/react';
 
 import { durationBase } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
-import { getDataComponentAttribute, useBodyLock } from '../../../../bpk-react-utils';
+import { getDataComponentAttribute, portalLock, useBodyLock } from '../../../../bpk-react-utils';
 import { focusScope } from '../../../../bpk-scrim-utils';
 import { ModalTypeProvider } from '../BpkModalV3Context';
 import { MODAL_V3_TYPES, type BpkModalV3Type } from '../common-types';
@@ -58,18 +58,27 @@ const BpkModalV3Root = ({
 
   useBodyLock(type === MODAL_V3_TYPES.chatbot && bodyLockOpen);
 
-  // When this modal opens, pause any active focusScope (used by legacy
-  // withScrim components such as BpkDrawer). Both systems listen to 'focusin'
-  // on document, and their simultaneous presence causes an infinite focus
-  // redirect loop that overflows the call stack. The scope is resumed without
-  // stealing focus when the modal closes, restoring the drawer's focus trap.
-  // TODO: Remove once BpkDrawer is migrated to ark-ui.
+  // When this modal opens, pause the active focusScope (used by legacy withScrim
+  // components such as BpkDrawer) and lock the Portal event handlers so legacy
+  // overlays do not respond to clicks/Esc while the modal is visible.
+  //
+  // focusScope: prevents an infinite focus-redirect loop — both systems listen
+  //   to 'focusin' on document and would fight each other without this guard.
+  // portalLock: prevents legacy Portal (BpkDrawer/BpkModal/BpkDialog) from
+  //   starting their close animation simultaneously, which causes a visible flash.
+  //
+  // The cleanup function runs both on isOpen→false AND on unmount-while-open,
+  // ensuring the locks are always released.
+  //
+  // TODO: Remove once BpkDrawer, BpkModal, BpkDialog are deprecated. (CLOV-1643)
   useEffect(() => {
-    if (isOpen) {
-      focusScope.pauseFocus();
-    } else {
+    if (!isOpen) return undefined;
+    focusScope.pauseFocus();
+    portalLock.lock();
+    return () => {
       focusScope.resumeFocus();
-    }
+      portalLock.unlock();
+    };
   }, [isOpen]);
 
   const handleOpenChange = (details: { open: boolean }) => {

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
@@ -67,19 +67,25 @@ const BpkModalV3Root = ({
   // portalLock: prevents legacy Portal (BpkDrawer/BpkModal/BpkDialog) from
   //   starting their close animation simultaneously, which causes a visible flash.
   //
-  // The cleanup function runs both on isOpen→false AND on unmount-while-open,
+  // bodyLockOpen (rather than isOpen) is used as the dependency so that the
+  // locks stay active for the full exit-animation duration (durationBase ms)
+  // after isOpen becomes false. Without the delay, events fired during the
+  // exit animation (e.g. the mousedown that triggered the close falling through
+  // to a BpkScrim below) would reach legacy overlays and cause a flash.
+  //
+  // The cleanup function runs both on bodyLockOpen→false AND on unmount-while-open,
   // ensuring the locks are always released.
   //
   // TODO: CLOV-1643 Remove once BpkDrawer, BpkModal, BpkDialog are deprecated.
   useEffect(() => {
-    if (!isOpen) return undefined;
+    if (!bodyLockOpen) return undefined;
     focusScope.pauseFocus();
     portalLock.lock();
     return () => {
       focusScope.resumeFocus();
       portalLock.unlock();
     };
-  }, [isOpen]);
+  }, [bodyLockOpen]);
 
   const handleOpenChange = (details: { open: boolean }) => {
     if (open === undefined) {

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Root/BpkModalV3Root.tsx
@@ -23,6 +23,7 @@ import { Dialog } from '@ark-ui/react';
 import { durationBase } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 
 import { getDataComponentAttribute, useBodyLock } from '../../../../bpk-react-utils';
+import focusScope from '../../../../bpk-scrim-utils/src/focusScope';
 import { ModalTypeProvider } from '../BpkModalV3Context';
 import { MODAL_V3_TYPES, type BpkModalV3Type } from '../common-types';
 
@@ -56,6 +57,16 @@ const BpkModalV3Root = ({
   }, [isOpen]);
 
   useBodyLock(type === MODAL_V3_TYPES.chatbot && bodyLockOpen);
+
+  // When this modal opens, deactivate any active focusScope (used by legacy
+  // withScrim components such as BpkDrawer). Both systems listen to 'focusin'
+  // on document, and their simultaneous presence causes an infinite focus
+  // redirect loop that overflows the call stack.
+  useEffect(() => {
+    if (isOpen) {
+      focusScope.unscopeFocus();
+    }
+  }, [isOpen]);
 
   const handleOpenChange = (details: { open: boolean }) => {
     if (open === undefined) {

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Scrim/BpkModalV3Scrim.module.scss
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Scrim/BpkModalV3Scrim.module.scss
@@ -34,6 +34,14 @@
 
   &[data-state='closed'] {
     opacity: 0;
+
+    // Keep pointer-events active during the close animation so events do NOT
+    // fall through to legacy overlays beneath (e.g. BpkDrawer's close button,
+    // which shares z-index 1100) and trigger an unintended close.  The scrim
+    // absorbs all pointer events while it fades; once ark-ui removes the element
+    // the underlying content becomes interactive again.
+    // TODO: CLOV-1643 Remove once BpkDrawer, BpkModal, BpkDialog are deprecated.
+    pointer-events: auto;
   }
 
   // Auto-hide scrim for full variant

--- a/packages/backpack-web/src/bpk-react-utils/index.ts
+++ b/packages/backpack-web/src/bpk-react-utils/index.ts
@@ -30,6 +30,7 @@ import {
 import { getDataComponentAttribute } from './src/getDataComponentAttribute';
 import isRTL from './src/isRTL';
 import { setNativeValue } from './src/nativeEventHandler';
+import portalLock from './src/portalLock';
 import { SURFACE_COLORS } from './src/surfaceColors';
 import useBodyLock from './src/useBodyLock';
 import withDefaultProps from './src/withDefaultProps';
@@ -52,6 +53,7 @@ export {
   getDataComponentAttribute,
   SURFACE_COLORS,
   useBodyLock,
+  portalLock,
 };
 export default {
   Portal,
@@ -69,4 +71,5 @@ export default {
   getDataComponentAttribute,
   SURFACE_COLORS,
   useBodyLock,
+  portalLock,
 };

--- a/packages/backpack-web/src/bpk-react-utils/src/Portal.tsx
+++ b/packages/backpack-web/src/bpk-react-utils/src/Portal.tsx
@@ -23,6 +23,9 @@ import { createPortal } from 'react-dom';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import assign from 'object-assign';
 
+// TODO: Remove portalLock import once BpkDrawer, BpkModal, BpkDialog are deprecated. (CLOV-1643)
+import portalLock from './portalLock';
+
 const KEYCODES = {
   ESCAPE: 'Escape',
 } as const;
@@ -134,6 +137,13 @@ class Portal extends Component<Props, State> {
   }
 
   onDocumentMouseDown(event: MouseEvent | TouchEvent) {
+    // A higher-priority overlay (e.g. BpkModalV3) is open — do not close.
+    // TODO: Remove once BpkDrawer, BpkModal, BpkDialog are deprecated. (CLOV-1643)
+    if (portalLock.isLocked()) {
+      this.shouldClose = false;
+      return;
+    }
+
     const clickEventProperties = this.getClickEventProperties(event);
     if (
       clickEventProperties.isNotLeftClick ||
@@ -167,6 +177,12 @@ class Portal extends Component<Props, State> {
   }
 
   onDocumentKeyDown(event: KeyboardEvent) {
+    // A higher-priority overlay (e.g. BpkModalV3) is open — do not intercept Esc.
+    // TODO: Remove once BpkDrawer, BpkModal, BpkDialog are deprecated. (CLOV-1643)
+    if (portalLock.isLocked()) {
+      return;
+    }
+
     if (
       event.key === KEYCODES.ESCAPE &&
       this.props.isOpen &&

--- a/packages/backpack-web/src/bpk-react-utils/src/Portal.tsx
+++ b/packages/backpack-web/src/bpk-react-utils/src/Portal.tsx
@@ -23,7 +23,7 @@ import { createPortal } from 'react-dom';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import assign from 'object-assign';
 
-// TODO: Remove portalLock import once BpkDrawer, BpkModal, BpkDialog are deprecated. (CLOV-1643)
+// TODO: CLOV-1643 Remove portalLock import once BpkDrawer, BpkModal, BpkDialog are deprecated.
 import portalLock from './portalLock';
 
 const KEYCODES = {
@@ -138,7 +138,7 @@ class Portal extends Component<Props, State> {
 
   onDocumentMouseDown(event: MouseEvent | TouchEvent) {
     // A higher-priority overlay (e.g. BpkModalV3) is open — do not close.
-    // TODO: Remove once BpkDrawer, BpkModal, BpkDialog are deprecated. (CLOV-1643)
+    // TODO: CLOV-1643 Remove once BpkDrawer, BpkModal, BpkDialog are deprecated.
     if (portalLock.isLocked()) {
       this.shouldClose = false;
       return;
@@ -178,7 +178,7 @@ class Portal extends Component<Props, State> {
 
   onDocumentKeyDown(event: KeyboardEvent) {
     // A higher-priority overlay (e.g. BpkModalV3) is open — do not intercept Esc.
-    // TODO: Remove once BpkDrawer, BpkModal, BpkDialog are deprecated. (CLOV-1643)
+    // TODO: CLOV-1643 Remove once BpkDrawer, BpkModal, BpkDialog are deprecated.
     if (portalLock.isLocked()) {
       return;
     }

--- a/packages/backpack-web/src/bpk-react-utils/src/portalLock-test.ts
+++ b/packages/backpack-web/src/bpk-react-utils/src/portalLock-test.ts
@@ -1,0 +1,61 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import portalLock from './portalLock';
+
+describe('portalLock', () => {
+  beforeEach(() => {
+    portalLock.resetForTesting();
+  });
+
+  it('is not locked by default', () => {
+    expect(portalLock.isLocked()).toBe(false);
+  });
+
+  it('is locked after lock() is called', () => {
+    portalLock.lock();
+    expect(portalLock.isLocked()).toBe(true);
+  });
+
+  it('is not locked after lock() then unlock()', () => {
+    portalLock.lock();
+    portalLock.unlock();
+    expect(portalLock.isLocked()).toBe(false);
+  });
+
+  it('requires matching unlock() calls when locked multiple times (nested modals)', () => {
+    portalLock.lock();
+    portalLock.lock();
+    portalLock.unlock();
+    expect(portalLock.isLocked()).toBe(true);
+
+    portalLock.unlock();
+    expect(portalLock.isLocked()).toBe(false);
+  });
+
+  it('does not go below zero when unlock() is called without a prior lock()', () => {
+    portalLock.unlock();
+    expect(portalLock.isLocked()).toBe(false);
+
+    // A subsequent lock/unlock pair should still work correctly.
+    portalLock.lock();
+    expect(portalLock.isLocked()).toBe(true);
+    portalLock.unlock();
+    expect(portalLock.isLocked()).toBe(false);
+  });
+});

--- a/packages/backpack-web/src/bpk-react-utils/src/portalLock.ts
+++ b/packages/backpack-web/src/bpk-react-utils/src/portalLock.ts
@@ -1,0 +1,50 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// When a higher-priority overlay (e.g. BpkModalV3) is open, legacy Portal
+// components (used by BpkDrawer, BpkModal, BpkDialog) should not respond to
+// document click or keydown events — otherwise they start their close animation
+// simultaneously with the overlay, causing a visible flash.
+//
+// A counter (not a boolean) is used so that nested BpkModalV3 instances each
+// hold their own lock: opening a second modal increments to 2, closing it
+// decrements back to 1, and the first modal's lock is still active.
+//
+// TODO: Remove once BpkDrawer, BpkModal, and BpkDialog are deprecated. (CLOV-1643)
+
+let lockCount = 0;
+
+const portalLock = {
+  lock() {
+    lockCount += 1;
+  },
+  unlock() {
+    if (lockCount > 0) {
+      lockCount -= 1;
+    }
+  },
+  isLocked() {
+    return lockCount > 0;
+  },
+  // Exposed for testing only — do not use in production code.
+  resetForTesting() {
+    lockCount = 0;
+  },
+};
+
+export default portalLock;

--- a/packages/backpack-web/src/bpk-react-utils/src/portalLock.ts
+++ b/packages/backpack-web/src/bpk-react-utils/src/portalLock.ts
@@ -25,7 +25,7 @@
 // hold their own lock: opening a second modal increments to 2, closing it
 // decrements back to 1, and the first modal's lock is still active.
 //
-// TODO: Remove once BpkDrawer, BpkModal, and BpkDialog are deprecated. (CLOV-1643)
+// TODO: CLOV-1643 Remove once BpkDrawer, BpkModal, and BpkDialog are deprecated.
 
 let lockCount = 0;
 

--- a/packages/backpack-web/src/bpk-scrim-utils/index.ts
+++ b/packages/backpack-web/src/bpk-scrim-utils/index.ts
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
+import focusScope from './src/focusScope';
 import withScrim from './src/withScrim';
 import withScrimmedPortal from './src/withScrimmedPortal';
 
-export { withScrim, withScrimmedPortal };
+export { focusScope, withScrim, withScrimmedPortal };
 export default {
   withScrim,
 };

--- a/packages/backpack-web/src/bpk-scrim-utils/src/BpkScrim.tsx
+++ b/packages/backpack-web/src/bpk-scrim-utils/src/BpkScrim.tsx
@@ -18,7 +18,7 @@
 
 import type { SyntheticEvent } from 'react';
 
-import { TransitionInitialMount, cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
+import { TransitionInitialMount, cssModules, getDataComponentAttribute, portalLock } from '../../bpk-react-utils';
 
 import STYLES from './bpk-scrim.module.scss';
 
@@ -27,20 +27,35 @@ const getClassName = cssModules(STYLES);
 type Props = {
   onClose?: (e?: SyntheticEvent) => void | null;
 };
-const BpkScrim = ({ onClose = () => {} }: Props) => (
-  <TransitionInitialMount
-    appearClassName={getClassName('bpk-scrim--appear')}
-    appearActiveClassName={getClassName('bpk-scrim--appear-active')}
-    transitionTimeout={200}
-  >
-    <div
-      role="presentation"
-      className={getClassName('bpk-scrim')}
-      {...getDataComponentAttribute('Scrim')}
-      onMouseDown={onClose}
-      onTouchStart={onClose}
-    />
-  </TransitionInitialMount>
-);
+const BpkScrim = ({ onClose = () => {} }: Props) => {
+  // When a higher-priority overlay (e.g. BpkModalV3) closes, ark-ui's
+  // pointerdown handler fires first and changes data-state to 'closed',
+  // making the modal scrim pointer-events:none before mousedown fires.
+  // The mousedown then falls through to this scrim and would immediately
+  // trigger onClose (hide), causing a visible flash. Guard against this
+  // by ignoring mousedown/touchstart while the portal lock is active.
+  // TODO: CLOV-1643 Remove once BpkDrawer, BpkModal, BpkDialog are deprecated.
+  const handlePointerDown = (e: SyntheticEvent) => {
+    if (!portalLock.isLocked()) {
+      onClose(e);
+    }
+  };
+
+  return (
+    <TransitionInitialMount
+      appearClassName={getClassName('bpk-scrim--appear')}
+      appearActiveClassName={getClassName('bpk-scrim--appear-active')}
+      transitionTimeout={200}
+    >
+      <div
+        role="presentation"
+        className={getClassName('bpk-scrim')}
+        {...getDataComponentAttribute('Scrim')}
+        onMouseDown={handlePointerDown}
+        onTouchStart={handlePointerDown}
+      />
+    </TransitionInitialMount>
+  );
+};
 
 export default BpkScrim;

--- a/packages/backpack-web/src/bpk-scrim-utils/src/focusScope-test.ts
+++ b/packages/backpack-web/src/bpk-scrim-utils/src/focusScope-test.ts
@@ -103,4 +103,59 @@ describe('focusScope', () => {
 
     expect(document.activeElement).toBe(secondContainer);
   });
+
+  describe('pauseFocus / resumeFocus', () => {
+    it('should stop capturing focus after pauseFocus', () => {
+      focusScope.scopeFocus(container);
+      focusScope.pauseFocus();
+
+      outsideButton.focus();
+      outsideButton.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+      expect(document.activeElement).toBe(outsideButton);
+    });
+
+    it('should resume capturing focus after resumeFocus, without stealing focus immediately', () => {
+      focusScope.scopeFocus(container);
+      focusScope.pauseFocus();
+
+      // focus has moved outside while paused
+      outsideButton.focus();
+      outsideButton.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      expect(document.activeElement).toBe(outsideButton);
+
+      // resume — does NOT immediately steal focus back
+      focusScope.resumeFocus();
+      expect(document.activeElement).toBe(outsideButton);
+
+      // but a new focusin outside the container IS now intercepted
+      outsideButton.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      expect(document.activeElement).toBe(container);
+    });
+
+    it('should be a no-op when pauseFocus is called with no active scope', () => {
+      expect(() => focusScope.pauseFocus()).not.toThrow();
+    });
+
+    it('should be a no-op when resumeFocus is called with no previously scoped element', () => {
+      expect(() => focusScope.resumeFocus()).not.toThrow();
+
+      outsideButton.focus();
+      outsideButton.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      // focus should not have been redirected
+      expect(document.activeElement).toBe(outsideButton);
+    });
+
+    it('should not resume after unscopeFocus clears the paused element', () => {
+      focusScope.scopeFocus(container);
+      focusScope.pauseFocus();
+      focusScope.unscopeFocus(); // permanent clear — discards pausedElement
+
+      focusScope.resumeFocus(); // should be no-op
+
+      outsideButton.focus();
+      outsideButton.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      expect(document.activeElement).toBe(outsideButton);
+    });
+  });
 });

--- a/packages/backpack-web/src/bpk-scrim-utils/src/focusScope.ts
+++ b/packages/backpack-web/src/bpk-scrim-utils/src/focusScope.ts
@@ -53,30 +53,31 @@
 import { tabbable } from 'tabbable';
 
 let teardownFn: (() => void) | null = null;
+let pausedElement: HTMLElement | null = null;
 
-function init(element: HTMLElement): () => void {
-  function focus() {
-    const firstTabbable = tabbable(element)[0];
-    if (firstTabbable) {
-      firstTabbable.focus();
-    } else {
-      if (!element.hasAttribute('tabindex')) {
-        element.setAttribute('tabindex', '-1');
-      }
-      element.focus();
+function focusElement(element: HTMLElement) {
+  const firstTabbable = tabbable(element)[0];
+  if (firstTabbable) {
+    firstTabbable.focus();
+  } else {
+    if (!element.hasAttribute('tabindex')) {
+      element.setAttribute('tabindex', '-1');
     }
+    element.focus();
   }
+}
 
+// Registers the focusin listener that redirects focus back into element.
+// Does NOT call focus() immediately — use init() when initial focus steal is needed.
+function registerListener(element: HTMLElement): () => void {
   function onFocusIn(event: FocusEvent) {
     if (
       element !== event.target &&
       !element.contains(event.target as Node)
     ) {
-      focus();
+      focusElement(element);
     }
   }
-
-  focus();
 
   document.addEventListener('focusin', onFocusIn);
 
@@ -85,15 +86,42 @@ function init(element: HTMLElement): () => void {
   };
 }
 
+function init(element: HTMLElement): () => void {
+  focusElement(element);
+  return registerListener(element);
+}
+
 const focusScope = {
   scopeFocus(element: HTMLElement) {
     if (teardownFn) teardownFn();
+    pausedElement = element;
     teardownFn = init(element);
   },
 
   unscopeFocus() {
     if (teardownFn) teardownFn();
     teardownFn = null;
+    pausedElement = null;
+  },
+
+  // Temporarily deactivates the active focusScope listener without discarding
+  // the scoped element. Call resumeFocus() to re-register the listener.
+  // Used by BpkModalV3 to prevent a focus loop when opened over a withScrim
+  // component (e.g. BpkDrawer). To be removed when BpkDrawer migrates to ark-ui.
+  pauseFocus() {
+    if (teardownFn) {
+      teardownFn();
+      teardownFn = null;
+    }
+  },
+
+  // Re-registers the focusin listener for the previously paused element
+  // without stealing focus. This lets ark-ui's own focus-return logic run
+  // first before the focusScope listener takes effect.
+  resumeFocus() {
+    if (pausedElement) {
+      teardownFn = registerListener(pausedElement);
+    }
   },
 };
 


### PR DESCRIPTION
## Description

When a `BpkDrawer` (which uses the legacy `withScrim`/`focusScope` focus management system) is open at the same time as a `BpkModalV3` (which uses ark-ui's `@zag-js/focus-trap`), both systems simultaneously listen to `focusin` on `document`. This causes an infinite focus redirect loop that overflows the call stack.

**Root cause**: `focusScope` registers a bubble-phase `focusin` listener that synchronously calls `element.focus()`. `@zag-js/focus-trap` registers a capture-phase listener but does not call `stopImmediatePropagation` when focus is already inside the modal. The result is a recursive `focusin` dispatch loop (~8 frames per iteration) that overflows the call stack after ~100–200 iterations.

**Fix**: When `BpkModalV3Root` opens, it calls `focusScope.unscopeFocus()` to deactivate the legacy listener before ark-ui's focus trap takes over. This is a compatibility patch that keeps both systems stable while `BpkDrawer` has not yet been migrated to ark-ui.

## Changes

- **`BpkModalV3Root.tsx`**: Call `focusScope.unscopeFocus()` in a `useEffect` when `isOpen` becomes `true`, with a comment explaining why.
- **`BpkModalV3-test.tsx`**: Mock `focusScope` and add 3 test cases covering: modal opens (`unscopeFocus` called), modal closed (`unscopeFocus` not called), and closed → open transition.
- **`BpkModalV3.stories.tsx`**: Add `WithDrawer` story demonstrating `BpkModalV3` opened from within a `BpkDrawer`.

## Test Screenshots 

Tested it in local carhire
|  Platform  |  Before  |  After  |
| :--------: | :------: | :-----: | 
|  mWeb  |   <img width="450"  alt="before-fix-mweb" src="https://github.com/user-attachments/assets/94d1e654-1b49-48d5-a487-fa4561a28e9c" />  |   <img width="450"  alt="after-fix-mweb" src="https://github.com/user-attachments/assets/a3b83dbf-497b-48dc-a62c-bf2189aea22c" />  | 
|  destop  |   <img width="450"  alt="before-fix-desktop" src="https://github.com/user-attachments/assets/09703cc4-d343-400c-b273-c38c2afc0cdd" />  |   <img width="450"  alt="after-fix-desktop" src="https://github.com/user-attachments/assets/42bf8dc2-516e-41bd-ac76-93be2cbe97d4" />  | 

- no error in mWeb 
- no change in desktop, no issue with keyboard management in desktop


## Checklist

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[CLOV-1606][BpkModalV3] Fix infinite focus redirect loop when BpkModalV3 and BpkDrawer coexist`
- [ ] `README.md` (If you have created a new component) — N/A, no new component
- [ ] Component `README.md` — N/A
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/) — this fix restores correct keyboard focus when both components coexist
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated — `WithDrawer` story added to `bpk-component-modal-v3`
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR — N/A, this is a bug fix

[CLOV-1606]: https://skyscanner.atlassian.net/browse/CLOV-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ