### PR TITLE
ci: add Percy debug logging to diagnose flaky snapshots

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -191,6 +191,8 @@ jobs:
         if: ( github.ref == 'refs/heads/main' || github.repository == github.event.pull_request.head.repo.full_name) && github.actor != 'dependabot[bot]'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          LOG_LEVEL: debug
+          PERCY_DEBUG: '*'
         run: |
           npm run percy-test 2>&1 | tee "${RUNNER_TEMP}/percy.log"
           # Assert success by the presence of a percy.io build URL rather than


### PR DESCRIPTION
## Summary
- Add `LOG_LEVEL=debug` and `PERCY_DEBUG=*` env vars to the Percy Test CI step
- Temporary change to gather detailed logs for diagnosing flaky Percy snapshot failures

## Note
Remove these env vars once the flaky issue is identified and resolved.