### PR TITLE
[codex] Add Backpack adoption guard action

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+libs/backpack-adoption-action/dist
 packages/backpack-web/dist
 dist-storybook
 coverage

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Build (affected)
         run: npx nx affected -t build --parallel=3
 
+      - name: Verify committed dist (affected)
+        run: npx nx affected -t verify-dist --parallel=3
+
       - name: Confirm the build hasn't changed any files
         run: ./scripts/check-pristine-state package-lock.json
 

--- a/.github/workflows/backpack-adoption-action-release.yml
+++ b/.github/workflows/backpack-adoption-action-release.yml
@@ -1,0 +1,75 @@
+name: Backpack Adoption Action Release
+
+on:
+  release:
+    types: [published]
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+permissions: {}
+
+jobs:
+  Validate:
+    if: ${{ startsWith(github.event.release.tag_name, 'backpack-adoption-action/') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+
+      - run: npx nx run backpack-adoption-action:lint
+
+      - run: npx nx run backpack-adoption-action:typecheck
+
+      - run: npx nx run backpack-adoption-action:test
+
+      - run: npx nx run backpack-adoption-action:verify-dist
+
+  UpdateMajorTag:
+    if: ${{ startsWith(github.event.release.tag_name, 'backpack-adoption-action/') }}
+    runs-on: ubuntu-latest
+    needs: [Validate]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Move floating major tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^backpack-adoption-action/v([0-9]+)\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match backpack-adoption-action/vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+
+          major_tag="backpack-adoption-action/v${BASH_REMATCH[1]}"
+          release_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag --force "$major_tag" "$release_commit"
+          git push origin "refs/tags/$major_tag" --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ permissions: {}
 
 jobs:
   Create-NPM-Cache:
+    if: ${{ !startsWith(github.event.release.tag_name, 'backpack-adoption-action/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -40,6 +41,7 @@ jobs:
         run: npm ci
 
   Create-Build-Cache:
+    if: ${{ !startsWith(github.event.release.tag_name, 'backpack-adoption-action/') }}
     runs-on: ubuntu-latest
     needs: [Create-NPM-Cache]
     steps:
@@ -76,6 +78,7 @@ jobs:
           npm run storybook:dist
 
   Build:
+    if: ${{ !startsWith(github.event.release.tag_name, 'backpack-adoption-action/') }}
     permissions:
       actions: read
       contents: read
@@ -89,6 +92,7 @@ jobs:
 
   ReleaseWeb:
     name: Release @skyscanner/backpack-web to NPM
+    if: ${{ !startsWith(github.event.release.tag_name, 'backpack-adoption-action/') }}
     runs-on: ubuntu-latest
     environment: Publishing
     needs: [Create-NPM-Cache, Build]
@@ -124,6 +128,7 @@ jobs:
         RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
   SupernovaPublish:
+    if: ${{ !startsWith(github.event.release.tag_name, 'backpack-adoption-action/') }}
     runs-on: ubuntu-latest
     environment: Publishing
     needs: [Build]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 /packages/backpack-web/src/bpk-component-icon/lg/
 /packages/backpack-web/src/bpk-component-icon/sm/
 /packages/backpack-web/src/bpk-component-icon/xxxl/
+/libs/backpack-adoption-action/dist/

--- a/libs/backpack-adoption-action/.eslintrc
+++ b/libs/backpack-adoption-action/.eslintrc
@@ -1,0 +1,18 @@
+{
+  "extends": "../../.eslintrc",
+  "env": {
+    "browser": false,
+    "node": true,
+    "jest": true
+  },
+  "rules": {
+    "backpack/use-tokens": "off",
+    "compat/compat": "off",
+    "import/order": "off",
+    "import/prefer-default-export": "off",
+    "no-console": "off",
+    "no-continue": "off",
+    "no-param-reassign": "off",
+    "prefer-destructuring": "off"
+  }
+}

--- a/libs/backpack-adoption-action/README.md
+++ b/libs/backpack-adoption-action/README.md
@@ -1,0 +1,23 @@
+# Backpack Adoption Guard
+
+This GitHub Action calculates Backpack adoption for a consuming repository.
+On `main`, it writes a results JSON file and can upload the data to Cortex.
+On pull requests, it compares the PR checkout against the base checkout and
+fails only when the base adoption is already at least 60% and the PR lowers the
+Backpack adoption rate.
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    fetch-depth: 0
+
+- name: Backpack Adoption Guard
+  uses: Skyscanner/backpack/libs/backpack-adoption-action@backpack-adoption-action/v1
+  with:
+    dry-run: ${{ vars.BACKPACK_ADOPTION_DRY_RUN }}
+    cortex-webhook-uuid: ${{ secrets.BACKPACK_ADOPTION_CORTEX_WEBHOOK_UUID }}
+    cortex-entity: carhire-homepage
+```
+
+The guard threshold is maintained inside the action and is not configurable by
+consumer repositories.

--- a/libs/backpack-adoption-action/action.yml
+++ b/libs/backpack-adoption-action/action.yml
@@ -1,0 +1,26 @@
+name: Backpack Adoption Guard
+description: Calculate Backpack adoption and block PRs that reduce adoption after reaching the guard threshold.
+
+inputs:
+  dry-run:
+    description: If true, adoption drops are reported as warnings instead of failing the PR.
+    required: false
+    default: "false"
+  pattern:
+    description: Files scanned for Backpack adoption.
+    required: false
+    default: "**/*.{jsx,tsx}"
+  output-path:
+    description: Path for the generated adoption result JSON.
+    required: false
+    default: backpack-adoption-results.json
+  cortex-webhook-uuid:
+    description: Cortex webhook UUID used only on the main branch.
+    required: false
+  cortex-entity:
+    description: Cortex entity name, for example carhire-homepage.
+    required: false
+
+runs:
+  using: node24
+  main: dist/index.js

--- a/libs/backpack-adoption-action/jest.config.js
+++ b/libs/backpack-adoption-action/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  rootDir: __dirname,
+  transform: {
+    '^.+\\.[jt]s$': ['babel-jest', { rootMode: 'upward' }],
+  },
+  testEnvironment: 'node',
+  testRegex: 'src/.*-test\\.ts$',
+  verbose: true,
+};

--- a/libs/backpack-adoption-action/package.json
+++ b/libs/backpack-adoption-action/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@skyscanner/backpack-adoption-action",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.js",
+    "lint": "eslint src jest.config.js --ext .js,.ts",
+    "test": "jest --config jest.config.js",
+    "typecheck": "tsc --project tsconfig.json",
+    "verify-dist": "npm run build && git diff --exit-code -- dist/index.js"
+  }
+}

--- a/libs/backpack-adoption-action/project.json
+++ b/libs/backpack-adoption-action/project.json
@@ -1,0 +1,59 @@
+{
+  "name": "backpack-adoption-action",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/backpack-adoption-action/src",
+  "projectType": "library",
+  "tags": ["scope:internal", "type:tooling"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm --workspace @skyscanner/backpack-adoption-action run build"
+      },
+      "outputs": ["{projectRoot}/dist"],
+      "cache": true,
+      "inputs": ["production", "^production"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm --workspace @skyscanner/backpack-adoption-action run lint"
+      },
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/**/*.{js,ts}",
+        "{workspaceRoot}/.eslintrc*",
+        "{workspaceRoot}/.eslintignore"
+      ]
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm --workspace @skyscanner/backpack-adoption-action run test"
+      },
+      "cache": true,
+      "inputs": ["default", "^production"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm --workspace @skyscanner/backpack-adoption-action run typecheck"
+      },
+      "outputs": [],
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/**/*.ts",
+        "{projectRoot}/tsconfig*.json",
+        "{workspaceRoot}/tsconfig.base.json",
+        "{workspaceRoot}/tsconfig.json"
+      ]
+    },
+    "verify-dist": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm --workspace @skyscanner/backpack-adoption-action run verify-dist"
+      },
+      "cache": false
+    }
+  }
+}

--- a/libs/backpack-adoption-action/src/action-io.ts
+++ b/libs/backpack-adoption-action/src/action-io.ts
@@ -1,0 +1,56 @@
+import { appendFile } from "node:fs/promises";
+
+export type ActionIO = {
+  getInput: (name: string) => string;
+  info: (message: string) => void;
+  warning: (message: string) => void;
+  error: (message: string) => void;
+  setFailed: (message: string) => void;
+  appendSummary: (markdown: string) => Promise<void>;
+};
+
+const escapeCommandValue = (value: string) =>
+  value
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+
+const inputKey = (name: string) =>
+  `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
+
+export const getBooleanInput = (
+  io: Pick<ActionIO, "getInput">,
+  name: string,
+) => io.getInput(name).trim().toLowerCase() === "true";
+
+export const createGitHubActionsIO = (): ActionIO => ({
+  getInput(name) {
+    return process.env[inputKey(name)] || "";
+  },
+
+  info(message) {
+    console.log(message);
+  },
+
+  warning(message) {
+    console.log(`::warning::${escapeCommandValue(message)}`);
+  },
+
+  error(message) {
+    console.log(`::error::${escapeCommandValue(message)}`);
+  },
+
+  setFailed(message) {
+    this.error(message);
+    process.exitCode = 1;
+  },
+
+  async appendSummary(markdown) {
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+    if (!summaryPath) {
+      return;
+    }
+
+    await appendFile(summaryPath, markdown, "utf8");
+  },
+});

--- a/libs/backpack-adoption-action/src/action.ts
+++ b/libs/backpack-adoption-action/src/action.ts
@@ -1,0 +1,154 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+
+import { createGitHubActionsIO, getBooleanInput } from "./action-io";
+import type { ActionIO } from "./action-io";
+import { analyzeRepository } from "./analyser";
+import {
+  BACKPACK_ADOPTION_CORTEX_KEY,
+  DEFAULT_OUTPUT_PATH,
+  DEFAULT_PATTERN,
+} from "./constants";
+import { uploadToCortex } from "./cortex";
+import { evaluateGuard } from "./guard";
+import {
+  getPullRequestBaseRef,
+  isMainBranch,
+  isPullRequestEvent,
+  withBaseWorktree,
+} from "./git";
+import { createPendingActionResult } from "./result";
+import { buildStepSummary } from "./summary";
+import type { ActionResult, AdoptionReport, ResultsFile } from "./types";
+
+export type RunOptions = {
+  cwd?: string;
+  fetchImpl?: typeof fetch;
+  io?: ActionIO;
+};
+
+const writeResults = async (
+  cwd: string,
+  outputPath: string,
+  result: ActionResult,
+) => {
+  const absolutePath = resolve(cwd, outputPath);
+  await mkdir(dirname(absolutePath), { recursive: true });
+
+  const resultsFile: ResultsFile = {
+    [BACKPACK_ADOPTION_CORTEX_KEY]: result,
+  };
+
+  await writeFile(
+    absolutePath,
+    `${JSON.stringify(resultsFile, null, 2)}\n`,
+    "utf8",
+  );
+};
+
+const analyzeBaseReport = async ({
+  cwd,
+  pattern,
+}: {
+  cwd: string;
+  pattern: string;
+}): Promise<AdoptionReport | null> => {
+  if (!isPullRequestEvent()) {
+    return null;
+  }
+
+  const baseRef = getPullRequestBaseRef();
+  if (!baseRef) {
+    return null;
+  }
+
+  return withBaseWorktree(cwd, baseRef, (basePath) =>
+    analyzeRepository(basePath, { pattern }),
+  );
+};
+
+export const run = async ({
+  cwd = process.cwd(),
+  fetchImpl,
+  io = createGitHubActionsIO(),
+}: RunOptions = {}) => {
+  const dryRun = getBooleanInput(io, "dry-run");
+  const pattern = io.getInput("pattern") || DEFAULT_PATTERN;
+  const outputPath = io.getInput("output-path") || DEFAULT_OUTPUT_PATH;
+  const cortexWebhookUuid = io.getInput("cortex-webhook-uuid");
+  const cortexEntity = io.getInput("cortex-entity");
+  const main = isMainBranch();
+  const pullRequest = isPullRequestEvent();
+
+  io.info(`Analyzing Backpack adoption in ${cwd}`);
+  io.info(`Using file pattern: ${pattern}`);
+
+  const headReport = await analyzeRepository(cwd, { pattern });
+  const baseReport = main
+    ? null
+    : await analyzeBaseReport({
+        cwd,
+        pattern,
+      });
+  const guard = evaluateGuard({
+    baseReport,
+    dryRun,
+    headReport,
+    isMain: main,
+  });
+  const pendingResult = createPendingActionResult({
+    baseReport,
+    eventName: process.env.GITHUB_EVENT_NAME || null,
+    guard,
+    headReport,
+    isMain: main,
+    isPullRequest: pullRequest,
+    ref: process.env.GITHUB_REF || null,
+    repository: basename(cwd),
+  });
+  const cortex = await uploadToCortex({
+    actionResult: pendingResult,
+    cortexEntity,
+    fetchImpl,
+    io,
+    isMain: main,
+    webhookUuid: cortexWebhookUuid,
+  });
+  const result: ActionResult = {
+    ...pendingResult,
+    cortex,
+  };
+
+  await writeResults(cwd, outputPath, result);
+  await io.appendSummary(buildStepSummary(result));
+
+  io.info(`Backpack adoption results written to ${outputPath}`);
+  io.info(`Head Backpack adoption: ${headReport.usage.backpack.percentage}%`);
+
+  if (baseReport) {
+    io.info(`Base Backpack adoption: ${baseReport.usage.backpack.percentage}%`);
+    io.info(`Backpack adoption delta: ${guard.delta}%`);
+  }
+
+  if (headReport.parseErrors.length > 0) {
+    io.warning(
+      `${headReport.parseErrors.length} file(s) could not be parsed during head analysis.`,
+    );
+  }
+
+  if (baseReport && baseReport.parseErrors.length > 0) {
+    io.warning(
+      `${baseReport.parseErrors.length} file(s) could not be parsed during base analysis.`,
+    );
+  }
+
+  if (guard.status === "warn") {
+    io.warning(guard.reason);
+  }
+
+  if (guard.status === "fail") {
+    io.setFailed(guard.reason);
+  }
+
+  return result;
+};

--- a/libs/backpack-adoption-action/src/analyser-test.ts
+++ b/libs/backpack-adoption-action/src/analyser-test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { analyzeRepository } from "./analyser";
+
+const createRepo = async () => mkdtemp(join(tmpdir(), "bpk-adoption-test-"));
+
+const writeRepoFile = async (repoPath: string, filePath: string, content: string) => {
+  const absolutePath = join(repoPath, filePath);
+  await mkdir(join(absolutePath, ".."), { recursive: true });
+  await writeFile(absolutePath, content, "utf8");
+};
+
+describe("analyzeRepository", () => {
+  let repoPath: string;
+
+  beforeEach(async () => {
+    repoPath = await createRepo();
+  });
+
+  afterEach(async () => {
+    await rm(repoPath, { force: true, recursive: true });
+  });
+
+  it("classifies Backpack, non-Backpack, raw HTML, and className overrides", async () => {
+    await writeRepoFile(
+      repoPath,
+      "package.json",
+      JSON.stringify({
+        dependencies: {
+          "@skyscanner/backpack-web": "^42.0.0",
+        },
+      }),
+    );
+    await writeRepoFile(
+      repoPath,
+      "src/App.module.scss",
+      `
+.ButtonOverride {
+  color: red;
+  margin: 0;
+}
+`,
+    );
+    await writeRepoFile(
+      repoPath,
+      "src/App.tsx",
+      `
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
+import { BpkText } from '@skyscanner/backpack-web';
+import styles from './App.module.scss';
+
+const LocalCard = () => (
+  <section>
+    <BpkText>Nested Backpack text</BpkText>
+  </section>
+);
+
+const NonVisual = () => null;
+
+export const App = () => (
+  <>
+    <BpkButton className={styles.ButtonOverride}>Book</BpkButton>
+    <BpkText>Visible Backpack text</BpkText>
+    <LocalCard />
+    <NonVisual />
+    <div className="layout-wrapper">Raw HTML</div>
+  </>
+);
+`,
+    );
+
+    const report = await analyzeRepository(repoPath);
+
+    expect(report.filesAnalyzed).toBe(1);
+    expect(report.backpackWebVersion).toBe("^42.0.0");
+    expect(report.usage.backpack.count).toBe(3);
+    expect(report.usage.nonBackpack.count).toBe(1);
+    expect(report.usage.rawHtml.count).toBe(2);
+    expect(report.usage.backpack.percentage).toBe(50);
+    expect(report.usage.pureBackpack.count).toBe(2);
+    expect(report.componentCounts).toEqual({
+      BpkButton: 1,
+      BpkText: 2,
+    });
+    expect(report.cssOverrides.byCategory.color).toBe(1);
+    expect(report.cssOverrides.byCategory.layout).toBe(1);
+    expect(report.cssOverrides.total).toBe(2);
+    expect(report.rawHtmlCssOverrides.byCategory.layout).toBe(2);
+  });
+
+  it("ignores generated, test, story, mock, and dependency files", async () => {
+    await writeRepoFile(
+      repoPath,
+      "src/App.tsx",
+      `
+import BpkText from '@skyscanner/backpack-web/bpk-component-text';
+
+export const App = () => <BpkText>Only production file</BpkText>;
+`,
+    );
+    await writeRepoFile(repoPath, "src/App.test.tsx", "export const Test = () => <div />;");
+    await writeRepoFile(repoPath, "src/App.spec.tsx", "export const Spec = () => <div />;");
+    await writeRepoFile(repoPath, "src/App.stories.tsx", "export const Story = () => <div />;");
+    await writeRepoFile(repoPath, "src/__mocks__/Mock.tsx", "export const Mock = () => <div />;");
+    await writeRepoFile(repoPath, "dist/Generated.tsx", "export const Generated = () => <div />;");
+    await writeRepoFile(repoPath, "build/Generated.tsx", "export const Built = () => <div />;");
+    await writeRepoFile(repoPath, "node_modules/pkg/Component.tsx", "export const Dep = () => <div />;");
+
+    const report = await analyzeRepository(repoPath);
+
+    expect(report.filesAnalyzed).toBe(1);
+    expect(report.usage.backpack.count).toBe(1);
+    expect(report.usage.rawHtml.count).toBe(0);
+  });
+});

--- a/libs/backpack-adoption-action/src/analyser.ts
+++ b/libs/backpack-adoption-action/src/analyser.ts
@@ -1,0 +1,1031 @@
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import { glob } from "glob";
+import ts from "typescript";
+
+import { DEFAULT_IGNORE_PATTERNS, DEFAULT_PATTERN } from "./constants";
+import {
+  addCategories,
+  analyzeClassNameCategories,
+  analyzeCssRulesCategories,
+  categoryTotal,
+  createEmptyCategoryCounts,
+  parseCssModule,
+} from "./css";
+import type { AdoptionReport, CssCategoryCounts } from "./types";
+
+type CssModuleImport = {
+  modulePath: string;
+  filePath: string;
+};
+
+type ClassNameInfo = {
+  hasOverride: boolean;
+  value: string | null;
+  type: string | null;
+  cssCategories: string[];
+  overrideCount: number;
+};
+
+type FileAnalysis = {
+  backpackUsages: number;
+  classNameOverrides: number;
+  nonBackpackUsages: number;
+  rawHtmlUsages: number;
+  componentCounts: Record<string, number>;
+  cssOverrides: CssCategoryCounts;
+  rawHtmlCssOverrides: CssCategoryCounts;
+};
+
+type AnalyzerOptions = {
+  pattern?: string;
+  ignore?: string[];
+};
+
+const HTML_ELEMENTS = new Set([
+  "a",
+  "abbr",
+  "address",
+  "area",
+  "article",
+  "aside",
+  "audio",
+  "b",
+  "base",
+  "bdi",
+  "bdo",
+  "blockquote",
+  "body",
+  "br",
+  "button",
+  "canvas",
+  "caption",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "data",
+  "datalist",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "embed",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hgroup",
+  "hr",
+  "html",
+  "i",
+  "iframe",
+  "img",
+  "input",
+  "ins",
+  "kbd",
+  "label",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "map",
+  "mark",
+  "menu",
+  "meta",
+  "meter",
+  "nav",
+  "noscript",
+  "object",
+  "ol",
+  "optgroup",
+  "option",
+  "output",
+  "p",
+  "param",
+  "picture",
+  "pre",
+  "progress",
+  "q",
+  "rp",
+  "rt",
+  "ruby",
+  "s",
+  "samp",
+  "script",
+  "section",
+  "select",
+  "slot",
+  "small",
+  "source",
+  "span",
+  "strong",
+  "style",
+  "sub",
+  "summary",
+  "sup",
+  "svg",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "title",
+  "tr",
+  "track",
+  "u",
+  "ul",
+  "var",
+  "video",
+  "wbr",
+]);
+
+const NON_VISUAL_REACT_COMPONENTS = new Set([
+  "Fragment",
+  "StrictMode",
+  "Suspense",
+  "Profiler",
+  "Portal",
+]);
+
+const roundPercentage = (value: number) => Number(value.toFixed(2));
+
+const sourceFileFor = (filePath: string, content: string) => {
+  const scriptKind = filePath.endsWith(".tsx")
+    ? ts.ScriptKind.TSX
+    : ts.ScriptKind.JSX;
+
+  return ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+};
+
+const isDesignSystemImport = (source: string) =>
+  source.startsWith("@skyscanner/backpack-web");
+
+const isBackpackComponent = (componentName: string | null) =>
+  !!componentName && componentName.startsWith("Bpk");
+
+const isRawHtmlElement = (elementName: string | null) =>
+  !!elementName &&
+  elementName === elementName.toLowerCase() &&
+  HTML_ELEMENTS.has(elementName);
+
+const isNonBackpackComponent = (componentName: string | null) =>
+  !!componentName &&
+  /^[A-Z][a-zA-Z0-9]*$/.test(componentName) &&
+  !isBackpackComponent(componentName) &&
+  !isRawHtmlElement(componentName);
+
+const tagNameText = (name: ts.JsxTagNameExpression): string | null => {
+  if (ts.isIdentifier(name)) {
+    return name.text;
+  }
+
+  if (ts.isPropertyAccessExpression(name)) {
+    const left = tagNameText(name.expression as ts.JsxTagNameExpression);
+    return left ? `${left}.${name.name.text}` : name.name.text;
+  }
+
+  if (ts.isJsxNamespacedName(name)) {
+    return `${name.namespace.text}:${name.name.text}`;
+  }
+
+  return null;
+};
+
+const lastMemberName = (elementName: string) => {
+  const segments = elementName.split(".");
+  return segments[segments.length - 1];
+};
+
+const firstMemberName = (elementName: string) => elementName.split(".")[0];
+
+const isCssModuleImport = (source: string) =>
+  /\.(module\.)?(css|scss|sass|less)$/.test(source);
+
+const resolveCssModulePath = (
+  modulePath: string,
+  sourceFilePath: string,
+) => {
+  const resolved = resolve(dirname(sourceFilePath), modulePath);
+  const extensions = ["", ".css", ".scss", ".sass", ".less"];
+
+  for (const extension of extensions) {
+    const candidate = `${resolved}${extension}`;
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return existsSync(resolved) ? resolved : null;
+};
+
+const collectImports = (
+  sourceFile: ts.SourceFile,
+  filePath: string,
+  importedComponents: Set<string>,
+  namespaceImports: Set<string>,
+  cssModuleImports: Map<string, CssModuleImport>,
+  nonVisualImports: Set<string>,
+) => {
+  sourceFile.statements.forEach((statement) => {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      return;
+    }
+
+    const source = statement.moduleSpecifier.text;
+    const importClause = statement.importClause;
+
+    if (!importClause) {
+      return;
+    }
+
+    if (isDesignSystemImport(source)) {
+      if (importClause.name) {
+        importedComponents.add(importClause.name.text);
+      }
+
+      const namedBindings = importClause.namedBindings;
+      if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+        namespaceImports.add(namedBindings.name.text);
+      } else if (namedBindings && ts.isNamedImports(namedBindings)) {
+        namedBindings.elements.forEach((element) => {
+          const importedName = element.propertyName?.text || element.name.text;
+          const localName = element.name.text;
+          if (
+            isBackpackComponent(importedName) ||
+            isBackpackComponent(localName)
+          ) {
+            importedComponents.add(localName);
+          }
+        });
+      }
+    }
+
+    if (isCssModuleImport(source) && importClause.name) {
+      const resolvedPath = resolveCssModulePath(source, filePath);
+      if (resolvedPath) {
+        cssModuleImports.set(importClause.name.text, {
+          modulePath: source,
+          filePath: resolvedPath,
+        });
+      }
+    }
+
+    if (source === "react" || source === "react-dom") {
+      const namedBindings = importClause.namedBindings;
+      if (namedBindings && ts.isNamedImports(namedBindings)) {
+        namedBindings.elements.forEach((element) => {
+          const importedName = element.propertyName?.text || element.name.text;
+          if (NON_VISUAL_REACT_COMPONENTS.has(importedName)) {
+            nonVisualImports.add(element.name.text);
+          }
+        });
+      }
+    }
+  });
+};
+
+const isNonVisualComponent = (
+  elementName: string,
+  nonVisualImports: Set<string>,
+) => {
+  if (nonVisualImports.has(elementName)) {
+    return true;
+  }
+
+  if (!elementName.includes(".")) {
+    return false;
+  }
+
+  const owner = firstMemberName(elementName);
+  const property = lastMemberName(elementName);
+
+  return (
+    property === "Provider" ||
+    (owner === "React" && NON_VISUAL_REACT_COMPONENTS.has(property))
+  );
+};
+
+const expressionName = (expression: ts.Expression): string | null => {
+  if (ts.isIdentifier(expression)) {
+    return expression.text;
+  }
+
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text;
+  }
+
+  return null;
+};
+
+const stringFromExpression = (expression: ts.Expression): string | null => {
+  if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
+    return expression.text;
+  }
+
+  if (ts.isTemplateExpression(expression)) {
+    return [
+      expression.head.text,
+      ...expression.templateSpans.map((span) => span.literal.text),
+    ]
+      .filter((part) => part.trim())
+      .join("...");
+  }
+
+  return null;
+};
+
+const cssModuleClassName = (
+  expression: ts.Expression,
+  cssModuleImports: Map<string, CssModuleImport>,
+) => {
+  if (
+    ts.isPropertyAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression)
+  ) {
+    const objectName = expression.expression.text;
+    if (cssModuleImports.has(objectName)) {
+      return {
+        objectName,
+        className: expression.name.text,
+      };
+    }
+  }
+
+  if (
+    ts.isElementAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    ts.isStringLiteralLike(expression.argumentExpression)
+  ) {
+    const objectName = expression.expression.text;
+    if (cssModuleImports.has(objectName)) {
+      return {
+        objectName,
+        className: expression.argumentExpression.text,
+      };
+    }
+  }
+
+  return null;
+};
+
+const categoriesForCssModuleClass = (
+  moduleImport: CssModuleImport,
+  className: string,
+) => {
+  const cssInfo = parseCssModule(moduleImport.filePath, className);
+  return analyzeCssRulesCategories(cssInfo.rules);
+};
+
+const classNameFromPropertyName = (
+  name: ts.PropertyName,
+  cssModuleImports: Map<string, CssModuleImport>,
+) => {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+    return {
+      className: name.text,
+      categories: analyzeClassNameCategories(name.text),
+    };
+  }
+
+  if (ts.isComputedPropertyName(name)) {
+    const cssClass = cssModuleClassName(name.expression, cssModuleImports);
+    if (cssClass) {
+      const moduleImport = cssModuleImports.get(cssClass.objectName);
+      return {
+        className: cssClass.className,
+        categories: moduleImport
+          ? categoriesForCssModuleClass(moduleImport, cssClass.className)
+          : [],
+      };
+    }
+
+    const stringValue = stringFromExpression(name.expression);
+    if (stringValue) {
+      return {
+        className: stringValue,
+        categories: analyzeClassNameCategories(stringValue),
+      };
+    }
+  }
+
+  return null;
+};
+
+const extractClassNameParts = (
+  expression: ts.Expression,
+  cssModuleImports: Map<string, CssModuleImport>,
+): Array<{ className: string; categories: string[] }> => {
+  const stringValue = stringFromExpression(expression);
+  if (stringValue) {
+    return [
+      {
+        className: stringValue,
+        categories: analyzeClassNameCategories(stringValue),
+      },
+    ];
+  }
+
+  const cssClass = cssModuleClassName(expression, cssModuleImports);
+  if (cssClass) {
+    const moduleImport = cssModuleImports.get(cssClass.objectName);
+    return [
+      {
+        className: cssClass.className,
+        categories: moduleImport
+          ? categoriesForCssModuleClass(moduleImport, cssClass.className)
+          : [],
+      },
+    ];
+  }
+
+  if (ts.isConditionalExpression(expression)) {
+    return [
+      ...extractClassNameParts(expression.whenTrue, cssModuleImports),
+      ...extractClassNameParts(expression.whenFalse, cssModuleImports),
+    ];
+  }
+
+  if (ts.isArrayLiteralExpression(expression)) {
+    return expression.elements.flatMap((element) =>
+      ts.isSpreadElement(element)
+        ? []
+        : extractClassNameParts(element, cssModuleImports),
+    );
+  }
+
+  if (ts.isObjectLiteralExpression(expression)) {
+    return expression.properties.flatMap((property) => {
+      if (
+        ts.isPropertyAssignment(property) ||
+        ts.isShorthandPropertyAssignment(property)
+      ) {
+        const part = classNameFromPropertyName(property.name, cssModuleImports);
+        return part ? [part] : [];
+      }
+      return [];
+    });
+  }
+
+  return [];
+};
+
+const extractClassNamesFromFunction = (
+  callExpression: ts.CallExpression,
+  cssModuleImports: Map<string, CssModuleImport>,
+): ClassNameInfo => {
+  const parts = callExpression.arguments.flatMap((argument) =>
+    ts.isSpreadElement(argument)
+      ? []
+      : extractClassNameParts(argument, cssModuleImports),
+  );
+
+  if (parts.length === 0) {
+    return {
+      hasOverride: false,
+      value: "classNames(...)",
+      type: "function",
+      cssCategories: [],
+      overrideCount: 0,
+    };
+  }
+
+  return {
+    hasOverride: true,
+    value: parts.map((part) => part.className).join(", "),
+    type: "function",
+    cssCategories: parts.flatMap((part) => part.categories),
+    overrideCount: parts.length,
+  };
+};
+
+const extractClassNameInfo = (
+  attributes: ts.JsxAttributes,
+  cssModuleImports: Map<string, CssModuleImport>,
+): ClassNameInfo => {
+  const classNameAttribute = attributes.properties.find(
+    (attribute): attribute is ts.JsxAttribute =>
+      ts.isJsxAttribute(attribute) &&
+      ts.isIdentifier(attribute.name) &&
+      attribute.name.text === "className",
+  );
+
+  if (!classNameAttribute) {
+    return {
+      hasOverride: false,
+      value: null,
+      type: null,
+      cssCategories: [],
+      overrideCount: 0,
+    };
+  }
+
+  if (!classNameAttribute.initializer) {
+    return {
+      hasOverride: true,
+      value: "className",
+      type: "boolean",
+      cssCategories: ["custom"],
+      overrideCount: 1,
+    };
+  }
+
+  const initializer = classNameAttribute.initializer;
+
+  if (ts.isStringLiteral(initializer)) {
+    return {
+      hasOverride: true,
+      value: initializer.text,
+      type: "string",
+      cssCategories: analyzeClassNameCategories(initializer.text),
+      overrideCount: 1,
+    };
+  }
+
+  if (!ts.isJsxExpression(initializer) || !initializer.expression) {
+    return {
+      hasOverride: true,
+      value: "complex expression",
+      type: "expression",
+      cssCategories: [],
+      overrideCount: 1,
+    };
+  }
+
+  const expression = initializer.expression;
+  const stringValue = stringFromExpression(expression);
+  if (stringValue) {
+    return {
+      hasOverride: true,
+      value: stringValue,
+      type: "string",
+      cssCategories: analyzeClassNameCategories(stringValue),
+      overrideCount: 1,
+    };
+  }
+
+  if (ts.isCallExpression(expression)) {
+    const functionName = expressionName(expression.expression);
+    if (functionName === "cls" || functionName === "classNames") {
+      return extractClassNamesFromFunction(expression, cssModuleImports);
+    }
+
+    return {
+      hasOverride: true,
+      value: `${functionName || "function"}(...)`,
+      type: "function",
+      cssCategories: [],
+      overrideCount: 1,
+    };
+  }
+
+  const cssClass = cssModuleClassName(expression, cssModuleImports);
+  if (cssClass) {
+    const moduleImport = cssModuleImports.get(cssClass.objectName);
+    return {
+      hasOverride: true,
+      value: cssClass.className,
+      type: "css-module",
+      cssCategories: moduleImport
+        ? categoriesForCssModuleClass(moduleImport, cssClass.className)
+        : [],
+      overrideCount: 1,
+    };
+  }
+
+  if (ts.isConditionalExpression(expression)) {
+    const parts = extractClassNameParts(expression, cssModuleImports);
+    return {
+      hasOverride: true,
+      value: parts.map((part) => part.className).join(", ") || "conditional",
+      type: "conditional",
+      cssCategories: parts.flatMap((part) => part.categories),
+      overrideCount: Math.max(parts.length, 1),
+    };
+  }
+
+  if (ts.isBinaryExpression(expression) && expression.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    return {
+      hasOverride: true,
+      value: "concatenation",
+      type: "concatenation",
+      cssCategories: [],
+      overrideCount: 1,
+    };
+  }
+
+  if (ts.isIdentifier(expression)) {
+    return {
+      hasOverride: true,
+      value: expression.text,
+      type: "variable",
+      cssCategories: analyzeClassNameCategories(expression.text),
+      overrideCount: 1,
+    };
+  }
+
+  return {
+    hasOverride: true,
+    value: "complex expression",
+    type: "expression",
+    cssCategories: [],
+    overrideCount: 1,
+  };
+};
+
+const hasVisualJsx = (node: ts.Node): boolean => {
+  let found = false;
+
+  const visit = (child: ts.Node) => {
+    if (found) {
+      return;
+    }
+
+    if (
+      child !== node &&
+      (ts.isFunctionDeclaration(child) ||
+        ts.isFunctionExpression(child) ||
+        ts.isArrowFunction(child) ||
+        ts.isClassDeclaration(child) ||
+        ts.isClassExpression(child))
+    ) {
+      return;
+    }
+
+    if (ts.isJsxOpeningElement(child) || ts.isJsxSelfClosingElement(child)) {
+      const name = tagNameText(child.tagName);
+      if (isRawHtmlElement(name) || isBackpackComponent(name)) {
+        found = true;
+        return;
+      }
+    }
+
+    ts.forEachChild(child, visit);
+  };
+
+  ts.forEachChild(node, visit);
+
+  return found;
+};
+
+const buildVisualComponentRegistry = (files: string[]) => {
+  const registry = new Set<string>();
+
+  files.forEach((filePath) => {
+    try {
+      const content = readFileSync(filePath, "utf8");
+      const sourceFile = sourceFileFor(filePath, content);
+
+      const visit = (node: ts.Node) => {
+        if (
+          ts.isFunctionDeclaration(node) &&
+          node.name &&
+          /^[A-Z]/.test(node.name.text) &&
+          hasVisualJsx(node.body || node)
+        ) {
+          registry.add(node.name.text);
+        }
+
+        if (
+          ts.isVariableDeclaration(node) &&
+          ts.isIdentifier(node.name) &&
+          /^[A-Z]/.test(node.name.text) &&
+          node.initializer
+        ) {
+          const initializer = node.initializer;
+
+          if (
+            (ts.isArrowFunction(initializer) ||
+              ts.isFunctionExpression(initializer)) &&
+            hasVisualJsx(initializer.body)
+          ) {
+            registry.add(node.name.text);
+          }
+
+          if (ts.isCallExpression(initializer)) {
+            const functionName = expressionName(initializer.expression);
+            const isForwardRef = functionName === "forwardRef";
+            const callback = initializer.arguments.find(
+              (argument) =>
+                ts.isArrowFunction(argument) || ts.isFunctionExpression(argument),
+            );
+
+            if (isForwardRef && callback && hasVisualJsx(callback)) {
+              registry.add(node.name.text);
+            }
+          }
+        }
+
+        ts.forEachChild(node, visit);
+      };
+
+      visit(sourceFile);
+    } catch {
+      // Parse errors are recorded during the main analysis pass.
+    }
+  });
+
+  return registry;
+};
+
+const emptyFileAnalysis = (): FileAnalysis => ({
+  backpackUsages: 0,
+  classNameOverrides: 0,
+  nonBackpackUsages: 0,
+  rawHtmlUsages: 0,
+  componentCounts: {},
+  cssOverrides: createEmptyCategoryCounts(),
+  rawHtmlCssOverrides: createEmptyCategoryCounts(),
+});
+
+const incrementComponentCount = (
+  componentCounts: Record<string, number>,
+  componentName: string,
+) => {
+  componentCounts[componentName] = (componentCounts[componentName] || 0) + 1;
+};
+
+const analyzeFile = (
+  filePath: string,
+  repoPath: string,
+  visualComponentRegistry: Set<string>,
+): FileAnalysis => {
+  const content = readFileSync(filePath, "utf8");
+  const sourceFile = sourceFileFor(filePath, content);
+  const importedComponents = new Set<string>();
+  const namespaceImports = new Set<string>();
+  const cssModuleImports = new Map<string, CssModuleImport>();
+  const nonVisualImports = new Set<string>();
+  const result = emptyFileAnalysis();
+
+  collectImports(
+    sourceFile,
+    filePath,
+    importedComponents,
+    namespaceImports,
+    cssModuleImports,
+    nonVisualImports,
+  );
+
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxFragment(node)) {
+      ts.forEachChild(node, visit);
+      return;
+    }
+
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const elementName = tagNameText(node.tagName);
+      if (!elementName || isNonVisualComponent(elementName, nonVisualImports)) {
+        ts.forEachChild(node, visit);
+        return;
+      }
+
+      if (elementName.includes(".")) {
+        const namespace = firstMemberName(elementName);
+        const componentName = lastMemberName(elementName);
+
+        if (namespaceImports.has(namespace)) {
+          result.backpackUsages += 1;
+          incrementComponentCount(result.componentCounts, componentName);
+
+          const classNameInfo = extractClassNameInfo(
+            node.attributes,
+            cssModuleImports,
+          );
+          if (classNameInfo.hasOverride) {
+            result.classNameOverrides += classNameInfo.overrideCount;
+            addCategories(result.cssOverrides, classNameInfo.cssCategories);
+          }
+        } else {
+          const classNameInfo = extractClassNameInfo(
+            node.attributes,
+            cssModuleImports,
+          );
+          if (
+            classNameInfo.hasOverride ||
+            visualComponentRegistry.has(elementName)
+          ) {
+            result.nonBackpackUsages += 1;
+          }
+        }
+
+        ts.forEachChild(node, visit);
+        return;
+      }
+
+      if (isRawHtmlElement(elementName)) {
+        result.rawHtmlUsages += 1;
+        const classNameInfo = extractClassNameInfo(
+          node.attributes,
+          cssModuleImports,
+        );
+        if (classNameInfo.hasOverride) {
+          addCategories(
+            result.rawHtmlCssOverrides,
+            classNameInfo.cssCategories,
+          );
+        }
+
+        ts.forEachChild(node, visit);
+        return;
+      }
+
+      if (isBackpackComponent(elementName) || importedComponents.has(elementName)) {
+        result.backpackUsages += 1;
+        incrementComponentCount(result.componentCounts, elementName);
+
+        const classNameInfo = extractClassNameInfo(
+          node.attributes,
+          cssModuleImports,
+        );
+        if (classNameInfo.hasOverride) {
+          result.classNameOverrides += classNameInfo.overrideCount;
+          addCategories(result.cssOverrides, classNameInfo.cssCategories);
+        }
+
+        ts.forEachChild(node, visit);
+        return;
+      }
+
+      if (isNonBackpackComponent(elementName)) {
+        const classNameInfo = extractClassNameInfo(
+          node.attributes,
+          cssModuleImports,
+        );
+        if (
+          classNameInfo.hasOverride ||
+          visualComponentRegistry.has(elementName)
+        ) {
+          result.nonBackpackUsages += 1;
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  return result;
+};
+
+const findBackpackWebVersion = async (repoPath: string) => {
+  const packageJsonFiles = await glob("**/package.json", {
+    cwd: repoPath,
+    absolute: true,
+    ignore: DEFAULT_IGNORE_PATTERNS,
+  });
+
+  const rootPackageJson = join(repoPath, "package.json");
+  const sortedFiles = [
+    rootPackageJson,
+    ...packageJsonFiles.filter((file) => file !== rootPackageJson),
+  ];
+
+  for (const filePath of sortedFiles) {
+    try {
+      const packageJson = JSON.parse(readFileSync(filePath, "utf8")) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+      };
+      const version =
+        packageJson.dependencies?.["@skyscanner/backpack-web"] ||
+        packageJson.devDependencies?.["@skyscanner/backpack-web"];
+
+      if (version) {
+        return version;
+      }
+    } catch {
+      // Ignore invalid package files.
+    }
+  }
+
+  return null;
+};
+
+export const analyzeRepository = async (
+  repoPath: string,
+  options: AnalyzerOptions = {},
+): Promise<AdoptionReport> => {
+  const pattern = options.pattern || DEFAULT_PATTERN;
+  const ignore = options.ignore || DEFAULT_IGNORE_PATTERNS;
+  const files = await glob(pattern, {
+    cwd: repoPath,
+    absolute: true,
+    ignore,
+    nodir: true,
+  });
+  const visualComponentRegistry = buildVisualComponentRegistry(files);
+  const parseErrors: AdoptionReport["parseErrors"] = [];
+  const totals = emptyFileAnalysis();
+
+  files.forEach((filePath) => {
+    try {
+      const fileResult = analyzeFile(filePath, repoPath, visualComponentRegistry);
+      totals.backpackUsages += fileResult.backpackUsages;
+      totals.classNameOverrides += fileResult.classNameOverrides;
+      totals.nonBackpackUsages += fileResult.nonBackpackUsages;
+      totals.rawHtmlUsages += fileResult.rawHtmlUsages;
+      addCategories(
+        totals.cssOverrides,
+        Object.entries(fileResult.cssOverrides).flatMap(([category, count]) =>
+          Array.from({ length: count }, () => category),
+        ),
+      );
+      addCategories(
+        totals.rawHtmlCssOverrides,
+        Object.entries(fileResult.rawHtmlCssOverrides).flatMap(
+          ([category, count]) => Array.from({ length: count }, () => category),
+        ),
+      );
+      Object.entries(fileResult.componentCounts).forEach(
+        ([componentName, count]) => {
+          totals.componentCounts[componentName] =
+            (totals.componentCounts[componentName] || 0) + count;
+        },
+      );
+    } catch (error) {
+      parseErrors.push({
+        file: relative(repoPath, filePath),
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  const nonPureBackpackUsages = Math.min(
+    totals.classNameOverrides,
+    totals.backpackUsages,
+  );
+  const pureBackpackUsages = totals.backpackUsages - nonPureBackpackUsages;
+  const totalElementUsages =
+    totals.backpackUsages + totals.nonBackpackUsages + totals.rawHtmlUsages;
+  const percentage = (count: number) =>
+    totalElementUsages > 0 ? roundPercentage((count / totalElementUsages) * 100) : 0;
+
+  return {
+    repository: basename(repoPath),
+    generatedAt: new Date().toISOString(),
+    filesAnalyzed: files.length,
+    parseErrors,
+    backpackWebVersion: await findBackpackWebVersion(repoPath),
+    usage: {
+      backpack: {
+        count: totals.backpackUsages,
+        percentage: percentage(totals.backpackUsages),
+      },
+      pureBackpack: {
+        count: pureBackpackUsages,
+        percentage: percentage(pureBackpackUsages),
+      },
+      nonPureBackpack: {
+        count: nonPureBackpackUsages,
+        percentage: percentage(nonPureBackpackUsages),
+      },
+      nonBackpack: {
+        count: totals.nonBackpackUsages,
+        percentage: percentage(totals.nonBackpackUsages),
+      },
+      rawHtml: {
+        count: totals.rawHtmlUsages,
+        percentage: percentage(totals.rawHtmlUsages),
+      },
+    },
+    cssOverrides: {
+      byCategory: totals.cssOverrides,
+      total: categoryTotal(totals.cssOverrides),
+    },
+    rawHtmlCssOverrides: {
+      byCategory: totals.rawHtmlCssOverrides,
+      total: categoryTotal(totals.rawHtmlCssOverrides),
+    },
+    componentCounts: totals.componentCounts,
+  };
+};

--- a/libs/backpack-adoption-action/src/constants.ts
+++ b/libs/backpack-adoption-action/src/constants.ts
@@ -1,0 +1,32 @@
+export const ADOPTION_GUARD_THRESHOLD = 60;
+
+export const BACKPACK_ADOPTION_CORTEX_KEY = "backpack-adoption";
+
+export const DEFAULT_PATTERN = "**/*.{jsx,tsx}";
+
+export const DEFAULT_OUTPUT_PATH = "backpack-adoption-results.json";
+
+export const DEFAULT_IGNORE_PATTERNS = [
+  "**/node_modules/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/*.test.*",
+  "**/*.spec.*",
+  "**/*.stories.*",
+  "**/__mocks__/**",
+  "**/__mock__/**",
+  "**/mocks/**",
+];
+
+export const CSS_CATEGORY_NAMES = [
+  "color",
+  "layout",
+  "typography",
+  "size",
+  "position",
+  "visibility",
+  "border",
+  "shadow",
+  "transform",
+  "custom",
+] as const;

--- a/libs/backpack-adoption-action/src/cortex-test.ts
+++ b/libs/backpack-adoption-action/src/cortex-test.ts
@@ -1,0 +1,122 @@
+import { uploadToCortex, cortexWebhookUrl } from "./cortex";
+import type { ActionResult } from "./types";
+
+const actionResult = {
+  generatedAt: "2026-06-03T00:00:00.000Z",
+  repository: "repo",
+  branch: {
+    ref: "refs/heads/main",
+    eventName: "push",
+    isMain: true,
+    isPullRequest: false,
+  },
+  head: {},
+  base: null,
+  comparison: {
+    baseBackpackPercentage: null,
+    headBackpackPercentage: 60,
+    delta: null,
+    threshold: 60,
+  },
+  guard: {
+    status: "not_applicable",
+    reason: "main",
+    dryRun: false,
+    threshold: 60,
+    baseBackpackPercentage: null,
+    headBackpackPercentage: 60,
+    delta: null,
+  },
+  cortex: {
+    status: "skipped",
+    reason: "pending",
+  },
+} as ActionResult;
+
+describe("uploadToCortex", () => {
+  it("uploads custom data on main when Cortex inputs are present", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+    });
+    const io = { warning: jest.fn() };
+
+    const result = await uploadToCortex({
+      actionResult,
+      cortexEntity: "carhire-homepage",
+      fetchImpl,
+      io,
+      isMain: true,
+      webhookUuid: "abc-123",
+    });
+
+    expect(result.status).toBe("uploaded");
+    expect(fetchImpl).toHaveBeenCalledWith(cortexWebhookUrl("abc-123"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        entity_tag: "carhire-homepage",
+        "backpack-adoption": actionResult,
+      }),
+    });
+  });
+
+  it("skips upload outside main", async () => {
+    const fetchImpl = jest.fn();
+
+    const result = await uploadToCortex({
+      actionResult,
+      cortexEntity: "carhire-homepage",
+      fetchImpl,
+      io: { warning: jest.fn() },
+      isMain: false,
+      webhookUuid: "abc-123",
+    });
+
+    expect(result.status).toBe("skipped");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("skips upload when Cortex inputs are missing", async () => {
+    const fetchImpl = jest.fn();
+
+    const result = await uploadToCortex({
+      actionResult,
+      cortexEntity: "",
+      fetchImpl,
+      io: { warning: jest.fn() },
+      isMain: true,
+      webhookUuid: "",
+    });
+
+    expect(result.status).toBe("skipped");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("warns instead of failing when Cortex upload fails", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: async () => "Nope",
+    });
+    const io = { warning: jest.fn() };
+
+    const result = await uploadToCortex({
+      actionResult,
+      cortexEntity: "carhire-homepage",
+      fetchImpl,
+      io,
+      isMain: true,
+      webhookUuid: "abc-123",
+    });
+
+    expect(result.status).toBe("warning");
+    expect(io.warning).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to upload Backpack adoption data to Cortex"),
+    );
+  });
+});

