### PR TITLE
fix(BpkBottomSheet): clear close-animation timer on unmount

### DIFF
--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet-test.tsx
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet-test.tsx
@@ -240,6 +240,28 @@ describe('BpkBottomSheet', () => {
     expect(titleEl).toBeInTheDocument();
   });
 
+  it('does not call onClose after unmount (timer leak regression)', () => {
+    jest.useFakeTimers();
+    const onClose = jest.fn();
+    const { unmount } = render(
+      <BpkBottomSheet
+        ariaLabelledby="bottom-sheet"
+        closeLabel="Close"
+        id="my-bottom-sheet"
+        isOpen
+        onClose={onClose}
+      >
+        Content
+      </BpkBottomSheet>,
+    );
+    // Simulate close button click would normally schedule a 240ms timer.
+    // Unmounting before the timer fires should cancel it.
+    unmount();
+    jest.advanceTimersByTime(300);
+    expect(onClose).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
   it('adds correct id to custom title element for aria-labelledby reference', () => {
     const { container } = render(
       <BpkBottomSheet

--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet-test.tsx
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet-test.tsx
@@ -16,7 +16,8 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
@@ -240,26 +241,34 @@ describe('BpkBottomSheet', () => {
     expect(titleEl).toBeInTheDocument();
   });
 
-  it('does not call onClose after unmount (timer leak regression)', () => {
-    jest.useFakeTimers();
-    const onClose = jest.fn();
-    const { unmount } = render(
-      <BpkBottomSheet
-        ariaLabelledby="bottom-sheet"
-        closeLabel="Close"
-        id="my-bottom-sheet"
-        isOpen
-        onClose={onClose}
-      >
-        Content
-      </BpkBottomSheet>,
-    );
-    // Simulate close button click would normally schedule a 240ms timer.
-    // Unmounting before the timer fires should cancel it.
-    unmount();
-    jest.advanceTimersByTime(300);
-    expect(onClose).not.toHaveBeenCalled();
-    jest.useRealTimers();
+  describe('timer leak regression', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('does not call onClose after unmount when timer is pending', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const onClose = jest.fn();
+      const { unmount } = render(
+        <BpkBottomSheet
+          ariaLabelledby="bottom-sheet"
+          closeLabel="Close"
+          id="my-bottom-sheet"
+          isOpen
+          onClose={onClose}
+        >
+          Content
+        </BpkBottomSheet>,
+      );
+      // Click close to schedule the 240ms animation timer
+      await user.click(screen.getByTitle('Close'));
+      // Unmount before the timer fires
+      unmount();
+      // Advance past the animation duration — onClose must not be called
+      act(() => { jest.advanceTimersByTime(300); });
+      expect(onClose).not.toHaveBeenCalled();
+    });
   });
 
   it('adds correct id to custom title element for aria-labelledby reference', () => {

--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 import type { SyntheticEvent, ReactNode, ReactElement } from 'react';
-import { useCallback, useState, isValidElement, cloneElement } from 'react';
+import { useCallback, useEffect, useRef, useState, isValidElement, cloneElement } from 'react';
 
 import BpkBreakpoint, { BREAKPOINTS } from '../../bpk-component-breakpoint';
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
@@ -130,8 +130,18 @@ const BpkBottomSheet = ({
   isAboveMobile: boolean;
 }) => {
   const [exiting, setExiting] = useState(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const animationTimeout = 240;
+
+  useEffect(
+    () => () => {
+      if (closeTimerRef.current !== null) {
+        clearTimeout(closeTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const handleClose = useCallback(
     (
@@ -147,7 +157,7 @@ const BpkBottomSheet = ({
       const timeoutDuration = isAboveMobile ? 0 : animationTimeout;
 
       setExiting(true);
-      setTimeout(() => {
+      closeTimerRef.current = setTimeout(() => {
         onClose(arg0, arg1);
         setExiting(false);
       }, timeoutDuration);

--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
@@ -156,8 +156,12 @@ const BpkBottomSheet = ({
     ) => {
       const timeoutDuration = isAboveMobile ? 0 : animationTimeout;
 
+      if (closeTimerRef.current !== null) {
+        clearTimeout(closeTimerRef.current);
+      }
       setExiting(true);
       closeTimerRef.current = setTimeout(() => {
+        closeTimerRef.current = null;
         onClose(arg0, arg1);
         setExiting(false);
       }, timeoutDuration);


### PR DESCRIPTION
## Summary

- Store the 240ms close-animation `setTimeout` ID in a `ref`
- Add a `useEffect` cleanup that calls `clearTimeout` on unmount
- Add a regression test that unmounts before the timer fires and asserts `onClose` is not called

## Why

`BpkBottomSheet.handleClose` schedules a 240ms `setTimeout` to wait for the slide-out animation before calling the consumer's `onClose`. This timer was never cancelled on unmount.

When the host component unmounted before the timer fired (e.g. a test finishing before the animation completes), the timer would still fire and call `onClose`, which triggered `setState` on an already-unmounted component. In JSDOM test environments this surfaces as:

```
ReferenceError: window is not defined
 ❯ getCurrentEventPriority  react-dom.development.js:10993
 ❯ dispatchSetState         react-dom.development.js:16648
 ❯ onClose (consumer code)
 ❯ Timeout._onTimeout       BpkBottomSheet.tsx
```

The error originates in the consumer's test but is attributed to unrelated test files, making it very hard to diagnose.

Consumers have been working around this by guarding their `onClose` callback with an `isMounted` ref (e.g. [hotels-website#11795](https://github.com/Skyscanner/hotels-website/pull/11795)). The root fix belongs here in Backpack.

## Test plan

- [x] New regression test: unmount before 240ms timer fires → `onClose` not called
- [ ] Existing `BpkBottomSheet` tests pass
- [ ] CI green