### PR TITLE
[NO JIRA][build] Fix backpack-web:build failing in fresh workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8278,7 +8278,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8318,7 +8317,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8339,7 +8337,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8360,7 +8357,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8381,7 +8377,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8402,7 +8397,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8423,7 +8417,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8444,7 +8437,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8465,7 +8457,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8486,7 +8477,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8507,7 +8497,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8528,7 +8517,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8549,7 +8537,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8570,7 +8557,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12041,17 +12027,6 @@
       "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/eslint": {
-      "version": "8.44.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
     },
     "node_modules/@types/esquery": {
       "version": "1.5.4",
@@ -16218,7 +16193,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -18570,7 +18545,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -21236,7 +21210,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -23983,7 +23957,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24046,7 +24020,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -24181,7 +24155,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -29130,7 +29104,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -29563,7 +29537,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -31679,7 +31652,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -34903,7 +34876,6 @@
         "!riscv64",
         "!x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34917,7 +34889,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34934,7 +34905,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34951,7 +34921,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34968,7 +34937,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34985,7 +34953,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35002,7 +34969,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35019,7 +34985,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35036,7 +35001,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35053,7 +35017,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35070,7 +35033,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35087,7 +35049,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35104,7 +35065,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35121,7 +35081,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35138,7 +35097,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35152,7 +35110,6 @@
       "version": "1.90.0",
       "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.90.0.tgz",
       "integrity": "sha512-DBGzHVCJDqtjTHZFohush9YTxd4ZxhIygIRTNRXnA0359woF9Z8AS7/YxfzwkqrTX5durSJa6ZamGFYVLoRphQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35172,7 +35129,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35189,7 +35145,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38385,7 +38340,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/packages/backpack-web/project.json
+++ b/packages/backpack-web/project.json
@@ -47,6 +47,12 @@
         "{workspaceRoot}/scripts/scss/styles-prod.js",
         "{workspaceRoot}/scripts/scss/style-compiler.js"
       ],
+      "outputs": [
+        "{projectRoot}/src/**/*.module.css",
+        "{projectRoot}/src/bpk-stylesheets/font.css",
+        "{projectRoot}/src/bpk-stylesheets/larken.css",
+        "{projectRoot}/src/bpk-stylesheets/normalize.css"
+      ],
       "cache": true
     },
     "copy-token-css": {

--- a/scripts/transpilation/copy-css.js
+++ b/scripts/transpilation/copy-css.js
@@ -16,20 +16,24 @@
  * limitations under the License.
  */
 
-const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+
+const { globSync } = require('glob');
 
 // eslint-disable-next-line no-console
 console.log('Copying CSS files...');
 
-// `grep` exits 1 when it matches nothing, which would make `execSync` throw.
-// Pipe through `cat` so the pipeline's exit code reflects a real failure
-// (e.g. `find` erroring) rather than an empty—but valid—result set.
-const cssFiles = execSync('find packages/backpack-web/src -name "*.css" | grep -v node_modules | grep -v "bpk-stylesheets" | cat')
-  .toString()
-  .split('\n')
-  .filter((s) => s !== '');
+// Glob in Node rather than shelling out: an empty result is unambiguously an
+// empty array, while a genuine I/O error throws — neither is conflated with a
+// pipeline exit code (the old `find | grep` exited 1 on zero matches and
+// crashed the build).
+const cssFiles = globSync('packages/backpack-web/src/**/*.css', {
+  ignore: [
+    '**/node_modules/**',
+    'packages/backpack-web/src/bpk-stylesheets/**',
+  ],
+});
 
 cssFiles.forEach((cssFile) => {
   const destDir = path.dirname(cssFile).replace(/^packages\/backpack-web\/src\//, 'packages/backpack-web/dist/');

--- a/scripts/transpilation/copy-css.js
+++ b/scripts/transpilation/copy-css.js
@@ -23,7 +23,10 @@ const path = require('path');
 // eslint-disable-next-line no-console
 console.log('Copying CSS files...');
 
-const cssFiles = execSync('find packages/backpack-web/src -name "*.css" | grep -v node_modules | grep -v "bpk-stylesheets"')
+// `grep` exits 1 when it matches nothing, which would make `execSync` throw.
+// Pipe through `cat` so the pipeline's exit code reflects a real failure
+// (e.g. `find` erroring) rather than an empty—but valid—result set.
+const cssFiles = execSync('find packages/backpack-web/src -name "*.css" | grep -v node_modules | grep -v "bpk-stylesheets" | cat')
   .toString()
   .split('\n')
   .filter((s) => s !== '');


### PR DESCRIPTION
Fixes `npm run build` crashing in a freshly-created workspace. The cacheable `backpack-web:build-sass` Nx target declared no `outputs`, so on a cache hit it restored none of the generated (git-ignored) `.module.css` files into `src/`, after which `copy-css.js`'s `find | grep` pipeline matched zero lines, exited 1, and threw via `execSync`. This PR declares the `build-sass` outputs so Nx restores the compiled CSS on cache hits, and pipes `copy-css.js`'s command through `cat` so an empty-but-valid result set no longer crashes the build. The `package-lock.json` changes are an incidental `npm install` side effect (optional native deps re-flagged as `devOptional`).

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR

_Build-tooling only change — no component, story, test, or accessibility changes apply. Suggest `skip-changelog`._