--- a/libs/backpack-adoption-action/src/cortex.ts
+++ b/libs/backpack-adoption-action/src/cortex.ts
@@ -1,0 +1,70 @@
+import { BACKPACK_ADOPTION_CORTEX_KEY } from "./constants";
+import type { ActionIO } from "./action-io";
+import type { ActionResult, CortexResult } from "./types";
+
+export type CortexUploadOptions = {
+  actionResult: ActionResult;
+  cortexEntity: string;
+  fetchImpl?: typeof fetch;
+  io: Pick<ActionIO, "warning">;
+  isMain: boolean;
+  webhookUuid: string;
+};
+
+export const cortexWebhookUrl = (webhookUuid: string) =>
+  `https://api.getcortexapp.com/api/v1/custom-integrations/data/${webhookUuid}`;
+
+export const uploadToCortex = async ({
+  actionResult,
+  cortexEntity,
+  fetchImpl = fetch,
+  io,
+  isMain,
+  webhookUuid,
+}: CortexUploadOptions): Promise<CortexResult> => {
+  if (!isMain) {
+    return {
+      status: "skipped",
+      reason: "Cortex upload only runs on refs/heads/main.",
+    };
+  }
+
+  if (!webhookUuid || !cortexEntity) {
+    return {
+      status: "skipped",
+      reason: "Cortex webhook UUID or entity input was not provided.",
+    };
+  }
+
+  try {
+    const response = await fetchImpl(cortexWebhookUrl(webhookUuid), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        entity_tag: cortexEntity,
+        [BACKPACK_ADOPTION_CORTEX_KEY]: actionResult,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Cortex responded with ${response.status} ${response.statusText}${body ? `: ${body}` : ""}`,
+      );
+    }
+
+    return {
+      status: "uploaded",
+      reason: "Uploaded Backpack adoption data to Cortex.",
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    io.warning(`Failed to upload Backpack adoption data to Cortex: ${message}`);
+    return {
+      status: "warning",
+      reason: `Failed to upload Backpack adoption data to Cortex: ${message}`,
+    };
+  }
+};

--- a/libs/backpack-adoption-action/src/css.ts
+++ b/libs/backpack-adoption-action/src/css.ts
@@ -1,0 +1,433 @@
+import { existsSync, readFileSync } from "node:fs";
+import { extname } from "node:path";
+
+import { CSS_CATEGORY_NAMES } from "./constants";
+import type { CssCategoryCounts } from "./types";
+
+type CssRule = {
+  property: string;
+  value: string;
+};
+
+type CssModuleInfo = {
+  rules: CssRule[];
+  mixins: string[];
+};
+
+export const createEmptyCategoryCounts = (): CssCategoryCounts => ({
+  color: 0,
+  layout: 0,
+  typography: 0,
+  size: 0,
+  position: 0,
+  visibility: 0,
+  border: 0,
+  shadow: 0,
+  transform: 0,
+  custom: 0,
+});
+
+export const addCategories = (
+  counts: CssCategoryCounts,
+  categories: string[],
+) => {
+  categories.forEach((category) => {
+    if (CSS_CATEGORY_NAMES.includes(category as keyof CssCategoryCounts)) {
+      counts[category as keyof CssCategoryCounts] += 1;
+    } else {
+      counts.custom += 1;
+    }
+  });
+};
+
+export const categoryTotal = (counts: CssCategoryCounts) =>
+  CSS_CATEGORY_NAMES.reduce((total, category) => total + counts[category], 0);
+
+const propertyCategories = (propertyName: string) => {
+  const categories = new Set<string>();
+  const lowerProperty = propertyName.toLowerCase();
+
+  if (
+    lowerProperty === "color" ||
+    lowerProperty.includes("background") ||
+    lowerProperty.startsWith("bg-") ||
+    lowerProperty.includes("border-color")
+  ) {
+    categories.add("color");
+  }
+
+  if (
+    lowerProperty === "display" ||
+    lowerProperty === "position" ||
+    lowerProperty === "float" ||
+    lowerProperty === "clear" ||
+    lowerProperty.includes("flex") ||
+    lowerProperty.includes("grid") ||
+    lowerProperty.startsWith("margin") ||
+    lowerProperty.startsWith("padding") ||
+    lowerProperty === "gap" ||
+    lowerProperty === "row-gap" ||
+    lowerProperty === "column-gap"
+  ) {
+    categories.add("layout");
+  }
+
+  if (
+    lowerProperty.includes("font") ||
+    lowerProperty.includes("text") ||
+    lowerProperty === "line-height" ||
+    lowerProperty === "letter-spacing" ||
+    lowerProperty === "word-spacing" ||
+    lowerProperty === "white-space" ||
+    lowerProperty === "word-wrap" ||
+    lowerProperty === "word-break" ||
+    lowerProperty === "vertical-align"
+  ) {
+    categories.add("typography");
+  }
+
+  if (
+    lowerProperty === "width" ||
+    lowerProperty === "height" ||
+    lowerProperty === "min-width" ||
+    lowerProperty === "max-width" ||
+    lowerProperty === "min-height" ||
+    lowerProperty === "max-height" ||
+    lowerProperty === "size" ||
+    lowerProperty === "box-sizing"
+  ) {
+    categories.add("size");
+  }
+
+  if (
+    lowerProperty === "top" ||
+    lowerProperty === "right" ||
+    lowerProperty === "bottom" ||
+    lowerProperty === "left" ||
+    lowerProperty === "inset" ||
+    lowerProperty === "z-index"
+  ) {
+    categories.add("position");
+  }
+
+  if (
+    lowerProperty === "visibility" ||
+    lowerProperty === "opacity" ||
+    lowerProperty === "display" ||
+    lowerProperty === "overflow" ||
+    lowerProperty === "overflow-x" ||
+    lowerProperty === "overflow-y"
+  ) {
+    categories.add("visibility");
+  }
+
+  if (
+    lowerProperty === "border" ||
+    lowerProperty.includes("border-") ||
+    lowerProperty === "border-radius" ||
+    lowerProperty === "outline" ||
+    lowerProperty.includes("outline-")
+  ) {
+    categories.add("border");
+  }
+
+  if (lowerProperty.includes("shadow")) {
+    categories.add("shadow");
+  }
+
+  if (
+    lowerProperty.includes("transform") ||
+    lowerProperty.includes("transition") ||
+    lowerProperty.includes("animation") ||
+    lowerProperty === "rotate" ||
+    lowerProperty === "scale" ||
+    lowerProperty === "translate"
+  ) {
+    categories.add("transform");
+  }
+
+  return Array.from(categories);
+};
+
+export const analyzeCssRulesCategories = (rules: CssRule[]) =>
+  rules.flatMap((rule) => propertyCategories(rule.property));
+
+export const analyzeClassNameCategories = (classNameValue: string | null) => {
+  if (!classNameValue) {
+    return [];
+  }
+
+  const categories: string[] = [];
+  const lowerValue = classNameValue.toLowerCase();
+  const pushMatches = (category: string, count: number) => {
+    for (let index = 0; index < count; index += 1) {
+      categories.push(category);
+    }
+  };
+
+  pushMatches(
+    "color",
+    (lowerValue.match(/\b(text|text-|color|fg-|text-color)\b/g) || [])
+      .length +
+      (lowerValue.match(/\b(bg|background|bg-)\b/g) || []).length +
+      (lowerValue.match(/\b(border|border-)\b/g) || []).length,
+  );
+
+  pushMatches(
+    "layout",
+    (lowerValue.match(/\b(flex|grid|block|inline|absolute|relative|fixed|sticky)\b/g) ||
+      []).length +
+      (lowerValue.match(/\b(container|wrapper|layout)\b/g) || []).length +
+      (lowerValue.match(/\b(m|margin|p|padding|gap|space)\b/g) || [])
+        .length +
+      (lowerValue.match(/\b(mt|mb|ml|mr|mx|my|pt|pb|pl|pr|px|py)\b/g) ||
+        []).length,
+  );
+
+  pushMatches(
+    "typography",
+    (lowerValue.match(/\b(font|text-|text-size|text-lg|text-sm|text-xs|text-xl|text-2xl|text-3xl|text-4xl|text-5xl|text-6xl|text-base|leading|line-height|tracking|letter-spacing)\b/g) ||
+      []).length +
+      (lowerValue.match(/\b(bold|semibold|medium|light|italic|underline|uppercase|lowercase|capitalize)\b/g) ||
+        []).length,
+  );
+
+  pushMatches(
+    "size",
+    (lowerValue.match(/\b(w|width|h|height|size|min-|max-|w-|h-)\b/g) ||
+      []).length,
+  );
+  pushMatches(
+    "position",
+    (lowerValue.match(/\b(top|bottom|left|right|inset|z-|z-index)\b/g) ||
+      []).length,
+  );
+  pushMatches(
+    "visibility",
+    (lowerValue.match(/\b(hidden|visible|display|show|hide|opacity)\b/g) ||
+      []).length,
+  );
+  pushMatches(
+    "border",
+    (lowerValue.match(/\b(rounded|border|radius|ring)\b/g) || []).length,
+  );
+  pushMatches(
+    "shadow",
+    (lowerValue.match(/\b(shadow|drop-shadow)\b/g) || []).length,
+  );
+  pushMatches(
+    "transform",
+    (lowerValue.match(/\b(transform|transition|animate|animation|rotate|scale|translate)\b/g) ||
+      []).length,
+  );
+
+  if (
+    categories.length === 0 &&
+    classNameValue !== "conditional" &&
+    classNameValue !== "concatenation" &&
+    classNameValue !== "complex expression"
+  ) {
+    categories.push("custom");
+  }
+
+  return categories;
+};
+
+const extractBlockContent = (content: string, startPosition: number) => {
+  let depth = 1;
+  let position = startPosition;
+  let result = "";
+
+  while (position < content.length && depth > 0) {
+    const character = content[position];
+
+    if (character === "{") {
+      depth += 1;
+    } else if (character === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        break;
+      }
+    }
+
+    result += character;
+    position += 1;
+  }
+
+  return result;
+};
+
+const extractPropertiesRecursively = (
+  content: string,
+  rules: CssRule[],
+) => {
+  let position = 0;
+
+  while (position < content.length) {
+    while (position < content.length && /\s/.test(content[position])) {
+      position += 1;
+    }
+
+    if (position >= content.length) {
+      break;
+    }
+
+    if (content.substring(position).startsWith("//")) {
+      while (position < content.length && content[position] !== "\n") {
+        position += 1;
+      }
+      continue;
+    }
+
+    if (content.substring(position).startsWith("/*")) {
+      const commentEnd = content.indexOf("*/", position);
+      if (commentEnd === -1) {
+        break;
+      }
+      position = commentEnd + 2;
+      continue;
+    }
+
+    if (content[position] === "@") {
+      const directiveMatch = /^@[a-zA-Z-]+\s/.exec(
+        content.substring(position),
+      );
+      if (
+        directiveMatch &&
+        !content.substring(position).startsWith("@include")
+      ) {
+        while (position < content.length && content[position] !== "\n") {
+          position += 1;
+        }
+        continue;
+      }
+    }
+
+    const nestedBlockMatch =
+      /^([&a-zA-Z0-9_-]+(?:\s+[&a-zA-Z0-9_-]+)*)\s*\{/.exec(
+        content.substring(position),
+      );
+
+    if (nestedBlockMatch) {
+      const blockStart = position + nestedBlockMatch[0].length;
+      const nestedContent = extractBlockContent(content, blockStart);
+      if (nestedContent) {
+        extractPropertiesRecursively(nestedContent, rules);
+        position = blockStart + nestedContent.length + 1;
+        continue;
+      }
+    }
+
+    const propertyMatch = /^([a-zA-Z-]+)\s*:\s*([^;]+?)\s*;/.exec(
+      content.substring(position),
+    );
+
+    if (propertyMatch) {
+      rules.push({
+        property: propertyMatch[1].trim(),
+        value: propertyMatch[2].trim(),
+      });
+      position += propertyMatch[0].length;
+      continue;
+    }
+
+    position += 1;
+  }
+};
+
+const extractRulesAndMixins = (blockContent: string, isScss: boolean) => {
+  const rules: CssRule[] = [];
+  const mixins: string[] = [];
+
+  if (isScss) {
+    const mixinRegex = /@include\s+([a-zA-Z0-9_-]+(?:\s*\([^)]*\))?)/g;
+    let mixinMatch = mixinRegex.exec(blockContent);
+    while (mixinMatch) {
+      const mixinName = mixinMatch[1].split("(")[0].trim();
+      if (mixinName) {
+        mixins.push(mixinName);
+      }
+      mixinMatch = mixinRegex.exec(blockContent);
+    }
+  }
+
+  extractPropertiesRecursively(blockContent, rules);
+
+  return { rules, mixins };
+};
+
+export const parseCssModule = (
+  cssFilePath: string,
+  className: string,
+): CssModuleInfo => {
+  if (!existsSync(cssFilePath)) {
+    return { rules: [], mixins: [] };
+  }
+
+  try {
+    const content = readFileSync(cssFilePath, "utf8");
+    const extension = extname(cssFilePath).toLowerCase();
+    const isScss = extension === ".scss" || extension === ".sass";
+    const rules: CssRule[] = [];
+    const mixins: string[] = [];
+    const bemMatch = className.match(/^(.+?)(__(.+?))?(--(.+?))?$/);
+
+    if (bemMatch && (bemMatch[3] || bemMatch[5])) {
+      const blockName = bemMatch[1];
+      const targetSelector = bemMatch[3]
+        ? `__${bemMatch[3]}`
+        : `--${bemMatch[5]}`;
+      const escapedBlockName = blockName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const blockRegex = new RegExp(`\\.${escapedBlockName}\\s*\\{`, "g");
+      let blockMatch = blockRegex.exec(content);
+
+      while (blockMatch) {
+        const blockStart = blockMatch.index + blockMatch[0].length;
+        const blockContent = extractBlockContent(content, blockStart);
+        const blockResults = extractRulesAndMixins(blockContent, isScss);
+        rules.push(...blockResults.rules);
+        mixins.push(...blockResults.mixins);
+
+        const escapedSelector = targetSelector.replace(
+          /[.*+?^${}()|[\]\\]/g,
+          "\\$&",
+        );
+        const nestedRegex = new RegExp(`&${escapedSelector}\\s*\\{`, "g");
+        let nestedMatch = nestedRegex.exec(blockContent);
+        while (nestedMatch) {
+          const nestedStart = nestedMatch.index + nestedMatch[0].length;
+          const nestedContent = extractBlockContent(
+            blockContent,
+            nestedStart,
+          );
+          const nestedResults = extractRulesAndMixins(nestedContent, isScss);
+          rules.push(...nestedResults.rules);
+          mixins.push(...nestedResults.mixins);
+          nestedMatch = nestedRegex.exec(blockContent);
+        }
+
+        blockMatch = blockRegex.exec(content);
+      }
+    } else {
+      const escapedClassName = className.replace(
+        /[.*+?^${}()|[\]\\]/g,
+        "\\$&",
+      );
+      const classRegex = new RegExp(`\\.${escapedClassName}\\s*\\{`, "g");
+      let match = classRegex.exec(content);
+
+      while (match) {
+        const blockStart = match.index + match[0].length;
+        const blockContent = extractBlockContent(content, blockStart);
+        const result = extractRulesAndMixins(blockContent, isScss);
+        rules.push(...result.rules);
+        mixins.push(...result.mixins);
+        match = classRegex.exec(content);
+      }
+    }
+
+    return { rules, mixins: Array.from(new Set(mixins)) };
+  } catch {
+    return { rules: [], mixins: [] };
+  }
+};

--- a/libs/backpack-adoption-action/src/git.ts
+++ b/libs/backpack-adoption-action/src/git.ts
@@ -1,0 +1,80 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+type GitHubEventPayload = {
+  pull_request?: {
+    base?: {
+      sha?: string;
+    };
+  };
+};
+
+export const isPullRequestEvent = () =>
+  process.env.GITHUB_EVENT_NAME === "pull_request" ||
+  process.env.GITHUB_EVENT_NAME === "pull_request_target";
+
+export const isMainBranch = () => process.env.GITHUB_REF === "refs/heads/main";
+
+const readBaseShaFromEvent = () => {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    return null;
+  }
+
+  try {
+    // Require avoids adding a second async filesystem path to the action startup.
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const payload = require(eventPath) as GitHubEventPayload;
+    return payload.pull_request?.base?.sha || null;
+  } catch {
+    return null;
+  }
+};
+
+export const getPullRequestBaseRef = () =>
+  readBaseShaFromEvent() ||
+  (process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : null);
+
+export const withBaseWorktree = async <T>(
+  repoPath: string,
+  baseRef: string,
+  callback: (basePath: string) => Promise<T>,
+) => {
+  const parentDirectory = await mkdtemp(
+    join(tmpdir(), "backpack-adoption-base-"),
+  );
+  const basePath = join(parentDirectory, "base");
+
+  try {
+    await execFileAsync("git", [
+      "-C",
+      repoPath,
+      "worktree",
+      "add",
+      "--detach",
+      basePath,
+      baseRef,
+    ]);
+
+    return await callback(basePath);
+  } finally {
+    await execFileAsync("git", [
+      "-C",
+      repoPath,
+      "worktree",
+      "remove",
+      "--force",
+      basePath,
+    ]).catch(() => undefined);
+    await rm(parentDirectory, { force: true, recursive: true }).catch(
+      () => undefined,
+    );
+  }
+};

--- a/libs/backpack-adoption-action/src/guard-test.ts
+++ b/libs/backpack-adoption-action/src/guard-test.ts
@@ -1,0 +1,119 @@
+import { evaluateGuard } from "./guard";
+import type { AdoptionReport } from "./types";
+
+const reportWithBackpackPercentage = (percentage: number): AdoptionReport => ({
+  repository: "repo",
+  generatedAt: "2026-06-03T00:00:00.000Z",
+  filesAnalyzed: 1,
+  parseErrors: [],
+  backpackWebVersion: null,
+  usage: {
+    backpack: { count: percentage, percentage },
+    pureBackpack: { count: percentage, percentage },
+    nonPureBackpack: { count: 0, percentage: 0 },
+    nonBackpack: { count: 0, percentage: 0 },
+    rawHtml: { count: 0, percentage: 0 },
+  },
+  cssOverrides: {
+    byCategory: {
+      color: 0,
+      layout: 0,
+      typography: 0,
+      size: 0,
+      position: 0,
+      visibility: 0,
+      border: 0,
+      shadow: 0,
+      transform: 0,
+      custom: 0,
+    },
+    total: 0,
+  },
+  rawHtmlCssOverrides: {
+    byCategory: {
+      color: 0,
+      layout: 0,
+      typography: 0,
+      size: 0,
+      position: 0,
+      visibility: 0,
+      border: 0,
+      shadow: 0,
+      transform: 0,
+      custom: 0,
+    },
+    total: 0,
+  },
+  componentCounts: {},
+});
+
+describe("evaluateGuard", () => {
+  it("passes when base adoption is below the threshold even if head decreases", () => {
+    const result = evaluateGuard({
+      baseReport: reportWithBackpackPercentage(59),
+      dryRun: false,
+      headReport: reportWithBackpackPercentage(58),
+      isMain: false,
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.delta).toBe(-1);
+  });
+
+  it("fails when base adoption is at threshold and head decreases", () => {
+    const result = evaluateGuard({
+      baseReport: reportWithBackpackPercentage(60),
+      dryRun: false,
+      headReport: reportWithBackpackPercentage(59.5),
+      isMain: false,
+    });
+
+    expect(result.status).toBe("fail");
+    expect(result.delta).toBe(-0.5);
+  });
+
+  it("passes when base adoption is at threshold and head is unchanged", () => {
+    const result = evaluateGuard({
+      baseReport: reportWithBackpackPercentage(60),
+      dryRun: false,
+      headReport: reportWithBackpackPercentage(60),
+      isMain: false,
+    });
+
+    expect(result.status).toBe("pass");
+  });
+
+  it("passes when base adoption is at threshold and head increases", () => {
+    const result = evaluateGuard({
+      baseReport: reportWithBackpackPercentage(61),
+      dryRun: false,
+      headReport: reportWithBackpackPercentage(62),
+      isMain: false,
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.delta).toBe(1);
+  });
+
+  it("converts a failing PR result to warning in dry-run mode", () => {
+    const result = evaluateGuard({
+      baseReport: reportWithBackpackPercentage(70),
+      dryRun: true,
+      headReport: reportWithBackpackPercentage(69),
+      isMain: false,
+    });
+
+    expect(result.status).toBe("warn");
+  });
+
+  it("never fails on main", () => {
+    const result = evaluateGuard({
+      baseReport: reportWithBackpackPercentage(80),
+      dryRun: false,
+      headReport: reportWithBackpackPercentage(10),
+      isMain: true,
+    });
+
+    expect(result.status).toBe("not_applicable");
+  });
+});

--- a/libs/backpack-adoption-action/src/guard.ts
+++ b/libs/backpack-adoption-action/src/guard.ts
@@ -1,0 +1,79 @@
+import { ADOPTION_GUARD_THRESHOLD } from "./constants";
+import type { AdoptionReport, GuardResult } from "./types";
+
+export const evaluateGuard = ({
+  baseReport,
+  dryRun,
+  headReport,
+  isMain,
+}: {
+  baseReport: AdoptionReport | null;
+  dryRun: boolean;
+  headReport: AdoptionReport;
+  isMain: boolean;
+}): GuardResult => {
+  const headBackpackPercentage = headReport.usage.backpack.percentage;
+
+  if (isMain) {
+    return {
+      status: "not_applicable",
+      reason: "Main branch runs report adoption but never fail on adoption changes.",
+      dryRun,
+      threshold: ADOPTION_GUARD_THRESHOLD,
+      baseBackpackPercentage: null,
+      headBackpackPercentage,
+      delta: null,
+    };
+  }
+
+  if (!baseReport) {
+    return {
+      status: "not_applicable",
+      reason: "No pull request base report was available.",
+      dryRun,
+      threshold: ADOPTION_GUARD_THRESHOLD,
+      baseBackpackPercentage: null,
+      headBackpackPercentage,
+      delta: null,
+    };
+  }
+
+  const baseBackpackPercentage = baseReport.usage.backpack.percentage;
+  const delta = Number((headBackpackPercentage - baseBackpackPercentage).toFixed(2));
+
+  if (baseBackpackPercentage < ADOPTION_GUARD_THRESHOLD) {
+    return {
+      status: "pass",
+      reason: `Base adoption is below ${ADOPTION_GUARD_THRESHOLD}%, so this PR is reported but not blocked.`,
+      dryRun,
+      threshold: ADOPTION_GUARD_THRESHOLD,
+      baseBackpackPercentage,
+      headBackpackPercentage,
+      delta,
+    };
+  }
+
+  if (headBackpackPercentage < baseBackpackPercentage) {
+    return {
+      status: dryRun ? "warn" : "fail",
+      reason: dryRun
+        ? "Backpack adoption decreased, but dry-run is enabled."
+        : "Backpack adoption decreased after the repository had reached the guard threshold.",
+      dryRun,
+      threshold: ADOPTION_GUARD_THRESHOLD,
+      baseBackpackPercentage,
+      headBackpackPercentage,
+      delta,
+    };
+  }
+
+  return {
+    status: "pass",
+    reason: "Backpack adoption did not decrease.",
+    dryRun,
+    threshold: ADOPTION_GUARD_THRESHOLD,
+    baseBackpackPercentage,
+    headBackpackPercentage,
+    delta,
+  };
+};

--- a/libs/backpack-adoption-action/src/index.ts
+++ b/libs/backpack-adoption-action/src/index.ts
@@ -1,0 +1,7 @@
+import { run } from "./action";
+
+run().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.log(`::error::${message}`);
+  process.exitCode = 1;
+});

--- a/libs/backpack-adoption-action/src/result.ts
+++ b/libs/backpack-adoption-action/src/result.ts
@@ -1,0 +1,43 @@
+import type { ActionResult, AdoptionReport } from "./types";
+
+export const createPendingActionResult = ({
+  baseReport,
+  eventName,
+  guard,
+  headReport,
+  isMain,
+  isPullRequest,
+  ref,
+  repository,
+}: {
+  baseReport: AdoptionReport | null;
+  eventName: string | null;
+  guard: ActionResult["guard"];
+  headReport: AdoptionReport;
+  isMain: boolean;
+  isPullRequest: boolean;
+  ref: string | null;
+  repository: string;
+}): ActionResult => ({
+  generatedAt: new Date().toISOString(),
+  repository,
+  branch: {
+    ref,
+    eventName,
+    isMain,
+    isPullRequest,
+  },
+  head: headReport,
+  base: baseReport,
+  comparison: {
+    baseBackpackPercentage: guard.baseBackpackPercentage,
+    headBackpackPercentage: guard.headBackpackPercentage,
+    delta: guard.delta,
+    threshold: guard.threshold,
+  },
+  guard,
+  cortex: {
+    status: "skipped",
+    reason: "Cortex upload has not run yet.",
+  },
+});

--- a/libs/backpack-adoption-action/src/summary.ts
+++ b/libs/backpack-adoption-action/src/summary.ts
@@ -1,0 +1,44 @@
+import type { ActionResult } from "./types";
+
+const percentage = (value: number | null) =>
+  value === null ? "n/a" : `${value.toFixed(2)}%`;
+
+const delta = (value: number | null) => {
+  if (value === null) {
+    return "n/a";
+  }
+
+  return `${value >= 0 ? "+" : ""}${value.toFixed(2)}pp`;
+};
+
+const statusLabel = (status: ActionResult["guard"]["status"]) => {
+  if (status === "fail") {
+    return "Fail";
+  }
+
+  if (status === "warn") {
+    return "Warning";
+  }
+
+  if (status === "pass") {
+    return "Pass";
+  }
+
+  return "Not applicable";
+};
+
+export const buildStepSummary = (result: ActionResult) => `## Backpack Adoption Guard
+
+| Metric | Value |
+| --- | ---: |
+| Base Backpack adoption | ${percentage(result.comparison.baseBackpackPercentage)} |
+| Head Backpack adoption | ${percentage(result.comparison.headBackpackPercentage)} |
+| Delta | ${delta(result.comparison.delta)} |
+| Guard threshold | ${result.comparison.threshold.toFixed(2)}% |
+| Dry run | ${result.guard.dryRun ? "true" : "false"} |
+| Guard status | ${statusLabel(result.guard.status)} |
+| Cortex upload | ${result.cortex.status} |
+
+${result.guard.reason}
+
+`;

--- a/libs/backpack-adoption-action/src/types.ts
+++ b/libs/backpack-adoption-action/src/types.ts
@@ -1,0 +1,89 @@
+export type UsageMetric = {
+  count: number;
+  percentage: number;
+};
+
+export type CssCategoryCounts = {
+  color: number;
+  layout: number;
+  typography: number;
+  size: number;
+  position: number;
+  visibility: number;
+  border: number;
+  shadow: number;
+  transform: number;
+  custom: number;
+};
+
+export type CssOverrideSummary = {
+  byCategory: CssCategoryCounts;
+  total: number;
+};
+
+export type UsageSummary = {
+  backpack: UsageMetric;
+  pureBackpack: UsageMetric;
+  nonPureBackpack: UsageMetric;
+  nonBackpack: UsageMetric;
+  rawHtml: UsageMetric;
+};
+
+export type AdoptionReport = {
+  repository: string;
+  generatedAt: string;
+  filesAnalyzed: number;
+  parseErrors: Array<{
+    file: string;
+    message: string;
+  }>;
+  backpackWebVersion: string | null;
+  usage: UsageSummary;
+  cssOverrides: CssOverrideSummary;
+  rawHtmlCssOverrides: CssOverrideSummary;
+  componentCounts: Record<string, number>;
+};
+
+export type GuardStatus = "pass" | "fail" | "warn" | "not_applicable";
+
+export type GuardResult = {
+  status: GuardStatus;
+  reason: string;
+  dryRun: boolean;
+  threshold: number;
+  baseBackpackPercentage: number | null;
+  headBackpackPercentage: number;
+  delta: number | null;
+};
+
+export type CortexStatus = "skipped" | "uploaded" | "warning";
+
+export type CortexResult = {
+  status: CortexStatus;
+  reason: string;
+};
+
+export type ActionResult = {
+  generatedAt: string;
+  repository: string;
+  branch: {
+    ref: string | null;
+    eventName: string | null;
+    isMain: boolean;
+    isPullRequest: boolean;
+  };
+  head: AdoptionReport;
+  base: AdoptionReport | null;
+  comparison: {
+    baseBackpackPercentage: number | null;
+    headBackpackPercentage: number;
+    delta: number | null;
+    threshold: number;
+  };
+  guard: GuardResult;
+  cortex: CortexResult;
+};
+
+export type ResultsFile = {
+  "backpack-adoption": ActionResult;
+};

--- a/libs/backpack-adoption-action/tsconfig.json
+++ b/libs/backpack-adoption-action/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node", "jest"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,10 @@
         "npm": ">=10.8.3"
       }
     },
+    "libs/backpack-adoption-action": {
+      "name": "@skyscanner/backpack-adoption-action",
+      "version": "0.0.0"
+    },
     "libs/backpack-storybook-host": {
       "version": "0.0.0",
       "license": "Apache-2.0",
@@ -10527,6 +10531,10 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@skyscanner/backpack-adoption-action": {
+      "resolved": "libs/backpack-adoption-action",
+      "link": true
     },
     "node_modules/@skyscanner/backpack-web": {
       "resolved": "packages/backpack-web",


### PR DESCRIPTION
## Summary

Adds a Backpack Adoption Guard GitHub Action under `libs/backpack-adoption-action`.

The action calculates Backpack adoption in consuming repositories, writes `backpack-adoption-results.json`, uploads to Cortex on `main`, and blocks PRs only when a repository has already reached the fixed 60% Backpack adoption threshold and the PR lowers adoption.

## What changed

- Added a private Nx tooling project for the action, including `action.yml`, TypeScript source, tests, and committed `dist/index.js`.
- Vendored the minimum analyser logic needed to classify Backpack components, visual non-Backpack components, raw HTML, and `className` overrides.
- Added guard logic for main vs PR behaviour, base/head comparison via `git worktree`, dry-run warnings, step summary output, and Cortex upload handling.
- Added release workflow support for `backpack-adoption-action/vX.Y.Z` tags and floating major tags like `backpack-adoption-action/v1`.
- Updated Backpack release workflow so action tags do not trigger `@skyscanner/backpack-web` npm publishing.
- Added affected `verify-dist` to CI so source changes cannot drift from the committed action bundle.

## Validation

- `npx nx run backpack-adoption-action:typecheck`
- `npx nx run backpack-adoption-action:test`
- `npx nx run backpack-adoption-action:lint`
- `npx nx run backpack-adoption-action:verify-dist`
- Bundled action smoke test against a temporary repo, confirming expected adoption output.