### PR TITLE
[NO-JIRA] Add textAlign prop to layout components

### DIFF
--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
@@ -108,6 +108,15 @@ describe('BpkBox', () => {
     expect(getByText('Styled text')).toBeInTheDocument();
   });
 
+  it('renders when textAlign is provided', () => {
+    const { getByText } = render(
+      <BpkProvider>
+        <BpkBox textAlign="center">Aligned text</BpkBox>
+      </BpkProvider>,
+    );
+    expect(getByText('Aligned text')).toBeInTheDocument();
+  });
+
   it('renders when textStyle is not provided', () => {
     const { getByText } = render(
       <BpkProvider>

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
@@ -108,20 +108,13 @@ describe('BpkBox', () => {
     expect(getByText('Styled text')).toBeInTheDocument();
   });
 
-  it('applies textAlign — produces different className than without it', () => {
-    const { container: withAlign } = render(
+  it('applies textAlign to the DOM element', () => {
+    const { container } = render(
       <BpkProvider>
         <BpkBox textAlign="center">Aligned text</BpkBox>
       </BpkProvider>,
     );
-    const { container: withoutAlign } = render(
-      <BpkProvider>
-        <BpkBox>Aligned text</BpkBox>
-      </BpkProvider>,
-    );
-    expect(withAlign.querySelector('div')?.className).not.toBe(
-      withoutAlign.querySelector('div')?.className,
-    );
+    expect(container.firstChild).toHaveStyle('text-align: center');
   });
 
   it('renders when textStyle is not provided', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
@@ -108,13 +108,20 @@ describe('BpkBox', () => {
     expect(getByText('Styled text')).toBeInTheDocument();
   });
 
-  it('renders when textAlign is provided', () => {
-    const { getByText } = render(
+  it('applies textAlign — produces different className than without it', () => {
+    const { container: withAlign } = render(
       <BpkProvider>
         <BpkBox textAlign="center">Aligned text</BpkBox>
       </BpkProvider>,
     );
-    expect(getByText('Aligned text')).toBeInTheDocument();
+    const { container: withoutAlign } = render(
+      <BpkProvider>
+        <BpkBox>Aligned text</BpkBox>
+      </BpkProvider>,
+    );
+    expect(withAlign.querySelector('div')?.className).not.toBe(
+      withoutAlign.querySelector('div')?.className,
+    );
   });
 
   it('renders when textStyle is not provided', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
@@ -560,6 +560,8 @@ export const ResponsiveTextStyle = {
 
 /**
  * textAlign example – demonstrates all four alignment values on BpkBox.
+ *
+ * @returns {JSX.Element} Boxes with different textAlign values applied.
  */
 const TextAlignExample = () => (
   <LayoutWrapper>
@@ -581,6 +583,8 @@ const TextAlignExample = () => (
 
 /**
  * Responsive textAlign example – alignment changes across breakpoints.
+ *
+ * @returns {JSX.Element} A box whose text alignment changes across breakpoints.
  */
 const ResponsiveTextAlignExample = () => (
   <LayoutWrapper>

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
@@ -23,6 +23,7 @@ import { ArgTypes, Title, Markdown } from '@storybook/addon-docs/blocks';
 import { BACKGROUND_COLORS, BpkBox, BpkProvider, BpkSpacing } from '..';
 import BpkButton from '../../bpk-component-button';
 import BpkText, {
+  TEXT_ALIGN,
   TEXT_COLORS,
   TEXT_STYLES,
 } from '../../bpk-component-text';
@@ -555,6 +556,53 @@ export const TextStyle = {
 
 export const ResponsiveTextStyle = {
   render: () => <ResponsiveTextStyleExample />,
+};
+
+/**
+ * textAlign example – demonstrates all four alignment values on BpkBox.
+ */
+const TextAlignExample = () => (
+  <LayoutWrapper>
+    <BpkBox padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.start}>
+      start — aligns to the inline-start edge (left in LTR, right in RTL)
+    </BpkBox>
+    <BpkBox padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.center}>
+      center — centred horizontally
+    </BpkBox>
+    <BpkBox padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.end}>
+      end — aligns to the inline-end edge (right in LTR, left in RTL)
+    </BpkBox>
+    <BpkBox padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.justify}>
+      justify — stretches each line to fill the full width. Works best with
+      longer sentences that span several words.
+    </BpkBox>
+  </LayoutWrapper>
+);
+
+/**
+ * Responsive textAlign example – alignment changes across breakpoints.
+ */
+const ResponsiveTextAlignExample = () => (
+  <LayoutWrapper>
+    <BpkBox
+      padding={BpkSpacing.MD}
+      textAlign={{
+        base: TEXT_ALIGN.start,
+        tablet: TEXT_ALIGN.center,
+        desktop: TEXT_ALIGN.end,
+      }}
+    >
+      Alignment changes: start (base) → center (tablet) → end (desktop)
+    </BpkBox>
+  </LayoutWrapper>
+);
+
+export const TextAlign = {
+  render: () => <TextAlignExample />,
+};
+
+export const ResponsiveTextAlign = {
+  render: () => <ResponsiveTextAlignExample />,
 };
 
 export const Ref = {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
@@ -122,6 +122,15 @@ describe('BpkFlex', () => {
     expect(getByText('Content')).toBeInTheDocument();
   });
 
+  it('renders when textAlign is provided', () => {
+    const { getByText } = render(
+      <BpkProvider>
+        <BpkFlex textAlign="center">Content</BpkFlex>
+      </BpkProvider>,
+    );
+    expect(getByText('Content')).toBeInTheDocument();
+  });
+
   it('supports responsive direction', () => {
     const { container } = render(
       <BpkProvider>

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
@@ -122,13 +122,20 @@ describe('BpkFlex', () => {
     expect(getByText('Content')).toBeInTheDocument();
   });
 
-  it('renders when textAlign is provided', () => {
-    const { getByText } = render(
+  it('applies textAlign — produces different className than without it', () => {
+    const { container: withAlign } = render(
       <BpkProvider>
         <BpkFlex textAlign="center">Content</BpkFlex>
       </BpkProvider>,
     );
-    expect(getByText('Content')).toBeInTheDocument();
+    const { container: withoutAlign } = render(
+      <BpkProvider>
+        <BpkFlex>Content</BpkFlex>
+      </BpkProvider>,
+    );
+    expect(withAlign.querySelector('div')?.className).not.toBe(
+      withoutAlign.querySelector('div')?.className,
+    );
   });
 
   it('supports responsive direction', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
@@ -122,20 +122,13 @@ describe('BpkFlex', () => {
     expect(getByText('Content')).toBeInTheDocument();
   });
 
-  it('applies textAlign — produces different className than without it', () => {
-    const { container: withAlign } = render(
+  it('applies textAlign to the DOM element', () => {
+    const { container } = render(
       <BpkProvider>
         <BpkFlex textAlign="center">Content</BpkFlex>
       </BpkProvider>,
     );
-    const { container: withoutAlign } = render(
-      <BpkProvider>
-        <BpkFlex>Content</BpkFlex>
-      </BpkProvider>,
-    );
-    expect(withAlign.querySelector('div')?.className).not.toBe(
-      withoutAlign.querySelector('div')?.className,
-    );
+    expect(container.firstChild).toHaveStyle('text-align: center');
   });
 
   it('supports responsive direction', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.stories.tsx
@@ -19,7 +19,7 @@
 import { ArgTypes, Title, Markdown } from '@storybook/addon-docs/blocks';
 
 import { BACKGROUND_COLORS, BpkBox, BpkFlex, BpkProvider, BpkSpacing } from '..';
-import BpkText, { TEXT_COLORS, TEXT_STYLES } from '../../bpk-component-text';
+import BpkText, { TEXT_ALIGN, TEXT_COLORS, TEXT_STYLES } from '../../bpk-component-text';
 
 import LayoutWrapper from './BpkLayout.stories-wrapper';
 
@@ -235,4 +235,31 @@ export const Color = {
 
 export const LayoutProps = {
   render: () => <BpkFlexLayoutPropsExample />,
+};
+
+/**
+ * textAlign example – demonstrates all four alignment values on BpkFlex.
+ */
+const BpkFlexTextAlignExample = () => (
+  <LayoutWrapper>
+    <BpkFlex direction="column" gap={BpkSpacing.SM}>
+      <BpkFlex padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.start}>
+        start — inline-start edge
+      </BpkFlex>
+      <BpkFlex padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.center}>
+        center — centred horizontally
+      </BpkFlex>
+      <BpkFlex padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.end}>
+        end — inline-end edge
+      </BpkFlex>
+      <BpkFlex padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.justify}>
+        justify — stretches lines to fill the full width. Works best with
+        longer sentences.
+      </BpkFlex>
+    </BpkFlex>
+  </LayoutWrapper>
+);
+
+export const TextAlign = {
+  render: () => <BpkFlexTextAlignExample />,
 };

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.stories.tsx
@@ -239,6 +239,8 @@ export const LayoutProps = {
 
 /**
  * textAlign example – demonstrates all four alignment values on BpkFlex.
+ *
+ * @returns {JSX.Element} Flex containers with different textAlign values applied.
  */
 const BpkFlexTextAlignExample = () => (
   <LayoutWrapper>

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkGrid-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkGrid-test.tsx
@@ -100,20 +100,13 @@ describe('BpkGrid', () => {
     expect(getByText('Content')).toBeInTheDocument();
   });
 
-  it('applies textAlign — produces different className than without it', () => {
-    const { container: withAlign } = render(
+  it('applies textAlign to the DOM element', () => {
+    const { container } = render(
       <BpkProvider>
         <BpkGrid textAlign="center">Content</BpkGrid>
       </BpkProvider>,
     );
-    const { container: withoutAlign } = render(
-      <BpkProvider>
-        <BpkGrid>Content</BpkGrid>
-      </BpkProvider>,
-    );
-    expect(withAlign.querySelector('div')?.className).not.toBe(
-      withoutAlign.querySelector('div')?.className,
-    );
+    expect(container.firstChild).toHaveStyle('text-align: center');
   });
 
   it('accepts grid props: justify, align, gap', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkGrid-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkGrid-test.tsx
@@ -100,6 +100,15 @@ describe('BpkGrid', () => {
     expect(getByText('Content')).toBeInTheDocument();
   });
 
+  it('renders when textAlign is provided', () => {
+    const { getByText } = render(
+      <BpkProvider>
+        <BpkGrid textAlign="center">Content</BpkGrid>
+      </BpkProvider>,
+    );
+    expect(getByText('Content')).toBeInTheDocument();
+  });
+
   it('accepts grid props: justify, align, gap', () => {
     const { container } = render(
       <BpkProvider>

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkGrid-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkGrid-test.tsx
@@ -100,13 +100,20 @@ describe('BpkGrid', () => {
     expect(getByText('Content')).toBeInTheDocument();
   });
 
-  it('renders when textAlign is provided', () => {
-    const { getByText } = render(
+  it('applies textAlign — produces different className than without it', () => {
+    const { container: withAlign } = render(
       <BpkProvider>
         <BpkGrid textAlign="center">Content</BpkGrid>
       </BpkProvider>,
     );
-    expect(getByText('Content')).toBeInTheDocument();
+    const { container: withoutAlign } = render(
+      <BpkProvider>
+        <BpkGrid>Content</BpkGrid>
+      </BpkProvider>,
+    );
+    expect(withAlign.querySelector('div')?.className).not.toBe(
+      withoutAlign.querySelector('div')?.className,
+    );
   });
 
   it('accepts grid props: justify, align, gap', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkGrid.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkGrid.stories.tsx
@@ -215,6 +215,8 @@ export const LayoutProps = {
 
 /**
  * textAlign example – demonstrates all four alignment values on BpkGrid.
+ *
+ * @returns {JSX.Element} Grid containers with different textAlign values applied.
  */
 const BpkGridTextAlignExample = () => (
   <LayoutWrapper>

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkGrid.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkGrid.stories.tsx
@@ -19,7 +19,7 @@
 import { ArgTypes, Title, Markdown } from '@storybook/addon-docs/blocks';
 
 import { BACKGROUND_COLORS, BpkBox, BpkGrid, BpkGridItem, BpkProvider, BpkSpacing } from '..';
-import BpkText, { TEXT_COLORS, TEXT_STYLES } from '../../bpk-component-text';
+import BpkText, { TEXT_ALIGN, TEXT_COLORS, TEXT_STYLES } from '../../bpk-component-text';
 
 import LayoutWrapper from './BpkLayout.stories-wrapper';
 
@@ -211,4 +211,31 @@ export const Color = {
 
 export const LayoutProps = {
   render: () => <BpkGridLayoutPropsExample />,
+};
+
+/**
+ * textAlign example – demonstrates all four alignment values on BpkGrid.
+ */
+const BpkGridTextAlignExample = () => (
+  <LayoutWrapper>
+    <BpkGrid templateColumns="1fr" gap={BpkSpacing.SM}>
+      <BpkGrid padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.start}>
+        start — inline-start edge
+      </BpkGrid>
+      <BpkGrid padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.center}>
+        center — centred horizontally
+      </BpkGrid>
+      <BpkGrid padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.end}>
+        end — inline-end edge
+      </BpkGrid>
+      <BpkGrid padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.justify}>
+        justify — stretches lines to fill the full width. Works best with
+        longer sentences.
+      </BpkGrid>
+    </BpkGrid>
+  </LayoutWrapper>
+);
+
+export const TextAlign = {
+  render: () => <BpkGridTextAlignExample />,
 };

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkGridItem-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkGridItem-test.tsx
@@ -63,20 +63,13 @@ describe('BpkGridItem', () => {
     expect(getByText('Item')).toBeInTheDocument();
   });
 
-  it('applies textAlign — produces different className than without it', () => {
-    const { container: withAlign } = render(
+  it('applies textAlign to the DOM element', () => {
+    const { container } = render(
       <BpkProvider>
         <BpkGridItem textAlign="center">Item</BpkGridItem>
       </BpkProvider>,
     );
-    const { container: withoutAlign } = render(
-      <BpkProvider>
-        <BpkGridItem>Item</BpkGridItem>
-      </BpkProvider>,
-    );
-    expect(withAlign.querySelector('div')?.className).not.toBe(
-      withoutAlign.querySelector('div')?.className,
-    );
+    expect(container.firstChild).toHaveStyle('text-align: center');
   });
 
   it('supports Backpack spacing tokens', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkGridItem-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkGridItem-test.tsx
@@ -63,13 +63,20 @@ describe('BpkGridItem', () => {
     expect(getByText('Item')).toBeInTheDocument();
   });
 
-  it('renders when textAlign is provided', () => {
-    const { getByText } = render(
+  it('applies textAlign — produces different className than without it', () => {
+    const { container: withAlign } = render(
       <BpkProvider>
         <BpkGridItem textAlign="center">Item</BpkGridItem>
       </BpkProvider>,
     );
-    expect(getByText('Item')).toBeInTheDocument();
+    const { container: withoutAlign } = render(
+      <BpkProvider>
+        <BpkGridItem>Item</BpkGridItem>
+      </BpkProvider>,
+    );
+    expect(withAlign.querySelector('div')?.className).not.toBe(
+      withoutAlign.querySelector('div')?.className,
+    );
   });
 
   it('supports Backpack spacing tokens', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkGridItem-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkGridItem-test.tsx
@@ -63,6 +63,15 @@ describe('BpkGridItem', () => {
     expect(getByText('Item')).toBeInTheDocument();
   });
 
+  it('renders when textAlign is provided', () => {
+    const { getByText } = render(
+      <BpkProvider>
+        <BpkGridItem textAlign="center">Item</BpkGridItem>
+      </BpkProvider>,
+    );
+    expect(getByText('Item')).toBeInTheDocument();
+  });
+
   it('supports Backpack spacing tokens', () => {
     const { container } = render(
       <BpkProvider>

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkStack-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkStack-test.tsx
@@ -116,24 +116,15 @@ describe('BpkStack', () => {
     expect(getByText('Child')).toBeInTheDocument();
   });
 
-  it('applies textAlign — produces different className than without it', () => {
-    const { container: withAlign } = render(
+  it('applies textAlign to the DOM element', () => {
+    const { container } = render(
       <BpkProvider>
         <BpkStack textAlign="center" gap={BpkSpacing.MD}>
           <div>Child</div>
         </BpkStack>
       </BpkProvider>,
     );
-    const { container: withoutAlign } = render(
-      <BpkProvider>
-        <BpkStack gap={BpkSpacing.MD}>
-          <div>Child</div>
-        </BpkStack>
-      </BpkProvider>,
-    );
-    expect(withAlign.firstChild?.className).not.toBe(
-      withoutAlign.firstChild?.className,
-    );
+    expect(container.firstChild).toHaveStyle('text-align: center');
   });
 
   describe('BpkHStack', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkStack-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkStack-test.tsx
@@ -116,6 +116,17 @@ describe('BpkStack', () => {
     expect(getByText('Child')).toBeInTheDocument();
   });
 
+  it('renders when textAlign is provided', () => {
+    const { getByText } = render(
+      <BpkProvider>
+        <BpkStack textAlign="center" gap={BpkSpacing.MD}>
+          <div>Child</div>
+        </BpkStack>
+      </BpkProvider>,
+    );
+    expect(getByText('Child')).toBeInTheDocument();
+  });
+
   describe('BpkHStack', () => {
     it('defaults to row direction', () => {
       const { container } = render(

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkStack-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkStack-test.tsx
@@ -116,15 +116,24 @@ describe('BpkStack', () => {
     expect(getByText('Child')).toBeInTheDocument();
   });
 
-  it('renders when textAlign is provided', () => {
-    const { getByText } = render(
+  it('applies textAlign — produces different className than without it', () => {
+    const { container: withAlign } = render(
       <BpkProvider>
         <BpkStack textAlign="center" gap={BpkSpacing.MD}>
           <div>Child</div>
         </BpkStack>
       </BpkProvider>,
     );
-    expect(getByText('Child')).toBeInTheDocument();
+    const { container: withoutAlign } = render(
+      <BpkProvider>
+        <BpkStack gap={BpkSpacing.MD}>
+          <div>Child</div>
+        </BpkStack>
+      </BpkProvider>,
+    );
+    expect(withAlign.firstChild?.className).not.toBe(
+      withoutAlign.firstChild?.className,
+    );
   });
 
   describe('BpkHStack', () => {

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkStack.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkStack.stories.tsx
@@ -19,7 +19,7 @@
 import { ArgTypes, Title, Markdown } from '@storybook/addon-docs/blocks';
 
 import { BACKGROUND_COLORS, BpkBox, BpkHStack, BpkProvider, BpkSpacing, BpkStack, BpkVStack } from '..';
-import BpkText, { TEXT_COLORS, TEXT_STYLES } from '../../bpk-component-text';
+import BpkText, { TEXT_ALIGN, TEXT_COLORS, TEXT_STYLES } from '../../bpk-component-text';
 
 import LayoutWrapper from './BpkLayout.stories-wrapper';
 
@@ -254,4 +254,31 @@ const BpkStackAliasExample = () => (
 
 export const Aliases = {
   render: () => <BpkStackAliasExample />,
+};
+
+/**
+ * textAlign example – demonstrates all four alignment values on BpkStack.
+ */
+const BpkStackTextAlignExample = () => (
+  <LayoutWrapper>
+    <BpkStack direction="column" gap={BpkSpacing.SM}>
+      <BpkStack padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.start}>
+        start — inline-start edge
+      </BpkStack>
+      <BpkStack padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.center}>
+        center — centred horizontally
+      </BpkStack>
+      <BpkStack padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.end}>
+        end — inline-end edge
+      </BpkStack>
+      <BpkStack padding={BpkSpacing.SM} textAlign={TEXT_ALIGN.justify}>
+        justify — stretches lines to fill the full width. Works best with
+        longer sentences.
+      </BpkStack>
+    </BpkStack>
+  </LayoutWrapper>
+);
+
+export const TextAlign = {
+  render: () => <BpkStackTextAlignExample />,
 };

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkStack.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkStack.stories.tsx
@@ -258,6 +258,8 @@ export const Aliases = {
 
 /**
  * textAlign example – demonstrates all four alignment values on BpkStack.
+ *
+ * @returns {JSX.Element} Stack containers with different textAlign values applied.
  */
 const BpkStackTextAlignExample = () => (
   <LayoutWrapper>

--- a/packages/backpack-web/src/bpk-component-layout/src/commonProps.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/commonProps.ts
@@ -29,7 +29,7 @@ import type {
   BpkZIndexValue,
   BpkResponsiveValue,
 } from './tokens';
-import type { TextColor, TextStyle } from '../../bpk-component-text';
+import type { TextAlign, TextColor, TextStyle } from '../../bpk-component-text';
 
 /**
  * Common spacing-related props shared by all Backpack layout components
@@ -109,6 +109,7 @@ export interface BpkCommonLayoutProps extends BpkSpacingProps, AriaAttributes {
 
   // Typography
   textStyle?: BpkResponsiveValue<TextStyle>;
+  textAlign?: BpkResponsiveValue<TextAlign>;
 
   // CSS `position` keyword (static | relative | absolute | fixed | sticky)
   position?: BpkResponsiveValue<BpkPositionKeyword>;

--- a/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
@@ -60,6 +60,7 @@ export const BPK_RESPONSIVE_PROP_GROUPS_BY_COMPONENT: Record<
     container: [
       // Typography
       'textStyle',
+      'textAlign',
       // Display
       'display',
       // Flex container props
@@ -99,6 +100,7 @@ export const BPK_RESPONSIVE_PROP_GROUPS_BY_COMPONENT: Record<
   BpkFlex: {
     container: [
       'textStyle',
+      'textAlign',
       'flexDirection',
       'justifyContent',
       'alignItems',
@@ -119,6 +121,7 @@ export const BPK_RESPONSIVE_PROP_GROUPS_BY_COMPONENT: Record<
   BpkGrid: {
     container: [
       'textStyle',
+      'textAlign',
       'justifyContent',
       'alignItems',
       'gridTemplateColumns',
@@ -140,12 +143,13 @@ export const BPK_RESPONSIVE_PROP_GROUPS_BY_COMPONENT: Record<
     ],
   },
   BpkGridItem: {
-    container: ['textStyle', 'position', 'overflow', 'overflowX', 'overflowY'],
+    container: ['textStyle', 'textAlign', 'position', 'overflow', 'overflowX', 'overflowY'],
   },
   // Note: BpkStack uses Chakra Stack option prop names directly.
   BpkStack: {
     container: [
       'textStyle',
+      'textAlign',
       ...(StackOptionKeys as unknown as readonly string[]),
       // Position keyword and overflow (from BpkCommonLayoutProps)
       'position',


### PR DESCRIPTION
## What

Adds a `textAlign` prop to all Backpack layout components (`BpkBox`, `BpkFlex`, `BpkGrid`, `BpkGridItem`, `BpkStack`).

## How

- `textAlign?: BpkResponsiveValue<TextAlign>` added to `BpkCommonLayoutProps` in `commonProps.ts`
- Reuses the `TextAlign` type (`'start' | 'end' | 'center' | 'justify'`) already exported from `bpk-component-text` — consistent with `textStyle` (uses `TextStyle`) and `color` (uses `TextColor`)
- Added `'textAlign'` to the responsive-processing allowlist for all 5 components in `tokenUtils.ts`, so it goes through the same breakpoint-normalisation pipeline as `position`, `overflow`, and `textStyle`
- No new SCSS classes needed — Chakra handles it as a plain `text-align` inline style

## Usage

```tsx
// Static
<BpkBox textAlign="center">...</BpkBox>

// Responsive
<BpkFlex textAlign={{ base: 'start', tablet: 'center' }}>...</BpkFlex>
```

## Test plan

- [ ] Added a `renders when textAlign is provided` test to each of the 5 component test files, mirroring the existing `textStyle` test pattern
- [ ] TypeScript will catch any misuse at compile time (only `'start' | 'end' | 'center' | 'justify'` are valid)