### PR TITLE
[NO-JIRA]: fix(BpkProvider): validate html[lang] in explicit-dir branch to prevent crash loop

### DIFF
--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
@@ -93,6 +93,9 @@ describe('BpkProvider - RTL support', () => {
   afterEach(() => {
     document.documentElement.removeAttribute('dir');
     document.documentElement.removeAttribute('lang');
+    // Restore any console.error spy set up within this describe block.
+    // Doing this in afterEach guarantees cleanup even when an assertion throws.
+    jest.restoreAllMocks();
   });
 
   it('passes en-US locale to Ark when document dir is ltr', () => {
@@ -290,8 +293,6 @@ describe('BpkProvider - RTL support', () => {
     );
 
     expect(boundary.current?.catchCount).toBe(0);
-
-    jest.restoreAllMocks();
   });
 
   it('does not loop when ErrorBoundary fallback also mounts BpkProvider with invalid html[lang]', () => {
@@ -314,8 +315,6 @@ describe('BpkProvider - RTL support', () => {
     );
 
     expect(boundary.current?.catchCount).toBe(0);
-
-    jest.restoreAllMocks();
   });
 
   it('passes a valid html[lang] through to Ark unchanged', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider-test.tsx
@@ -247,6 +247,53 @@ describe('BpkProvider - RTL support', () => {
     expect(getByTestId('locale').textContent).toBe('en-US');
   });
 
+  it('falls back to direction locale and does not crash when html[dir] is set and html[lang] is invalid', () => {
+    document.documentElement.setAttribute('dir', 'ltr');
+    document.documentElement.setAttribute('lang', '123');
+
+    const { getByTestId } = render(
+      <BpkProvider>
+        <LocaleReader />
+      </BpkProvider>,
+    );
+
+    expect(getByTestId('locale').textContent).toBe('en-US');
+  });
+
+  it('falls back to ar-SA and does not crash when html[dir] is rtl and html[lang] is invalid', () => {
+    document.documentElement.setAttribute('dir', 'rtl');
+    document.documentElement.setAttribute('lang', 'en_US');
+
+    const { getByTestId } = render(
+      <BpkProvider>
+        <LocaleReader />
+      </BpkProvider>,
+    );
+
+    expect(getByTestId('locale').textContent).toBe('ar-SA');
+  });
+
+  it('does not loop when ErrorBoundary fallback mounts BpkProvider with html[dir] set and invalid html[lang]', () => {
+    document.documentElement.setAttribute('dir', 'ltr');
+    document.documentElement.setAttribute('lang', '123');
+
+    // Suppress expected React error output for this test
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+    const boundary = { current: null as LoopBoundary | null };
+    render(
+      <LoopBoundary ref={(el) => { boundary.current = el; }}>
+        <BpkProvider>
+          <div>content</div>
+        </BpkProvider>
+      </LoopBoundary>,
+    );
+
+    expect(boundary.current?.catchCount).toBe(0);
+
+    jest.restoreAllMocks();
+  });
+
   it('does not loop when ErrorBoundary fallback also mounts BpkProvider with invalid html[lang]', () => {
     document.documentElement.setAttribute('lang', '123');
 

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
@@ -53,6 +53,20 @@ const RTL_LANGUAGE_SUBTAGS = new Set([
   'ar', 'he', 'fa', 'ur', 'yi', 'iw', 'ps', 'sd', 'ug', 'ku',
 ]);
 
+// Returns true when `locale` is a BCP 47 string that Intl.Locale accepts.
+// Ark's LocaleProvider calls `new Intl.Locale(locale)` without a try/catch,
+// so any value we hand it must be validated here first or it throws
+// "Incorrect locale information provided".
+const isValidLocale = (locale: string): boolean => {
+  try {
+    // Assigning the result (rather than bare `new`) satisfies the no-new lint rule.
+    const parsed = new Intl.Locale(locale);
+    return Boolean(parsed);
+  } catch {
+    return false;
+  }
+};
+
 // Returns the text direction implied by a BCP 47 locale string.
 // Uses Intl.Locale.textInfo when available (Chrome 99+, Safari 15.4+, Firefox 126+, Node 22+);
 // falls back to a known-RTL-subtag lookup.
@@ -72,11 +86,18 @@ const getLangDir = (locale: string): Direction => {
 //
 // Priority rules:
 //   1. If html[dir] is explicitly set:
-//      - Use html[lang] only when its direction is consistent with html[dir].
+//      - Use html[lang] only when it is a valid locale AND its direction is
+//        consistent with html[dir].
 //      - Otherwise fall back to FALLBACK_LOCALE_BY_DIRECTION[dir].
 //      This prevents an LTR html[lang] (e.g. 'en' from a page template) from
 //      overriding an explicit html[dir]="rtl" signal (e.g. from a dev RTL toggle).
-//   2. If html[dir] is not set: use html[lang] if present, else 'en-US'.
+//   2. If html[dir] is not set: use html[lang] if it is a valid locale, else 'en-US'.
+//
+// Every value returned here is validated with isValidLocale() because Ark's
+// LocaleProvider passes it straight to `new Intl.Locale()`, which throws on
+// malformed input (e.g. '', '123', 'en_US'). An unvalidated value crashes the
+// provider, and when the ErrorBoundary fallback also mounts BpkProvider the same
+// bad value is re-read on every remount, producing an indefinite crash loop.
 //
 // SSR-safe: returns 'en-US' when document is unavailable.
 const getArkLocale = (): string => {
@@ -86,18 +107,13 @@ const getArkLocale = (): string => {
   const lang = document.documentElement.getAttribute('lang');
 
   if (explicitDir === 'rtl' || explicitDir === 'ltr') {
-    if (lang && getLangDir(lang) === explicitDir) return lang;
+    if (lang && isValidLocale(lang) && getLangDir(lang) === explicitDir) {
+      return lang;
+    }
     return FALLBACK_LOCALE_BY_DIRECTION[explicitDir];
   }
 
-  if (lang) {
-    try {
-      const locale = new Intl.Locale(lang);
-      if (locale) return lang;
-    } catch {
-      // Invalid locale string — fall through to default
-    }
-  }
+  if (lang && isValidLocale(lang)) return lang;
   return 'en-US';
 };
 

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkProvider.tsx
@@ -59,9 +59,8 @@ const RTL_LANGUAGE_SUBTAGS = new Set([
 // "Incorrect locale information provided".
 const isValidLocale = (locale: string): boolean => {
   try {
-    // Assigning the result (rather than bare `new`) satisfies the no-new lint rule.
-    const parsed = new Intl.Locale(locale);
-    return Boolean(parsed);
+    // Reading a property on the result (rather than bare `new`) satisfies the no-new lint rule.
+    return Boolean(new Intl.Locale(locale).baseName);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

Closes the remaining hole in the `BpkProvider` crash-loop fix from #4690.

#4690 added `Intl.Locale` validation **only** to the branch where `html[dir]` is *not* set. But `getArkLocale()` has a second branch — taken when `html[dir]` is explicitly `ltr`/`rtl` — that returned `html[lang]` **without** validating it:

```ts
if (explicitDir === 'rtl' || explicitDir === 'ltr') {
  if (lang && getLangDir(lang) === explicitDir) return lang; // ← no Intl validation
  return FALLBACK_LOCALE_BY_DIRECTION[explicitDir];
}
```

`getLangDir()` swallows the `Intl.Locale` error internally and defaults to `'ltr'`, so for a page with `html[dir]="ltr"` and a malformed `html[lang]` (e.g. `""`, `"123"`, `"en_US"`) the guard `getLangDir(lang) === explicitDir` passes and the invalid `lang` is handed straight to Ark's `LocaleProvider`. Ark calls `new Intl.Locale(lang)` with no try/catch and throws **`Incorrect locale information provided`**.

When the `ErrorBoundary` fallback also mounts `BpkProvider` (the topology being restored in web-platform [#26096](https://github.com/Skyscanner/web-platform/pull/26096)), the same bad `lang` is re-read on every remount — reproducing the exact indefinite crash loop #4690 was meant to kill, even on `42.25.0`.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/d10a49db-b72e-47d0-b84b-ebfce1231c2e" />


## Fix

Extract an `isValidLocale()` helper and apply it in **both** branches, so every value `getArkLocale()` returns is a locale that `Intl.Locale` accepts. Invalid values now fall back to the direction-based locale (`en-US` / `ar-SA`).

| `html[dir]` | `html[lang]` | before | after |
|-------------|--------------|--------|-------|
| `ltr` | `123` | `123` → 💥 Ark throws | `en-US` ✅ |
| `ltr` | `en_US` | `en_US` → 💥 | `en-US` ✅ |
| `rtl` | `123` | `123` → 💥 | `ar-SA` ✅ |
| `ltr` | `en-GB` | `en-GB` | `en-GB` (unchanged) |
| `rtl` | `ar-EG` | `ar-EG` | `ar-EG` (unchanged) |

## Tests

Added 3 regression tests covering the explicit-`dir` + invalid-`lang` path, including a `LoopBoundary` test that asserts `catchCount === 0` (no remount loop).

- ✅ `npx jest BpkProvider-test` — 19 passed
- ✅ `eslint` — 0 errors (pre-existing `JSX` warning unchanged)

## Screenshots
||before|after|
|---|---|---|
| Deliberately set invalid `lang` `document.documentElement.setAttribute('lang', 'x-default')` | <img width="300"  alt="image" src="https://github.com/user-attachments/assets/2408ab93-596a-4be2-ad38-407353d0d30e" /> | <img width="300"  alt="image" src="https://github.com/user-attachments/assets/240119ef-512d-414a-acf6-f9ffacb3c5ed" /> |
|Deliberately throw an error in root <img width="300" alt="image" src="https://github.com/user-attachments/assets/292d7fe0-87ef-4baf-aac8-13ca4c5993bf" /> |<img width="300"  alt="image" src="https://github.com/user-attachments/assets/3fe635db-e7c5-411d-8dcf-be9984598e99" />| NO Error exposed from LocaleProvider <img width="300" alt="image" src="https://github.com/user-attachments/assets/6505ec45-5781-4f9d-ab33-18ecab4aa797" />| 

🤖 Generated with [Claude Code](https://claude.com/claude-code)