### PR TITLE
docs: update corepack pnpm version from latest-9 to latest-10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To install pnpm, set it up via Corepack:
 ```bash
 npm install --global corepack@latest
 corepack enable pnpm
-corepack use pnpm@latest-9
+corepack use pnpm@latest-10
 ```
 
 ### Code style


### PR DESCRIPTION
Fixes the last remaining `pnpm@latest-9` reference in `CONTRIBUTING.md`, updating it to `pnpm@latest-10` to match the repo's `packageManager: pnpm@10.33.0` declaration.

## What has changed, and why?

- `CONTRIBUTING.md` line 38: `corepack use pnpm@latest-9` → `corepack use pnpm@latest-10`

This is the final cleanup step of the pnpm 9 → 10 migration on this branch.