### PR TITLE
[IRN-6612]: use 1fr columns in grid layout to fix oversized single-item cards

### DIFF
--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.stories.tsx
@@ -306,6 +306,29 @@ const RowToStackWithExpandExample = () => {
   );
 };
 
+const RowToRailWithSingleItemExample = () => (
+  <PageContainer>
+    <BpkCardList
+      {...commonProps}
+      cardList={makeList(DestinationCard, 1)}
+      layoutDesktop={LAYOUTS.row}
+      layoutMobile={LAYOUTS.rail}
+      accessoryDesktop={ACCESSORY_DESKTOP_TYPES.pagination}
+    />
+  </PageContainer>
+);
+
+const GridToStackWithSingleItemExample = () => (
+  <PageContainer>
+    <BpkCardList
+      {...commonProps}
+      cardList={makeList(DestinationCard, 1)}
+      layoutDesktop={LAYOUTS.grid}
+      layoutMobile={LAYOUTS.stack}
+    />
+  </PageContainer>
+);
+
 const GridToStackWithExpandExample = () => {
   const [expandText, setExpandText] = useState('Show more');
 
@@ -405,6 +428,8 @@ export const RowToRail = { render: () => <RowToRailExample /> };
 export const RowToStack = { render: () => <RowToStackExample /> };
 export const GridToRail = { render: () => <GridToRailExample /> };
 export const GridToStack = { render: () => <GridToStackExample /> };
+export const GridToStackWithSingleItem = { render: () => <GridToStackWithSingleItemExample /> };
+export const RowToRailWithSingleItem = { render: () => <RowToRailWithSingleItemExample /> };
 export const RowToStackWithExpand = { render: () => <RowToStackWithExpandExample /> };
 export const GridToStackWithExpand = { render: () => <GridToStackWithExpandExample /> };
 export const RowToRailForSnippets = { render: () => <RowToRailForSnippetsExample /> };

--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListGridStack/BpkCardListGridStack.module.scss
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListGridStack/BpkCardListGridStack.module.scss
@@ -24,7 +24,10 @@
 
   &__grid {
     display: grid;
-    grid-template-columns: repeat(var(--initially-shown-cards, 3), minmax(0, 1fr));
+    grid-template-columns: repeat(
+      var(--initially-shown-cards, 3),
+      minmax(0, 1fr)
+    );
     gap: tokens.bpk-spacing-lg();
   }
 

--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListGridStack/BpkCardListGridStack.module.scss
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListGridStack/BpkCardListGridStack.module.scss
@@ -24,7 +24,7 @@
 
   &__grid {
     display: grid;
-    grid-template-columns: repeat(var(--initially-shown-cards, 3), 1fr);
+    grid-template-columns: repeat(var(--initially-shown-cards, 3), minmax(0, 1fr));
     gap: tokens.bpk-spacing-lg();
   }
 

--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListGridStack/BpkCardListGridStack.module.scss
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListGridStack/BpkCardListGridStack.module.scss
@@ -24,7 +24,7 @@
 
   &__grid {
     display: grid;
-    grid-template-columns: repeat(var(--initially-shown-cards, 3), auto);
+    grid-template-columns: repeat(var(--initially-shown-cards, 3), 1fr);
     gap: tokens.bpk-spacing-lg();
   }
 


### PR DESCRIPTION
## Problem

`BpkCardListGridStack` uses `grid-template-columns: repeat(N, auto)` for its grid layout. When there are fewer items than columns (e.g. a single card in a 3-column grid), the empty columns have no content to size against and effectively collapse, allowing the occupied column to grow beyond its intended `1/N` share of the container.

This produces oversized cards — a single item nearly fills half the viewport instead of one third.

## Fix

Change `auto` to `1fr` for grid column tracks:

```scss
- grid-template-columns: repeat(var(--initially-shown-cards, 3), auto);
+ grid-template-columns: repeat(var(--initially-shown-cards, 3), 1fr);
```

`1fr` tracks always distribute available space equally, regardless of how many items are present — matching the behaviour of the row/rail carousel which hard-codes `flex-basis: calc(100% / N)`.

## Before / After

**Before** (`auto` — single card bloated):
<img width="1280" height="800" alt="before" src="https://github.com/user-attachments/assets/edd1748f-da9a-42fd-99a7-b9014a34d928" />


**After** (`1fr` — single card correctly sized to 1/3):
<img width="1280" height="800" alt="after" src="https://github.com/user-attachments/assets/18cd213f-78de-4aa6-95e4-602d7fadea32" />


> Screenshots taken from the new `GridToStackWithSingleItem` Storybook story added in this PR.

## Changes

- `BpkCardListGridStack.module.scss` — `auto` → `1fr` for grid column tracks
- `BpkCardList.stories.tsx` — adds `GridToStackWithSingleItem` and `RowToRailWithSingleItem` stories to surface this edge case

## Test plan

- [ ] `GridToStackWithSingleItem` story: single card is ~1/3 container width
- [ ] `GridToStack` / `GridToStackWithExpand` stories with multiple items: no regression in column sizing
- [ ] `RowToRailWithSingleItem` story: single card sized correctly in carousel