### PR TITLE
Fix Percy CI condition to handle non-PR event contexts

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -230,7 +230,10 @@ jobs:
           key: ${{ env.BUILD_CACHE_NAME }}-${{ hashFiles('packages/backpack-web/**', 'libs/backpack-storybook-utils/**', 'libs/backpack-storybook-host/**') }}
 
       - name: Percy Test
-        if: ( github.ref == 'refs/heads/main' || github.repository == github.event.pull_request.head.repo.full_name) && github.actor != 'dependabot[bot]'
+        if: |
+          github.actor != 'dependabot[bot]' &&
+          (github.ref == 'refs/heads/main' ||
+           (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name))
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           LOG_LEVEL: debug


### PR DESCRIPTION
## Summary
- Fix the `if` condition on the Percy Test step to add `github.event_name == 'pull_request' &&` before the repo comparison
- Without this, `github.event.pull_request.head.repo.full_name` is `null` on push-to-main events, causing the condition to behave unexpectedly
- Change requested by Percy support team (Yugandhara Rajhansa)

## Test plan
- [ ] Verify Percy runs correctly on PRs from non-fork branches
- [ ] Verify Percy runs correctly on pushes to main
- [ ] Verify Percy is skipped for dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)