### PR TITLE
[SDBCK-281] Fix carousel nav button specificity

### DIFF
--- a/packages/backpack-web/src/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
+++ b/packages/backpack-web/src/bpk-component-page-indicator/src/BpkPageIndicator.module.scss
@@ -111,15 +111,17 @@ $container-width: $dot-size * $displayed-total + $dot-margin *
     --bpk-button-secondary-on-dark-text-color: #{tokens.$bpk-text-primary-day};
     --bpk-button-secondary-on-dark-hover-text-color: #{tokens.$bpk-text-primary-day};
     --bpk-button-secondary-on-dark-active-text-color: #{tokens.$bpk-text-primary-day};
-  }
 
-  &__nav-carousel-button {
-    display: inline-flex;
-    width: tokens.bpk-spacing-xl();
-    height: tokens.bpk-spacing-xl();
-    min-height: tokens.bpk-spacing-xl();
-    padding: 0;
-    justify-content: center;
-    align-items: center;
+    // Keep this selector more specific than BpkButton's icon-only padding,
+    // which may be loaded later in production CSS chunks.
+    & &-button {
+      display: inline-flex;
+      width: tokens.bpk-spacing-xl();
+      height: tokens.bpk-spacing-xl();
+      min-height: tokens.bpk-spacing-xl();
+      padding: 0;
+      justify-content: center;
+      align-items: center;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fix the carousel page indicator nav button so its circular arrow size is stable in production Storybook builds.

## Root cause

`BpkPageIndicator` passes a carousel-specific class to `BpkButton` for the circular nav arrows. The old selector for that override was a single class, so it had the same specificity as `BpkButton`'s `iconOnly` padding rule. In local Storybook the page-indicator CSS happened to be injected after the button CSS, so the circular button kept `padding: 0`. In production Storybook, CSS is split into chunks and `BpkButton` styles can be loaded later, causing `.bpk-button--icon-only-*` to override the carousel nav padding and stretch the circular arrows.

## Change

Nest the carousel nav button rule under the carousel nav wrapper using `& &-button`. This compiles to a two-class selector, making the page-indicator override more specific than the button icon-only padding regardless of CSS chunk load order. A short comment was added to explain why the repeated `&` is intentional.

Before
<img width="744" height="344" alt="image" src="https://github.com/user-attachments/assets/c0cda3ce-d377-4a7c-b682-00f0e4e8ea0b" />

After
<img width="856" height="943" alt="image" src="https://github.com/user-attachments/assets/95cef8fe-4fd9-4783-a782-e4c631d6c67d" />

## Validation

- `npx stylelint packages/backpack-web/src/bpk-component-page-indicator/src/BpkPageIndicator.module.scss --fix`
- `node -e "require('./scripts/scss/style-compiler.js').compile('./packages/backpack-web/src/bpk-component-page-indicator/src/BpkPageIndicator.module.scss')"`
- `TZ=Etc/UTC npx jest packages/backpack-web/src/bpk-component-page-indicator/src/BpkPageIndicator-test.tsx packages/backpack-web/src/bpk-component-page-indicator/src/accessibility-test.tsx --runInBand`