### PR TITLE
[NO-JIRA][BpkModalV3] Fix missing opacity transition on default modal close

### DIFF
--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Content/BpkModalV3Content.module.scss
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Content/BpkModalV3Content.module.scss
@@ -68,7 +68,9 @@
     max-width: 50rem; // 800px
     max-height: 90vh;
     transform: scale(0.9);
-    transition: transform tokens.$bpk-duration-sm ease-in-out;
+    transition:
+      transform tokens.$bpk-duration-sm ease-in-out,
+      opacity tokens.$bpk-duration-sm ease-in-out;
     border-radius: tokens.$bpk-border-radius-lg;
     opacity: 0;
 


### PR DESCRIPTION
## Summary

- `BpkModalV3` `--default` variant's `transition` only included `transform`, causing its `opacity` to jump instantly to `0` on close while the scrim (`BpkModalV3.Scrim`) faded over 200ms
- This left the dark backdrop (`rgba(0,0,0,0.7)`) fully visible for 200ms after the modal content had already disappeared — a noticeable black shadow flash on close
- `--sheet` and `--full` variants already include `opacity` in their transitions; `--default` was inconsistent

**One-line fix:** add `opacity tokens.$bpk-duration-sm ease-in-out` to the `--default` transition so content and scrim animate in sync.

### Before
```scss
transition: transform tokens.$bpk-duration-sm ease-in-out;
```

### After
```scss
transition:
  transform tokens.$bpk-duration-sm ease-in-out,
  opacity tokens.$bpk-duration-sm ease-in-out;
```

## Test plan

- [ ] Open a `BpkModalV3` with no `type` (default) — verify modal opens and closes with a smooth fade, no dark backdrop flash after content disappears
- [ ] Verify `--sheet` and `--full` variants are unaffected
- [ ] Verify `prefers-reduced-motion` path still disables all transitions correctly (existing rule `transition: none` covers this)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)