### PR TITLE
[NO-JIRA]: fix(BpkProvider): validate html[lang] before passing to Ark to prevent crash loop

### DIFF
--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
@@ -223,7 +223,7 @@ describe('BpkProvider - RTL support', () => {
     expect(getByTestId('locale').textContent).toBe('en-US');
   });
 
-  it('falls back to en-US and does not crash when html[lang] is an invalid locale (numeric string)', async () => {
+  it('falls back to en-US and does not crash when html[lang] is an invalid locale (numeric string)', () => {
     document.documentElement.setAttribute('lang', '123');
 
     const { getByTestId } = render(
@@ -235,7 +235,7 @@ describe('BpkProvider - RTL support', () => {
     expect(getByTestId('locale').textContent).toBe('en-US');
   });
 
-  it('falls back to en-US and does not crash when html[lang] is an empty string', async () => {
+  it('falls back to en-US and does not crash when html[lang] is an empty string', () => {
     document.documentElement.setAttribute('lang', '');
 
     const { getByTestId } = render(

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
@@ -16,6 +16,9 @@
  * limitations under the License.
  */
 
+import type { ReactNode } from 'react';
+import { Component } from 'react';
+
 import { useLocaleContext } from '@ark-ui/react';
 import { act, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -23,6 +26,39 @@ import '@testing-library/jest-dom';
 import { BpkBox } from './BpkBox';
 import { BpkProvider } from './BpkProvider';
 import { BpkSpacing } from './tokens';
+
+// Mirrors the production topology: error boundary whose fallback also mounts BpkProvider.
+// This is exactly the structure that causes the infinite remount loop.
+class LoopBoundary extends Component<
+  { children: ReactNode },
+  { errored: boolean }
+> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { errored: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { errored: true };
+  }
+
+  componentDidCatch() {
+    this.catchCount += 1;
+  }
+
+  catchCount = 0;
+
+  render() {
+    if (this.state.errored) {
+      return (
+        <BpkProvider>
+          <div data-testid="fallback">fallback</div>
+        </BpkProvider>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 const LocaleReader = () => {
   const { locale } = useLocaleContext();
@@ -209,6 +245,30 @@ describe('BpkProvider - RTL support', () => {
     );
 
     expect(getByTestId('locale').textContent).toBe('en-US');
+  });
+
+  it('does not loop when ErrorBoundary fallback also mounts BpkProvider with invalid html[lang]', () => {
+    document.documentElement.setAttribute('lang', '123');
+
+    // Suppress expected React error output for this test
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+    const boundary = { current: null as LoopBoundary | null };
+    render(
+      // LoopBoundary mirrors the production topology: ErrorBoundary whose fallback
+      // also mounts BpkProvider. Without the fix this render() never returns —
+      // it exhausts the JS heap as BpkProvider → Ark throws → boundary remounts
+      // BpkProvider → repeat. With the fix BpkProvider never throws.
+      <LoopBoundary ref={(el) => { boundary.current = el; }}>
+        <BpkProvider>
+          <div>content</div>
+        </BpkProvider>
+      </LoopBoundary>,
+    );
+
+    expect(boundary.current?.catchCount).toBe(0);
+
+    jest.restoreAllMocks();
   });
 
   it('passes a valid html[lang] through to Ark unchanged', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
@@ -187,6 +187,42 @@ describe('BpkProvider - RTL support', () => {
     expect(getByTestId('locale').textContent).toBe('en-US');
   });
 
+  it('falls back to en-US and does not crash when html[lang] is an invalid locale (numeric string)', async () => {
+    document.documentElement.setAttribute('lang', '123');
+
+    const { getByTestId } = render(
+      <BpkProvider>
+        <LocaleReader />
+      </BpkProvider>,
+    );
+
+    expect(getByTestId('locale').textContent).toBe('en-US');
+  });
+
+  it('falls back to en-US and does not crash when html[lang] is an empty string', async () => {
+    document.documentElement.setAttribute('lang', '');
+
+    const { getByTestId } = render(
+      <BpkProvider>
+        <LocaleReader />
+      </BpkProvider>,
+    );
+
+    expect(getByTestId('locale').textContent).toBe('en-US');
+  });
+
+  it('passes a valid html[lang] through to Ark unchanged', () => {
+    document.documentElement.setAttribute('lang', 'en-GB');
+
+    const { getByTestId } = render(
+      <BpkProvider>
+        <LocaleReader />
+      </BpkProvider>,
+    );
+
+    expect(getByTestId('locale').textContent).toBe('en-GB');
+  });
+
   it('disconnects MutationObserver on unmount', () => {
     const disconnectSpy = jest.spyOn(MutationObserver.prototype, 'disconnect');
 

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
@@ -92,8 +92,9 @@ const getArkLocale = (): string => {
 
   if (lang) {
     try {
-      new Intl.Locale(lang);
-      return lang;
+      // Validates lang — Intl.Locale throws if not a valid BCP 47 tag
+      const isValid = !!new Intl.Locale(lang);
+      if (isValid) return lang;
     } catch {
       // Invalid locale string — fall through to default
     }

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
@@ -90,7 +90,15 @@ const getArkLocale = (): string => {
     return FALLBACK_LOCALE_BY_DIRECTION[explicitDir];
   }
 
-  return lang || 'en-US';
+  if (lang) {
+    try {
+      const locale = new Intl.Locale(lang);
+      if (locale) return lang;
+    } catch {
+      // Invalid locale string — fall through to default
+    }
+  }
+  return 'en-US';
 };
 
 // Reactive hook: subscribes to document.documentElement[dir] and [lang] changes

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
@@ -92,8 +92,8 @@ const getArkLocale = (): string => {
 
   if (lang) {
     try {
-      const locale = new Intl.Locale(lang);
-      if (locale) return lang;
+      new Intl.Locale(lang);
+      return lang;
     } catch {
       // Invalid locale string — fall through to default
     }

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
@@ -92,9 +92,11 @@ const getArkLocale = (): string => {
 
   if (lang) {
     try {
-      // Validates lang — Intl.Locale throws if not a valid BCP 47 tag
-      const isValid = !!new Intl.Locale(lang);
-      if (isValid) return lang;
+      // Intl.Locale throws if lang is not a valid BCP 47 tag.
+      // The assignment and if-check are intentional to satisfy the no-new
+      // ESLint rule — Intl.Locale always returns a truthy object on success.
+      const locale = new Intl.Locale(lang);
+      if (locale) return lang;
     } catch {
       // Invalid locale string — fall through to default
     }

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
@@ -92,9 +92,6 @@ const getArkLocale = (): string => {
 
   if (lang) {
     try {
-      // Intl.Locale throws if lang is not a valid BCP 47 tag.
-      // The assignment and if-check are intentional to satisfy the no-new
-      // ESLint rule — Intl.Locale always returns a truthy object on success.
       const locale = new Intl.Locale(lang);
       if (locale) return lang;
     } catch {


### PR DESCRIPTION
## Summary

- Fixes an indefinite crash loop introduced by https://github.com/Skyscanner/web-platform/pull/26006 on Jun 10 that caused ~55,000 errors across ~20 sessions before it was identified
- `getArkLocale()` now validates `html[lang]` with `new Intl.Locale()` before returning it, falling back to `'en-US'` for any value that throws — matching the pattern already used in `getLangDir()`

## Root cause

`getArkLocale()` reads `document.documentElement.getAttribute('lang')` and returns it directly if truthy (`return lang || 'en-US'`). That value is passed to Ark's `<LocaleProvider locale={locale}>`, which calls `@zag-js/i18n-utils` `isRTL(locale)` → `new Intl.Locale(locale)` with no try/catch.

Two truthy values that throw a `RangeError`:
- `""` (empty string) — `getAttribute('lang')` returns `""` not `null` when `<html lang="">` is present
- `"123"` (numeric string) — produced by some Skyscanner market locale configs

Confirmed affected markets: skyscanner.nl, skyscanner.pl, skyscanner.net, tianxun.com.

## Why it loops

The `RangeError` is thrown during `BpkProvider`'s re-render (triggered by `useEffect → setLocale(getArkLocale())`). The App `ErrorBoundary` catches it and renders its fallback — which #26006 also wrapped in `BpkProvider`. That fallback `BpkProvider` mounts, its `useEffect` fires, reads the same bad `html[lang]`, throws again. Repeat indefinitely. Each cycle fires `componentDidCatch` → one New Relic error event → Houston redirect on first cycle. Observed sessions generating 1,000–6,401 error events each.

## Validation

**Red/green TDD:**
1. Added three failing tests first (covering `lang="123"`, `lang=""`, and `lang="en-GB"` regression)
2. Confirmed `lang="123"` test fails against unfixed code: `new Intl.Locale("123")` throws `"Incorrect locale information provided"`
3. Applied fix → all 16 tests pass

**Loop regression test:**

`LoopBoundary` is an `ErrorBoundary` whose fallback also mounts `BpkProvider` — the exact production topology. The test renders `LoopBoundary > BpkProvider` with `html[lang]="123"` and asserts `catchCount === 0`.

<details>
<summary>What happens without the fix</summary>

Running the loop test against the unfixed code never returns — it exhausts the Node.js heap:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

The full React + jsdom cycle runs unbounded: `BpkProvider` renders → Ark's `LocaleProvider` calls `isRTL("123")` → `new Intl.Locale("123")` throws `RangeError: Incorrect locale information provided` → `LoopBoundary.componentDidCatch` fires → fallback renders another `BpkProvider` → same `html[lang]` → throws again → repeat.

The crash stack confirms the real production call path:

```
RangeError: Incorrect locale information provided
    at new Locale (<anonymous>)
    at isRTL (@zag-js/i18n-utils/dist/is-rtl.js)
    at LocaleProvider (@ark-ui/react/dist/providers/locale/locale-provider.cjs)
    at BpkProvider (BpkProvider.tsx)
```

</details>

<details>
<summary>What happens with the fix</summary>

`getArkLocale()` catches the `RangeError` before it reaches Ark and returns `'en-US'`. `BpkProvider` renders cleanly, `LoopBoundary` never catches, `catchCount` stays at 0. The test completes in ~1s.

</details>

## Test plan

- [ ] `lang="123"` → BpkProvider renders without crashing, Ark receives `"en-US"`
- [ ] `lang=""` → BpkProvider renders without crashing, Ark receives `"en-US"`  
- [ ] `lang="en-GB"` → Ark still receives `"en-GB"` (no regression for valid locales)
- [ ] ErrorBoundary+BpkProvider loop topology → no catch, no OOM, `catchCount === 0`
- [ ] Existing RTL tests unchanged (all 16 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)