### PR TITLE
[NO-JIRA][Code Connect] Add Figma Code Connect mappings for components and icons

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,4 @@ coverage
 /packages/backpack-web/src/bpk-component-spinner/src/spinners
 /packages/backpack-web/src/bpk-stylesheets/base.js
 *.d.ts
+*.figma.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
         "@babel/register": "^7.28.3",
-        "@figma/code-connect": "^1.4.3",
+        "@figma/code-connect": "^1.4.8",
         "@figma/rest-api-spec": "^0.37.0",
         "@nx/eslint-plugin": "22.7.1",
         "@nx/jest": "22.7.1",
@@ -3726,9 +3726,9 @@
       }
     },
     "node_modules/@figma/code-connect": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-1.4.3.tgz",
-      "integrity": "sha512-Tj3QMhx3pfBB0I0tgvT82FTVbJb+DnSEE8hTJ0K+d1/8XXgrBzG62I5K8OLG9Vj+OkVmdOnnbC4MDl4DgP5wLA==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-1.4.8.tgz",
+      "integrity": "sha512-Z9KyZPCx88ryFoRbe5M+vs3ZlPo7hFzD8yqeT+43nJM1PaIag04Xm2a0+9C7bCgwyn8jmKKNtDNG5f++Nn1tfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3742,7 +3742,7 @@
         "find-up": "^5.0.0",
         "glob": "^11.0.4",
         "jsdom": "^24.1.1",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "minimatch": "^9.0.3",
         "ora": "^5.4.1",
         "parse5": "^7.1.2",
@@ -3750,7 +3750,7 @@
         "prompts": "^2.4.2",
         "strip-ansi": "^6.0.0",
         "ts-morph": "^27.0.0",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "undici": "^7.19.1",
         "zod": "3.25.58",
         "zod-validation-error": "^3.2.0"
@@ -4047,13 +4047,6 @@
         }
       }
     },
-    "node_modules/@figma/code-connect/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@figma/code-connect/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -4148,6 +4141,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@figma/code-connect/node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@babel/register": "^7.28.3",
-    "@figma/code-connect": "^1.4.3",
+    "@figma/code-connect": "^1.4.8",
     "@figma/rest-api-spec": "^0.37.0",
     "@nx/eslint-plugin": "22.7.1",
     "@nx/jest": "22.7.1",

--- a/packages/backpack-web/src/bpk-component-accordion/src/BpkAccordion.figma.ts
+++ b/packages/backpack-web/src/bpk-component-accordion/src/BpkAccordion.figma.ts
@@ -1,0 +1,18 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=15011%3A6144
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-accordion/src/BpkAccordion.tsx
+// component=BpkAccordion
+
+import figma from "figma"
+
+const children = figma.properties.slot("List")
+
+export default {
+  id: "BpkAccordion",
+  imports: [
+    "import BpkAccordion from '@skyscanner/backpack-web/bpk-component-accordion';",
+  ],
+  example: figma.code`<BpkAccordion>
+        ${figma.helpers.react.renderChildren(children)}
+      </BpkAccordion>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-accordion/src/BpkAccordionItem.figma.ts
+++ b/packages/backpack-web/src/bpk-component-accordion/src/BpkAccordionItem.figma.ts
@@ -1,0 +1,25 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=15011%3A6079
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-accordion/src/BpkAccordionItem.tsx
+// component=BpkAccordionItem
+
+import figma from "figma"
+
+const title = figma.selectedInstance.findText("Title").__render__()
+const textStyle = figma.selectedInstance.getEnum("Size", {
+  "Heading 3": "heading-3",
+  "Heading 5": "heading-5",
+})
+
+export default {
+  id: "BpkAccordionItem",
+  imports: [
+    "import BpkAccordionItem from '@skyscanner/backpack-web/bpk-component-accordion';",
+  ],
+  example: figma.code`<BpkAccordionItem id="accordion-item"${figma.helpers.react.renderProp(
+    "title",
+    title,
+  )}${figma.helpers.react.renderProp("textStyle", textStyle)}>
+        Content goes here
+      </BpkAccordionItem>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-ai-blurb/src/BpkAiBlurb.figma.ts
+++ b/packages/backpack-web/src/bpk-component-ai-blurb/src/BpkAiBlurb.figma.ts
@@ -1,0 +1,73 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=15024%3A6380
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-ai-blurb/src/BpkAiBlurb.tsx
+// component=BpkAiBlurb.Root
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("State") === "Default") {
+  const summaryText = figma.selectedInstance.findText("Text").__render__()
+  const headerTitle = figma.selectedInstance.findText("Attribute").__render__()
+
+  template = {
+    id: "BpkAiBlurb.Root",
+    imports: [
+      "import BpkAiBlurb from '@skyscanner/backpack-web/bpk-component-ai-blurb';",
+    ],
+    example: figma.code`<BpkAiBlurb.Root>
+        <BpkAiBlurb.Header${figma.helpers.react.renderProp(
+          "title",
+          headerTitle,
+        )}/>
+        <BpkAiBlurb.Summary state="aiResponse"${figma.helpers.react.renderProp(
+          "aiResponseText",
+          summaryText,
+        )}/>
+        <BpkAiBlurb.Feedback feedbackText="Was this helpful?" thankYouText="Thanks for your feedback!" thumbsUpLabel="Thumbs up" thumbsDownLabel="Thumbs down" onFeedback={() => { }}/>
+      </BpkAiBlurb.Root>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("State") === "Thinking") {
+  const thinkingText = figma.selectedInstance.findText("Text").__render__()
+
+  template = {
+    id: "BpkAiBlurb.Root",
+    imports: [
+      "import BpkAiBlurb from '@skyscanner/backpack-web/bpk-component-ai-blurb';",
+    ],
+    example: figma.code`<BpkAiBlurb.Root>
+        <BpkAiBlurb.Header title="Summarized by AI"/>
+        <BpkAiBlurb.Summary state="thinking"${figma.helpers.react.renderProp(
+          "thinkingText",
+          thinkingText,
+        )}/>
+      </BpkAiBlurb.Root>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("State") === "Error") {
+  template = {
+    id: "BpkAiBlurb.Root",
+    imports: [
+      "import BpkAiBlurb from '@skyscanner/backpack-web/bpk-component-ai-blurb';",
+    ],
+    example: figma.code`<BpkAiBlurb.Root>
+        <BpkAiBlurb.Header title="Summarized by AI"/>
+        <BpkAiBlurb.Summary state="error" errorText="Something went wrong" errorActionText="Try again" onErrorClick={() => { }}/>
+      </BpkAiBlurb.Root>`,
+  }
+} else {
+  template = {
+    id: "BpkAiBlurb.Root",
+    imports: [
+      "import BpkAiBlurb from '@skyscanner/backpack-web/bpk-component-ai-blurb';",
+    ],
+    example: figma.code`<BpkAiBlurb.Root>
+        <BpkAiBlurb.Header title="Summarized by AI"/>
+        <BpkAiBlurb.Summary state="error" errorText="Something went wrong" errorActionText="Try again" onErrorClick={() => { }}/>
+      </BpkAiBlurb.Root>`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-autosuggest/src/BpkAutosuggest.figma.ts
+++ b/packages/backpack-web/src/bpk-component-autosuggest/src/BpkAutosuggest.figma.ts
@@ -1,0 +1,12 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A5529
+// component=BpkAutosuggest
+
+import figma from "figma"
+
+export default {
+  id: "BpkAutosuggest",
+  imports: [
+    "import BpkAutosuggest from '@skyscanner/backpack-web/bpk-component-autosuggest';",
+  ],
+  example: figma.code`<BpkAutosuggest />`,
+}

--- a/packages/backpack-web/src/bpk-component-badge/src/BpkBadge.figma.ts
+++ b/packages/backpack-web/src/bpk-component-badge/src/BpkBadge.figma.ts
@@ -1,0 +1,29 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A5938
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-badge/src/BpkBadge.tsx
+// component=BpkBadge
+
+import figma from "figma"
+
+const style = figma.selectedInstance.getEnum("Style", {
+  Normal: figma.helpers.react.identifier("BADGE_TYPES.normal"),
+  Success: figma.helpers.react.identifier("BADGE_TYPES.success"),
+  Warning: figma.helpers.react.identifier("BADGE_TYPES.warning"),
+  Critical: figma.helpers.react.identifier("BADGE_TYPES.critical"),
+  Inverse: figma.helpers.react.identifier("BADGE_TYPES.inverse"),
+  Outline: figma.helpers.react.identifier("BADGE_TYPES.outline"),
+  Brand: figma.helpers.react.identifier("BADGE_TYPES.brand"),
+  Strong: figma.helpers.react.identifier("BADGE_TYPES.strong"),
+})
+const label = figma.selectedInstance.findText("Attribute").__render__()
+
+export default {
+  id: "BpkBadge",
+  imports: [
+    "import BpkBadge, { BADGE_TYPES } from '@skyscanner/backpack-web/bpk-component-badge';",
+  ],
+  example: figma.code`<BpkBadge${figma.helpers.react.renderProp(
+    "type",
+    style,
+  )}>${figma.helpers.react.renderChildren(label)}</BpkBadge>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-barchart/src/BpkBarchart.figma.ts
+++ b/packages/backpack-web/src/bpk-component-barchart/src/BpkBarchart.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A6128
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-barchart/src/BpkBarchart.js
+// component=BpkBarchart
+
+import figma from "figma"
+
+export default {
+  id: "BpkBarchart",
+  imports: [
+    "import BpkBarchart from '@skyscanner/backpack-web/bpk-component-barchart';",
+  ],
+  example: figma.code`<BpkBarchart />`,
+}

--- a/packages/backpack-web/src/bpk-component-blockquote/src/BpkBlockquote.figma.ts
+++ b/packages/backpack-web/src/bpk-component-blockquote/src/BpkBlockquote.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A7014
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-blockquote/src/BpkBlockquote.tsx
+// component=BpkBlockquote
+
+import figma from "figma"
+
+export default {
+  id: "BpkBlockquote",
+  imports: [
+    "import BpkBlockquote from '@skyscanner/backpack-web/bpk-component-blockquote';",
+  ],
+  example: figma.code`<BpkBlockquote />`,
+}

--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.figma.ts
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A7593
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.tsx
+// component=BpkBottomSheet
+
+import figma from "figma"
+
+export default {
+  id: "BpkBottomSheet",
+  imports: [
+    "import BpkBottomSheet from '@skyscanner/backpack-web/bpk-component-bottom-sheet';",
+  ],
+  example: figma.code`<BpkBottomSheet />`,
+}

--- a/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumb.figma.ts
+++ b/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumb.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A7044
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumb.tsx
+// component=BpkBreadcrumb
+
+import figma from "figma"
+
+export default {
+  id: "BpkBreadcrumb",
+  imports: [
+    "import BpkBreadcrumb from '@skyscanner/backpack-web/bpk-component-breadcrumb';",
+  ],
+  example: figma.code`<BpkBreadcrumb />`,
+}

--- a/packages/backpack-web/src/bpk-component-bubble/src/BpkBubble.figma.ts
+++ b/packages/backpack-web/src/bpk-component-bubble/src/BpkBubble.figma.ts
@@ -1,0 +1,18 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A16303
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-bubble/src/BpkBubble.tsx
+// component=BpkBubble
+
+import figma from "figma"
+
+const children = figma.selectedInstance.findText("*").__render__()
+
+export default {
+  id: "BpkBubble",
+  imports: [
+    "import BpkBubble from '@skyscanner/backpack-web/bpk-component-bubble';",
+  ],
+  example: figma.code`<BpkBubble>${figma.helpers.react.renderChildren(
+    children,
+  )}</BpkBubble>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-button/src/BpkButton.figma.ts
+++ b/packages/backpack-web/src/bpk-component-button/src/BpkButton.figma.ts
@@ -1,0 +1,267 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A8677
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
+// component=BpkButton
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Icon") === "Icon only") {
+  const style = figma.selectedInstance.getEnum("Style", {
+    Primary: figma.helpers.react.identifier("BUTTON_TYPES.primary"),
+    Secondary: figma.helpers.react.identifier("BUTTON_TYPES.secondary"),
+    Featured: figma.helpers.react.identifier("BUTTON_TYPES.featured"),
+    "Primary on light": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnLight",
+    ),
+    "Primary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnDark",
+    ),
+    "Secondary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.secondaryOnDark",
+    ),
+    Destructive: figma.helpers.react.identifier("BUTTON_TYPES.destructive"),
+    Link: figma.helpers.react.identifier("BUTTON_TYPES.link"),
+    "Link on dark": figma.helpers.react.identifier("BUTTON_TYPES.linkOnDark"),
+  })
+  const size = figma.selectedInstance.getEnum("Size", {
+    Default: figma.helpers.react.identifier("SIZE_TYPES.small"),
+    Large: figma.helpers.react.identifier("SIZE_TYPES.large"),
+  })
+  const isDisabled = figma.selectedInstance.getEnum("State", {
+    Disabled: true,
+  })
+  const isLoading = figma.selectedInstance.getEnum("State", {
+    Loading: true,
+  })
+  const label = figma.selectedInstance.findText("Label").__render__()
+
+  template = {
+    id: "BpkButton",
+    imports: [
+      "import LightningIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/lightning';",
+      "import BpkButton from '@skyscanner/backpack-web/bpk-component-button'",
+    ],
+    example: figma.code`<BpkButton${figma.helpers.react.renderProp(
+      "type",
+      style,
+    )}${figma.helpers.react.renderProp(
+      "size",
+      size,
+    )}${figma.helpers.react.renderProp(
+      "disabled",
+      isDisabled,
+    )} iconOnly${figma.helpers.react.renderProp(
+      "loading",
+      isLoading,
+    )}${figma.helpers.react.renderProp("aria-label", label)}>
+        <LightningIcon />
+      </BpkButton>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("Icon") === "Left") {
+  const style = figma.selectedInstance.getEnum("Style", {
+    Primary: figma.helpers.react.identifier("BUTTON_TYPES.primary"),
+    Secondary: figma.helpers.react.identifier("BUTTON_TYPES.secondary"),
+    Featured: figma.helpers.react.identifier("BUTTON_TYPES.featured"),
+    "Primary on light": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnLight",
+    ),
+    "Primary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnDark",
+    ),
+    "Secondary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.secondaryOnDark",
+    ),
+    Destructive: figma.helpers.react.identifier("BUTTON_TYPES.destructive"),
+    Link: figma.helpers.react.identifier("BUTTON_TYPES.link"),
+    "Link on dark": figma.helpers.react.identifier("BUTTON_TYPES.linkOnDark"),
+  })
+  const size = figma.selectedInstance.getEnum("Size", {
+    Default: figma.helpers.react.identifier("SIZE_TYPES.small"),
+    Large: figma.helpers.react.identifier("SIZE_TYPES.large"),
+  })
+  const isDisabled = figma.selectedInstance.getEnum("State", {
+    Disabled: true,
+  })
+  const isLoading = figma.selectedInstance.getEnum("State", {
+    Loading: true,
+  })
+  const label = figma.selectedInstance.findText("Label").__render__()
+
+  template = {
+    id: "BpkButton",
+    imports: [
+      "import BpkButton from '@skyscanner/backpack-web/bpk-component-button'",
+    ],
+    example: figma.code`<BpkButton${figma.helpers.react.renderProp(
+      "type",
+      style,
+    )}${figma.helpers.react.renderProp(
+      "size",
+      size,
+    )}${figma.helpers.react.renderProp(
+      "disabled",
+      isDisabled,
+    )} leadingIcon={LightningIcon}${figma.helpers.react.renderProp(
+      "loading",
+      isLoading,
+    )}>
+        ${figma.helpers.react.renderChildren(label)}
+      </BpkButton>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("Icon") === "Right") {
+  const style = figma.selectedInstance.getEnum("Style", {
+    Primary: figma.helpers.react.identifier("BUTTON_TYPES.primary"),
+    Secondary: figma.helpers.react.identifier("BUTTON_TYPES.secondary"),
+    Featured: figma.helpers.react.identifier("BUTTON_TYPES.featured"),
+    "Primary on light": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnLight",
+    ),
+    "Primary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnDark",
+    ),
+    "Secondary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.secondaryOnDark",
+    ),
+    Destructive: figma.helpers.react.identifier("BUTTON_TYPES.destructive"),
+    Link: figma.helpers.react.identifier("BUTTON_TYPES.link"),
+    "Link on dark": figma.helpers.react.identifier("BUTTON_TYPES.linkOnDark"),
+  })
+  const size = figma.selectedInstance.getEnum("Size", {
+    Default: figma.helpers.react.identifier("SIZE_TYPES.small"),
+    Large: figma.helpers.react.identifier("SIZE_TYPES.large"),
+  })
+  const isDisabled = figma.selectedInstance.getEnum("State", {
+    Disabled: true,
+  })
+  const isLoading = figma.selectedInstance.getEnum("State", {
+    Loading: true,
+  })
+  const label = figma.selectedInstance.findText("Label").__render__()
+
+  template = {
+    id: "BpkButton",
+    imports: [
+      "import BpkButton from '@skyscanner/backpack-web/bpk-component-button'",
+    ],
+    example: figma.code`<BpkButton${figma.helpers.react.renderProp(
+      "type",
+      style,
+    )}${figma.helpers.react.renderProp(
+      "size",
+      size,
+    )}${figma.helpers.react.renderProp(
+      "disabled",
+      isDisabled,
+    )} trailingIcon={LongArrowRightIcon}${figma.helpers.react.renderProp(
+      "loading",
+      isLoading,
+    )}>
+        ${figma.helpers.react.renderChildren(label)}
+      </BpkButton>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("Icon") === "None") {
+  const style = figma.selectedInstance.getEnum("Style", {
+    Primary: figma.helpers.react.identifier("BUTTON_TYPES.primary"),
+    Secondary: figma.helpers.react.identifier("BUTTON_TYPES.secondary"),
+    Featured: figma.helpers.react.identifier("BUTTON_TYPES.featured"),
+    "Primary on light": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnLight",
+    ),
+    "Primary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnDark",
+    ),
+    "Secondary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.secondaryOnDark",
+    ),
+    Destructive: figma.helpers.react.identifier("BUTTON_TYPES.destructive"),
+    Link: figma.helpers.react.identifier("BUTTON_TYPES.link"),
+    "Link on dark": figma.helpers.react.identifier("BUTTON_TYPES.linkOnDark"),
+  })
+  const size = figma.selectedInstance.getEnum("Size", {
+    Default: figma.helpers.react.identifier("SIZE_TYPES.small"),
+    Large: figma.helpers.react.identifier("SIZE_TYPES.large"),
+  })
+  const isDisabled = figma.selectedInstance.getEnum("State", {
+    Disabled: true,
+  })
+  const isLoading = figma.selectedInstance.getEnum("State", {
+    Loading: true,
+  })
+  const label = figma.selectedInstance.findText("Label").__render__()
+
+  template = {
+    id: "BpkButton",
+    imports: [
+      "import BpkButton from '@skyscanner/backpack-web/bpk-component-button'",
+    ],
+    example: figma.code`<BpkButton${figma.helpers.react.renderProp(
+      "type",
+      style,
+    )}${figma.helpers.react.renderProp(
+      "size",
+      size,
+    )}${figma.helpers.react.renderProp(
+      "disabled",
+      isDisabled,
+    )}${figma.helpers.react.renderProp("loading", isLoading)}>
+        ${figma.helpers.react.renderChildren(label)}
+      </BpkButton>`,
+    metadata: { nestable: true },
+  }
+} else {
+  const style = figma.selectedInstance.getEnum("Style", {
+    Primary: figma.helpers.react.identifier("BUTTON_TYPES.primary"),
+    Secondary: figma.helpers.react.identifier("BUTTON_TYPES.secondary"),
+    Featured: figma.helpers.react.identifier("BUTTON_TYPES.featured"),
+    "Primary on light": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnLight",
+    ),
+    "Primary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.primaryOnDark",
+    ),
+    "Secondary on dark": figma.helpers.react.identifier(
+      "BUTTON_TYPES.secondaryOnDark",
+    ),
+    Destructive: figma.helpers.react.identifier("BUTTON_TYPES.destructive"),
+    Link: figma.helpers.react.identifier("BUTTON_TYPES.link"),
+    "Link on dark": figma.helpers.react.identifier("BUTTON_TYPES.linkOnDark"),
+  })
+  const size = figma.selectedInstance.getEnum("Size", {
+    Default: figma.helpers.react.identifier("SIZE_TYPES.small"),
+    Large: figma.helpers.react.identifier("SIZE_TYPES.large"),
+  })
+  const isDisabled = figma.selectedInstance.getEnum("State", {
+    Disabled: true,
+  })
+  const isLoading = figma.selectedInstance.getEnum("State", {
+    Loading: true,
+  })
+  const label = figma.selectedInstance.findText("Label").__render__()
+
+  template = {
+    id: "BpkButton",
+    imports: [
+      "import BpkButton from '@skyscanner/backpack-web/bpk-component-button'",
+    ],
+    example: figma.code`<BpkButton${figma.helpers.react.renderProp(
+      "type",
+      style,
+    )}${figma.helpers.react.renderProp(
+      "size",
+      size,
+    )}${figma.helpers.react.renderProp(
+      "disabled",
+      isDisabled,
+    )}${figma.helpers.react.renderProp("loading", isLoading)}>
+        ${figma.helpers.react.renderChildren(label)}
+      </BpkButton>`,
+    metadata: { nestable: true },
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-calendar/src/BpkCalendar.figma.ts
+++ b/packages/backpack-web/src/bpk-component-calendar/src/BpkCalendar.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A19950
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-calendar/src/BpkCalendarContainer.tsx
+// component=BpkCalendarContainer
+
+import figma from "figma"
+
+export default {
+  id: "BpkCalendarContainer",
+  imports: [
+    "import BpkCalendarContainer from '@skyscanner/backpack-web/bpk-component-calendar';",
+  ],
+  example: figma.code`<BpkCalendarContainer />`,
+}

--- a/packages/backpack-web/src/bpk-component-card-button/src/BpkSaveButton.figma.ts
+++ b/packages/backpack-web/src/bpk-component-card-button/src/BpkSaveButton.figma.ts
@@ -1,0 +1,33 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A50640
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-card-button/src/BpkSaveButton.tsx
+// component=BpkSaveButton
+
+import figma from "figma"
+
+const size = figma.selectedInstance.getEnum("Size", {
+  Default: figma.helpers.react.identifier("SIZE_TYPES.default"),
+  Small: figma.helpers.react.identifier("SIZE_TYPES.small"),
+})
+const style = figma.selectedInstance.getEnum("Style", {
+  Default: figma.helpers.react.identifier("STYLE_TYPES.default"),
+  Contained: figma.helpers.react.identifier("STYLE_TYPES.contained"),
+  "On Dark": figma.helpers.react.identifier("STYLE_TYPES.onDark"),
+})
+const checked = figma.selectedInstance.getEnum("State", {
+  Saved: true,
+})
+
+export default {
+  id: "BpkSaveButton",
+  imports: [
+    "import BpkSaveButton, { SIZE_TYPES, STYLE_TYPES } from '@skyscanner/backpack-web/bpk-component-card-button'",
+  ],
+  example: figma.code`<BpkSaveButton${figma.helpers.react.renderProp(
+    "checked",
+    checked,
+  )} accessibilityLabel="Save" onCheckedChange={() => { }}${figma.helpers.react.renderProp(
+    "size",
+    size,
+  )}${figma.helpers.react.renderProp("style", style)}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-card-button/src/BpkShareButton.figma.ts
+++ b/packages/backpack-web/src/bpk-component-card-button/src/BpkShareButton.figma.ts
@@ -1,0 +1,12 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A50721
+// component=BpkSaveButton
+
+import figma from "figma"
+
+export default {
+  id: "BpkSaveButton",
+  imports: [
+    "import { BpkSaveButton } from '@skyscanner/backpack-web/bpk-component-card-button';",
+  ],
+  example: figma.code`<BpkSaveButton />`,
+}

--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.figma.ts
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A37194
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.tsx
+// component=BpkCardList
+
+import figma from "figma"
+
+export default {
+  id: "BpkCardList",
+  imports: [
+    "import BpkCardList from '@skyscanner/backpack-web/bpk-component-card-list';",
+  ],
+  example: figma.code`<BpkCardList />`,
+}

--- a/packages/backpack-web/src/bpk-component-card/src/BpkCard.figma.ts
+++ b/packages/backpack-web/src/bpk-component-card/src/BpkCard.figma.ts
@@ -1,0 +1,51 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=15086%3A15207
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-card/src/BpkCardV2/BpkCardV2.tsx
+// component=BpkCardV2
+
+import figma from "figma"
+
+const bgColor = figma.selectedInstance.getEnum("Style", {
+  "Surface default": figma.helpers.react.identifier(
+    "CARD_V2_SURFACE_COLORS.surfaceDefault",
+  ),
+  "Surface low contrast": figma.helpers.react.identifier(
+    "CARD_V2_SURFACE_COLORS.surfaceLowContrast",
+  ),
+  "Surface elevated": figma.helpers.react.identifier(
+    "CARD_V2_SURFACE_COLORS.surfaceElevated",
+  ),
+  "Surface tint": figma.helpers.react.identifier(
+    "CARD_V2_SURFACE_COLORS.surfaceTint",
+  ),
+  "Surface subtle": figma.helpers.react.identifier(
+    "CARD_V2_SURFACE_COLORS.surfaceSubtle",
+  ),
+  "Surface contrast": figma.helpers.react.identifier(
+    "CARD_V2_SURFACE_COLORS.surfaceContrast",
+  ),
+})
+const variant = figma.selectedInstance.getEnum("Style", {
+  "Panel • Keyline": figma.helpers.react.identifier(
+    "CARD_V2_VARIANTS.outlined",
+  ),
+  "Panel • No keyline": figma.helpers.react.identifier(
+    "CARD_V2_VARIANTS.noElevation",
+  ),
+})
+const children = figma.properties.slot("Contents")
+
+export default {
+  id: "BpkCardV2",
+  imports: [
+    "import BpkCardV2 from '@skyscanner/backpack-web/bpk-component-card';",
+  ],
+  example: figma.code`<BpkCardV2.Root${figma.helpers.react.renderProp(
+    "bgColor",
+    bgColor,
+  )}${figma.helpers.react.renderProp("variant", variant)}>
+        <BpkCardV2.Body>${figma.helpers.react.renderChildren(
+          children,
+        )}</BpkCardV2.Body>
+      </BpkCardV2.Root>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-card/src/BpkCardWrapper.figma.ts
+++ b/packages/backpack-web/src/bpk-component-card/src/BpkCardWrapper.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A49736
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-card/src/BpkCardWrapper.tsx
+// component=BpkCardWrapper
+
+import figma from "figma"
+
+export default {
+  id: "BpkCardWrapper",
+  imports: [
+    "import BpkCardWrapper from '@skyscanner/backpack-web/bpk-component-card';",
+  ],
+  example: figma.code`<BpkCardWrapper card={<div>Card content</div>} backgroundColor={coreAccentDay} header={<span>Header</span>}/>`,
+}

--- a/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel.figma.ts
+++ b/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A50288
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel.tsx
+// component=BpkCarousel
+
+import figma from "figma"
+
+export default {
+  id: "BpkCarousel",
+  imports: [
+    "import BpkCarousel from '@skyscanner/backpack-web/bpk-component-carousel';",
+  ],
+  example: figma.code`<BpkCarousel images={imageList}/>`,
+}

--- a/packages/backpack-web/src/bpk-component-chat-bubble/src/BpkChatBubble.figma.ts
+++ b/packages/backpack-web/src/bpk-component-chat-bubble/src/BpkChatBubble.figma.ts
@@ -1,0 +1,30 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=17976-8767
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-chat-bubble/src/BpkChatBubble.tsx
+// component=BpkChatBubble
+
+import figma from "figma"
+
+const type = figma.selectedInstance.getEnum("Type", {
+  System: figma.helpers.react.identifier("CHAT_BUBBLE_TYPE.bot"),
+  User: figma.helpers.react.identifier("CHAT_BUBBLE_TYPE.user"),
+})
+const position = figma.selectedInstance.getEnum("State", {
+  Top: figma.helpers.react.identifier("CHAT_BUBBLE_POSITION.first"),
+  Middle: figma.helpers.react.identifier("CHAT_BUBBLE_POSITION.middle"),
+  Bottom: figma.helpers.react.identifier("CHAT_BUBBLE_POSITION.last"),
+})
+const content = figma.selectedInstance.findText("chat text").__render__()
+
+export default {
+  id: "BpkChatBubble",
+  imports: [
+    "import BpkChatBubble from '@skyscanner/backpack-web/bpk-component-chat-bubble';",
+  ],
+  example: figma.code`<BpkChatBubble${figma.helpers.react.renderProp(
+    "type",
+    type,
+  )}${figma.helpers.react.renderProp("systemPosition", position)}>
+        ${figma.helpers.react.renderChildren(content)}
+      </BpkChatBubble>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-chat-thought-bubble/src/BpkChatThoughtBubble.figma.ts
+++ b/packages/backpack-web/src/bpk-component-chat-thought-bubble/src/BpkChatThoughtBubble.figma.ts
@@ -1,0 +1,19 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=17976-8783
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-chat-thought-bubble/src/BpkChatThoughtBubble.tsx
+// component=BpkChatThoughtBubble
+
+import figma from "figma"
+
+const content = figma.selectedInstance.findText("Label").__render__()
+
+export default {
+  id: "BpkChatThoughtBubble",
+  imports: [
+    "import BpkChatThoughtBubble from '@skyscanner/backpack-web/bpk-component-chat-thought-bubble';",
+  ],
+  example: figma.code`<BpkChatThoughtBubble${figma.helpers.react.renderProp(
+    "content",
+    content,
+  )}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-chatbot-input/src/BpkChatbotInput.figma.ts
+++ b/packages/backpack-web/src/bpk-component-chatbot-input/src/BpkChatbotInput.figma.ts
@@ -1,0 +1,21 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=17976-8833
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-chatbot-input/src/BpkChatbotInput.tsx
+// component=BpkChatbotInput.Root
+
+import figma from "figma"
+
+const placeholder = figma.selectedInstance.findText("Your message").__render__()
+
+export default {
+  id: "BpkChatbotInput.Root",
+  imports: [
+    "import BpkChatbotInput from '@skyscanner/backpack-web/bpk-component-chatbot-input';",
+  ],
+  example: figma.code`<BpkChatbotInput.Root>
+        <BpkChatbotInput.Input inputValue=""${figma.helpers.react.renderProp(
+          "placeholder",
+          placeholder,
+        )} onInputChange={() => { }} onInputFocus={() => { }} onInputBlur={() => { }} onSubmit={() => { }} sendAriaLabel="Send message" loadingAriaLabel="Sending message"/>
+      </BpkChatbotInput.Root>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-checkbox-card/src/BpkCheckboxCard.figma.ts
+++ b/packages/backpack-web/src/bpk-component-checkbox-card/src/BpkCheckboxCard.figma.ts
@@ -1,0 +1,46 @@
+// url=https://www.figma.com/design/ITvypOGdga42nM2ipBM4uk/Bpk-2.0?node-id=90-7627
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-checkbox-card/src/BpkCheckboxCard.tsx
+// component=BpkCheckboxCard
+
+import figma from "figma"
+
+const checked = figma.selectedInstance.getEnum("State", {
+  selected: true,
+})
+const variant = figma.selectedInstance.getEnum("Style", {
+  "On Canvas Default": figma.helpers.react.identifier(
+    "CHECKBOX_CARD_VARIANTS.onCanvasDefault",
+  ),
+  "On Canvas Contrast": figma.helpers.react.identifier(
+    "CHECKBOX_CARD_VARIANTS.onCanvasContrast",
+  ),
+  "On Surface Contrast": figma.helpers.react.identifier(
+    "CHECKBOX_CARD_VARIANTS.onSurfaceContrast",
+  ),
+})
+const disabled = figma.selectedInstance.getEnum("State", {
+  disabled: true,
+})
+const label = figma.selectedInstance.findText("Label").__render__()
+
+export default {
+  id: "BpkCheckboxCard",
+  imports: [
+    "import { BpkCheckboxCard } from '@skyscanner/backpack-web/bpk-component-checkbox-card';",
+  ],
+  example: figma.code`<BpkCheckboxCard.Root${figma.helpers.react.renderProp(
+    "checked",
+    checked,
+  )} onCheckedChange={() => { }}${figma.helpers.react.renderProp(
+    "variant",
+    variant,
+  )}${figma.helpers.react.renderProp("disabled", disabled)}>
+        <BpkCheckboxCard.HiddenInput />
+        <BpkCheckboxCard.Content>
+          <BpkCheckboxCard.Label>${figma.helpers.react.renderChildren(
+            label,
+          )}</BpkCheckboxCard.Label>
+        </BpkCheckboxCard.Content>
+      </BpkCheckboxCard.Root>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckbox.figma.ts
+++ b/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckbox.figma.ts
@@ -1,0 +1,19 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A4777
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckbox.tsx
+// component=BpkCheckbox
+
+import figma from "figma"
+
+const label = figma.selectedInstance.findText("Option").__render__()
+
+export default {
+  id: "BpkCheckbox",
+  imports: [
+    "import BpkCheckbox from '@skyscanner/backpack-web/bpk-component-checkbox';",
+  ],
+  example: figma.code`<BpkCheckbox${figma.helpers.react.renderProp(
+    "name",
+    label,
+  )}${figma.helpers.react.renderProp("label", label)} onChange={() => { }}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroupRail.figma.ts
+++ b/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroupRail.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A56092
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-chip-group/src/BpkMultiSelectChipGroup.tsx
+// component=BpkMultiSelectChipGroup
+
+import figma from "figma"
+
+export default {
+  id: "BpkMultiSelectChipGroup",
+  imports: [
+    "import BpkMultiSelectChipGroup from '@skyscanner/backpack-web/bpk-component-chip-group';",
+  ],
+  example: figma.code`<BpkMultiSelectChipGroup />`,
+}

--- a/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroupWrap.figma.ts
+++ b/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroupWrap.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A55870
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-chip-group/src/BpkMultiSelectChipGroup.tsx
+// component=BpkMultiSelectChipGroup
+
+import figma from "figma"
+
+export default {
+  id: "BpkMultiSelectChipGroup",
+  imports: [
+    "import BpkMultiSelectChipGroup from '@skyscanner/backpack-web/bpk-component-chip-group';",
+  ],
+  example: figma.code`<BpkMultiSelectChipGroup />`,
+}

--- a/packages/backpack-web/src/bpk-component-chip/src/BpkSelectableChip.figma.ts
+++ b/packages/backpack-web/src/bpk-component-chip/src/BpkSelectableChip.figma.ts
@@ -1,0 +1,146 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A52134
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-chip/src/BpkSelectableChip.tsx
+// component=BpkSelectableChip
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Type") === "Selectable") {
+  const label = figma.selectedInstance.getString("Label")
+  const type = figma.selectedInstance.getEnum("Style", {
+    Default: figma.helpers.react.identifier("CHIP_TYPES.default"),
+    "On Dark": figma.helpers.react.identifier("CHIP_TYPES.onDark"),
+    "On Image": figma.helpers.react.identifier("CHIP_TYPES.onImage"),
+  })
+  const disabled = figma.selectedInstance.getEnum("State", {
+    Disabled: true,
+  })
+  const icon = figma.selectedInstance.getBoolean("Icon", {
+    true: figma.helpers.react.jsxElement("<DealsIconSm />"),
+    false: undefined,
+  })
+
+  template = {
+    id: "BpkSelectableChip",
+    imports: [
+      "import BpkSelectableChip from '@skyscanner/backpack-web/bpk-component-chip';",
+    ],
+    example: figma.code`<BpkSelectableChip onClick={() => null}${figma.helpers.react.renderProp(
+      "leadingAccessoryView",
+      icon,
+    )}${figma.helpers.react.renderProp(
+      "accessibilityLabel",
+      label,
+    )}${figma.helpers.react.renderProp(
+      "type",
+      type,
+    )}${figma.helpers.react.renderProp(
+      "disabled",
+      disabled,
+    )}>${figma.helpers.react.renderChildren(label)}</BpkSelectableChip>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("Type") === "Dropdown") {
+  const label = figma.selectedInstance.getString("Label")
+  const type = figma.selectedInstance.getEnum("Style", {
+    Default: figma.helpers.react.identifier("CHIP_TYPES.default"),
+    "On Dark": figma.helpers.react.identifier("CHIP_TYPES.onDark"),
+    "On Image": figma.helpers.react.identifier("CHIP_TYPES.onImage"),
+  })
+  const disabled = figma.selectedInstance.getEnum("State", {
+    Disabled: true,
+  })
+  const icon = figma.selectedInstance.getBoolean("Icon", {
+    true: figma.helpers.react.jsxElement("<DealsIconSm />"),
+    false: undefined,
+  })
+
+  template = {
+    id: "BpkDropdownChip",
+    imports: [
+      "import BpkDropdownChip from '@skyscanner/backpack-web/bpk-component-chip';",
+    ],
+    example: figma.code`<BpkDropdownChip onClick={() => null}${figma.helpers.react.renderProp(
+      "accessibilityLabel",
+      label,
+    )}${figma.helpers.react.renderProp(
+      "leadingAccessoryView",
+      icon,
+    )}${figma.helpers.react.renderProp(
+      "type",
+      type,
+    )}${figma.helpers.react.renderProp(
+      "disabled",
+      disabled,
+    )}>${figma.helpers.react.renderChildren(label)}</BpkDropdownChip>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("Type") === "Dismissible") {
+  const label = figma.selectedInstance.getString("Label")
+  const type = figma.selectedInstance.getEnum("Style", {
+    Default: figma.helpers.react.identifier("CHIP_TYPES.default"),
+    "On Dark": figma.helpers.react.identifier("CHIP_TYPES.onDark"),
+    "On Image": figma.helpers.react.identifier("CHIP_TYPES.onImage"),
+  })
+  const disabled = figma.selectedInstance.getEnum("State", {
+    Disabled: true,
+  })
+  const icon = figma.selectedInstance.getBoolean("Icon", {
+    true: figma.helpers.react.jsxElement("<DealsIconSm />"),
+    false: undefined,
+  })
+
+  template = {
+    id: "BpkDismissibleChip",
+    imports: [
+      "import BpkDismissibleChip from '@skyscanner/backpack-web/bpk-component-chip';",
+    ],
+    example: figma.code`<BpkDismissibleChip onClick={() => null}${figma.helpers.react.renderProp(
+      "leadingAccessoryView",
+      icon,
+    )}${figma.helpers.react.renderProp(
+      "accessibilityLabel",
+      label,
+    )}${figma.helpers.react.renderProp(
+      "type",
+      type,
+    )}>${figma.helpers.react.renderChildren(label)}</BpkDismissibleChip>`,
+    metadata: { nestable: true },
+  }
+} else {
+  const label = figma.selectedInstance.getString("Label")
+  const type = figma.selectedInstance.getEnum("Style", {
+    Default: figma.helpers.react.identifier("CHIP_TYPES.default"),
+    "On Dark": figma.helpers.react.identifier("CHIP_TYPES.onDark"),
+    "On Image": figma.helpers.react.identifier("CHIP_TYPES.onImage"),
+  })
+  const disabled = figma.selectedInstance.getEnum("State", {
+    Disabled: true,
+  })
+  const icon = figma.selectedInstance.getBoolean("Icon", {
+    true: figma.helpers.react.jsxElement("<DealsIconSm />"),
+    false: undefined,
+  })
+
+  template = {
+    id: "BpkDismissibleChip",
+    imports: [
+      "import BpkDismissibleChip from '@skyscanner/backpack-web/bpk-component-chip';",
+    ],
+    example: figma.code`<BpkDismissibleChip onClick={() => null}${figma.helpers.react.renderProp(
+      "leadingAccessoryView",
+      icon,
+    )}${figma.helpers.react.renderProp(
+      "accessibilityLabel",
+      label,
+    )}${figma.helpers.react.renderProp(
+      "type",
+      type,
+    )}>${figma.helpers.react.renderChildren(label)}</BpkDismissibleChip>`,
+    metadata: { nestable: true },
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-code/src/BpkCode.figma.ts
+++ b/packages/backpack-web/src/bpk-component-code/src/BpkCode.figma.ts
@@ -1,0 +1,12 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A59646
+// component=BpkCode
+
+import figma from "figma"
+
+export default {
+  id: "BpkCode",
+  imports: [
+    "import { BpkCode } from '@skyscanner/backpack-web/bpk-component-code';",
+  ],
+  example: figma.code`<BpkCode />`,
+}

--- a/packages/backpack-web/src/bpk-component-code/src/BpkCodeBlock.figma.ts
+++ b/packages/backpack-web/src/bpk-component-code/src/BpkCodeBlock.figma.ts
@@ -1,0 +1,12 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A59644
+// component=BpkCodeBlock
+
+import figma from "figma"
+
+export default {
+  id: "BpkCodeBlock",
+  imports: [
+    "import { BpkCodeBlock } from '@skyscanner/backpack-web/bpk-component-code';",
+  ],
+  example: figma.code`<BpkCodeBlock />`,
+}

--- a/packages/backpack-web/src/bpk-component-content-cards/src/BpkContentCards.figma.ts
+++ b/packages/backpack-web/src/bpk-component-content-cards/src/BpkContentCards.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A58524
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-content-cards/src/BpkContentCards.tsx
+// component=BpkContentCards
+
+import figma from "figma"
+
+export default {
+  id: "BpkContentCards",
+  imports: [
+    "import BpkContentCards from '@skyscanner/backpack-web/bpk-component-content-cards';",
+  ],
+  example: figma.code`<BpkContentCards />`,
+}

--- a/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.figma.ts
+++ b/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A52631
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.tsx
+// component=BpkDataTable
+
+import figma from "figma"
+
+export default {
+  id: "BpkDataTable",
+  imports: [
+    "import BpkDataTable from '@skyscanner/backpack-web/bpk-component-datatable';",
+  ],
+  example: figma.code`<BpkDataTable />`,
+}

--- a/packages/backpack-web/src/bpk-component-dialog/src/BpkDialog.figma.ts
+++ b/packages/backpack-web/src/bpk-component-dialog/src/BpkDialog.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A24078
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-dialog/src/BpkDialog.tsx
+// component=BpkDialog
+
+import figma from "figma"
+
+export default {
+  id: "BpkDialog",
+  imports: [
+    "import BpkDialog from '@skyscanner/backpack-web/bpk-component-dialog';",
+  ],
+  example: figma.code`<BpkDialog />`,
+}

--- a/packages/backpack-web/src/bpk-component-drawer/src/BpkDrawer.figma.ts
+++ b/packages/backpack-web/src/bpk-component-drawer/src/BpkDrawer.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A24040
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-drawer/src/BpkDrawer.tsx
+// component=BpkDrawer
+
+import figma from "figma"
+
+export default {
+  id: "BpkDrawer",
+  imports: [
+    "import BpkDrawer from '@skyscanner/backpack-web/bpk-component-drawer';",
+  ],
+  example: figma.code`<BpkDrawer />`,
+}

--- a/packages/backpack-web/src/bpk-component-fieldset/src/BpkFieldset.figma.ts
+++ b/packages/backpack-web/src/bpk-component-fieldset/src/BpkFieldset.figma.ts
@@ -1,0 +1,152 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A4953
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-fieldset/src/BpkFieldset.tsx
+// component=BpkFieldset
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Type") === "Input") {
+  const error = figma.selectedInstance.getBoolean("Error")
+  const labelInstance = (function () {
+    const nestedLayer0 = figma.selectedInstance.findInstance("Label")
+    return {
+      label:
+        nestedLayer0.type !== "ERROR"
+          ? nestedLayer0.findText("Label").__render__()
+          : undefined,
+    }
+  })()
+
+  template = {
+    id: "BpkFieldset",
+    imports: [
+      'import BpkInput, { INPUT_TYPES } from "../../bpk-component-input";',
+      "import BpkFieldset from '@skyscanner/backpack-web/bpk-component-fieldset';",
+    ],
+    example: figma.code`<BpkFieldset${figma.helpers.react.renderProp(
+      "label",
+      labelInstance.label,
+    )} required={false} disabled={false} valid={!error}>
+      <BpkInput id="example-input" name="example-input" value="" type={INPUT_TYPES.text}/>
+    </BpkFieldset>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("Type") === "Select") {
+  const error = figma.selectedInstance.getBoolean("Error")
+  const labelInstance = (function () {
+    const nestedLayer1 = figma.selectedInstance.findInstance("Label")
+    return {
+      label:
+        nestedLayer1.type !== "ERROR"
+          ? nestedLayer1.findText("Label").__render__()
+          : undefined,
+    }
+  })()
+
+  template = {
+    id: "BpkFieldset",
+    imports: [
+      'import BpkSelect from "../../bpk-component-select";',
+      "import BpkFieldset from '@skyscanner/backpack-web/bpk-component-fieldset';",
+    ],
+    example: figma.code`<BpkFieldset${figma.helpers.react.renderProp(
+      "label",
+      labelInstance.label,
+    )} required={false} disabled={false} valid={!error}>
+      <BpkSelect id="example-select" name="example-select" value="">
+        <option value="">Select</option>
+        <option value="option1">Option 1</option>
+        <option value="option2">Option 2</option>
+      </BpkSelect>
+    </BpkFieldset>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("Type") === "Text area") {
+  const error = figma.selectedInstance.getBoolean("Error")
+  const labelInstance = (function () {
+    const nestedLayer2 = figma.selectedInstance.findInstance("Label")
+    return {
+      label:
+        nestedLayer2.type !== "ERROR"
+          ? nestedLayer2.findText("Label").__render__()
+          : undefined,
+    }
+  })()
+
+  template = {
+    id: "BpkFieldset",
+    imports: [
+      'import BpkTextarea from "../../bpk-component-textarea";',
+      "import BpkFieldset from '@skyscanner/backpack-web/bpk-component-fieldset';",
+    ],
+    example: figma.code`<BpkFieldset${figma.helpers.react.renderProp(
+      "label",
+      labelInstance.label,
+    )} required={false} disabled={false} valid={!error}>
+      <BpkTextarea id="textarea" name="textarea" value=""/>
+    </BpkFieldset>`,
+    metadata: { nestable: true },
+  }
+} else if (figma.selectedInstance.getPropertyValue("Type") === "Radio group") {
+  const error = figma.selectedInstance.getBoolean("Error")
+  const labelInstance = (function () {
+    const nestedLayer3 = figma.selectedInstance.findInstance("Label")
+    return {
+      label:
+        nestedLayer3.type !== "ERROR"
+          ? nestedLayer3.findText("Label").__render__()
+          : undefined,
+    }
+  })()
+
+  template = {
+    id: "BpkFieldset",
+    imports: [
+      'import BpkCheckbox from "../../bpk-component-checkbox";',
+      "import BpkFieldset from '@skyscanner/backpack-web/bpk-component-fieldset';",
+    ],
+    example: figma.code`<BpkFieldset${figma.helpers.react.renderProp(
+      "label",
+      labelInstance.label,
+    )} required={false} disabled={false} valid={!error}>
+      <div id="example-radio-group">
+        <BpkCheckbox name="group" label="Radio 1" checked={false}/>
+        <BpkCheckbox name="group" label="Radio 2" checked={false}/>
+      </div>
+    </BpkFieldset>`,
+    metadata: { nestable: true },
+  }
+} else {
+  const error = figma.selectedInstance.getBoolean("Error")
+  const labelInstance = (function () {
+    const nestedLayer3 = figma.selectedInstance.findInstance("Label")
+    return {
+      label:
+        nestedLayer3.type !== "ERROR"
+          ? nestedLayer3.findText("Label").__render__()
+          : undefined,
+    }
+  })()
+
+  template = {
+    id: "BpkFieldset",
+    imports: [
+      'import BpkCheckbox from "../../bpk-component-checkbox";',
+      "import BpkFieldset from '@skyscanner/backpack-web/bpk-component-fieldset';",
+    ],
+    example: figma.code`<BpkFieldset${figma.helpers.react.renderProp(
+      "label",
+      labelInstance.label,
+    )} required={false} disabled={false} valid={!error}>
+      <div id="example-radio-group">
+        <BpkCheckbox name="group" label="Radio 1" checked={false}/>
+        <BpkCheckbox name="group" label="Radio 2" checked={false}/>
+      </div>
+    </BpkFieldset>`,
+    metadata: { nestable: true },
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-flare/src/BpkFlare.figma.ts
+++ b/packages/backpack-web/src/bpk-component-flare/src/BpkFlare.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A59738
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-flare/src/BpkFlareBar.js
+// component=BpkFlareBar
+
+import figma from "figma"
+
+export default {
+  id: "BpkFlareBar",
+  imports: [
+    "import BpkFlareBar from '@skyscanner/backpack-web/bpk-component-flare';",
+  ],
+  example: figma.code`<BpkFlareBar />`,
+}

--- a/packages/backpack-web/src/bpk-component-floating-notification/src/BpkFloatingNotification.figma.ts
+++ b/packages/backpack-web/src/bpk-component-floating-notification/src/BpkFloatingNotification.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10858%3A59850
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-floating-notification/src/BpkFloatingNotification.tsx
+// component=BpkFloatingNotification
+
+import figma from "figma"
+
+export default {
+  id: "BpkFloatingNotification",
+  imports: [
+    "import BpkFloatingNotification from '@skyscanner/backpack-web/bpk-component-floating-notification';",
+  ],
+  example: figma.code`<BpkFloatingNotification />`,
+}

--- a/packages/backpack-web/src/bpk-component-form-validation/src/BpkFormValidation.figma.ts
+++ b/packages/backpack-web/src/bpk-component-form-validation/src/BpkFormValidation.figma.ts
@@ -1,0 +1,18 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A5121
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-form-validation/src/BpkFormValidation.tsx
+// component=BpkFormValidation
+
+import figma from "figma"
+
+const children = figma.selectedInstance.findText("*").__render__()
+
+export default {
+  id: "BpkFormValidation",
+  imports: [
+    "import BpkFormValidation from '@skyscanner/backpack-web/bpk-component-form-validation';",
+  ],
+  example: figma.code`<BpkFormValidation id="form-validation" expanded>
+        ${figma.helpers.react.renderChildren(children)}
+      </BpkFormValidation>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-graphic-promotion/src/BpkGraphicPromoLandscape.figma.ts
+++ b/packages/backpack-web/src/bpk-component-graphic-promotion/src/BpkGraphicPromoLandscape.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A2461
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-graphic-promotion/src/BpkGraphicPromo.tsx
+// component=BpkGraphicPromo
+
+import figma from "figma"
+
+export default {
+  id: "BpkGraphicPromo",
+  imports: [
+    "import BpkGraphicPromo from '@skyscanner/backpack-web/bpk-component-graphic-promotion';",
+  ],
+  example: figma.code`<BpkGraphicPromo />`,
+}

--- a/packages/backpack-web/src/bpk-component-graphic-promotion/src/BpkGraphicPromoPortrait.figma.ts
+++ b/packages/backpack-web/src/bpk-component-graphic-promotion/src/BpkGraphicPromoPortrait.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A2409
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-graphic-promotion/src/BpkGraphicPromo.tsx
+// component=BpkGraphicPromo
+
+import figma from "figma"
+
+export default {
+  id: "BpkGraphicPromo",
+  imports: [
+    "import BpkGraphicPromo from '@skyscanner/backpack-web/bpk-component-graphic-promotion';",
+  ],
+  example: figma.code`<BpkGraphicPromo />`,
+}

--- a/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.figma.ts
+++ b/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.figma.ts
@@ -1,0 +1,29 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10908%3A3878
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.tsx
+// component=BpkHorizontalNav
+
+import figma from "figma"
+
+const showUnderline = figma.selectedInstance.getBoolean("Line")
+const type = figma.selectedInstance.getEnum("Style", {
+  Default: figma.helpers.react.identifier("HORIZONTAL_NAV_TYPES.default"),
+  "On Contrast": figma.helpers.react.identifier("HORIZONTAL_NAV_TYPES.light"),
+})
+
+export default {
+  id: "BpkHorizontalNav",
+  imports: [
+    "import BpkHorizontalNav, { HORIZONTAL_NAV_TYPES } from '@skyscanner/backpack-web/bpk-component-horizontal-nav';",
+    "import BpkHorizontalNavItem from '@skyscanner/backpack-web/bpk-component-horizontal-nav';",
+  ],
+  example: figma.code`<BpkHorizontalNav${figma.helpers.react.renderProp(
+    "showUnderline",
+    showUnderline,
+  )}${figma.helpers.react.renderProp("type", type)}>
+        <BpkHorizontalNavItem>One</BpkHorizontalNavItem>
+        <BpkHorizontalNavItem>Two</BpkHorizontalNavItem>
+        <BpkHorizontalNavItem>Three</BpkHorizontalNavItem>
+        <BpkHorizontalNavItem>Four</BpkHorizontalNavItem>
+      </BpkHorizontalNav>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.figma.ts
+++ b/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.figma.ts
@@ -1,0 +1,28 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10908%3A3845
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.tsx
+// component=BpkHorizontalNavItem
+
+import figma from "figma"
+
+const selected = figma.selectedInstance.getEnum("State", {
+  Active: true,
+})
+const type = figma.selectedInstance.getEnum("Style", {
+  Default: figma.helpers.react.identifier("HORIZONTAL_NAV_TYPES.default"),
+  Light: figma.helpers.react.identifier("HORIZONTAL_NAV_TYPES.light"),
+})
+const children = figma.selectedInstance.findText("Label").__render__()
+
+export default {
+  id: "BpkHorizontalNavItem",
+  imports: [
+    "import BpkHorizontalNavItem from '@skyscanner/backpack-web/bpk-component-horizontal-nav';",
+  ],
+  example: figma.code`<BpkHorizontalNavItem${figma.helpers.react.renderProp(
+    "selected",
+    selected,
+  )}${figma.helpers.react.renderProp("type", type)}>
+        ${figma.helpers.react.renderChildren(children)}
+      </BpkHorizontalNavItem>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A0
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/accessibility.d.ts
+// component=BpkSmallAccessibilityIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAccessibilityIcon",
+    imports: [
+      "import BpkSmallAccessibilityIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/accessibility';",
+    ],
+    example: figma.code`<BpkSmallAccessibilityIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAccessibilityIcon",
+    imports: [
+      "import BpkLargeAccessibilityIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/accessibility';",
+    ],
+    example: figma.code`<BpkLargeAccessibilityIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAccessibilityIcon",
+    imports: [
+      "import BpkLargeAccessibilityIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/accessibility';",
+    ],
+    example: figma.code`<BpkLargeAccessibilityIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_1.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_1.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A1
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/account.d.ts
+// component=BpkSmallAccountIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAccountIcon",
+    imports: [
+      "import BpkSmallAccountIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/account';",
+    ],
+    example: figma.code`<BpkSmallAccountIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAccountIcon",
+    imports: [
+      "import BpkLargeAccountIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account';",
+    ],
+    example: figma.code`<BpkLargeAccountIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAccountIcon",
+    imports: [
+      "import BpkLargeAccountIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account';",
+    ],
+    example: figma.code`<BpkLargeAccountIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_10.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_10.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=9244%3A148
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/ai.d.ts
+// component=BpkSmallAiIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAiIcon",
+    imports: [
+      "import BpkSmallAiIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/ai';",
+    ],
+    example: figma.code`<BpkSmallAiIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAiIcon",
+    imports: [
+      "import BpkLargeAiIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/ai';",
+    ],
+    example: figma.code`<BpkLargeAiIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAiIcon",
+    imports: [
+      "import BpkLargeAiIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/ai';",
+    ],
+    example: figma.code`<BpkLargeAiIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_100.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_100.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A98
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/fast-train.d.ts
+// component=BpkSmallFastTrainIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFastTrainIcon",
+    imports: [
+      "import BpkSmallFastTrainIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/fast-train';",
+    ],
+    example: figma.code`<BpkSmallFastTrainIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFastTrainIcon",
+    imports: [
+      "import BpkLargeFastTrainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/fast-train';",
+    ],
+    example: figma.code`<BpkLargeFastTrainIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFastTrainIcon",
+    imports: [
+      "import BpkLargeFastTrainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/fast-train';",
+    ],
+    example: figma.code`<BpkLargeFastTrainIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_101.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_101.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A99
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/filter.d.ts
+// component=BpkSmallFilterIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFilterIcon",
+    imports: [
+      "import BpkSmallFilterIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/filter';",
+    ],
+    example: figma.code`<BpkSmallFilterIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFilterIcon",
+    imports: [
+      "import BpkLargeFilterIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/filter';",
+    ],
+    example: figma.code`<BpkLargeFilterIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFilterIcon",
+    imports: [
+      "import BpkLargeFilterIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/filter';",
+    ],
+    example: figma.code`<BpkLargeFilterIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_102.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_102.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A100
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/fingerprint.d.ts
+// component=BpkSmallFingerprintIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFingerprintIcon",
+    imports: [
+      "import BpkSmallFingerprintIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/fingerprint';",
+    ],
+    example: figma.code`<BpkSmallFingerprintIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFingerprintIcon",
+    imports: [
+      "import BpkLargeFingerprintIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/fingerprint';",
+    ],
+    example: figma.code`<BpkLargeFingerprintIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFingerprintIcon",
+    imports: [
+      "import BpkLargeFingerprintIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/fingerprint';",
+    ],
+    example: figma.code`<BpkLargeFingerprintIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_103.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_103.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A101
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/flag.d.ts
+// component=BpkSmallFlagIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFlagIcon",
+    imports: [
+      "import BpkSmallFlagIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flag';",
+    ],
+    example: figma.code`<BpkSmallFlagIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFlagIcon",
+    imports: [
+      "import BpkLargeFlagIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flag';",
+    ],
+    example: figma.code`<BpkLargeFlagIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFlagIcon",
+    imports: [
+      "import BpkLargeFlagIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flag';",
+    ],
+    example: figma.code`<BpkLargeFlagIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_104.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_104.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=8992%3A156
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/flame.d.ts
+// component=BpkSmallFlameIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFlameIcon",
+    imports: [
+      "import BpkSmallFlameIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flame';",
+    ],
+    example: figma.code`<BpkSmallFlameIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFlameIcon",
+    imports: [
+      "import BpkLargeFlameIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flame';",
+    ],
+    example: figma.code`<BpkLargeFlameIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFlameIcon",
+    imports: [
+      "import BpkLargeFlameIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flame';",
+    ],
+    example: figma.code`<BpkLargeFlameIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_105.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_105.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A102
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/flask.d.ts
+// component=BpkSmallFlaskIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFlaskIcon",
+    imports: [
+      "import BpkSmallFlaskIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flask';",
+    ],
+    example: figma.code`<BpkSmallFlaskIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFlaskIcon",
+    imports: [
+      "import BpkLargeFlaskIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flask';",
+    ],
+    example: figma.code`<BpkLargeFlaskIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFlaskIcon",
+    imports: [
+      "import BpkLargeFlaskIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flask';",
+    ],
+    example: figma.code`<BpkLargeFlaskIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_106.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_106.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A103
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/flight.d.ts
+// component=BpkSmallFlightIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFlightIcon",
+    imports: [
+      "import BpkSmallFlightIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flight';",
+    ],
+    example: figma.code`<BpkSmallFlightIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFlightIcon",
+    imports: [
+      "import BpkLargeFlightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flight';",
+    ],
+    example: figma.code`<BpkLargeFlightIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFlightIcon",
+    imports: [
+      "import BpkLargeFlightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flight';",
+    ],
+    example: figma.code`<BpkLargeFlightIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_107.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_107.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A104
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/flight-flexible.d.ts
+// component=BpkSmallFlightFlexibleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFlightFlexibleIcon",
+    imports: [
+      "import BpkSmallFlightFlexibleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flight-flexible';",
+    ],
+    example: figma.code`<BpkSmallFlightFlexibleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFlightFlexibleIcon",
+    imports: [
+      "import BpkLargeFlightFlexibleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flight-flexible';",
+    ],
+    example: figma.code`<BpkLargeFlightFlexibleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFlightFlexibleIcon",
+    imports: [
+      "import BpkLargeFlightFlexibleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flight-flexible';",
+    ],
+    example: figma.code`<BpkLargeFlightFlexibleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_108.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_108.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A105
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/flight-landing.d.ts
+// component=BpkSmallFlightLandingIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFlightLandingIcon",
+    imports: [
+      "import BpkSmallFlightLandingIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flight-landing';",
+    ],
+    example: figma.code`<BpkSmallFlightLandingIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFlightLandingIcon",
+    imports: [
+      "import BpkLargeFlightLandingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flight-landing';",
+    ],
+    example: figma.code`<BpkLargeFlightLandingIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFlightLandingIcon",
+    imports: [
+      "import BpkLargeFlightLandingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flight-landing';",
+    ],
+    example: figma.code`<BpkLargeFlightLandingIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_109.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_109.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A106
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/flight-takeoff.d.ts
+// component=BpkSmallFlightTakeoffIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFlightTakeoffIcon",
+    imports: [
+      "import BpkSmallFlightTakeoffIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/flight-takeoff';",
+    ],
+    example: figma.code`<BpkSmallFlightTakeoffIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFlightTakeoffIcon",
+    imports: [
+      "import BpkLargeFlightTakeoffIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flight-takeoff';",
+    ],
+    example: figma.code`<BpkLargeFlightTakeoffIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFlightTakeoffIcon",
+    imports: [
+      "import BpkLargeFlightTakeoffIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/flight-takeoff';",
+    ],
+    example: figma.code`<BpkLargeFlightTakeoffIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_11.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_11.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A10
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/aircon.d.ts
+// component=BpkSmallAirconIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAirconIcon",
+    imports: [
+      "import BpkSmallAirconIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/aircon';",
+    ],
+    example: figma.code`<BpkSmallAirconIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAirconIcon",
+    imports: [
+      "import BpkLargeAirconIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/aircon';",
+    ],
+    example: figma.code`<BpkLargeAirconIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAirconIcon",
+    imports: [
+      "import BpkLargeAirconIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/aircon';",
+    ],
+    example: figma.code`<BpkLargeAirconIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_110.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_110.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A107
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/food.d.ts
+// component=BpkSmallFoodIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFoodIcon",
+    imports: [
+      "import BpkSmallFoodIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/food';",
+    ],
+    example: figma.code`<BpkSmallFoodIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFoodIcon",
+    imports: [
+      "import BpkLargeFoodIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/food';",
+    ],
+    example: figma.code`<BpkLargeFoodIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFoodIcon",
+    imports: [
+      "import BpkLargeFoodIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/food';",
+    ],
+    example: figma.code`<BpkLargeFoodIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_111.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_111.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A108
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/gears-automatic.d.ts
+// component=BpkSmallGearsAutomaticIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallGearsAutomaticIcon",
+    imports: [
+      "import BpkSmallGearsAutomaticIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/gears-automatic';",
+    ],
+    example: figma.code`<BpkSmallGearsAutomaticIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeGearsAutomaticIcon",
+    imports: [
+      "import BpkLargeGearsAutomaticIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/gears-automatic';",
+    ],
+    example: figma.code`<BpkLargeGearsAutomaticIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeGearsAutomaticIcon",
+    imports: [
+      "import BpkLargeGearsAutomaticIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/gears-automatic';",
+    ],
+    example: figma.code`<BpkLargeGearsAutomaticIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_112.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_112.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A109
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/gears-automatic-circle.d.ts
+// component=BpkSmallGearsAutomaticCircleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallGearsAutomaticCircleIcon",
+    imports: [
+      "import BpkSmallGearsAutomaticCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/gears-automatic-circle';",
+    ],
+    example: figma.code`<BpkSmallGearsAutomaticCircleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeGearsAutomaticCircleIcon",
+    imports: [
+      "import BpkLargeGearsAutomaticCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/gears-automatic-circle';",
+    ],
+    example: figma.code`<BpkLargeGearsAutomaticCircleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeGearsAutomaticCircleIcon",
+    imports: [
+      "import BpkLargeGearsAutomaticCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/gears-automatic-circle';",
+    ],
+    example: figma.code`<BpkLargeGearsAutomaticCircleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_113.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_113.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A110
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/gears-manual.d.ts
+// component=BpkSmallGearsManualIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallGearsManualIcon",
+    imports: [
+      "import BpkSmallGearsManualIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/gears-manual';",
+    ],
+    example: figma.code`<BpkSmallGearsManualIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeGearsManualIcon",
+    imports: [
+      "import BpkLargeGearsManualIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/gears-manual';",
+    ],
+    example: figma.code`<BpkLargeGearsManualIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeGearsManualIcon",
+    imports: [
+      "import BpkLargeGearsManualIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/gears-manual';",
+    ],
+    example: figma.code`<BpkLargeGearsManualIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_114.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_114.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A111
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/gears-manual-circle.d.ts
+// component=BpkSmallGearsManualCircleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallGearsManualCircleIcon",
+    imports: [
+      "import BpkSmallGearsManualCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/gears-manual-circle';",
+    ],
+    example: figma.code`<BpkSmallGearsManualCircleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeGearsManualCircleIcon",
+    imports: [
+      "import BpkLargeGearsManualCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/gears-manual-circle';",
+    ],
+    example: figma.code`<BpkLargeGearsManualCircleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeGearsManualCircleIcon",
+    imports: [
+      "import BpkLargeGearsManualCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/gears-manual-circle';",
+    ],
+    example: figma.code`<BpkLargeGearsManualCircleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_115.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_115.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A112
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/globe.d.ts
+// component=BpkSmallGlobeIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallGlobeIcon",
+    imports: [
+      "import BpkSmallGlobeIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/globe';",
+    ],
+    example: figma.code`<BpkSmallGlobeIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeGlobeIcon",
+    imports: [
+      "import BpkLargeGlobeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/globe';",
+    ],
+    example: figma.code`<BpkLargeGlobeIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeGlobeIcon",
+    imports: [
+      "import BpkLargeGlobeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/globe';",
+    ],
+    example: figma.code`<BpkLargeGlobeIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_116.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_116.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A114
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/grid-layout.d.ts
+// component=BpkSmallGridLayoutIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallGridLayoutIcon",
+    imports: [
+      "import BpkSmallGridLayoutIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/grid-layout';",
+    ],
+    example: figma.code`<BpkSmallGridLayoutIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeGridLayoutIcon",
+    imports: [
+      "import BpkLargeGridLayoutIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/grid-layout';",
+    ],
+    example: figma.code`<BpkLargeGridLayoutIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeGridLayoutIcon",
+    imports: [
+      "import BpkLargeGridLayoutIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/grid-layout';",
+    ],
+    example: figma.code`<BpkLargeGridLayoutIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_117.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_117.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A115
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/headset.d.ts
+// component=BpkSmallHeadsetIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHeadsetIcon",
+    imports: [
+      "import BpkSmallHeadsetIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/headset';",
+    ],
+    example: figma.code`<BpkSmallHeadsetIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHeadsetIcon",
+    imports: [
+      "import BpkLargeHeadsetIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/headset';",
+    ],
+    example: figma.code`<BpkLargeHeadsetIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHeadsetIcon",
+    imports: [
+      "import BpkLargeHeadsetIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/headset';",
+    ],
+    example: figma.code`<BpkLargeHeadsetIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_118.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_118.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A116
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/health-fitness.d.ts
+// component=BpkSmallHealthFitnessIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHealthFitnessIcon",
+    imports: [
+      "import BpkSmallHealthFitnessIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/health-fitness';",
+    ],
+    example: figma.code`<BpkSmallHealthFitnessIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHealthFitnessIcon",
+    imports: [
+      "import BpkLargeHealthFitnessIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/health-fitness';",
+    ],
+    example: figma.code`<BpkLargeHealthFitnessIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHealthFitnessIcon",
+    imports: [
+      "import BpkLargeHealthFitnessIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/health-fitness';",
+    ],
+    example: figma.code`<BpkLargeHealthFitnessIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_119.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_119.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A117
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/heart.d.ts
+// component=BpkSmallHeartIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHeartIcon",
+    imports: [
+      "import BpkSmallHeartIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/heart';",
+    ],
+    example: figma.code`<BpkSmallHeartIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHeartIcon",
+    imports: [
+      "import BpkLargeHeartIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/heart';",
+    ],
+    example: figma.code`<BpkLargeHeartIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHeartIcon",
+    imports: [
+      "import BpkLargeHeartIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/heart';",
+    ],
+    example: figma.code`<BpkLargeHeartIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_12.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_12.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A11
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/aircraft.d.ts
+// component=BpkSmallAircraftIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAircraftIcon",
+    imports: [
+      "import BpkSmallAircraftIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/aircraft';",
+    ],
+    example: figma.code`<BpkSmallAircraftIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAircraftIcon",
+    imports: [
+      "import BpkLargeAircraftIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/aircraft';",
+    ],
+    example: figma.code`<BpkLargeAircraftIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAircraftIcon",
+    imports: [
+      "import BpkLargeAircraftIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/aircraft';",
+    ],
+    example: figma.code`<BpkLargeAircraftIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_120.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_120.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A118
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/heart--outline.d.ts
+// component=BpkSmallHeartOutlineIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHeartOutlineIcon",
+    imports: [
+      "import BpkSmallHeartOutlineIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/heart--outline';",
+    ],
+    example: figma.code`<BpkSmallHeartOutlineIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHeartOutlineIcon",
+    imports: [
+      "import BpkLargeHeartOutlineIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/heart--outline';",
+    ],
+    example: figma.code`<BpkLargeHeartOutlineIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHeartOutlineIcon",
+    imports: [
+      "import BpkLargeHeartOutlineIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/heart--outline';",
+    ],
+    example: figma.code`<BpkLargeHeartOutlineIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_121.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_121.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A119
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/help.d.ts
+// component=BpkSmallHelpIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHelpIcon",
+    imports: [
+      "import BpkSmallHelpIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/help';",
+    ],
+    example: figma.code`<BpkSmallHelpIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHelpIcon",
+    imports: [
+      "import BpkLargeHelpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/help';",
+    ],
+    example: figma.code`<BpkLargeHelpIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHelpIcon",
+    imports: [
+      "import BpkLargeHelpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/help';",
+    ],
+    example: figma.code`<BpkLargeHelpIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_122.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_122.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A120
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/help-circle.d.ts
+// component=BpkSmallHelpCircleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHelpCircleIcon",
+    imports: [
+      "import BpkSmallHelpCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/help-circle';",
+    ],
+    example: figma.code`<BpkSmallHelpCircleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHelpCircleIcon",
+    imports: [
+      "import BpkLargeHelpCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/help-circle';",
+    ],
+    example: figma.code`<BpkLargeHelpCircleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHelpCircleIcon",
+    imports: [
+      "import BpkLargeHelpCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/help-circle';",
+    ],
+    example: figma.code`<BpkLargeHelpCircleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_123.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_123.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A121
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/hide.d.ts
+// component=BpkSmallHideIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHideIcon",
+    imports: [
+      "import BpkSmallHideIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/hide';",
+    ],
+    example: figma.code`<BpkSmallHideIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHideIcon",
+    imports: [
+      "import BpkLargeHideIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hide';",
+    ],
+    example: figma.code`<BpkLargeHideIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHideIcon",
+    imports: [
+      "import BpkLargeHideIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hide';",
+    ],
+    example: figma.code`<BpkLargeHideIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_124.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_124.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A122
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/hotel-flexible.d.ts
+// component=BpkSmallHotelFlexibleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHotelFlexibleIcon",
+    imports: [
+      "import BpkSmallHotelFlexibleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/hotel-flexible';",
+    ],
+    example: figma.code`<BpkSmallHotelFlexibleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHotelFlexibleIcon",
+    imports: [
+      "import BpkLargeHotelFlexibleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotel-flexible';",
+    ],
+    example: figma.code`<BpkLargeHotelFlexibleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHotelFlexibleIcon",
+    imports: [
+      "import BpkLargeHotelFlexibleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotel-flexible';",
+    ],
+    example: figma.code`<BpkLargeHotelFlexibleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_125.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_125.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A123
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/hotels.d.ts
+// component=BpkSmallHotelsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHotelsIcon",
+    imports: [
+      "import BpkSmallHotelsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/hotels';",
+    ],
+    example: figma.code`<BpkSmallHotelsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHotelsIcon",
+    imports: [
+      "import BpkLargeHotelsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels';",
+    ],
+    example: figma.code`<BpkLargeHotelsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHotelsIcon",
+    imports: [
+      "import BpkLargeHotelsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels';",
+    ],
+    example: figma.code`<BpkLargeHotelsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_126.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_126.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A124
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/hotels--disabled-facilities.d.ts
+// component=BpkSmallHotelsDisabledFacilitiesIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHotelsDisabledFacilitiesIcon",
+    imports: [
+      "import BpkSmallHotelsDisabledFacilitiesIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/hotels--disabled-facilities';",
+    ],
+    example: figma.code`<BpkSmallHotelsDisabledFacilitiesIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHotelsDisabledFacilitiesIcon",
+    imports: [
+      "import BpkLargeHotelsDisabledFacilitiesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels--disabled-facilities';",
+    ],
+    example: figma.code`<BpkLargeHotelsDisabledFacilitiesIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHotelsDisabledFacilitiesIcon",
+    imports: [
+      "import BpkLargeHotelsDisabledFacilitiesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels--disabled-facilities';",
+    ],
+    example: figma.code`<BpkLargeHotelsDisabledFacilitiesIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_127.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_127.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A125
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/hotels--jacuzzi.d.ts
+// component=BpkSmallHotelsJacuzziIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHotelsJacuzziIcon",
+    imports: [
+      "import BpkSmallHotelsJacuzziIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/hotels--jacuzzi';",
+    ],
+    example: figma.code`<BpkSmallHotelsJacuzziIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHotelsJacuzziIcon",
+    imports: [
+      "import BpkLargeHotelsJacuzziIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels--jacuzzi';",
+    ],
+    example: figma.code`<BpkLargeHotelsJacuzziIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHotelsJacuzziIcon",
+    imports: [
+      "import BpkLargeHotelsJacuzziIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels--jacuzzi';",
+    ],
+    example: figma.code`<BpkLargeHotelsJacuzziIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_128.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_128.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A126
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/hotels--pets-allowed.d.ts
+// component=BpkSmallHotelsPetsAllowedIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHotelsPetsAllowedIcon",
+    imports: [
+      "import BpkSmallHotelsPetsAllowedIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/hotels--pets-allowed';",
+    ],
+    example: figma.code`<BpkSmallHotelsPetsAllowedIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHotelsPetsAllowedIcon",
+    imports: [
+      "import BpkLargeHotelsPetsAllowedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels--pets-allowed';",
+    ],
+    example: figma.code`<BpkLargeHotelsPetsAllowedIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHotelsPetsAllowedIcon",
+    imports: [
+      "import BpkLargeHotelsPetsAllowedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels--pets-allowed';",
+    ],
+    example: figma.code`<BpkLargeHotelsPetsAllowedIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_129.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_129.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A127
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/hotels--smoking.d.ts
+// component=BpkSmallHotelsSmokingIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallHotelsSmokingIcon",
+    imports: [
+      "import BpkSmallHotelsSmokingIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/hotels--smoking';",
+    ],
+    example: figma.code`<BpkSmallHotelsSmokingIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeHotelsSmokingIcon",
+    imports: [
+      "import BpkLargeHotelsSmokingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels--smoking';",
+    ],
+    example: figma.code`<BpkLargeHotelsSmokingIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeHotelsSmokingIcon",
+    imports: [
+      "import BpkLargeHotelsSmokingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/hotels--smoking';",
+    ],
+    example: figma.code`<BpkLargeHotelsSmokingIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_13.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_13.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A12
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/airline.d.ts
+// component=BpkSmallAirlineIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAirlineIcon",
+    imports: [
+      "import BpkSmallAirlineIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/airline';",
+    ],
+    example: figma.code`<BpkSmallAirlineIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAirlineIcon",
+    imports: [
+      "import BpkLargeAirlineIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/airline';",
+    ],
+    example: figma.code`<BpkLargeAirlineIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAirlineIcon",
+    imports: [
+      "import BpkLargeAirlineIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/airline';",
+    ],
+    example: figma.code`<BpkLargeAirlineIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_130.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_130.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=13884%3A52
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/incompatible.d.ts
+// component=BpkSmallIncompatibleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallIncompatibleIcon",
+    imports: [
+      "import BpkSmallIncompatibleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/incompatible';",
+    ],
+    example: figma.code`<BpkSmallIncompatibleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeIncompatibleIcon",
+    imports: [
+      "import BpkLargeIncompatibleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/incompatible';",
+    ],
+    example: figma.code`<BpkLargeIncompatibleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeIncompatibleIcon",
+    imports: [
+      "import BpkLargeIncompatibleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/incompatible';",
+    ],
+    example: figma.code`<BpkLargeIncompatibleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_131.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_131.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A128
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/infant.d.ts
+// component=BpkSmallInfantIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallInfantIcon",
+    imports: [
+      "import BpkSmallInfantIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/infant';",
+    ],
+    example: figma.code`<BpkSmallInfantIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeInfantIcon",
+    imports: [
+      "import BpkLargeInfantIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/infant';",
+    ],
+    example: figma.code`<BpkLargeInfantIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeInfantIcon",
+    imports: [
+      "import BpkLargeInfantIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/infant';",
+    ],
+    example: figma.code`<BpkLargeInfantIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_132.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_132.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A129
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/information.d.ts
+// component=BpkSmallInformationIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallInformationIcon",
+    imports: [
+      "import BpkSmallInformationIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/information';",
+    ],
+    example: figma.code`<BpkSmallInformationIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeInformationIcon",
+    imports: [
+      "import BpkLargeInformationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information';",
+    ],
+    example: figma.code`<BpkLargeInformationIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeInformationIcon",
+    imports: [
+      "import BpkLargeInformationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information';",
+    ],
+    example: figma.code`<BpkLargeInformationIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_133.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_133.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A130
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/information--language.d.ts
+// component=BpkSmallInformationLanguageIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallInformationLanguageIcon",
+    imports: [
+      "import BpkSmallInformationLanguageIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/information--language';",
+    ],
+    example: figma.code`<BpkSmallInformationLanguageIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeInformationLanguageIcon",
+    imports: [
+      "import BpkLargeInformationLanguageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information--language';",
+    ],
+    example: figma.code`<BpkLargeInformationLanguageIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeInformationLanguageIcon",
+    imports: [
+      "import BpkLargeInformationLanguageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information--language';",
+    ],
+    example: figma.code`<BpkLargeInformationLanguageIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_134.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_134.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A131
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/information--language-alert.d.ts
+// component=BpkSmallInformationLanguageAlertIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallInformationLanguageAlertIcon",
+    imports: [
+      "import BpkSmallInformationLanguageAlertIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/information--language-alert';",
+    ],
+    example: figma.code`<BpkSmallInformationLanguageAlertIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeInformationLanguageAlertIcon",
+    imports: [
+      "import BpkLargeInformationLanguageAlertIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information--language-alert';",
+    ],
+    example: figma.code`<BpkLargeInformationLanguageAlertIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeInformationLanguageAlertIcon",
+    imports: [
+      "import BpkLargeInformationLanguageAlertIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information--language-alert';",
+    ],
+    example: figma.code`<BpkLargeInformationLanguageAlertIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_135.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_135.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A132
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/information--language-question.d.ts
+// component=BpkSmallInformationLanguageQuestionIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallInformationLanguageQuestionIcon",
+    imports: [
+      "import BpkSmallInformationLanguageQuestionIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/information--language-question';",
+    ],
+    example: figma.code`<BpkSmallInformationLanguageQuestionIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeInformationLanguageQuestionIcon",
+    imports: [
+      "import BpkLargeInformationLanguageQuestionIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information--language-question';",
+    ],
+    example: figma.code`<BpkLargeInformationLanguageQuestionIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeInformationLanguageQuestionIcon",
+    imports: [
+      "import BpkLargeInformationLanguageQuestionIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information--language-question';",
+    ],
+    example: figma.code`<BpkLargeInformationLanguageQuestionIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_136.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_136.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A133
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/information-circle.d.ts
+// component=BpkSmallInformationCircleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallInformationCircleIcon",
+    imports: [
+      "import BpkSmallInformationCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/information-circle';",
+    ],
+    example: figma.code`<BpkSmallInformationCircleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeInformationCircleIcon",
+    imports: [
+      "import BpkLargeInformationCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information-circle';",
+    ],
+    example: figma.code`<BpkLargeInformationCircleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeInformationCircleIcon",
+    imports: [
+      "import BpkLargeInformationCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/information-circle';",
+    ],
+    example: figma.code`<BpkLargeInformationCircleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_137.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_137.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A134
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/insurance.d.ts
+// component=BpkSmallInsuranceIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallInsuranceIcon",
+    imports: [
+      "import BpkSmallInsuranceIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/insurance';",
+    ],
+    example: figma.code`<BpkSmallInsuranceIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeInsuranceIcon",
+    imports: [
+      "import BpkLargeInsuranceIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/insurance';",
+    ],
+    example: figma.code`<BpkLargeInsuranceIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeInsuranceIcon",
+    imports: [
+      "import BpkLargeInsuranceIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/insurance';",
+    ],
+    example: figma.code`<BpkLargeInsuranceIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_138.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_138.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A135
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/key.d.ts
+// component=BpkSmallKeyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallKeyIcon",
+    imports: [
+      "import BpkSmallKeyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/key';",
+    ],
+    example: figma.code`<BpkSmallKeyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeKeyIcon",
+    imports: [
+      "import BpkLargeKeyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/key';",
+    ],
+    example: figma.code`<BpkLargeKeyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeKeyIcon",
+    imports: [
+      "import BpkLargeKeyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/key';",
+    ],
+    example: figma.code`<BpkLargeKeyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_139.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_139.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A136
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/keypad.d.ts
+// component=BpkSmallKeypadIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallKeypadIcon",
+    imports: [
+      "import BpkSmallKeypadIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/keypad';",
+    ],
+    example: figma.code`<BpkSmallKeypadIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeKeypadIcon",
+    imports: [
+      "import BpkLargeKeypadIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/keypad';",
+    ],
+    example: figma.code`<BpkLargeKeypadIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeKeypadIcon",
+    imports: [
+      "import BpkLargeKeypadIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/keypad';",
+    ],
+    example: figma.code`<BpkLargeKeypadIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_14.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_14.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A13
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/airline--multiple.d.ts
+// component=BpkSmallAirlineMultipleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAirlineMultipleIcon",
+    imports: [
+      "import BpkSmallAirlineMultipleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/airline--multiple';",
+    ],
+    example: figma.code`<BpkSmallAirlineMultipleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAirlineMultipleIcon",
+    imports: [
+      "import BpkLargeAirlineMultipleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/airline--multiple';",
+    ],
+    example: figma.code`<BpkLargeAirlineMultipleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAirlineMultipleIcon",
+    imports: [
+      "import BpkLargeAirlineMultipleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/airline--multiple';",
+    ],
+    example: figma.code`<BpkLargeAirlineMultipleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_140.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_140.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A137
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/landmark.d.ts
+// component=BpkSmallLandmarkIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLandmarkIcon",
+    imports: [
+      "import BpkSmallLandmarkIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/landmark';",
+    ],
+    example: figma.code`<BpkSmallLandmarkIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLandmarkIcon",
+    imports: [
+      "import BpkLargeLandmarkIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/landmark';",
+    ],
+    example: figma.code`<BpkLargeLandmarkIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLandmarkIcon",
+    imports: [
+      "import BpkLargeLandmarkIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/landmark';",
+    ],
+    example: figma.code`<BpkLargeLandmarkIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_141.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_141.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A138
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/language.d.ts
+// component=BpkSmallLanguageIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLanguageIcon",
+    imports: [
+      "import BpkSmallLanguageIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/language';",
+    ],
+    example: figma.code`<BpkSmallLanguageIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLanguageIcon",
+    imports: [
+      "import BpkLargeLanguageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/language';",
+    ],
+    example: figma.code`<BpkLargeLanguageIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLanguageIcon",
+    imports: [
+      "import BpkLargeLanguageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/language';",
+    ],
+    example: figma.code`<BpkLargeLanguageIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_142.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_142.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A139
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/legroom--extra.d.ts
+// component=BpkSmallLegroomExtraIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLegroomExtraIcon",
+    imports: [
+      "import BpkSmallLegroomExtraIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/legroom--extra';",
+    ],
+    example: figma.code`<BpkSmallLegroomExtraIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLegroomExtraIcon",
+    imports: [
+      "import BpkLargeLegroomExtraIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/legroom--extra';",
+    ],
+    example: figma.code`<BpkLargeLegroomExtraIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLegroomExtraIcon",
+    imports: [
+      "import BpkLargeLegroomExtraIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/legroom--extra';",
+    ],
+    example: figma.code`<BpkLargeLegroomExtraIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_143.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_143.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A140
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/legroom--normal.d.ts
+// component=BpkSmallLegroomNormalIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLegroomNormalIcon",
+    imports: [
+      "import BpkSmallLegroomNormalIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/legroom--normal';",
+    ],
+    example: figma.code`<BpkSmallLegroomNormalIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLegroomNormalIcon",
+    imports: [
+      "import BpkLargeLegroomNormalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/legroom--normal';",
+    ],
+    example: figma.code`<BpkLargeLegroomNormalIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLegroomNormalIcon",
+    imports: [
+      "import BpkLargeLegroomNormalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/legroom--normal';",
+    ],
+    example: figma.code`<BpkLargeLegroomNormalIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_144.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_144.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A141
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/legroom--reduced.d.ts
+// component=BpkSmallLegroomReducedIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLegroomReducedIcon",
+    imports: [
+      "import BpkSmallLegroomReducedIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/legroom--reduced';",
+    ],
+    example: figma.code`<BpkSmallLegroomReducedIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLegroomReducedIcon",
+    imports: [
+      "import BpkLargeLegroomReducedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/legroom--reduced';",
+    ],
+    example: figma.code`<BpkLargeLegroomReducedIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLegroomReducedIcon",
+    imports: [
+      "import BpkLargeLegroomReducedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/legroom--reduced';",
+    ],
+    example: figma.code`<BpkLargeLegroomReducedIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_145.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_145.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A142
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/leisure.d.ts
+// component=BpkSmallLeisureIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLeisureIcon",
+    imports: [
+      "import BpkSmallLeisureIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/leisure';",
+    ],
+    example: figma.code`<BpkSmallLeisureIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLeisureIcon",
+    imports: [
+      "import BpkLargeLeisureIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/leisure';",
+    ],
+    example: figma.code`<BpkLargeLeisureIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLeisureIcon",
+    imports: [
+      "import BpkLargeLeisureIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/leisure';",
+    ],
+    example: figma.code`<BpkLargeLeisureIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_146.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_146.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A143
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/lightning.d.ts
+// component=BpkSmallLightningIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLightningIcon",
+    imports: [
+      "import BpkSmallLightningIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/lightning';",
+    ],
+    example: figma.code`<BpkSmallLightningIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLightningIcon",
+    imports: [
+      "import BpkLargeLightningIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/lightning';",
+    ],
+    example: figma.code`<BpkLargeLightningIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLightningIcon",
+    imports: [
+      "import BpkLargeLightningIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/lightning';",
+    ],
+    example: figma.code`<BpkLargeLightningIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_147.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_147.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A144
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/list.d.ts
+// component=BpkSmallListIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallListIcon",
+    imports: [
+      "import BpkSmallListIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/list';",
+    ],
+    example: figma.code`<BpkSmallListIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeListIcon",
+    imports: [
+      "import BpkLargeListIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/list';",
+    ],
+    example: figma.code`<BpkLargeListIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeListIcon",
+    imports: [
+      "import BpkLargeListIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/list';",
+    ],
+    example: figma.code`<BpkLargeListIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_148.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_148.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A145
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/location.d.ts
+// component=BpkSmallLocationIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLocationIcon",
+    imports: [
+      "import BpkSmallLocationIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/location';",
+    ],
+    example: figma.code`<BpkSmallLocationIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLocationIcon",
+    imports: [
+      "import BpkLargeLocationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/location';",
+    ],
+    example: figma.code`<BpkLargeLocationIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLocationIcon",
+    imports: [
+      "import BpkLargeLocationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/location';",
+    ],
+    example: figma.code`<BpkLargeLocationIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_149.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_149.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A146
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/lock.d.ts
+// component=BpkSmallLockIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLockIcon",
+    imports: [
+      "import BpkSmallLockIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/lock';",
+    ],
+    example: figma.code`<BpkSmallLockIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLockIcon",
+    imports: [
+      "import BpkLargeLockIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/lock';",
+    ],
+    example: figma.code`<BpkLargeLockIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLockIcon",
+    imports: [
+      "import BpkLargeLockIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/lock';",
+    ],
+    example: figma.code`<BpkLargeLockIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_15.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_15.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A14
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/airports.d.ts
+// component=BpkSmallAirportsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAirportsIcon",
+    imports: [
+      "import BpkSmallAirportsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/airports';",
+    ],
+    example: figma.code`<BpkSmallAirportsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAirportsIcon",
+    imports: [
+      "import BpkLargeAirportsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/airports';",
+    ],
+    example: figma.code`<BpkLargeAirportsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAirportsIcon",
+    imports: [
+      "import BpkLargeAirportsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/airports';",
+    ],
+    example: figma.code`<BpkLargeAirportsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_150.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_150.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A147
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/logout.d.ts
+// component=BpkSmallLogoutIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLogoutIcon",
+    imports: [
+      "import BpkSmallLogoutIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/logout';",
+    ],
+    example: figma.code`<BpkSmallLogoutIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLogoutIcon",
+    imports: [
+      "import BpkLargeLogoutIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/logout';",
+    ],
+    example: figma.code`<BpkLargeLogoutIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLogoutIcon",
+    imports: [
+      "import BpkLargeLogoutIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/logout';",
+    ],
+    example: figma.code`<BpkLargeLogoutIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_151.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_151.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A148
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/long-arrow-down.d.ts
+// component=BpkSmallLongArrowDownIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLongArrowDownIcon",
+    imports: [
+      "import BpkSmallLongArrowDownIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/long-arrow-down';",
+    ],
+    example: figma.code`<BpkSmallLongArrowDownIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLongArrowDownIcon",
+    imports: [
+      "import BpkLargeLongArrowDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/long-arrow-down';",
+    ],
+    example: figma.code`<BpkLargeLongArrowDownIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLongArrowDownIcon",
+    imports: [
+      "import BpkLargeLongArrowDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/long-arrow-down';",
+    ],
+    example: figma.code`<BpkLargeLongArrowDownIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_152.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_152.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A149
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/long-arrow-left.d.ts
+// component=BpkSmallLongArrowLeftIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLongArrowLeftIcon",
+    imports: [
+      "import BpkSmallLongArrowLeftIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/long-arrow-left';",
+    ],
+    example: figma.code`<BpkSmallLongArrowLeftIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLongArrowLeftIcon",
+    imports: [
+      "import BpkLargeLongArrowLeftIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/long-arrow-left';",
+    ],
+    example: figma.code`<BpkLargeLongArrowLeftIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLongArrowLeftIcon",
+    imports: [
+      "import BpkLargeLongArrowLeftIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/long-arrow-left';",
+    ],
+    example: figma.code`<BpkLargeLongArrowLeftIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_153.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_153.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A150
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/long-arrow-right.d.ts
+// component=BpkSmallLongArrowRightIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLongArrowRightIcon",
+    imports: [
+      "import BpkSmallLongArrowRightIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/long-arrow-right';",
+    ],
+    example: figma.code`<BpkSmallLongArrowRightIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLongArrowRightIcon",
+    imports: [
+      "import BpkLargeLongArrowRightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/long-arrow-right';",
+    ],
+    example: figma.code`<BpkLargeLongArrowRightIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLongArrowRightIcon",
+    imports: [
+      "import BpkLargeLongArrowRightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/long-arrow-right';",
+    ],
+    example: figma.code`<BpkLargeLongArrowRightIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_154.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_154.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A151
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/long-arrow-up.d.ts
+// component=BpkSmallLongArrowUpIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLongArrowUpIcon",
+    imports: [
+      "import BpkSmallLongArrowUpIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/long-arrow-up';",
+    ],
+    example: figma.code`<BpkSmallLongArrowUpIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLongArrowUpIcon",
+    imports: [
+      "import BpkLargeLongArrowUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/long-arrow-up';",
+    ],
+    example: figma.code`<BpkLargeLongArrowUpIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLongArrowUpIcon",
+    imports: [
+      "import BpkLargeLongArrowUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/long-arrow-up';",
+    ],
+    example: figma.code`<BpkLargeLongArrowUpIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_155.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_155.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A152
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/lounge.d.ts
+// component=BpkSmallLoungeIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallLoungeIcon",
+    imports: [
+      "import BpkSmallLoungeIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/lounge';",
+    ],
+    example: figma.code`<BpkSmallLoungeIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeLoungeIcon",
+    imports: [
+      "import BpkLargeLoungeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/lounge';",
+    ],
+    example: figma.code`<BpkLargeLoungeIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeLoungeIcon",
+    imports: [
+      "import BpkLargeLoungeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/lounge';",
+    ],
+    example: figma.code`<BpkLargeLoungeIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_156.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_156.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A154
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/mail.d.ts
+// component=BpkSmallMailIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMailIcon",
+    imports: [
+      "import BpkSmallMailIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/mail';",
+    ],
+    example: figma.code`<BpkSmallMailIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMailIcon",
+    imports: [
+      "import BpkLargeMailIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/mail';",
+    ],
+    example: figma.code`<BpkLargeMailIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMailIcon",
+    imports: [
+      "import BpkLargeMailIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/mail';",
+    ],
+    example: figma.code`<BpkLargeMailIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_157.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_157.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A155
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/map.d.ts
+// component=BpkSmallMapIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMapIcon",
+    imports: [
+      "import BpkSmallMapIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/map';",
+    ],
+    example: figma.code`<BpkSmallMapIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMapIcon",
+    imports: [
+      "import BpkLargeMapIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/map';",
+    ],
+    example: figma.code`<BpkLargeMapIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMapIcon",
+    imports: [
+      "import BpkLargeMapIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/map';",
+    ],
+    example: figma.code`<BpkLargeMapIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_158.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_158.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A156
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/meal.d.ts
+// component=BpkSmallMealIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMealIcon",
+    imports: [
+      "import BpkSmallMealIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/meal';",
+    ],
+    example: figma.code`<BpkSmallMealIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMealIcon",
+    imports: [
+      "import BpkLargeMealIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/meal';",
+    ],
+    example: figma.code`<BpkLargeMealIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMealIcon",
+    imports: [
+      "import BpkLargeMealIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/meal';",
+    ],
+    example: figma.code`<BpkLargeMealIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_159.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_159.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A157
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/media.d.ts
+// component=BpkSmallMediaIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMediaIcon",
+    imports: [
+      "import BpkSmallMediaIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/media';",
+    ],
+    example: figma.code`<BpkSmallMediaIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMediaIcon",
+    imports: [
+      "import BpkLargeMediaIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/media';",
+    ],
+    example: figma.code`<BpkLargeMediaIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMediaIcon",
+    imports: [
+      "import BpkLargeMediaIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/media';",
+    ],
+    example: figma.code`<BpkLargeMediaIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_16.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_16.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A15
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/alert--active.d.ts
+// component=BpkSmallAlertActiveIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAlertActiveIcon",
+    imports: [
+      "import BpkSmallAlertActiveIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/alert--active';",
+    ],
+    example: figma.code`<BpkSmallAlertActiveIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAlertActiveIcon",
+    imports: [
+      "import BpkLargeAlertActiveIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/alert--active';",
+    ],
+    example: figma.code`<BpkLargeAlertActiveIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAlertActiveIcon",
+    imports: [
+      "import BpkLargeAlertActiveIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/alert--active';",
+    ],
+    example: figma.code`<BpkLargeAlertActiveIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_160.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_160.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A158
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/menu.d.ts
+// component=BpkSmallMenuIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMenuIcon",
+    imports: [
+      "import BpkSmallMenuIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/menu';",
+    ],
+    example: figma.code`<BpkSmallMenuIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMenuIcon",
+    imports: [
+      "import BpkLargeMenuIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/menu';",
+    ],
+    example: figma.code`<BpkLargeMenuIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMenuIcon",
+    imports: [
+      "import BpkLargeMenuIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/menu';",
+    ],
+    example: figma.code`<BpkLargeMenuIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_161.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_161.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A159
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/menu--horizontal.d.ts
+// component=BpkSmallMenuHorizontalIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMenuHorizontalIcon",
+    imports: [
+      "import BpkSmallMenuHorizontalIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/menu--horizontal';",
+    ],
+    example: figma.code`<BpkSmallMenuHorizontalIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMenuHorizontalIcon",
+    imports: [
+      "import BpkLargeMenuHorizontalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/menu--horizontal';",
+    ],
+    example: figma.code`<BpkLargeMenuHorizontalIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMenuHorizontalIcon",
+    imports: [
+      "import BpkLargeMenuHorizontalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/menu--horizontal';",
+    ],
+    example: figma.code`<BpkLargeMenuHorizontalIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_162.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_162.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A160
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/menu--vertical.d.ts
+// component=BpkSmallMenuVerticalIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMenuVerticalIcon",
+    imports: [
+      "import BpkSmallMenuVerticalIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/menu--vertical';",
+    ],
+    example: figma.code`<BpkSmallMenuVerticalIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMenuVerticalIcon",
+    imports: [
+      "import BpkLargeMenuVerticalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/menu--vertical';",
+    ],
+    example: figma.code`<BpkLargeMenuVerticalIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMenuVerticalIcon",
+    imports: [
+      "import BpkLargeMenuVerticalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/menu--vertical';",
+    ],
+    example: figma.code`<BpkLargeMenuVerticalIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_163.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_163.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A161
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/mileage.d.ts
+// component=BpkSmallMileageIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMileageIcon",
+    imports: [
+      "import BpkSmallMileageIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/mileage';",
+    ],
+    example: figma.code`<BpkSmallMileageIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMileageIcon",
+    imports: [
+      "import BpkLargeMileageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/mileage';",
+    ],
+    example: figma.code`<BpkLargeMileageIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMileageIcon",
+    imports: [
+      "import BpkLargeMileageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/mileage';",
+    ],
+    example: figma.code`<BpkLargeMileageIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_164.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_164.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A162
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/minus.d.ts
+// component=BpkSmallMinusIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMinusIcon",
+    imports: [
+      "import BpkSmallMinusIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/minus';",
+    ],
+    example: figma.code`<BpkSmallMinusIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMinusIcon",
+    imports: [
+      "import BpkLargeMinusIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/minus';",
+    ],
+    example: figma.code`<BpkLargeMinusIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMinusIcon",
+    imports: [
+      "import BpkLargeMinusIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/minus';",
+    ],
+    example: figma.code`<BpkLargeMinusIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_165.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_165.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A163
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/mobile.d.ts
+// component=BpkSmallMobileIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMobileIcon",
+    imports: [
+      "import BpkSmallMobileIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/mobile';",
+    ],
+    example: figma.code`<BpkSmallMobileIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMobileIcon",
+    imports: [
+      "import BpkLargeMobileIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/mobile';",
+    ],
+    example: figma.code`<BpkLargeMobileIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMobileIcon",
+    imports: [
+      "import BpkLargeMobileIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/mobile';",
+    ],
+    example: figma.code`<BpkLargeMobileIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_166.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_166.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A164
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/money.d.ts
+// component=BpkSmallMoneyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMoneyIcon",
+    imports: [
+      "import BpkSmallMoneyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/money';",
+    ],
+    example: figma.code`<BpkSmallMoneyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMoneyIcon",
+    imports: [
+      "import BpkLargeMoneyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/money';",
+    ],
+    example: figma.code`<BpkLargeMoneyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMoneyIcon",
+    imports: [
+      "import BpkLargeMoneyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/money';",
+    ],
+    example: figma.code`<BpkLargeMoneyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_167.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_167.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A165
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/multiple-bookings.d.ts
+// component=BpkSmallMultipleBookingsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMultipleBookingsIcon",
+    imports: [
+      "import BpkSmallMultipleBookingsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/multiple-bookings';",
+    ],
+    example: figma.code`<BpkSmallMultipleBookingsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMultipleBookingsIcon",
+    imports: [
+      "import BpkLargeMultipleBookingsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/multiple-bookings';",
+    ],
+    example: figma.code`<BpkLargeMultipleBookingsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMultipleBookingsIcon",
+    imports: [
+      "import BpkLargeMultipleBookingsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/multiple-bookings';",
+    ],
+    example: figma.code`<BpkLargeMultipleBookingsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_168.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_168.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A166
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/music.d.ts
+// component=BpkSmallMusicIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMusicIcon",
+    imports: [
+      "import BpkSmallMusicIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/music';",
+    ],
+    example: figma.code`<BpkSmallMusicIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMusicIcon",
+    imports: [
+      "import BpkLargeMusicIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/music';",
+    ],
+    example: figma.code`<BpkLargeMusicIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMusicIcon",
+    imports: [
+      "import BpkLargeMusicIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/music';",
+    ],
+    example: figma.code`<BpkLargeMusicIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_169.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_169.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A167
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/mute.d.ts
+// component=BpkSmallMuteIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallMuteIcon",
+    imports: [
+      "import BpkSmallMuteIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/mute';",
+    ],
+    example: figma.code`<BpkSmallMuteIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeMuteIcon",
+    imports: [
+      "import BpkLargeMuteIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/mute';",
+    ],
+    example: figma.code`<BpkLargeMuteIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeMuteIcon",
+    imports: [
+      "import BpkLargeMuteIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/mute';",
+    ],
+    example: figma.code`<BpkLargeMuteIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_17.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_17.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A16
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/alert--add.d.ts
+// component=BpkSmallAlertAddIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAlertAddIcon",
+    imports: [
+      "import BpkSmallAlertAddIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/alert--add';",
+    ],
+    example: figma.code`<BpkSmallAlertAddIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAlertAddIcon",
+    imports: [
+      "import BpkLargeAlertAddIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/alert--add';",
+    ],
+    example: figma.code`<BpkLargeAlertAddIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAlertAddIcon",
+    imports: [
+      "import BpkLargeAlertAddIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/alert--add';",
+    ],
+    example: figma.code`<BpkLargeAlertAddIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_170.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_170.figma.ts
@@ -1,0 +1,28 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A168
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/native-android--back.d.ts
+// component=BpkSmallNativeAndroidBackIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallNativeAndroidBackIcon",
+    imports: [
+      "import BpkSmallNativeAndroidBackIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/native-android--back';",
+    ],
+    example: figma.code`<BpkSmallNativeAndroidBackIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkSmallNativeAndroidBackIcon",
+    imports: [
+      "import BpkSmallNativeAndroidBackIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/native-android--back';",
+    ],
+    example: figma.code`<BpkSmallNativeAndroidBackIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_171.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_171.figma.ts
@@ -1,0 +1,28 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A169
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/native-android--close.d.ts
+// component=BpkSmallNativeAndroidCloseIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallNativeAndroidCloseIcon",
+    imports: [
+      "import BpkSmallNativeAndroidCloseIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/native-android--close';",
+    ],
+    example: figma.code`<BpkSmallNativeAndroidCloseIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkSmallNativeAndroidCloseIcon",
+    imports: [
+      "import BpkSmallNativeAndroidCloseIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/native-android--close';",
+    ],
+    example: figma.code`<BpkSmallNativeAndroidCloseIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_172.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_172.figma.ts
@@ -1,0 +1,28 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A170
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/native-android--forward.d.ts
+// component=BpkSmallNativeAndroidForwardIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallNativeAndroidForwardIcon",
+    imports: [
+      "import BpkSmallNativeAndroidForwardIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/native-android--forward';",
+    ],
+    example: figma.code`<BpkSmallNativeAndroidForwardIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkSmallNativeAndroidForwardIcon",
+    imports: [
+      "import BpkSmallNativeAndroidForwardIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/native-android--forward';",
+    ],
+    example: figma.code`<BpkSmallNativeAndroidForwardIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_173.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_173.figma.ts
@@ -1,0 +1,28 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A171
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/native-ios-close.d.ts
+// component=BpkSmallNativeIosCloseIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallNativeIosCloseIcon",
+    imports: [
+      "import BpkSmallNativeIosCloseIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/native-ios-close';",
+    ],
+    example: figma.code`<BpkSmallNativeIosCloseIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkSmallNativeIosCloseIcon",
+    imports: [
+      "import BpkSmallNativeIosCloseIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/native-ios-close';",
+    ],
+    example: figma.code`<BpkSmallNativeIosCloseIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_174.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_174.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A172
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/navigation.d.ts
+// component=BpkSmallNavigationIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallNavigationIcon",
+    imports: [
+      "import BpkSmallNavigationIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/navigation';",
+    ],
+    example: figma.code`<BpkSmallNavigationIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeNavigationIcon",
+    imports: [
+      "import BpkLargeNavigationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/navigation';",
+    ],
+    example: figma.code`<BpkLargeNavigationIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeNavigationIcon",
+    imports: [
+      "import BpkLargeNavigationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/navigation';",
+    ],
+    example: figma.code`<BpkLargeNavigationIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_175.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_175.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A173
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/new-window.d.ts
+// component=BpkSmallNewWindowIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallNewWindowIcon",
+    imports: [
+      "import BpkSmallNewWindowIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/new-window';",
+    ],
+    example: figma.code`<BpkSmallNewWindowIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeNewWindowIcon",
+    imports: [
+      "import BpkLargeNewWindowIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/new-window';",
+    ],
+    example: figma.code`<BpkLargeNewWindowIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeNewWindowIcon",
+    imports: [
+      "import BpkLargeNewWindowIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/new-window';",
+    ],
+    example: figma.code`<BpkLargeNewWindowIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_176.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_176.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A174
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/news.d.ts
+// component=BpkSmallNewsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallNewsIcon",
+    imports: [
+      "import BpkSmallNewsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/news';",
+    ],
+    example: figma.code`<BpkSmallNewsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeNewsIcon",
+    imports: [
+      "import BpkLargeNewsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/news';",
+    ],
+    example: figma.code`<BpkLargeNewsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeNewsIcon",
+    imports: [
+      "import BpkLargeNewsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/news';",
+    ],
+    example: figma.code`<BpkLargeNewsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_177.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_177.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A175
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/night.d.ts
+// component=BpkSmallNightIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallNightIcon",
+    imports: [
+      "import BpkSmallNightIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/night';",
+    ],
+    example: figma.code`<BpkSmallNightIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeNightIcon",
+    imports: [
+      "import BpkLargeNightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/night';",
+    ],
+    example: figma.code`<BpkLargeNightIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeNightIcon",
+    imports: [
+      "import BpkLargeNightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/night';",
+    ],
+    example: figma.code`<BpkLargeNightIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_178.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_178.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A176
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/not-allowed.d.ts
+// component=BpkSmallNotAllowedIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallNotAllowedIcon",
+    imports: [
+      "import BpkSmallNotAllowedIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/not-allowed';",
+    ],
+    example: figma.code`<BpkSmallNotAllowedIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeNotAllowedIcon",
+    imports: [
+      "import BpkLargeNotAllowedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/not-allowed';",
+    ],
+    example: figma.code`<BpkLargeNotAllowedIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeNotAllowedIcon",
+    imports: [
+      "import BpkLargeNotAllowedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/not-allowed';",
+    ],
+    example: figma.code`<BpkLargeNotAllowedIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_179.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_179.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A177
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/onsen.d.ts
+// component=BpkSmallOnsenIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallOnsenIcon",
+    imports: [
+      "import BpkSmallOnsenIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/onsen';",
+    ],
+    example: figma.code`<BpkSmallOnsenIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeOnsenIcon",
+    imports: [
+      "import BpkLargeOnsenIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/onsen';",
+    ],
+    example: figma.code`<BpkLargeOnsenIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeOnsenIcon",
+    imports: [
+      "import BpkLargeOnsenIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/onsen';",
+    ],
+    example: figma.code`<BpkLargeOnsenIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_18.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_18.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A17
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/alert--expired.d.ts
+// component=BpkSmallAlertExpiredIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAlertExpiredIcon",
+    imports: [
+      "import BpkSmallAlertExpiredIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/alert--expired';",
+    ],
+    example: figma.code`<BpkSmallAlertExpiredIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAlertExpiredIcon",
+    imports: [
+      "import BpkLargeAlertExpiredIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/alert--expired';",
+    ],
+    example: figma.code`<BpkLargeAlertExpiredIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAlertExpiredIcon",
+    imports: [
+      "import BpkLargeAlertExpiredIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/alert--expired';",
+    ],
+    example: figma.code`<BpkLargeAlertExpiredIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_180.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_180.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=8663%3A167
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/origin.d.ts
+// component=BpkSmallOriginIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallOriginIcon",
+    imports: [
+      "import BpkSmallOriginIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/origin';",
+    ],
+    example: figma.code`<BpkSmallOriginIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeOriginIcon",
+    imports: [
+      "import BpkLargeOriginIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/origin';",
+    ],
+    example: figma.code`<BpkLargeOriginIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeOriginIcon",
+    imports: [
+      "import BpkLargeOriginIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/origin';",
+    ],
+    example: figma.code`<BpkLargeOriginIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_181.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_181.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A178
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/paid.d.ts
+// component=BpkSmallPaidIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPaidIcon",
+    imports: [
+      "import BpkSmallPaidIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/paid';",
+    ],
+    example: figma.code`<BpkSmallPaidIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePaidIcon",
+    imports: [
+      "import BpkLargePaidIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/paid';",
+    ],
+    example: figma.code`<BpkLargePaidIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePaidIcon",
+    imports: [
+      "import BpkLargePaidIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/paid';",
+    ],
+    example: figma.code`<BpkLargePaidIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_182.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_182.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A179
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/paperclip.d.ts
+// component=BpkSmallPaperclipIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPaperclipIcon",
+    imports: [
+      "import BpkSmallPaperclipIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/paperclip';",
+    ],
+    example: figma.code`<BpkSmallPaperclipIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePaperclipIcon",
+    imports: [
+      "import BpkLargePaperclipIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/paperclip';",
+    ],
+    example: figma.code`<BpkLargePaperclipIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePaperclipIcon",
+    imports: [
+      "import BpkLargePaperclipIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/paperclip';",
+    ],
+    example: figma.code`<BpkLargePaperclipIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_183.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_183.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A180
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/parking.d.ts
+// component=BpkSmallParkingIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallParkingIcon",
+    imports: [
+      "import BpkSmallParkingIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/parking';",
+    ],
+    example: figma.code`<BpkSmallParkingIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeParkingIcon",
+    imports: [
+      "import BpkLargeParkingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/parking';",
+    ],
+    example: figma.code`<BpkLargeParkingIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeParkingIcon",
+    imports: [
+      "import BpkLargeParkingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/parking';",
+    ],
+    example: figma.code`<BpkLargeParkingIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_184.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_184.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A181
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/passport.d.ts
+// component=BpkSmallPassportIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPassportIcon",
+    imports: [
+      "import BpkSmallPassportIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/passport';",
+    ],
+    example: figma.code`<BpkSmallPassportIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePassportIcon",
+    imports: [
+      "import BpkLargePassportIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/passport';",
+    ],
+    example: figma.code`<BpkLargePassportIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePassportIcon",
+    imports: [
+      "import BpkLargePassportIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/passport';",
+    ],
+    example: figma.code`<BpkLargePassportIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_185.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_185.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A182
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/pause.d.ts
+// component=BpkSmallPauseIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPauseIcon",
+    imports: [
+      "import BpkSmallPauseIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/pause';",
+    ],
+    example: figma.code`<BpkSmallPauseIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePauseIcon",
+    imports: [
+      "import BpkLargePauseIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/pause';",
+    ],
+    example: figma.code`<BpkLargePauseIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePauseIcon",
+    imports: [
+      "import BpkLargePauseIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/pause';",
+    ],
+    example: figma.code`<BpkLargePauseIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_186.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_186.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A183
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/payment-card.d.ts
+// component=BpkSmallPaymentCardIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPaymentCardIcon",
+    imports: [
+      "import BpkSmallPaymentCardIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/payment-card';",
+    ],
+    example: figma.code`<BpkSmallPaymentCardIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePaymentCardIcon",
+    imports: [
+      "import BpkLargePaymentCardIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/payment-card';",
+    ],
+    example: figma.code`<BpkLargePaymentCardIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePaymentCardIcon",
+    imports: [
+      "import BpkLargePaymentCardIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/payment-card';",
+    ],
+    example: figma.code`<BpkLargePaymentCardIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_187.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_187.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A184
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/petrol.d.ts
+// component=BpkSmallPetrolIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPetrolIcon",
+    imports: [
+      "import BpkSmallPetrolIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/petrol';",
+    ],
+    example: figma.code`<BpkSmallPetrolIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePetrolIcon",
+    imports: [
+      "import BpkLargePetrolIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/petrol';",
+    ],
+    example: figma.code`<BpkLargePetrolIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePetrolIcon",
+    imports: [
+      "import BpkLargePetrolIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/petrol';",
+    ],
+    example: figma.code`<BpkLargePetrolIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_188.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_188.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A185
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/phone-call.d.ts
+// component=BpkSmallPhoneCallIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPhoneCallIcon",
+    imports: [
+      "import BpkSmallPhoneCallIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/phone-call';",
+    ],
+    example: figma.code`<BpkSmallPhoneCallIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePhoneCallIcon",
+    imports: [
+      "import BpkLargePhoneCallIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/phone-call';",
+    ],
+    example: figma.code`<BpkLargePhoneCallIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePhoneCallIcon",
+    imports: [
+      "import BpkLargePhoneCallIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/phone-call';",
+    ],
+    example: figma.code`<BpkLargePhoneCallIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_189.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_189.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A186
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/picture.d.ts
+// component=BpkSmallPictureIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPictureIcon",
+    imports: [
+      "import BpkSmallPictureIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/picture';",
+    ],
+    example: figma.code`<BpkSmallPictureIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePictureIcon",
+    imports: [
+      "import BpkLargePictureIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/picture';",
+    ],
+    example: figma.code`<BpkLargePictureIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePictureIcon",
+    imports: [
+      "import BpkLargePictureIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/picture';",
+    ],
+    example: figma.code`<BpkLargePictureIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_19.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_19.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A18
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/alert--remove.d.ts
+// component=BpkSmallAlertRemoveIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAlertRemoveIcon",
+    imports: [
+      "import BpkSmallAlertRemoveIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/alert--remove';",
+    ],
+    example: figma.code`<BpkSmallAlertRemoveIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAlertRemoveIcon",
+    imports: [
+      "import BpkLargeAlertRemoveIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/alert--remove';",
+    ],
+    example: figma.code`<BpkLargeAlertRemoveIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAlertRemoveIcon",
+    imports: [
+      "import BpkLargeAlertRemoveIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/alert--remove';",
+    ],
+    example: figma.code`<BpkLargeAlertRemoveIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_190.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_190.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A187
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/pin.d.ts
+// component=BpkSmallPinIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPinIcon",
+    imports: [
+      "import BpkSmallPinIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/pin';",
+    ],
+    example: figma.code`<BpkSmallPinIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePinIcon",
+    imports: [
+      "import BpkLargePinIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/pin';",
+    ],
+    example: figma.code`<BpkLargePinIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePinIcon",
+    imports: [
+      "import BpkLargePinIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/pin';",
+    ],
+    example: figma.code`<BpkLargePinIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_191.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_191.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A188
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/plane-seat.d.ts
+// component=BpkSmallPlaneSeatIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPlaneSeatIcon",
+    imports: [
+      "import BpkSmallPlaneSeatIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/plane-seat';",
+    ],
+    example: figma.code`<BpkSmallPlaneSeatIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePlaneSeatIcon",
+    imports: [
+      "import BpkLargePlaneSeatIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/plane-seat';",
+    ],
+    example: figma.code`<BpkLargePlaneSeatIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePlaneSeatIcon",
+    imports: [
+      "import BpkLargePlaneSeatIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/plane-seat';",
+    ],
+    example: figma.code`<BpkLargePlaneSeatIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_192.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_192.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A189
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/play.d.ts
+// component=BpkSmallPlayIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPlayIcon",
+    imports: [
+      "import BpkSmallPlayIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/play';",
+    ],
+    example: figma.code`<BpkSmallPlayIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePlayIcon",
+    imports: [
+      "import BpkLargePlayIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/play';",
+    ],
+    example: figma.code`<BpkLargePlayIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePlayIcon",
+    imports: [
+      "import BpkLargePlayIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/play';",
+    ],
+    example: figma.code`<BpkLargePlayIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_193.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_193.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A190
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/plus.d.ts
+// component=BpkSmallPlusIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPlusIcon",
+    imports: [
+      "import BpkSmallPlusIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/plus';",
+    ],
+    example: figma.code`<BpkSmallPlusIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePlusIcon",
+    imports: [
+      "import BpkLargePlusIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/plus';",
+    ],
+    example: figma.code`<BpkLargePlusIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePlusIcon",
+    imports: [
+      "import BpkLargePlusIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/plus';",
+    ],
+    example: figma.code`<BpkLargePlusIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_194.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_194.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A191
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/policy.d.ts
+// component=BpkSmallPolicyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPolicyIcon",
+    imports: [
+      "import BpkSmallPolicyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/policy';",
+    ],
+    example: figma.code`<BpkSmallPolicyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePolicyIcon",
+    imports: [
+      "import BpkLargePolicyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/policy';",
+    ],
+    example: figma.code`<BpkLargePolicyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePolicyIcon",
+    imports: [
+      "import BpkLargePolicyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/policy';",
+    ],
+    example: figma.code`<BpkLargePolicyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_195.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_195.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A192
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/powerplug.d.ts
+// component=BpkSmallPowerplugIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPowerplugIcon",
+    imports: [
+      "import BpkSmallPowerplugIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/powerplug';",
+    ],
+    example: figma.code`<BpkSmallPowerplugIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePowerplugIcon",
+    imports: [
+      "import BpkLargePowerplugIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/powerplug';",
+    ],
+    example: figma.code`<BpkLargePowerplugIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePowerplugIcon",
+    imports: [
+      "import BpkLargePowerplugIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/powerplug';",
+    ],
+    example: figma.code`<BpkLargePowerplugIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_196.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_196.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A193
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/ppe.d.ts
+// component=BpkSmallPpeIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPpeIcon",
+    imports: [
+      "import BpkSmallPpeIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/ppe';",
+    ],
+    example: figma.code`<BpkSmallPpeIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePpeIcon",
+    imports: [
+      "import BpkLargePpeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/ppe';",
+    ],
+    example: figma.code`<BpkLargePpeIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePpeIcon",
+    imports: [
+      "import BpkLargePpeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/ppe';",
+    ],
+    example: figma.code`<BpkLargePpeIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_197.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_197.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A194
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/price-tag.d.ts
+// component=BpkSmallPriceTagIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPriceTagIcon",
+    imports: [
+      "import BpkSmallPriceTagIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/price-tag';",
+    ],
+    example: figma.code`<BpkSmallPriceTagIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePriceTagIcon",
+    imports: [
+      "import BpkLargePriceTagIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/price-tag';",
+    ],
+    example: figma.code`<BpkLargePriceTagIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePriceTagIcon",
+    imports: [
+      "import BpkLargePriceTagIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/price-tag';",
+    ],
+    example: figma.code`<BpkLargePriceTagIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_198.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_198.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A195
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/price-alerts.d.ts
+// component=BpkSmallPriceAlertsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPriceAlertsIcon",
+    imports: [
+      "import BpkSmallPriceAlertsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/price-alerts';",
+    ],
+    example: figma.code`<BpkSmallPriceAlertsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePriceAlertsIcon",
+    imports: [
+      "import BpkLargePriceAlertsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/price-alerts';",
+    ],
+    example: figma.code`<BpkLargePriceAlertsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePriceAlertsIcon",
+    imports: [
+      "import BpkLargePriceAlertsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/price-alerts';",
+    ],
+    example: figma.code`<BpkLargePriceAlertsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_199.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_199.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A196
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/print.d.ts
+// component=BpkSmallPrintIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallPrintIcon",
+    imports: [
+      "import BpkSmallPrintIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/print';",
+    ],
+    example: figma.code`<BpkSmallPrintIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargePrintIcon",
+    imports: [
+      "import BpkLargePrintIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/print';",
+    ],
+    example: figma.code`<BpkLargePrintIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargePrintIcon",
+    imports: [
+      "import BpkLargePrintIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/print';",
+    ],
+    example: figma.code`<BpkLargePrintIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_2.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_2.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A2
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/account--add.d.ts
+// component=BpkSmallAccountAddIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAccountAddIcon",
+    imports: [
+      "import BpkSmallAccountAddIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/account--add';",
+    ],
+    example: figma.code`<BpkSmallAccountAddIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAccountAddIcon",
+    imports: [
+      "import BpkLargeAccountAddIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--add';",
+    ],
+    example: figma.code`<BpkLargeAccountAddIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAccountAddIcon",
+    imports: [
+      "import BpkLargeAccountAddIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--add';",
+    ],
+    example: figma.code`<BpkLargeAccountAddIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_20.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_20.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A19
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/arrow-down.d.ts
+// component=BpkSmallArrowDownIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallArrowDownIcon",
+    imports: [
+      "import BpkSmallArrowDownIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/arrow-down';",
+    ],
+    example: figma.code`<BpkSmallArrowDownIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeArrowDownIcon",
+    imports: [
+      "import BpkLargeArrowDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/arrow-down';",
+    ],
+    example: figma.code`<BpkLargeArrowDownIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeArrowDownIcon",
+    imports: [
+      "import BpkLargeArrowDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/arrow-down';",
+    ],
+    example: figma.code`<BpkLargeArrowDownIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_200.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_200.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A199
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/recent-searches.d.ts
+// component=BpkSmallRecentSearchesIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallRecentSearchesIcon",
+    imports: [
+      "import BpkSmallRecentSearchesIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/recent-searches';",
+    ],
+    example: figma.code`<BpkSmallRecentSearchesIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeRecentSearchesIcon",
+    imports: [
+      "import BpkLargeRecentSearchesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/recent-searches';",
+    ],
+    example: figma.code`<BpkLargeRecentSearchesIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeRecentSearchesIcon",
+    imports: [
+      "import BpkLargeRecentSearchesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/recent-searches';",
+    ],
+    example: figma.code`<BpkLargeRecentSearchesIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_201.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_201.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6443%3A18
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/redo.d.ts
+// component=BpkSmallRedoIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallRedoIcon",
+    imports: [
+      "import BpkSmallRedoIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/redo';",
+    ],
+    example: figma.code`<BpkSmallRedoIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeRedoIcon",
+    imports: [
+      "import BpkLargeRedoIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/redo';",
+    ],
+    example: figma.code`<BpkLargeRedoIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeRedoIcon",
+    imports: [
+      "import BpkLargeRedoIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/redo';",
+    ],
+    example: figma.code`<BpkLargeRedoIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_202.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_202.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A200
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/refresh.d.ts
+// component=BpkSmallRefreshIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallRefreshIcon",
+    imports: [
+      "import BpkSmallRefreshIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/refresh';",
+    ],
+    example: figma.code`<BpkSmallRefreshIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeRefreshIcon",
+    imports: [
+      "import BpkLargeRefreshIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/refresh';",
+    ],
+    example: figma.code`<BpkLargeRefreshIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeRefreshIcon",
+    imports: [
+      "import BpkLargeRefreshIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/refresh';",
+    ],
+    example: figma.code`<BpkLargeRefreshIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_203.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_203.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A201
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/return.d.ts
+// component=BpkSmallReturnIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallReturnIcon",
+    imports: [
+      "import BpkSmallReturnIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/return';",
+    ],
+    example: figma.code`<BpkSmallReturnIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeReturnIcon",
+    imports: [
+      "import BpkLargeReturnIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/return';",
+    ],
+    example: figma.code`<BpkLargeReturnIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeReturnIcon",
+    imports: [
+      "import BpkLargeReturnIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/return';",
+    ],
+    example: figma.code`<BpkLargeReturnIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_204.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_204.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A202
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/room.d.ts
+// component=BpkSmallRoomIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallRoomIcon",
+    imports: [
+      "import BpkSmallRoomIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/room';",
+    ],
+    example: figma.code`<BpkSmallRoomIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeRoomIcon",
+    imports: [
+      "import BpkLargeRoomIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/room';",
+    ],
+    example: figma.code`<BpkLargeRoomIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeRoomIcon",
+    imports: [
+      "import BpkLargeRoomIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/room';",
+    ],
+    example: figma.code`<BpkLargeRoomIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_205.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_205.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A203
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/scales.d.ts
+// component=BpkSmallScalesIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallScalesIcon",
+    imports: [
+      "import BpkSmallScalesIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/scales';",
+    ],
+    example: figma.code`<BpkSmallScalesIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeScalesIcon",
+    imports: [
+      "import BpkLargeScalesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/scales';",
+    ],
+    example: figma.code`<BpkLargeScalesIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeScalesIcon",
+    imports: [
+      "import BpkLargeScalesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/scales';",
+    ],
+    example: figma.code`<BpkLargeScalesIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_206.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_206.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A204
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/search.d.ts
+// component=BpkSmallSearchIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSearchIcon",
+    imports: [
+      "import BpkSmallSearchIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/search';",
+    ],
+    example: figma.code`<BpkSmallSearchIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSearchIcon",
+    imports: [
+      "import BpkLargeSearchIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/search';",
+    ],
+    example: figma.code`<BpkLargeSearchIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSearchIcon",
+    imports: [
+      "import BpkLargeSearchIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/search';",
+    ],
+    example: figma.code`<BpkLargeSearchIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_207.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_207.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=7185%3A93
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/self-service.d.ts
+// component=BpkSmallSelfServiceIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Property 1") === "16") {
+  template = {
+    id: "BpkSmallSelfServiceIcon",
+    imports: [
+      "import BpkSmallSelfServiceIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/self-service';",
+    ],
+    example: figma.code`<BpkSmallSelfServiceIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Property 1") === "24") {
+  template = {
+    id: "BpkLargeSelfServiceIcon",
+    imports: [
+      "import BpkLargeSelfServiceIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/self-service';",
+    ],
+    example: figma.code`<BpkLargeSelfServiceIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSelfServiceIcon",
+    imports: [
+      "import BpkLargeSelfServiceIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/self-service';",
+    ],
+    example: figma.code`<BpkLargeSelfServiceIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_208.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_208.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A205
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/send-message.d.ts
+// component=BpkSmallSendMessageIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSendMessageIcon",
+    imports: [
+      "import BpkSmallSendMessageIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/send-message';",
+    ],
+    example: figma.code`<BpkSmallSendMessageIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSendMessageIcon",
+    imports: [
+      "import BpkLargeSendMessageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/send-message';",
+    ],
+    example: figma.code`<BpkLargeSendMessageIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSendMessageIcon",
+    imports: [
+      "import BpkLargeSendMessageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/send-message';",
+    ],
+    example: figma.code`<BpkLargeSendMessageIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_209.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_209.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A206
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/services.d.ts
+// component=BpkSmallServicesIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallServicesIcon",
+    imports: [
+      "import BpkSmallServicesIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/services';",
+    ],
+    example: figma.code`<BpkSmallServicesIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeServicesIcon",
+    imports: [
+      "import BpkLargeServicesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/services';",
+    ],
+    example: figma.code`<BpkLargeServicesIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeServicesIcon",
+    imports: [
+      "import BpkLargeServicesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/services';",
+    ],
+    example: figma.code`<BpkLargeServicesIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_21.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_21.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A20
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/arrow-left.d.ts
+// component=BpkSmallArrowLeftIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallArrowLeftIcon",
+    imports: [
+      "import BpkSmallArrowLeftIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/arrow-left';",
+    ],
+    example: figma.code`<BpkSmallArrowLeftIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeArrowLeftIcon",
+    imports: [
+      "import BpkLargeArrowLeftIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/arrow-left';",
+    ],
+    example: figma.code`<BpkLargeArrowLeftIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeArrowLeftIcon",
+    imports: [
+      "import BpkLargeArrowLeftIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/arrow-left';",
+    ],
+    example: figma.code`<BpkLargeArrowLeftIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_210.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_210.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A207
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/settings.d.ts
+// component=BpkSmallSettingsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSettingsIcon",
+    imports: [
+      "import BpkSmallSettingsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/settings';",
+    ],
+    example: figma.code`<BpkSmallSettingsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSettingsIcon",
+    imports: [
+      "import BpkLargeSettingsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/settings';",
+    ],
+    example: figma.code`<BpkLargeSettingsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSettingsIcon",
+    imports: [
+      "import BpkLargeSettingsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/settings';",
+    ],
+    example: figma.code`<BpkLargeSettingsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_211.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_211.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A208
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/share.d.ts
+// component=BpkSmallShareIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallShareIcon",
+    imports: [
+      "import BpkSmallShareIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/share';",
+    ],
+    example: figma.code`<BpkSmallShareIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeShareIcon",
+    imports: [
+      "import BpkLargeShareIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/share';",
+    ],
+    example: figma.code`<BpkLargeShareIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeShareIcon",
+    imports: [
+      "import BpkLargeShareIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/share';",
+    ],
+    example: figma.code`<BpkLargeShareIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_212.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_212.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A209
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/share--android.d.ts
+// component=BpkSmallShareAndroidIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallShareAndroidIcon",
+    imports: [
+      "import BpkSmallShareAndroidIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/share--android';",
+    ],
+    example: figma.code`<BpkSmallShareAndroidIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeShareAndroidIcon",
+    imports: [
+      "import BpkLargeShareAndroidIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/share--android';",
+    ],
+    example: figma.code`<BpkLargeShareAndroidIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeShareAndroidIcon",
+    imports: [
+      "import BpkLargeShareAndroidIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/share--android';",
+    ],
+    example: figma.code`<BpkLargeShareAndroidIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_213.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_213.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A210
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/share--ios.d.ts
+// component=BpkSmallShareIosIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallShareIosIcon",
+    imports: [
+      "import BpkSmallShareIosIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/share--ios';",
+    ],
+    example: figma.code`<BpkSmallShareIosIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeShareIosIcon",
+    imports: [
+      "import BpkLargeShareIosIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/share--ios';",
+    ],
+    example: figma.code`<BpkLargeShareIosIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeShareIosIcon",
+    imports: [
+      "import BpkLargeShareIosIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/share--ios';",
+    ],
+    example: figma.code`<BpkLargeShareIosIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_214.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_214.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A211
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/single-booking.d.ts
+// component=BpkSmallSingleBookingIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSingleBookingIcon",
+    imports: [
+      "import BpkSmallSingleBookingIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/single-booking';",
+    ],
+    example: figma.code`<BpkSmallSingleBookingIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSingleBookingIcon",
+    imports: [
+      "import BpkLargeSingleBookingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/single-booking';",
+    ],
+    example: figma.code`<BpkLargeSingleBookingIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSingleBookingIcon",
+    imports: [
+      "import BpkLargeSingleBookingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/single-booking';",
+    ],
+    example: figma.code`<BpkLargeSingleBookingIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_215.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_215.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A212
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/social-distancing.d.ts
+// component=BpkSmallSocialDistancingIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSocialDistancingIcon",
+    imports: [
+      "import BpkSmallSocialDistancingIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/social-distancing';",
+    ],
+    example: figma.code`<BpkSmallSocialDistancingIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSocialDistancingIcon",
+    imports: [
+      "import BpkLargeSocialDistancingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/social-distancing';",
+    ],
+    example: figma.code`<BpkLargeSocialDistancingIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSocialDistancingIcon",
+    imports: [
+      "import BpkLargeSocialDistancingIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/social-distancing';",
+    ],
+    example: figma.code`<BpkLargeSocialDistancingIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_216.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_216.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A213
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/sort.d.ts
+// component=BpkSmallSortIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSortIcon",
+    imports: [
+      "import BpkSmallSortIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/sort';",
+    ],
+    example: figma.code`<BpkSmallSortIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSortIcon",
+    imports: [
+      "import BpkLargeSortIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/sort';",
+    ],
+    example: figma.code`<BpkLargeSortIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSortIcon",
+    imports: [
+      "import BpkLargeSortIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/sort';",
+    ],
+    example: figma.code`<BpkLargeSortIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_217.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_217.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A214
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/sort-down.d.ts
+// component=BpkSmallSortDownIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSortDownIcon",
+    imports: [
+      "import BpkSmallSortDownIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/sort-down';",
+    ],
+    example: figma.code`<BpkSmallSortDownIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSortDownIcon",
+    imports: [
+      "import BpkLargeSortDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/sort-down';",
+    ],
+    example: figma.code`<BpkLargeSortDownIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSortDownIcon",
+    imports: [
+      "import BpkLargeSortDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/sort-down';",
+    ],
+    example: figma.code`<BpkLargeSortDownIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_218.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_218.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A215
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/sort-up.d.ts
+// component=BpkSmallSortUpIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSortUpIcon",
+    imports: [
+      "import BpkSmallSortUpIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/sort-up';",
+    ],
+    example: figma.code`<BpkSmallSortUpIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSortUpIcon",
+    imports: [
+      "import BpkLargeSortUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/sort-up';",
+    ],
+    example: figma.code`<BpkLargeSortUpIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSortUpIcon",
+    imports: [
+      "import BpkLargeSortUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/sort-up';",
+    ],
+    example: figma.code`<BpkLargeSortUpIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_219.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_219.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A216
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/speaker.d.ts
+// component=BpkSmallSpeakerIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSpeakerIcon",
+    imports: [
+      "import BpkSmallSpeakerIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/speaker';",
+    ],
+    example: figma.code`<BpkSmallSpeakerIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSpeakerIcon",
+    imports: [
+      "import BpkLargeSpeakerIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/speaker';",
+    ],
+    example: figma.code`<BpkLargeSpeakerIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSpeakerIcon",
+    imports: [
+      "import BpkLargeSpeakerIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/speaker';",
+    ],
+    example: figma.code`<BpkLargeSpeakerIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_22.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_22.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A21
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/arrow-right.d.ts
+// component=BpkSmallArrowRightIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallArrowRightIcon",
+    imports: [
+      "import BpkSmallArrowRightIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/arrow-right';",
+    ],
+    example: figma.code`<BpkSmallArrowRightIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeArrowRightIcon",
+    imports: [
+      "import BpkLargeArrowRightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/arrow-right';",
+    ],
+    example: figma.code`<BpkLargeArrowRightIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeArrowRightIcon",
+    imports: [
+      "import BpkLargeArrowRightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/arrow-right';",
+    ],
+    example: figma.code`<BpkLargeArrowRightIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_220.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_220.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=12895%3A198
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/speaker-mute.d.ts
+// component=BpkSmallSpeakerMuteIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSpeakerMuteIcon",
+    imports: [
+      "import BpkSmallSpeakerMuteIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/speaker-mute';",
+    ],
+    example: figma.code`<BpkSmallSpeakerMuteIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSpeakerMuteIcon",
+    imports: [
+      "import BpkLargeSpeakerMuteIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/speaker-mute';",
+    ],
+    example: figma.code`<BpkLargeSpeakerMuteIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSpeakerMuteIcon",
+    imports: [
+      "import BpkLargeSpeakerMuteIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/speaker-mute';",
+    ],
+    example: figma.code`<BpkLargeSpeakerMuteIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_221.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_221.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A218
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/star.d.ts
+// component=BpkSmallStarIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallStarIcon",
+    imports: [
+      "import BpkSmallStarIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/star';",
+    ],
+    example: figma.code`<BpkSmallStarIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeStarIcon",
+    imports: [
+      "import BpkLargeStarIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/star';",
+    ],
+    example: figma.code`<BpkLargeStarIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeStarIcon",
+    imports: [
+      "import BpkLargeStarIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/star';",
+    ],
+    example: figma.code`<BpkLargeStarIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_222.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_222.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A219
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/star-half.d.ts
+// component=BpkSmallStarHalfIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallStarHalfIcon",
+    imports: [
+      "import BpkSmallStarHalfIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/star-half';",
+    ],
+    example: figma.code`<BpkSmallStarHalfIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeStarHalfIcon",
+    imports: [
+      "import BpkLargeStarHalfIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/star-half';",
+    ],
+    example: figma.code`<BpkLargeStarHalfIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeStarHalfIcon",
+    imports: [
+      "import BpkLargeStarHalfIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/star-half';",
+    ],
+    example: figma.code`<BpkLargeStarHalfIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_223.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_223.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A220
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/star-outline.d.ts
+// component=BpkSmallStarOutlineIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallStarOutlineIcon",
+    imports: [
+      "import BpkSmallStarOutlineIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/star-outline';",
+    ],
+    example: figma.code`<BpkSmallStarOutlineIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeStarOutlineIcon",
+    imports: [
+      "import BpkLargeStarOutlineIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/star-outline';",
+    ],
+    example: figma.code`<BpkLargeStarOutlineIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeStarOutlineIcon",
+    imports: [
+      "import BpkLargeStarOutlineIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/star-outline';",
+    ],
+    example: figma.code`<BpkLargeStarOutlineIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_224.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_224.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A221
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/stops.d.ts
+// component=BpkSmallStopsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallStopsIcon",
+    imports: [
+      "import BpkSmallStopsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/stops';",
+    ],
+    example: figma.code`<BpkSmallStopsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeStopsIcon",
+    imports: [
+      "import BpkLargeStopsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/stops';",
+    ],
+    example: figma.code`<BpkLargeStopsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeStopsIcon",
+    imports: [
+      "import BpkLargeStopsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/stops';",
+    ],
+    example: figma.code`<BpkLargeStopsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_225.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_225.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A222
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/swap.d.ts
+// component=BpkSmallSwapIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSwapIcon",
+    imports: [
+      "import BpkSmallSwapIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/swap';",
+    ],
+    example: figma.code`<BpkSmallSwapIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSwapIcon",
+    imports: [
+      "import BpkLargeSwapIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/swap';",
+    ],
+    example: figma.code`<BpkLargeSwapIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSwapIcon",
+    imports: [
+      "import BpkLargeSwapIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/swap';",
+    ],
+    example: figma.code`<BpkLargeSwapIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_226.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_226.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A223
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/swap--horizontal.d.ts
+// component=BpkSmallSwapHorizontalIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSwapHorizontalIcon",
+    imports: [
+      "import BpkSmallSwapHorizontalIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/swap--horizontal';",
+    ],
+    example: figma.code`<BpkSmallSwapHorizontalIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSwapHorizontalIcon",
+    imports: [
+      "import BpkLargeSwapHorizontalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/swap--horizontal';",
+    ],
+    example: figma.code`<BpkLargeSwapHorizontalIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSwapHorizontalIcon",
+    imports: [
+      "import BpkLargeSwapHorizontalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/swap--horizontal';",
+    ],
+    example: figma.code`<BpkLargeSwapHorizontalIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_227.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_227.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A224
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/swap--vertical.d.ts
+// component=BpkSmallSwapVerticalIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallSwapVerticalIcon",
+    imports: [
+      "import BpkSmallSwapVerticalIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/swap--vertical';",
+    ],
+    example: figma.code`<BpkSmallSwapVerticalIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeSwapVerticalIcon",
+    imports: [
+      "import BpkLargeSwapVerticalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/swap--vertical';",
+    ],
+    example: figma.code`<BpkLargeSwapVerticalIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeSwapVerticalIcon",
+    imports: [
+      "import BpkLargeSwapVerticalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/swap--vertical';",
+    ],
+    example: figma.code`<BpkLargeSwapVerticalIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_228.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_228.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A225
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/taxi.d.ts
+// component=BpkSmallTaxiIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTaxiIcon",
+    imports: [
+      "import BpkSmallTaxiIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/taxi';",
+    ],
+    example: figma.code`<BpkSmallTaxiIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTaxiIcon",
+    imports: [
+      "import BpkLargeTaxiIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/taxi';",
+    ],
+    example: figma.code`<BpkLargeTaxiIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTaxiIcon",
+    imports: [
+      "import BpkLargeTaxiIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/taxi';",
+    ],
+    example: figma.code`<BpkLargeTaxiIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_229.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_229.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=14087%3A34
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/temperature.d.ts
+// component=BpkSmallTemperatureIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTemperatureIcon",
+    imports: [
+      "import BpkSmallTemperatureIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/temperature';",
+    ],
+    example: figma.code`<BpkSmallTemperatureIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTemperatureIcon",
+    imports: [
+      "import BpkLargeTemperatureIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/temperature';",
+    ],
+    example: figma.code`<BpkLargeTemperatureIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTemperatureIcon",
+    imports: [
+      "import BpkLargeTemperatureIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/temperature';",
+    ],
+    example: figma.code`<BpkLargeTemperatureIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_23.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_23.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A22
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/arrow-up.d.ts
+// component=BpkSmallArrowUpIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallArrowUpIcon",
+    imports: [
+      "import BpkSmallArrowUpIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/arrow-up';",
+    ],
+    example: figma.code`<BpkSmallArrowUpIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeArrowUpIcon",
+    imports: [
+      "import BpkLargeArrowUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/arrow-up';",
+    ],
+    example: figma.code`<BpkLargeArrowUpIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeArrowUpIcon",
+    imports: [
+      "import BpkLargeArrowUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/arrow-up';",
+    ],
+    example: figma.code`<BpkLargeArrowUpIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_230.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_230.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A226
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/thumbs-down.d.ts
+// component=BpkSmallThumbsDownIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallThumbsDownIcon",
+    imports: [
+      "import BpkSmallThumbsDownIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/thumbs-down';",
+    ],
+    example: figma.code`<BpkSmallThumbsDownIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeThumbsDownIcon",
+    imports: [
+      "import BpkLargeThumbsDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/thumbs-down';",
+    ],
+    example: figma.code`<BpkLargeThumbsDownIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeThumbsDownIcon",
+    imports: [
+      "import BpkLargeThumbsDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/thumbs-down';",
+    ],
+    example: figma.code`<BpkLargeThumbsDownIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_231.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_231.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A227
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/thumbs-up.d.ts
+// component=BpkSmallThumbsUpIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallThumbsUpIcon",
+    imports: [
+      "import BpkSmallThumbsUpIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/thumbs-up';",
+    ],
+    example: figma.code`<BpkSmallThumbsUpIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeThumbsUpIcon",
+    imports: [
+      "import BpkLargeThumbsUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/thumbs-up';",
+    ],
+    example: figma.code`<BpkLargeThumbsUpIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeThumbsUpIcon",
+    imports: [
+      "import BpkLargeThumbsUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/thumbs-up';",
+    ],
+    example: figma.code`<BpkLargeThumbsUpIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_232.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_232.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A228
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/tick.d.ts
+// component=BpkSmallTickIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTickIcon",
+    imports: [
+      "import BpkSmallTickIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/tick';",
+    ],
+    example: figma.code`<BpkSmallTickIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTickIcon",
+    imports: [
+      "import BpkLargeTickIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/tick';",
+    ],
+    example: figma.code`<BpkLargeTickIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTickIcon",
+    imports: [
+      "import BpkLargeTickIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/tick';",
+    ],
+    example: figma.code`<BpkLargeTickIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_233.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_233.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A229
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/tick-circle.d.ts
+// component=BpkSmallTickCircleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTickCircleIcon",
+    imports: [
+      "import BpkSmallTickCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/tick-circle';",
+    ],
+    example: figma.code`<BpkSmallTickCircleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTickCircleIcon",
+    imports: [
+      "import BpkLargeTickCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/tick-circle';",
+    ],
+    example: figma.code`<BpkLargeTickCircleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTickCircleIcon",
+    imports: [
+      "import BpkLargeTickCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/tick-circle';",
+    ],
+    example: figma.code`<BpkLargeTickCircleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_234.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_234.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A230
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/ticket.d.ts
+// component=BpkSmallTicketIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTicketIcon",
+    imports: [
+      "import BpkSmallTicketIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/ticket';",
+    ],
+    example: figma.code`<BpkSmallTicketIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTicketIcon",
+    imports: [
+      "import BpkLargeTicketIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/ticket';",
+    ],
+    example: figma.code`<BpkLargeTicketIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTicketIcon",
+    imports: [
+      "import BpkLargeTicketIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/ticket';",
+    ],
+    example: figma.code`<BpkLargeTicketIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_235.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_235.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A231
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/time.d.ts
+// component=BpkSmallTimeIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTimeIcon",
+    imports: [
+      "import BpkSmallTimeIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/time';",
+    ],
+    example: figma.code`<BpkSmallTimeIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTimeIcon",
+    imports: [
+      "import BpkLargeTimeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/time';",
+    ],
+    example: figma.code`<BpkLargeTimeIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTimeIcon",
+    imports: [
+      "import BpkLargeTimeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/time';",
+    ],
+    example: figma.code`<BpkLargeTimeIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_236.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_236.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A232
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/toilets.d.ts
+// component=BpkSmallToiletsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallToiletsIcon",
+    imports: [
+      "import BpkSmallToiletsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/toilets';",
+    ],
+    example: figma.code`<BpkSmallToiletsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeToiletsIcon",
+    imports: [
+      "import BpkLargeToiletsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/toilets';",
+    ],
+    example: figma.code`<BpkLargeToiletsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeToiletsIcon",
+    imports: [
+      "import BpkLargeToiletsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/toilets';",
+    ],
+    example: figma.code`<BpkLargeToiletsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_237.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_237.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A233
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/train.d.ts
+// component=BpkSmallTrainIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTrainIcon",
+    imports: [
+      "import BpkSmallTrainIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/train';",
+    ],
+    example: figma.code`<BpkSmallTrainIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTrainIcon",
+    imports: [
+      "import BpkLargeTrainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/train';",
+    ],
+    example: figma.code`<BpkLargeTrainIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTrainIcon",
+    imports: [
+      "import BpkLargeTrainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/train';",
+    ],
+    example: figma.code`<BpkLargeTrainIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_238.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_238.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A234
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/trash.d.ts
+// component=BpkSmallTrashIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTrashIcon",
+    imports: [
+      "import BpkSmallTrashIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/trash';",
+    ],
+    example: figma.code`<BpkSmallTrashIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTrashIcon",
+    imports: [
+      "import BpkLargeTrashIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trash';",
+    ],
+    example: figma.code`<BpkLargeTrashIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTrashIcon",
+    imports: [
+      "import BpkLargeTrashIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trash';",
+    ],
+    example: figma.code`<BpkLargeTrashIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_239.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_239.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A235
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/trend.d.ts
+// component=BpkSmallTrendIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTrendIcon",
+    imports: [
+      "import BpkSmallTrendIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/trend';",
+    ],
+    example: figma.code`<BpkSmallTrendIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTrendIcon",
+    imports: [
+      "import BpkLargeTrendIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trend';",
+    ],
+    example: figma.code`<BpkLargeTrendIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTrendIcon",
+    imports: [
+      "import BpkLargeTrendIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trend';",
+    ],
+    example: figma.code`<BpkLargeTrendIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_24.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_24.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A23
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/award.d.ts
+// component=BpkSmallAwardIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAwardIcon",
+    imports: [
+      "import BpkSmallAwardIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/award';",
+    ],
+    example: figma.code`<BpkSmallAwardIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAwardIcon",
+    imports: [
+      "import BpkLargeAwardIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/award';",
+    ],
+    example: figma.code`<BpkLargeAwardIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAwardIcon",
+    imports: [
+      "import BpkLargeAwardIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/award';",
+    ],
+    example: figma.code`<BpkLargeAwardIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_240.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_240.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A236
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/trend--down.d.ts
+// component=BpkSmallTrendDownIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTrendDownIcon",
+    imports: [
+      "import BpkSmallTrendDownIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/trend--down';",
+    ],
+    example: figma.code`<BpkSmallTrendDownIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTrendDownIcon",
+    imports: [
+      "import BpkLargeTrendDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trend--down';",
+    ],
+    example: figma.code`<BpkLargeTrendDownIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTrendDownIcon",
+    imports: [
+      "import BpkLargeTrendDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trend--down';",
+    ],
+    example: figma.code`<BpkLargeTrendDownIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_241.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_241.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A237
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/trend--steady.d.ts
+// component=BpkSmallTrendSteadyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTrendSteadyIcon",
+    imports: [
+      "import BpkSmallTrendSteadyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/trend--steady';",
+    ],
+    example: figma.code`<BpkSmallTrendSteadyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTrendSteadyIcon",
+    imports: [
+      "import BpkLargeTrendSteadyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trend--steady';",
+    ],
+    example: figma.code`<BpkLargeTrendSteadyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTrendSteadyIcon",
+    imports: [
+      "import BpkLargeTrendSteadyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trend--steady';",
+    ],
+    example: figma.code`<BpkLargeTrendSteadyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_242.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_242.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A238
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/trend--will-rise.d.ts
+// component=BpkSmallTrendWillRiseIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTrendWillRiseIcon",
+    imports: [
+      "import BpkSmallTrendWillRiseIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/trend--will-rise';",
+    ],
+    example: figma.code`<BpkSmallTrendWillRiseIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTrendWillRiseIcon",
+    imports: [
+      "import BpkLargeTrendWillRiseIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trend--will-rise';",
+    ],
+    example: figma.code`<BpkLargeTrendWillRiseIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTrendWillRiseIcon",
+    imports: [
+      "import BpkLargeTrendWillRiseIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trend--will-rise';",
+    ],
+    example: figma.code`<BpkLargeTrendWillRiseIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_243.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_243.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A239
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/trips.d.ts
+// component=BpkSmallTripsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallTripsIcon",
+    imports: [
+      "import BpkSmallTripsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/trips';",
+    ],
+    example: figma.code`<BpkSmallTripsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeTripsIcon",
+    imports: [
+      "import BpkLargeTripsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trips';",
+    ],
+    example: figma.code`<BpkLargeTripsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeTripsIcon",
+    imports: [
+      "import BpkLargeTripsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/trips';",
+    ],
+    example: figma.code`<BpkLargeTripsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_244.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_244.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6443%3A19
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/undo.d.ts
+// component=BpkSmallUndoIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallUndoIcon",
+    imports: [
+      "import BpkSmallUndoIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/undo';",
+    ],
+    example: figma.code`<BpkSmallUndoIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeUndoIcon",
+    imports: [
+      "import BpkLargeUndoIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/undo';",
+    ],
+    example: figma.code`<BpkLargeUndoIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeUndoIcon",
+    imports: [
+      "import BpkLargeUndoIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/undo';",
+    ],
+    example: figma.code`<BpkLargeUndoIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_245.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_245.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A240
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/unlock.d.ts
+// component=BpkSmallUnlockIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallUnlockIcon",
+    imports: [
+      "import BpkSmallUnlockIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/unlock';",
+    ],
+    example: figma.code`<BpkSmallUnlockIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeUnlockIcon",
+    imports: [
+      "import BpkLargeUnlockIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/unlock';",
+    ],
+    example: figma.code`<BpkLargeUnlockIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeUnlockIcon",
+    imports: [
+      "import BpkLargeUnlockIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/unlock';",
+    ],
+    example: figma.code`<BpkLargeUnlockIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_246.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_246.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A241
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/unmute.d.ts
+// component=BpkSmallUnmuteIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallUnmuteIcon",
+    imports: [
+      "import BpkSmallUnmuteIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/unmute';",
+    ],
+    example: figma.code`<BpkSmallUnmuteIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeUnmuteIcon",
+    imports: [
+      "import BpkLargeUnmuteIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/unmute';",
+    ],
+    example: figma.code`<BpkLargeUnmuteIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeUnmuteIcon",
+    imports: [
+      "import BpkLargeUnmuteIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/unmute';",
+    ],
+    example: figma.code`<BpkLargeUnmuteIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_247.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_247.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A242
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/upgrade.d.ts
+// component=BpkSmallUpgradeIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallUpgradeIcon",
+    imports: [
+      "import BpkSmallUpgradeIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/upgrade';",
+    ],
+    example: figma.code`<BpkSmallUpgradeIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeUpgradeIcon",
+    imports: [
+      "import BpkLargeUpgradeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/upgrade';",
+    ],
+    example: figma.code`<BpkLargeUpgradeIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeUpgradeIcon",
+    imports: [
+      "import BpkLargeUpgradeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/upgrade';",
+    ],
+    example: figma.code`<BpkLargeUpgradeIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_248.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_248.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=8875%3A146
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/upload.d.ts
+// component=BpkSmallUploadIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallUploadIcon",
+    imports: [
+      "import BpkSmallUploadIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/upload';",
+    ],
+    example: figma.code`<BpkSmallUploadIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeUploadIcon",
+    imports: [
+      "import BpkLargeUploadIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/upload';",
+    ],
+    example: figma.code`<BpkLargeUploadIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeUploadIcon",
+    imports: [
+      "import BpkLargeUploadIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/upload';",
+    ],
+    example: figma.code`<BpkLargeUploadIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_249.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_249.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A243
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/use-location.d.ts
+// component=BpkSmallUseLocationIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallUseLocationIcon",
+    imports: [
+      "import BpkSmallUseLocationIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/use-location';",
+    ],
+    example: figma.code`<BpkSmallUseLocationIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeUseLocationIcon",
+    imports: [
+      "import BpkLargeUseLocationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/use-location';",
+    ],
+    example: figma.code`<BpkLargeUseLocationIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeUseLocationIcon",
+    imports: [
+      "import BpkLargeUseLocationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/use-location';",
+    ],
+    example: figma.code`<BpkLargeUseLocationIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_25.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_25.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A24
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/baby-carriage.d.ts
+// component=BpkSmallBabyCarriageIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBabyCarriageIcon",
+    imports: [
+      "import BpkSmallBabyCarriageIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baby-carriage';",
+    ],
+    example: figma.code`<BpkSmallBabyCarriageIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBabyCarriageIcon",
+    imports: [
+      "import BpkLargeBabyCarriageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baby-carriage';",
+    ],
+    example: figma.code`<BpkLargeBabyCarriageIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBabyCarriageIcon",
+    imports: [
+      "import BpkLargeBabyCarriageIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baby-carriage';",
+    ],
+    example: figma.code`<BpkLargeBabyCarriageIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_250.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_250.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A244
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/view.d.ts
+// component=BpkSmallViewIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallViewIcon",
+    imports: [
+      "import BpkSmallViewIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/view';",
+    ],
+    example: figma.code`<BpkSmallViewIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeViewIcon",
+    imports: [
+      "import BpkLargeViewIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/view';",
+    ],
+    example: figma.code`<BpkLargeViewIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeViewIcon",
+    imports: [
+      "import BpkLargeViewIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/view';",
+    ],
+    example: figma.code`<BpkLargeViewIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_251.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_251.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A245
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/virus.d.ts
+// component=BpkSmallVirusIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallVirusIcon",
+    imports: [
+      "import BpkSmallVirusIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/virus';",
+    ],
+    example: figma.code`<BpkSmallVirusIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeVirusIcon",
+    imports: [
+      "import BpkLargeVirusIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/virus';",
+    ],
+    example: figma.code`<BpkLargeVirusIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeVirusIcon",
+    imports: [
+      "import BpkLargeVirusIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/virus';",
+    ],
+    example: figma.code`<BpkLargeVirusIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_252.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_252.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=14550%3A55
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/walk.d.ts
+// component=BpkSmallWalkIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWalkIcon",
+    imports: [
+      "import BpkSmallWalkIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/walk';",
+    ],
+    example: figma.code`<BpkSmallWalkIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWalkIcon",
+    imports: [
+      "import BpkLargeWalkIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/walk';",
+    ],
+    example: figma.code`<BpkLargeWalkIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWalkIcon",
+    imports: [
+      "import BpkLargeWalkIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/walk';",
+    ],
+    example: figma.code`<BpkLargeWalkIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_253.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_253.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A246
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/wallet.d.ts
+// component=BpkSmallWalletIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWalletIcon",
+    imports: [
+      "import BpkSmallWalletIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/wallet';",
+    ],
+    example: figma.code`<BpkSmallWalletIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWalletIcon",
+    imports: [
+      "import BpkLargeWalletIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/wallet';",
+    ],
+    example: figma.code`<BpkLargeWalletIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWalletIcon",
+    imports: [
+      "import BpkLargeWalletIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/wallet';",
+    ],
+    example: figma.code`<BpkLargeWalletIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_254.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_254.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A247
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather.d.ts
+// component=BpkSmallWeatherIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherIcon",
+    imports: [
+      "import BpkSmallWeatherIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather';",
+    ],
+    example: figma.code`<BpkSmallWeatherIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherIcon",
+    imports: [
+      "import BpkLargeWeatherIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather';",
+    ],
+    example: figma.code`<BpkLargeWeatherIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherIcon",
+    imports: [
+      "import BpkLargeWeatherIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather';",
+    ],
+    example: figma.code`<BpkLargeWeatherIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_255.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_255.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A248
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather--clear.d.ts
+// component=BpkSmallWeatherClearIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherClearIcon",
+    imports: [
+      "import BpkSmallWeatherClearIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather--clear';",
+    ],
+    example: figma.code`<BpkSmallWeatherClearIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherClearIcon",
+    imports: [
+      "import BpkLargeWeatherClearIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--clear';",
+    ],
+    example: figma.code`<BpkLargeWeatherClearIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherClearIcon",
+    imports: [
+      "import BpkLargeWeatherClearIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--clear';",
+    ],
+    example: figma.code`<BpkLargeWeatherClearIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_256.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_256.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A249
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather--cloudy.d.ts
+// component=BpkSmallWeatherCloudyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherCloudyIcon",
+    imports: [
+      "import BpkSmallWeatherCloudyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather--cloudy';",
+    ],
+    example: figma.code`<BpkSmallWeatherCloudyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherCloudyIcon",
+    imports: [
+      "import BpkLargeWeatherCloudyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--cloudy';",
+    ],
+    example: figma.code`<BpkLargeWeatherCloudyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherCloudyIcon",
+    imports: [
+      "import BpkLargeWeatherCloudyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--cloudy';",
+    ],
+    example: figma.code`<BpkLargeWeatherCloudyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_257.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_257.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A250
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather--fog.d.ts
+// component=BpkSmallWeatherFogIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherFogIcon",
+    imports: [
+      "import BpkSmallWeatherFogIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather--fog';",
+    ],
+    example: figma.code`<BpkSmallWeatherFogIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherFogIcon",
+    imports: [
+      "import BpkLargeWeatherFogIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--fog';",
+    ],
+    example: figma.code`<BpkLargeWeatherFogIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherFogIcon",
+    imports: [
+      "import BpkLargeWeatherFogIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--fog';",
+    ],
+    example: figma.code`<BpkLargeWeatherFogIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_258.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_258.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A251
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather--partly-cloudy.d.ts
+// component=BpkSmallWeatherPartlyCloudyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherPartlyCloudyIcon",
+    imports: [
+      "import BpkSmallWeatherPartlyCloudyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather--partly-cloudy';",
+    ],
+    example: figma.code`<BpkSmallWeatherPartlyCloudyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherPartlyCloudyIcon",
+    imports: [
+      "import BpkLargeWeatherPartlyCloudyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--partly-cloudy';",
+    ],
+    example: figma.code`<BpkLargeWeatherPartlyCloudyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherPartlyCloudyIcon",
+    imports: [
+      "import BpkLargeWeatherPartlyCloudyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--partly-cloudy';",
+    ],
+    example: figma.code`<BpkLargeWeatherPartlyCloudyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_259.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_259.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A252
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather--rain.d.ts
+// component=BpkSmallWeatherRainIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherRainIcon",
+    imports: [
+      "import BpkSmallWeatherRainIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather--rain';",
+    ],
+    example: figma.code`<BpkSmallWeatherRainIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherRainIcon",
+    imports: [
+      "import BpkLargeWeatherRainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--rain';",
+    ],
+    example: figma.code`<BpkLargeWeatherRainIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherRainIcon",
+    imports: [
+      "import BpkLargeWeatherRainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--rain';",
+    ],
+    example: figma.code`<BpkLargeWeatherRainIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_26.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_26.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=8308%3A186
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/baggage-cabin.d.ts
+// component=BpkSmallBaggageCabinIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBaggageCabinIcon",
+    imports: [
+      "import BpkSmallBaggageCabinIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baggage-cabin';",
+    ],
+    example: figma.code`<BpkSmallBaggageCabinIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBaggageCabinIcon",
+    imports: [
+      "import BpkLargeBaggageCabinIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-cabin';",
+    ],
+    example: figma.code`<BpkLargeBaggageCabinIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBaggageCabinIcon",
+    imports: [
+      "import BpkLargeBaggageCabinIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-cabin';",
+    ],
+    example: figma.code`<BpkLargeBaggageCabinIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_260.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_260.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A253
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather--snow.d.ts
+// component=BpkSmallWeatherSnowIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherSnowIcon",
+    imports: [
+      "import BpkSmallWeatherSnowIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather--snow';",
+    ],
+    example: figma.code`<BpkSmallWeatherSnowIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherSnowIcon",
+    imports: [
+      "import BpkLargeWeatherSnowIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--snow';",
+    ],
+    example: figma.code`<BpkLargeWeatherSnowIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherSnowIcon",
+    imports: [
+      "import BpkLargeWeatherSnowIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--snow';",
+    ],
+    example: figma.code`<BpkLargeWeatherSnowIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_261.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_261.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A254
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather--thunderstorm.d.ts
+// component=BpkSmallWeatherThunderstormIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherThunderstormIcon",
+    imports: [
+      "import BpkSmallWeatherThunderstormIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather--thunderstorm';",
+    ],
+    example: figma.code`<BpkSmallWeatherThunderstormIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherThunderstormIcon",
+    imports: [
+      "import BpkLargeWeatherThunderstormIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--thunderstorm';",
+    ],
+    example: figma.code`<BpkLargeWeatherThunderstormIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherThunderstormIcon",
+    imports: [
+      "import BpkLargeWeatherThunderstormIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--thunderstorm';",
+    ],
+    example: figma.code`<BpkLargeWeatherThunderstormIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_262.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_262.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A255
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather--tornado.d.ts
+// component=BpkSmallWeatherTornadoIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherTornadoIcon",
+    imports: [
+      "import BpkSmallWeatherTornadoIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather--tornado';",
+    ],
+    example: figma.code`<BpkSmallWeatherTornadoIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherTornadoIcon",
+    imports: [
+      "import BpkLargeWeatherTornadoIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--tornado';",
+    ],
+    example: figma.code`<BpkLargeWeatherTornadoIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherTornadoIcon",
+    imports: [
+      "import BpkLargeWeatherTornadoIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--tornado';",
+    ],
+    example: figma.code`<BpkLargeWeatherTornadoIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_263.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_263.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A256
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/weather--wind.d.ts
+// component=BpkSmallWeatherWindIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWeatherWindIcon",
+    imports: [
+      "import BpkSmallWeatherWindIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/weather--wind';",
+    ],
+    example: figma.code`<BpkSmallWeatherWindIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWeatherWindIcon",
+    imports: [
+      "import BpkLargeWeatherWindIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--wind';",
+    ],
+    example: figma.code`<BpkLargeWeatherWindIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWeatherWindIcon",
+    imports: [
+      "import BpkLargeWeatherWindIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/weather--wind';",
+    ],
+    example: figma.code`<BpkLargeWeatherWindIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_264.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_264.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A258
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/wifi.d.ts
+// component=BpkSmallWifiIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWifiIcon",
+    imports: [
+      "import BpkSmallWifiIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/wifi';",
+    ],
+    example: figma.code`<BpkSmallWifiIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWifiIcon",
+    imports: [
+      "import BpkLargeWifiIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/wifi';",
+    ],
+    example: figma.code`<BpkLargeWifiIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWifiIcon",
+    imports: [
+      "import BpkLargeWifiIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/wifi';",
+    ],
+    example: figma.code`<BpkLargeWifiIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_265.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_265.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A259
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/window.d.ts
+// component=BpkSmallWindowIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWindowIcon",
+    imports: [
+      "import BpkSmallWindowIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/window';",
+    ],
+    example: figma.code`<BpkSmallWindowIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWindowIcon",
+    imports: [
+      "import BpkLargeWindowIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/window';",
+    ],
+    example: figma.code`<BpkLargeWindowIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWindowIcon",
+    imports: [
+      "import BpkLargeWindowIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/window';",
+    ],
+    example: figma.code`<BpkLargeWindowIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_266.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_266.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A260
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/window--reduce.d.ts
+// component=BpkSmallWindowReduceIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWindowReduceIcon",
+    imports: [
+      "import BpkSmallWindowReduceIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/window--reduce';",
+    ],
+    example: figma.code`<BpkSmallWindowReduceIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWindowReduceIcon",
+    imports: [
+      "import BpkLargeWindowReduceIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/window--reduce';",
+    ],
+    example: figma.code`<BpkLargeWindowReduceIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWindowReduceIcon",
+    imports: [
+      "import BpkLargeWindowReduceIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/window--reduce';",
+    ],
+    example: figma.code`<BpkLargeWindowReduceIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_267.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_267.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A261
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/world--amer.d.ts
+// component=BpkSmallWorldAmerIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWorldAmerIcon",
+    imports: [
+      "import BpkSmallWorldAmerIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/world--amer';",
+    ],
+    example: figma.code`<BpkSmallWorldAmerIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWorldAmerIcon",
+    imports: [
+      "import BpkLargeWorldAmerIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/world--amer';",
+    ],
+    example: figma.code`<BpkLargeWorldAmerIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWorldAmerIcon",
+    imports: [
+      "import BpkLargeWorldAmerIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/world--amer';",
+    ],
+    example: figma.code`<BpkLargeWorldAmerIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_268.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_268.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A262
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/world--apac.d.ts
+// component=BpkSmallWorldApacIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWorldApacIcon",
+    imports: [
+      "import BpkSmallWorldApacIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/world--apac';",
+    ],
+    example: figma.code`<BpkSmallWorldApacIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWorldApacIcon",
+    imports: [
+      "import BpkLargeWorldApacIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/world--apac';",
+    ],
+    example: figma.code`<BpkLargeWorldApacIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWorldApacIcon",
+    imports: [
+      "import BpkLargeWorldApacIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/world--apac';",
+    ],
+    example: figma.code`<BpkLargeWorldApacIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_269.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_269.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A263
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/world--emea.d.ts
+// component=BpkSmallWorldEmeaIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallWorldEmeaIcon",
+    imports: [
+      "import BpkSmallWorldEmeaIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/world--emea';",
+    ],
+    example: figma.code`<BpkSmallWorldEmeaIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeWorldEmeaIcon",
+    imports: [
+      "import BpkLargeWorldEmeaIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/world--emea';",
+    ],
+    example: figma.code`<BpkLargeWorldEmeaIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeWorldEmeaIcon",
+    imports: [
+      "import BpkLargeWorldEmeaIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/world--emea';",
+    ],
+    example: figma.code`<BpkLargeWorldEmeaIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_27.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_27.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=8308%3A195
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/baggage-cabin-not-included.d.ts
+// component=BpkSmallBaggageCabinNotIncludedIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBaggageCabinNotIncludedIcon",
+    imports: [
+      "import BpkSmallBaggageCabinNotIncludedIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baggage-cabin-not-included';",
+    ],
+    example: figma.code`<BpkSmallBaggageCabinNotIncludedIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBaggageCabinNotIncludedIcon",
+    imports: [
+      "import BpkLargeBaggageCabinNotIncludedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-cabin-not-included';",
+    ],
+    example: figma.code`<BpkLargeBaggageCabinNotIncludedIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBaggageCabinNotIncludedIcon",
+    imports: [
+      "import BpkLargeBaggageCabinNotIncludedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-cabin-not-included';",
+    ],
+    example: figma.code`<BpkLargeBaggageCabinNotIncludedIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_28.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_28.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=14620%3A307
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/baggage-cabin-uncertain.d.ts
+// component=BpkSmallBaggageCabinUncertainIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBaggageCabinUncertainIcon",
+    imports: [
+      "import BpkSmallBaggageCabinUncertainIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baggage-cabin-uncertain';",
+    ],
+    example: figma.code`<BpkSmallBaggageCabinUncertainIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBaggageCabinUncertainIcon",
+    imports: [
+      "import BpkLargeBaggageCabinUncertainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-cabin-uncertain';",
+    ],
+    example: figma.code`<BpkLargeBaggageCabinUncertainIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBaggageCabinUncertainIcon",
+    imports: [
+      "import BpkLargeBaggageCabinUncertainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-cabin-uncertain';",
+    ],
+    example: figma.code`<BpkLargeBaggageCabinUncertainIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_29.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_29.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=8308%3A189
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/baggage-checked.d.ts
+// component=BpkSmallBaggageCheckedIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBaggageCheckedIcon",
+    imports: [
+      "import BpkSmallBaggageCheckedIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baggage-checked';",
+    ],
+    example: figma.code`<BpkSmallBaggageCheckedIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBaggageCheckedIcon",
+    imports: [
+      "import BpkLargeBaggageCheckedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-checked';",
+    ],
+    example: figma.code`<BpkLargeBaggageCheckedIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBaggageCheckedIcon",
+    imports: [
+      "import BpkLargeBaggageCheckedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-checked';",
+    ],
+    example: figma.code`<BpkLargeBaggageCheckedIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_3.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_3.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A3
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/account--female.d.ts
+// component=BpkSmallAccountFemaleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAccountFemaleIcon",
+    imports: [
+      "import BpkSmallAccountFemaleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/account--female';",
+    ],
+    example: figma.code`<BpkSmallAccountFemaleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAccountFemaleIcon",
+    imports: [
+      "import BpkLargeAccountFemaleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--female';",
+    ],
+    example: figma.code`<BpkLargeAccountFemaleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAccountFemaleIcon",
+    imports: [
+      "import BpkLargeAccountFemaleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--female';",
+    ],
+    example: figma.code`<BpkLargeAccountFemaleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_30.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_30.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=14620%3A282
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/baggage-checked-not-included.d.ts
+// component=BpkSmallBaggageCheckedNotIncludedIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBaggageCheckedNotIncludedIcon",
+    imports: [
+      "import BpkSmallBaggageCheckedNotIncludedIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baggage-checked-not-included';",
+    ],
+    example: figma.code`<BpkSmallBaggageCheckedNotIncludedIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBaggageCheckedNotIncludedIcon",
+    imports: [
+      "import BpkLargeBaggageCheckedNotIncludedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-checked-not-included';",
+    ],
+    example: figma.code`<BpkLargeBaggageCheckedNotIncludedIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBaggageCheckedNotIncludedIcon",
+    imports: [
+      "import BpkLargeBaggageCheckedNotIncludedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-checked-not-included';",
+    ],
+    example: figma.code`<BpkLargeBaggageCheckedNotIncludedIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_31.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_31.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=14620%3A292
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/baggage-checked-uncertain.d.ts
+// component=BpkSmallBaggageCheckedUncertainIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBaggageCheckedUncertainIcon",
+    imports: [
+      "import BpkSmallBaggageCheckedUncertainIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baggage-checked-uncertain';",
+    ],
+    example: figma.code`<BpkSmallBaggageCheckedUncertainIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBaggageCheckedUncertainIcon",
+    imports: [
+      "import BpkLargeBaggageCheckedUncertainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-checked-uncertain';",
+    ],
+    example: figma.code`<BpkLargeBaggageCheckedUncertainIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBaggageCheckedUncertainIcon",
+    imports: [
+      "import BpkLargeBaggageCheckedUncertainIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-checked-uncertain';",
+    ],
+    example: figma.code`<BpkLargeBaggageCheckedUncertainIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_32.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_32.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=8308%3A192
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/baggage-generic.d.ts
+// component=BpkSmallBaggageGenericIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBaggageGenericIcon",
+    imports: [
+      "import BpkSmallBaggageGenericIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baggage-generic';",
+    ],
+    example: figma.code`<BpkSmallBaggageGenericIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBaggageGenericIcon",
+    imports: [
+      "import BpkLargeBaggageGenericIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-generic';",
+    ],
+    example: figma.code`<BpkLargeBaggageGenericIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBaggageGenericIcon",
+    imports: [
+      "import BpkLargeBaggageGenericIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-generic';",
+    ],
+    example: figma.code`<BpkLargeBaggageGenericIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_33.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_33.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=13288%3A33
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/baggage-personal-item.d.ts
+// component=BpkSmallBaggagePersonalItemIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBaggagePersonalItemIcon",
+    imports: [
+      "import BpkSmallBaggagePersonalItemIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/baggage-personal-item';",
+    ],
+    example: figma.code`<BpkSmallBaggagePersonalItemIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBaggagePersonalItemIcon",
+    imports: [
+      "import BpkLargeBaggagePersonalItemIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-personal-item';",
+    ],
+    example: figma.code`<BpkLargeBaggagePersonalItemIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBaggagePersonalItemIcon",
+    imports: [
+      "import BpkLargeBaggagePersonalItemIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/baggage-personal-item';",
+    ],
+    example: figma.code`<BpkLargeBaggagePersonalItemIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_34.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_34.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A30
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/bar.d.ts
+// component=BpkSmallBarIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBarIcon",
+    imports: [
+      "import BpkSmallBarIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/bar';",
+    ],
+    example: figma.code`<BpkSmallBarIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBarIcon",
+    imports: [
+      "import BpkLargeBarIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/bar';",
+    ],
+    example: figma.code`<BpkLargeBarIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBarIcon",
+    imports: [
+      "import BpkLargeBarIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/bar';",
+    ],
+    example: figma.code`<BpkLargeBarIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_35.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_35.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A31
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/beach.d.ts
+// component=BpkSmallBeachIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBeachIcon",
+    imports: [
+      "import BpkSmallBeachIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/beach';",
+    ],
+    example: figma.code`<BpkSmallBeachIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBeachIcon",
+    imports: [
+      "import BpkLargeBeachIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/beach';",
+    ],
+    example: figma.code`<BpkLargeBeachIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBeachIcon",
+    imports: [
+      "import BpkLargeBeachIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/beach';",
+    ],
+    example: figma.code`<BpkLargeBeachIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_36.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_36.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A32
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/beer.d.ts
+// component=BpkSmallBeerIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBeerIcon",
+    imports: [
+      "import BpkSmallBeerIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/beer';",
+    ],
+    example: figma.code`<BpkSmallBeerIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBeerIcon",
+    imports: [
+      "import BpkLargeBeerIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/beer';",
+    ],
+    example: figma.code`<BpkLargeBeerIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBeerIcon",
+    imports: [
+      "import BpkLargeBeerIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/beer';",
+    ],
+    example: figma.code`<BpkLargeBeerIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_37.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_37.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A33
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/breakfast-cross.d.ts
+// component=BpkSmallBreakfastCrossIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBreakfastCrossIcon",
+    imports: [
+      "import BpkSmallBreakfastCrossIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/breakfast-cross';",
+    ],
+    example: figma.code`<BpkSmallBreakfastCrossIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBreakfastCrossIcon",
+    imports: [
+      "import BpkLargeBreakfastCrossIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/breakfast-cross';",
+    ],
+    example: figma.code`<BpkLargeBreakfastCrossIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBreakfastCrossIcon",
+    imports: [
+      "import BpkLargeBreakfastCrossIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/breakfast-cross';",
+    ],
+    example: figma.code`<BpkLargeBreakfastCrossIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_38.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_38.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A34
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/breakfast-tick.d.ts
+// component=BpkSmallBreakfastTickIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBreakfastTickIcon",
+    imports: [
+      "import BpkSmallBreakfastTickIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/breakfast-tick';",
+    ],
+    example: figma.code`<BpkSmallBreakfastTickIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBreakfastTickIcon",
+    imports: [
+      "import BpkLargeBreakfastTickIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/breakfast-tick';",
+    ],
+    example: figma.code`<BpkLargeBreakfastTickIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBreakfastTickIcon",
+    imports: [
+      "import BpkLargeBreakfastTickIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/breakfast-tick';",
+    ],
+    example: figma.code`<BpkLargeBreakfastTickIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_39.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_39.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A35
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/bus.d.ts
+// component=BpkSmallBusIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBusIcon",
+    imports: [
+      "import BpkSmallBusIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/bus';",
+    ],
+    example: figma.code`<BpkSmallBusIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBusIcon",
+    imports: [
+      "import BpkLargeBusIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/bus';",
+    ],
+    example: figma.code`<BpkLargeBusIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBusIcon",
+    imports: [
+      "import BpkLargeBusIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/bus';",
+    ],
+    example: figma.code`<BpkLargeBusIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_4.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_4.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A4
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/account--id-card.d.ts
+// component=BpkSmallAccountIdCardIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAccountIdCardIcon",
+    imports: [
+      "import BpkSmallAccountIdCardIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/account--id-card';",
+    ],
+    example: figma.code`<BpkSmallAccountIdCardIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAccountIdCardIcon",
+    imports: [
+      "import BpkLargeAccountIdCardIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--id-card';",
+    ],
+    example: figma.code`<BpkLargeAccountIdCardIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAccountIdCardIcon",
+    imports: [
+      "import BpkLargeAccountIdCardIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--id-card';",
+    ],
+    example: figma.code`<BpkLargeAccountIdCardIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_40.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_40.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A36
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/business.d.ts
+// component=BpkSmallBusinessIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallBusinessIcon",
+    imports: [
+      "import BpkSmallBusinessIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/business';",
+    ],
+    example: figma.code`<BpkSmallBusinessIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeBusinessIcon",
+    imports: [
+      "import BpkLargeBusinessIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/business';",
+    ],
+    example: figma.code`<BpkLargeBusinessIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeBusinessIcon",
+    imports: [
+      "import BpkLargeBusinessIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/business';",
+    ],
+    example: figma.code`<BpkLargeBusinessIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_41.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_41.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A37
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/cafe.d.ts
+// component=BpkSmallCafeIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCafeIcon",
+    imports: [
+      "import BpkSmallCafeIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/cafe';",
+    ],
+    example: figma.code`<BpkSmallCafeIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCafeIcon",
+    imports: [
+      "import BpkLargeCafeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cafe';",
+    ],
+    example: figma.code`<BpkLargeCafeIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCafeIcon",
+    imports: [
+      "import BpkLargeCafeIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cafe';",
+    ],
+    example: figma.code`<BpkLargeCafeIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_42.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_42.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A38
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/calendar.d.ts
+// component=BpkSmallCalendarIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCalendarIcon",
+    imports: [
+      "import BpkSmallCalendarIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/calendar';",
+    ],
+    example: figma.code`<BpkSmallCalendarIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCalendarIcon",
+    imports: [
+      "import BpkLargeCalendarIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/calendar';",
+    ],
+    example: figma.code`<BpkLargeCalendarIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCalendarIcon",
+    imports: [
+      "import BpkLargeCalendarIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/calendar';",
+    ],
+    example: figma.code`<BpkLargeCalendarIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_43.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_43.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A39
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/call-back.d.ts
+// component=BpkSmallCallBackIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCallBackIcon",
+    imports: [
+      "import BpkSmallCallBackIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/call-back';",
+    ],
+    example: figma.code`<BpkSmallCallBackIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCallBackIcon",
+    imports: [
+      "import BpkLargeCallBackIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/call-back';",
+    ],
+    example: figma.code`<BpkLargeCallBackIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCallBackIcon",
+    imports: [
+      "import BpkLargeCallBackIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/call-back';",
+    ],
+    example: figma.code`<BpkLargeCallBackIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_44.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_44.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A40
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/camera.d.ts
+// component=BpkSmallCameraIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCameraIcon",
+    imports: [
+      "import BpkSmallCameraIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/camera';",
+    ],
+    example: figma.code`<BpkSmallCameraIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCameraIcon",
+    imports: [
+      "import BpkLargeCameraIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/camera';",
+    ],
+    example: figma.code`<BpkLargeCameraIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCameraIcon",
+    imports: [
+      "import BpkLargeCameraIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/camera';",
+    ],
+    example: figma.code`<BpkLargeCameraIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_45.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_45.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A41
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/camper-van.d.ts
+// component=BpkSmallCamperVanIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCamperVanIcon",
+    imports: [
+      "import BpkSmallCamperVanIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/camper-van';",
+    ],
+    example: figma.code`<BpkSmallCamperVanIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCamperVanIcon",
+    imports: [
+      "import BpkLargeCamperVanIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/camper-van';",
+    ],
+    example: figma.code`<BpkLargeCamperVanIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCamperVanIcon",
+    imports: [
+      "import BpkLargeCamperVanIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/camper-van';",
+    ],
+    example: figma.code`<BpkLargeCamperVanIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_46.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_46.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6570%3A102
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/car-door.d.ts
+// component=BpkSmallCarDoorIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCarDoorIcon",
+    imports: [
+      "import BpkSmallCarDoorIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/car-door';",
+    ],
+    example: figma.code`<BpkSmallCarDoorIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCarDoorIcon",
+    imports: [
+      "import BpkLargeCarDoorIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/car-door';",
+    ],
+    example: figma.code`<BpkLargeCarDoorIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCarDoorIcon",
+    imports: [
+      "import BpkLargeCarDoorIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/car-door';",
+    ],
+    example: figma.code`<BpkLargeCarDoorIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_47.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_47.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A42
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/car-wash.d.ts
+// component=BpkSmallCarWashIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCarWashIcon",
+    imports: [
+      "import BpkSmallCarWashIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/car-wash';",
+    ],
+    example: figma.code`<BpkSmallCarWashIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCarWashIcon",
+    imports: [
+      "import BpkLargeCarWashIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/car-wash';",
+    ],
+    example: figma.code`<BpkLargeCarWashIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCarWashIcon",
+    imports: [
+      "import BpkLargeCarWashIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/car-wash';",
+    ],
+    example: figma.code`<BpkLargeCarWashIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_48.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_48.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A43
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/cars.d.ts
+// component=BpkSmallCarsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCarsIcon",
+    imports: [
+      "import BpkSmallCarsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/cars';",
+    ],
+    example: figma.code`<BpkSmallCarsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCarsIcon",
+    imports: [
+      "import BpkLargeCarsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cars';",
+    ],
+    example: figma.code`<BpkLargeCarsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCarsIcon",
+    imports: [
+      "import BpkLargeCarsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cars';",
+    ],
+    example: figma.code`<BpkLargeCarsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_49.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_49.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A44
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/cars-flexible.d.ts
+// component=BpkSmallCarsFlexibleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCarsFlexibleIcon",
+    imports: [
+      "import BpkSmallCarsFlexibleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/cars-flexible';",
+    ],
+    example: figma.code`<BpkSmallCarsFlexibleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCarsFlexibleIcon",
+    imports: [
+      "import BpkLargeCarsFlexibleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cars-flexible';",
+    ],
+    example: figma.code`<BpkLargeCarsFlexibleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCarsFlexibleIcon",
+    imports: [
+      "import BpkLargeCarsFlexibleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cars-flexible';",
+    ],
+    example: figma.code`<BpkLargeCarsFlexibleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_5.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_5.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A5
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/account--name.d.ts
+// component=BpkSmallAccountNameIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAccountNameIcon",
+    imports: [
+      "import BpkSmallAccountNameIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/account--name';",
+    ],
+    example: figma.code`<BpkSmallAccountNameIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAccountNameIcon",
+    imports: [
+      "import BpkLargeAccountNameIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--name';",
+    ],
+    example: figma.code`<BpkLargeAccountNameIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAccountNameIcon",
+    imports: [
+      "import BpkLargeAccountNameIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--name';",
+    ],
+    example: figma.code`<BpkLargeAccountNameIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_50.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_50.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6482%3A45
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/center-location.d.ts
+// component=BpkSmallCenterLocationIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCenterLocationIcon",
+    imports: [
+      "import BpkSmallCenterLocationIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/center-location';",
+    ],
+    example: figma.code`<BpkSmallCenterLocationIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCenterLocationIcon",
+    imports: [
+      "import BpkLargeCenterLocationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/center-location';",
+    ],
+    example: figma.code`<BpkLargeCenterLocationIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCenterLocationIcon",
+    imports: [
+      "import BpkLargeCenterLocationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/center-location';",
+    ],
+    example: figma.code`<BpkLargeCenterLocationIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_51.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_51.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A45
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/chart.d.ts
+// component=BpkSmallChartIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallChartIcon",
+    imports: [
+      "import BpkSmallChartIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/chart';",
+    ],
+    example: figma.code`<BpkSmallChartIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeChartIcon",
+    imports: [
+      "import BpkLargeChartIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chart';",
+    ],
+    example: figma.code`<BpkLargeChartIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeChartIcon",
+    imports: [
+      "import BpkLargeChartIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chart';",
+    ],
+    example: figma.code`<BpkLargeChartIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_52.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_52.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A46
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/chauffeur.d.ts
+// component=BpkSmallChauffeurIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallChauffeurIcon",
+    imports: [
+      "import BpkSmallChauffeurIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/chauffeur';",
+    ],
+    example: figma.code`<BpkSmallChauffeurIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeChauffeurIcon",
+    imports: [
+      "import BpkLargeChauffeurIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chauffeur';",
+    ],
+    example: figma.code`<BpkLargeChauffeurIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeChauffeurIcon",
+    imports: [
+      "import BpkLargeChauffeurIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chauffeur';",
+    ],
+    example: figma.code`<BpkLargeChauffeurIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_53.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_53.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A52
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/chevron-down.d.ts
+// component=BpkSmallChevronDownIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallChevronDownIcon",
+    imports: [
+      "import BpkSmallChevronDownIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/chevron-down';",
+    ],
+    example: figma.code`<BpkSmallChevronDownIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeChevronDownIcon",
+    imports: [
+      "import BpkLargeChevronDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chevron-down';",
+    ],
+    example: figma.code`<BpkLargeChevronDownIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeChevronDownIcon",
+    imports: [
+      "import BpkLargeChevronDownIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chevron-down';",
+    ],
+    example: figma.code`<BpkLargeChevronDownIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_54.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_54.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A53
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/chevron-left.d.ts
+// component=BpkSmallChevronLeftIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallChevronLeftIcon",
+    imports: [
+      "import BpkSmallChevronLeftIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/chevron-left';",
+    ],
+    example: figma.code`<BpkSmallChevronLeftIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeChevronLeftIcon",
+    imports: [
+      "import BpkLargeChevronLeftIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chevron-left';",
+    ],
+    example: figma.code`<BpkLargeChevronLeftIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeChevronLeftIcon",
+    imports: [
+      "import BpkLargeChevronLeftIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chevron-left';",
+    ],
+    example: figma.code`<BpkLargeChevronLeftIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_55.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_55.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A54
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/chevron-right.d.ts
+// component=BpkSmallChevronRightIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallChevronRightIcon",
+    imports: [
+      "import BpkSmallChevronRightIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/chevron-right';",
+    ],
+    example: figma.code`<BpkSmallChevronRightIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeChevronRightIcon",
+    imports: [
+      "import BpkLargeChevronRightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chevron-right';",
+    ],
+    example: figma.code`<BpkLargeChevronRightIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeChevronRightIcon",
+    imports: [
+      "import BpkLargeChevronRightIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chevron-right';",
+    ],
+    example: figma.code`<BpkLargeChevronRightIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_56.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_56.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A55
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/chevron-up.d.ts
+// component=BpkSmallChevronUpIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallChevronUpIcon",
+    imports: [
+      "import BpkSmallChevronUpIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/chevron-up';",
+    ],
+    example: figma.code`<BpkSmallChevronUpIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeChevronUpIcon",
+    imports: [
+      "import BpkLargeChevronUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chevron-up';",
+    ],
+    example: figma.code`<BpkLargeChevronUpIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeChevronUpIcon",
+    imports: [
+      "import BpkLargeChevronUpIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/chevron-up';",
+    ],
+    example: figma.code`<BpkLargeChevronUpIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_57.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_57.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A56
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/child.d.ts
+// component=BpkSmallChildIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallChildIcon",
+    imports: [
+      "import BpkSmallChildIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/child';",
+    ],
+    example: figma.code`<BpkSmallChildIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeChildIcon",
+    imports: [
+      "import BpkLargeChildIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/child';",
+    ],
+    example: figma.code`<BpkLargeChildIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeChildIcon",
+    imports: [
+      "import BpkLargeChildIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/child';",
+    ],
+    example: figma.code`<BpkLargeChildIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_58.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_58.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A57
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/child-seat.d.ts
+// component=BpkSmallChildSeatIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallChildSeatIcon",
+    imports: [
+      "import BpkSmallChildSeatIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/child-seat';",
+    ],
+    example: figma.code`<BpkSmallChildSeatIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeChildSeatIcon",
+    imports: [
+      "import BpkLargeChildSeatIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/child-seat';",
+    ],
+    example: figma.code`<BpkLargeChildSeatIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeChildSeatIcon",
+    imports: [
+      "import BpkLargeChildSeatIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/child-seat';",
+    ],
+    example: figma.code`<BpkLargeChildSeatIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_59.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_59.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A58
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/city.d.ts
+// component=BpkSmallCityIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCityIcon",
+    imports: [
+      "import BpkSmallCityIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/city';",
+    ],
+    example: figma.code`<BpkSmallCityIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCityIcon",
+    imports: [
+      "import BpkLargeCityIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/city';",
+    ],
+    example: figma.code`<BpkLargeCityIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCityIcon",
+    imports: [
+      "import BpkLargeCityIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/city';",
+    ],
+    example: figma.code`<BpkLargeCityIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_6.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_6.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A6
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/account--permit.d.ts
+// component=BpkSmallAccountPermitIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAccountPermitIcon",
+    imports: [
+      "import BpkSmallAccountPermitIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/account--permit';",
+    ],
+    example: figma.code`<BpkSmallAccountPermitIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAccountPermitIcon",
+    imports: [
+      "import BpkLargeAccountPermitIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--permit';",
+    ],
+    example: figma.code`<BpkLargeAccountPermitIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAccountPermitIcon",
+    imports: [
+      "import BpkLargeAccountPermitIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account--permit';",
+    ],
+    example: figma.code`<BpkLargeAccountPermitIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_60.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_60.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A59
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/city-center.d.ts
+// component=BpkSmallCityCenterIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCityCenterIcon",
+    imports: [
+      "import BpkSmallCityCenterIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/city-center';",
+    ],
+    example: figma.code`<BpkSmallCityCenterIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCityCenterIcon",
+    imports: [
+      "import BpkLargeCityCenterIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/city-center';",
+    ],
+    example: figma.code`<BpkLargeCityCenterIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCityCenterIcon",
+    imports: [
+      "import BpkLargeCityCenterIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/city-center';",
+    ],
+    example: figma.code`<BpkLargeCityCenterIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_61.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_61.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A60
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/clean.d.ts
+// component=BpkSmallCleanIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCleanIcon",
+    imports: [
+      "import BpkSmallCleanIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/clean';",
+    ],
+    example: figma.code`<BpkSmallCleanIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCleanIcon",
+    imports: [
+      "import BpkLargeCleanIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/clean';",
+    ],
+    example: figma.code`<BpkLargeCleanIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCleanIcon",
+    imports: [
+      "import BpkLargeCleanIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/clean';",
+    ],
+    example: figma.code`<BpkLargeCleanIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_62.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_62.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A61
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/clean-policy.d.ts
+// component=BpkSmallCleanPolicyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCleanPolicyIcon",
+    imports: [
+      "import BpkSmallCleanPolicyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/clean-policy';",
+    ],
+    example: figma.code`<BpkSmallCleanPolicyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCleanPolicyIcon",
+    imports: [
+      "import BpkLargeCleanPolicyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/clean-policy';",
+    ],
+    example: figma.code`<BpkLargeCleanPolicyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCleanPolicyIcon",
+    imports: [
+      "import BpkLargeCleanPolicyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/clean-policy';",
+    ],
+    example: figma.code`<BpkLargeCleanPolicyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_63.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_63.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A62
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/cleaning-medical.d.ts
+// component=BpkSmallCleaningMedicalIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCleaningMedicalIcon",
+    imports: [
+      "import BpkSmallCleaningMedicalIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/cleaning-medical';",
+    ],
+    example: figma.code`<BpkSmallCleaningMedicalIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCleaningMedicalIcon",
+    imports: [
+      "import BpkLargeCleaningMedicalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cleaning-medical';",
+    ],
+    example: figma.code`<BpkLargeCleaningMedicalIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCleaningMedicalIcon",
+    imports: [
+      "import BpkLargeCleaningMedicalIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cleaning-medical';",
+    ],
+    example: figma.code`<BpkLargeCleaningMedicalIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_64.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_64.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A63
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/cloakroom.d.ts
+// component=BpkSmallCloakroomIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCloakroomIcon",
+    imports: [
+      "import BpkSmallCloakroomIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/cloakroom';",
+    ],
+    example: figma.code`<BpkSmallCloakroomIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCloakroomIcon",
+    imports: [
+      "import BpkLargeCloakroomIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cloakroom';",
+    ],
+    example: figma.code`<BpkLargeCloakroomIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCloakroomIcon",
+    imports: [
+      "import BpkLargeCloakroomIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/cloakroom';",
+    ],
+    example: figma.code`<BpkLargeCloakroomIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_65.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_65.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A64
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/close.d.ts
+// component=BpkSmallCloseIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCloseIcon",
+    imports: [
+      "import BpkSmallCloseIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/close';",
+    ],
+    example: figma.code`<BpkSmallCloseIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCloseIcon",
+    imports: [
+      "import BpkLargeCloseIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/close';",
+    ],
+    example: figma.code`<BpkLargeCloseIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCloseIcon",
+    imports: [
+      "import BpkLargeCloseIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/close';",
+    ],
+    example: figma.code`<BpkLargeCloseIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_66.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_66.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A65
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/close-circle.d.ts
+// component=BpkSmallCloseCircleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCloseCircleIcon",
+    imports: [
+      "import BpkSmallCloseCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/close-circle';",
+    ],
+    example: figma.code`<BpkSmallCloseCircleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCloseCircleIcon",
+    imports: [
+      "import BpkLargeCloseCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/close-circle';",
+    ],
+    example: figma.code`<BpkLargeCloseCircleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCloseCircleIcon",
+    imports: [
+      "import BpkLargeCloseCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/close-circle';",
+    ],
+    example: figma.code`<BpkLargeCloseCircleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_67.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_67.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A66
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/collapse.d.ts
+// component=BpkSmallCollapseIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCollapseIcon",
+    imports: [
+      "import BpkSmallCollapseIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/collapse';",
+    ],
+    example: figma.code`<BpkSmallCollapseIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCollapseIcon",
+    imports: [
+      "import BpkLargeCollapseIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/collapse';",
+    ],
+    example: figma.code`<BpkLargeCollapseIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCollapseIcon",
+    imports: [
+      "import BpkLargeCollapseIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/collapse';",
+    ],
+    example: figma.code`<BpkLargeCollapseIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_68.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_68.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A67
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/content--copy.d.ts
+// component=BpkSmallContentCopyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallContentCopyIcon",
+    imports: [
+      "import BpkSmallContentCopyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/content--copy';",
+    ],
+    example: figma.code`<BpkSmallContentCopyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeContentCopyIcon",
+    imports: [
+      "import BpkLargeContentCopyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/content--copy';",
+    ],
+    example: figma.code`<BpkLargeContentCopyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeContentCopyIcon",
+    imports: [
+      "import BpkLargeContentCopyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/content--copy';",
+    ],
+    example: figma.code`<BpkLargeContentCopyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_69.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_69.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A68
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/content--event.d.ts
+// component=BpkSmallContentEventIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallContentEventIcon",
+    imports: [
+      "import BpkSmallContentEventIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/content--event';",
+    ],
+    example: figma.code`<BpkSmallContentEventIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeContentEventIcon",
+    imports: [
+      "import BpkLargeContentEventIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/content--event';",
+    ],
+    example: figma.code`<BpkLargeContentEventIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeContentEventIcon",
+    imports: [
+      "import BpkLargeContentEventIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/content--event';",
+    ],
+    example: figma.code`<BpkLargeContentEventIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_7.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_7.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A7
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/account-circle.d.ts
+// component=BpkSmallAccountCircleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAccountCircleIcon",
+    imports: [
+      "import BpkSmallAccountCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/account-circle';",
+    ],
+    example: figma.code`<BpkSmallAccountCircleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAccountCircleIcon",
+    imports: [
+      "import BpkLargeAccountCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account-circle';",
+    ],
+    example: figma.code`<BpkLargeAccountCircleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAccountCircleIcon",
+    imports: [
+      "import BpkLargeAccountCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/account-circle';",
+    ],
+    example: figma.code`<BpkLargeAccountCircleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_70.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_70.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A69
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/content--guides.d.ts
+// component=BpkSmallContentGuidesIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallContentGuidesIcon",
+    imports: [
+      "import BpkSmallContentGuidesIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/content--guides';",
+    ],
+    example: figma.code`<BpkSmallContentGuidesIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeContentGuidesIcon",
+    imports: [
+      "import BpkLargeContentGuidesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/content--guides';",
+    ],
+    example: figma.code`<BpkLargeContentGuidesIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeContentGuidesIcon",
+    imports: [
+      "import BpkLargeContentGuidesIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/content--guides';",
+    ],
+    example: figma.code`<BpkLargeContentGuidesIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_71.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_71.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A70
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/currency.d.ts
+// component=BpkSmallCurrencyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallCurrencyIcon",
+    imports: [
+      "import BpkSmallCurrencyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/currency';",
+    ],
+    example: figma.code`<BpkSmallCurrencyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeCurrencyIcon",
+    imports: [
+      "import BpkLargeCurrencyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/currency';",
+    ],
+    example: figma.code`<BpkLargeCurrencyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeCurrencyIcon",
+    imports: [
+      "import BpkLargeCurrencyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/currency';",
+    ],
+    example: figma.code`<BpkLargeCurrencyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_72.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_72.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A71
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/data.d.ts
+// component=BpkSmallDataIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDataIcon",
+    imports: [
+      "import BpkSmallDataIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/data';",
+    ],
+    example: figma.code`<BpkSmallDataIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDataIcon",
+    imports: [
+      "import BpkLargeDataIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/data';",
+    ],
+    example: figma.code`<BpkLargeDataIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDataIcon",
+    imports: [
+      "import BpkLargeDataIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/data';",
+    ],
+    example: figma.code`<BpkLargeDataIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_73.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_73.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A72
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/deals.d.ts
+// component=BpkSmallDealsIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDealsIcon",
+    imports: [
+      "import BpkSmallDealsIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/deals';",
+    ],
+    example: figma.code`<BpkSmallDealsIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDealsIcon",
+    imports: [
+      "import BpkLargeDealsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/deals';",
+    ],
+    example: figma.code`<BpkLargeDealsIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDealsIcon",
+    imports: [
+      "import BpkLargeDealsIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/deals';",
+    ],
+    example: figma.code`<BpkLargeDealsIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_74.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_74.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A73
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/depart.d.ts
+// component=BpkSmallDepartIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDepartIcon",
+    imports: [
+      "import BpkSmallDepartIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/depart';",
+    ],
+    example: figma.code`<BpkSmallDepartIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDepartIcon",
+    imports: [
+      "import BpkLargeDepartIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/depart';",
+    ],
+    example: figma.code`<BpkLargeDepartIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDepartIcon",
+    imports: [
+      "import BpkLargeDepartIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/depart';",
+    ],
+    example: figma.code`<BpkLargeDepartIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_75.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_75.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A74
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/device-mid.d.ts
+// component=BpkSmallDeviceMidIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDeviceMidIcon",
+    imports: [
+      "import BpkSmallDeviceMidIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/device-mid';",
+    ],
+    example: figma.code`<BpkSmallDeviceMidIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDeviceMidIcon",
+    imports: [
+      "import BpkLargeDeviceMidIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/device-mid';",
+    ],
+    example: figma.code`<BpkLargeDeviceMidIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDeviceMidIcon",
+    imports: [
+      "import BpkLargeDeviceMidIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/device-mid';",
+    ],
+    example: figma.code`<BpkLargeDeviceMidIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_76.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_76.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A75
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/device-wide.d.ts
+// component=BpkSmallDeviceWideIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDeviceWideIcon",
+    imports: [
+      "import BpkSmallDeviceWideIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/device-wide';",
+    ],
+    example: figma.code`<BpkSmallDeviceWideIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDeviceWideIcon",
+    imports: [
+      "import BpkLargeDeviceWideIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/device-wide';",
+    ],
+    example: figma.code`<BpkLargeDeviceWideIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDeviceWideIcon",
+    imports: [
+      "import BpkLargeDeviceWideIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/device-wide';",
+    ],
+    example: figma.code`<BpkLargeDeviceWideIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_77.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_77.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A76
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/direct.d.ts
+// component=BpkSmallDirectIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDirectIcon",
+    imports: [
+      "import BpkSmallDirectIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/direct';",
+    ],
+    example: figma.code`<BpkSmallDirectIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDirectIcon",
+    imports: [
+      "import BpkLargeDirectIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/direct';",
+    ],
+    example: figma.code`<BpkLargeDirectIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDirectIcon",
+    imports: [
+      "import BpkLargeDirectIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/direct';",
+    ],
+    example: figma.code`<BpkLargeDirectIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_78.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_78.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A77
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/document-csv.d.ts
+// component=BpkSmallDocumentCsvIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDocumentCsvIcon",
+    imports: [
+      "import BpkSmallDocumentCsvIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/document-csv';",
+    ],
+    example: figma.code`<BpkSmallDocumentCsvIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDocumentCsvIcon",
+    imports: [
+      "import BpkLargeDocumentCsvIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/document-csv';",
+    ],
+    example: figma.code`<BpkLargeDocumentCsvIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDocumentCsvIcon",
+    imports: [
+      "import BpkLargeDocumentCsvIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/document-csv';",
+    ],
+    example: figma.code`<BpkLargeDocumentCsvIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_79.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_79.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A78
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/document-pdf.d.ts
+// component=BpkSmallDocumentPdfIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDocumentPdfIcon",
+    imports: [
+      "import BpkSmallDocumentPdfIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/document-pdf';",
+    ],
+    example: figma.code`<BpkSmallDocumentPdfIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDocumentPdfIcon",
+    imports: [
+      "import BpkLargeDocumentPdfIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/document-pdf';",
+    ],
+    example: figma.code`<BpkLargeDocumentPdfIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDocumentPdfIcon",
+    imports: [
+      "import BpkLargeDocumentPdfIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/document-pdf';",
+    ],
+    example: figma.code`<BpkLargeDocumentPdfIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_8.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_8.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A8
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/add-circle.d.ts
+// component=BpkSmallAddCircleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAddCircleIcon",
+    imports: [
+      "import BpkSmallAddCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/add-circle';",
+    ],
+    example: figma.code`<BpkSmallAddCircleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAddCircleIcon",
+    imports: [
+      "import BpkLargeAddCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/add-circle';",
+    ],
+    example: figma.code`<BpkLargeAddCircleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAddCircleIcon",
+    imports: [
+      "import BpkLargeAddCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/add-circle';",
+    ],
+    example: figma.code`<BpkLargeAddCircleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_80.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_80.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=11818%3A15
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/dot.d.ts
+// component=BpkSmallDotIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDotIcon",
+    imports: [
+      "import BpkSmallDotIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/dot';",
+    ],
+    example: figma.code`<BpkSmallDotIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDotIcon",
+    imports: [
+      "import BpkLargeDotIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/dot';",
+    ],
+    example: figma.code`<BpkLargeDotIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDotIcon",
+    imports: [
+      "import BpkLargeDotIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/dot';",
+    ],
+    example: figma.code`<BpkLargeDotIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_81.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_81.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A79
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/download.d.ts
+// component=BpkSmallDownloadIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDownloadIcon",
+    imports: [
+      "import BpkSmallDownloadIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/download';",
+    ],
+    example: figma.code`<BpkSmallDownloadIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDownloadIcon",
+    imports: [
+      "import BpkLargeDownloadIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/download';",
+    ],
+    example: figma.code`<BpkLargeDownloadIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDownloadIcon",
+    imports: [
+      "import BpkLargeDownloadIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/download';",
+    ],
+    example: figma.code`<BpkLargeDownloadIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_82.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_82.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A80
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/duration.d.ts
+// component=BpkSmallDurationIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallDurationIcon",
+    imports: [
+      "import BpkSmallDurationIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/duration';",
+    ],
+    example: figma.code`<BpkSmallDurationIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeDurationIcon",
+    imports: [
+      "import BpkLargeDurationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/duration';",
+    ],
+    example: figma.code`<BpkLargeDurationIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeDurationIcon",
+    imports: [
+      "import BpkLargeDurationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/duration';",
+    ],
+    example: figma.code`<BpkLargeDurationIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_83.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_83.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A81
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/eco-leaf.d.ts
+// component=BpkSmallEcoLeafIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallEcoLeafIcon",
+    imports: [
+      "import BpkSmallEcoLeafIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/eco-leaf';",
+    ],
+    example: figma.code`<BpkSmallEcoLeafIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeEcoLeafIcon",
+    imports: [
+      "import BpkLargeEcoLeafIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/eco-leaf';",
+    ],
+    example: figma.code`<BpkLargeEcoLeafIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeEcoLeafIcon",
+    imports: [
+      "import BpkLargeEcoLeafIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/eco-leaf';",
+    ],
+    example: figma.code`<BpkLargeEcoLeafIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_84.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_84.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A82
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/edit.d.ts
+// component=BpkSmallEditIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallEditIcon",
+    imports: [
+      "import BpkSmallEditIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/edit';",
+    ],
+    example: figma.code`<BpkSmallEditIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeEditIcon",
+    imports: [
+      "import BpkLargeEditIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/edit';",
+    ],
+    example: figma.code`<BpkLargeEditIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeEditIcon",
+    imports: [
+      "import BpkLargeEditIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/edit';",
+    ],
+    example: figma.code`<BpkLargeEditIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_85.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_85.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A83
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/education.d.ts
+// component=BpkSmallEducationIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallEducationIcon",
+    imports: [
+      "import BpkSmallEducationIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/education';",
+    ],
+    example: figma.code`<BpkSmallEducationIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeEducationIcon",
+    imports: [
+      "import BpkLargeEducationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/education';",
+    ],
+    example: figma.code`<BpkLargeEducationIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeEducationIcon",
+    imports: [
+      "import BpkLargeEducationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/education';",
+    ],
+    example: figma.code`<BpkLargeEducationIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_86.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_86.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A84
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/electric.d.ts
+// component=BpkSmallElectricIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallElectricIcon",
+    imports: [
+      "import BpkSmallElectricIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/electric';",
+    ],
+    example: figma.code`<BpkSmallElectricIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeElectricIcon",
+    imports: [
+      "import BpkLargeElectricIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/electric';",
+    ],
+    example: figma.code`<BpkLargeElectricIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeElectricIcon",
+    imports: [
+      "import BpkLargeElectricIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/electric';",
+    ],
+    example: figma.code`<BpkLargeElectricIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_87.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_87.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A85
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/end-call.d.ts
+// component=BpkSmallEndCallIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallEndCallIcon",
+    imports: [
+      "import BpkSmallEndCallIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/end-call';",
+    ],
+    example: figma.code`<BpkSmallEndCallIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeEndCallIcon",
+    imports: [
+      "import BpkLargeEndCallIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/end-call';",
+    ],
+    example: figma.code`<BpkLargeEndCallIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeEndCallIcon",
+    imports: [
+      "import BpkLargeEndCallIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/end-call';",
+    ],
+    example: figma.code`<BpkLargeEndCallIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_88.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_88.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A86
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/estimated.d.ts
+// component=BpkSmallEstimatedIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallEstimatedIcon",
+    imports: [
+      "import BpkSmallEstimatedIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/estimated';",
+    ],
+    example: figma.code`<BpkSmallEstimatedIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeEstimatedIcon",
+    imports: [
+      "import BpkLargeEstimatedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/estimated';",
+    ],
+    example: figma.code`<BpkLargeEstimatedIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeEstimatedIcon",
+    imports: [
+      "import BpkLargeEstimatedIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/estimated';",
+    ],
+    example: figma.code`<BpkLargeEstimatedIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_89.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_89.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A87
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/exclamation.d.ts
+// component=BpkSmallExclamationIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallExclamationIcon",
+    imports: [
+      "import BpkSmallExclamationIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/exclamation';",
+    ],
+    example: figma.code`<BpkSmallExclamationIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeExclamationIcon",
+    imports: [
+      "import BpkLargeExclamationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/exclamation';",
+    ],
+    example: figma.code`<BpkLargeExclamationIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeExclamationIcon",
+    imports: [
+      "import BpkLargeExclamationIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/exclamation';",
+    ],
+    example: figma.code`<BpkLargeExclamationIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_9.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_9.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A9
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/adult.d.ts
+// component=BpkSmallAdultIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallAdultIcon",
+    imports: [
+      "import BpkSmallAdultIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/adult';",
+    ],
+    example: figma.code`<BpkSmallAdultIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeAdultIcon",
+    imports: [
+      "import BpkLargeAdultIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/adult';",
+    ],
+    example: figma.code`<BpkLargeAdultIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeAdultIcon",
+    imports: [
+      "import BpkLargeAdultIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/adult';",
+    ],
+    example: figma.code`<BpkLargeAdultIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_90.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_90.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A88
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/exclamation-circle.d.ts
+// component=BpkSmallExclamationCircleIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallExclamationCircleIcon",
+    imports: [
+      "import BpkSmallExclamationCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/exclamation-circle';",
+    ],
+    example: figma.code`<BpkSmallExclamationCircleIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeExclamationCircleIcon",
+    imports: [
+      "import BpkLargeExclamationCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/exclamation-circle';",
+    ],
+    example: figma.code`<BpkLargeExclamationCircleIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeExclamationCircleIcon",
+    imports: [
+      "import BpkLargeExclamationCircleIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/exclamation-circle';",
+    ],
+    example: figma.code`<BpkLargeExclamationCircleIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_91.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_91.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A89
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/expand.d.ts
+// component=BpkSmallExpandIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallExpandIcon",
+    imports: [
+      "import BpkSmallExpandIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/expand';",
+    ],
+    example: figma.code`<BpkSmallExpandIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeExpandIcon",
+    imports: [
+      "import BpkLargeExpandIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/expand';",
+    ],
+    example: figma.code`<BpkLargeExpandIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeExpandIcon",
+    imports: [
+      "import BpkLargeExpandIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/expand';",
+    ],
+    example: figma.code`<BpkLargeExpandIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_92.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_92.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A90
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/explore.d.ts
+// component=BpkSmallExploreIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallExploreIcon",
+    imports: [
+      "import BpkSmallExploreIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/explore';",
+    ],
+    example: figma.code`<BpkSmallExploreIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeExploreIcon",
+    imports: [
+      "import BpkLargeExploreIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/explore';",
+    ],
+    example: figma.code`<BpkLargeExploreIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeExploreIcon",
+    imports: [
+      "import BpkLargeExploreIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/explore';",
+    ],
+    example: figma.code`<BpkLargeExploreIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_93.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_93.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A91
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/face--blank.d.ts
+// component=BpkSmallFaceBlankIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFaceBlankIcon",
+    imports: [
+      "import BpkSmallFaceBlankIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/face--blank';",
+    ],
+    example: figma.code`<BpkSmallFaceBlankIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFaceBlankIcon",
+    imports: [
+      "import BpkLargeFaceBlankIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face--blank';",
+    ],
+    example: figma.code`<BpkLargeFaceBlankIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFaceBlankIcon",
+    imports: [
+      "import BpkLargeFaceBlankIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face--blank';",
+    ],
+    example: figma.code`<BpkLargeFaceBlankIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_94.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_94.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A92
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/face--happy.d.ts
+// component=BpkSmallFaceHappyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFaceHappyIcon",
+    imports: [
+      "import BpkSmallFaceHappyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/face--happy';",
+    ],
+    example: figma.code`<BpkSmallFaceHappyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFaceHappyIcon",
+    imports: [
+      "import BpkLargeFaceHappyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face--happy';",
+    ],
+    example: figma.code`<BpkLargeFaceHappyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFaceHappyIcon",
+    imports: [
+      "import BpkLargeFaceHappyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face--happy';",
+    ],
+    example: figma.code`<BpkLargeFaceHappyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_95.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_95.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A93
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/face-id.d.ts
+// component=BpkSmallFaceIdIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFaceIdIcon",
+    imports: [
+      "import BpkSmallFaceIdIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/face-id';",
+    ],
+    example: figma.code`<BpkSmallFaceIdIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFaceIdIcon",
+    imports: [
+      "import BpkLargeFaceIdIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face-id';",
+    ],
+    example: figma.code`<BpkLargeFaceIdIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFaceIdIcon",
+    imports: [
+      "import BpkLargeFaceIdIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face-id';",
+    ],
+    example: figma.code`<BpkLargeFaceIdIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_96.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_96.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A94
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/face-mask.d.ts
+// component=BpkSmallFaceMaskIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFaceMaskIcon",
+    imports: [
+      "import BpkSmallFaceMaskIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/face-mask';",
+    ],
+    example: figma.code`<BpkSmallFaceMaskIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFaceMaskIcon",
+    imports: [
+      "import BpkLargeFaceMaskIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face-mask';",
+    ],
+    example: figma.code`<BpkLargeFaceMaskIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFaceMaskIcon",
+    imports: [
+      "import BpkLargeFaceMaskIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face-mask';",
+    ],
+    example: figma.code`<BpkLargeFaceMaskIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_97.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_97.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A95
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/face--sad.d.ts
+// component=BpkSmallFaceSadIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFaceSadIcon",
+    imports: [
+      "import BpkSmallFaceSadIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/face--sad';",
+    ],
+    example: figma.code`<BpkSmallFaceSadIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFaceSadIcon",
+    imports: [
+      "import BpkLargeFaceSadIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face--sad';",
+    ],
+    example: figma.code`<BpkLargeFaceSadIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFaceSadIcon",
+    imports: [
+      "import BpkLargeFaceSadIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/face--sad';",
+    ],
+    example: figma.code`<BpkLargeFaceSadIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_98.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_98.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A96
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/family.d.ts
+// component=BpkSmallFamilyIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFamilyIcon",
+    imports: [
+      "import BpkSmallFamilyIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/family';",
+    ],
+    example: figma.code`<BpkSmallFamilyIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFamilyIcon",
+    imports: [
+      "import BpkLargeFamilyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/family';",
+    ],
+    example: figma.code`<BpkLargeFamilyIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFamilyIcon",
+    imports: [
+      "import BpkLargeFamilyIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/family';",
+    ],
+    example: figma.code`<BpkLargeFamilyIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-icon/BpkIcon_99.figma.ts
+++ b/packages/backpack-web/src/bpk-component-icon/BpkIcon_99.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/I9hynSlX2wyrlhceZr7z1u/Backpack-Icons?node-id=6033%3A97
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-icon/sm/fast-track.d.ts
+// component=BpkSmallFastTrackIcon
+
+import figma from "figma"
+
+// Branch per variant; no default, else first.
+
+let template
+if (figma.selectedInstance.getPropertyValue("Size") === "16") {
+  template = {
+    id: "BpkSmallFastTrackIcon",
+    imports: [
+      "import BpkSmallFastTrackIcon from '@skyscanner/backpack-web/bpk-component-icon/sm/fast-track';",
+    ],
+    example: figma.code`<BpkSmallFastTrackIcon />`,
+  }
+} else if (figma.selectedInstance.getPropertyValue("Size") === "24") {
+  template = {
+    id: "BpkLargeFastTrackIcon",
+    imports: [
+      "import BpkLargeFastTrackIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/fast-track';",
+    ],
+    example: figma.code`<BpkLargeFastTrackIcon />`,
+  }
+} else {
+  template = {
+    id: "BpkLargeFastTrackIcon",
+    imports: [
+      "import BpkLargeFastTrackIcon from '@skyscanner/backpack-web/bpk-component-icon/lg/fast-track';",
+    ],
+    example: figma.code`<BpkLargeFastTrackIcon />`,
+  }
+}
+
+export default template

--- a/packages/backpack-web/src/bpk-component-image/src/BpkImage.figma.ts
+++ b/packages/backpack-web/src/bpk-component-image/src/BpkImage.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A6138
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-image/src/BpkImage.tsx
+// component=BpkImage
+
+import figma from "figma"
+
+export default {
+  id: "BpkImage",
+  imports: [
+    "import BpkImage from '@skyscanner/backpack-web/bpk-component-image';",
+  ],
+  example: figma.code`<BpkImage altText="" src="" aspectRatio={16 / 9}/>`,
+}

--- a/packages/backpack-web/src/bpk-component-info-banner/src/BpkInfoBanner.figma.ts
+++ b/packages/backpack-web/src/bpk-component-info-banner/src/BpkInfoBanner.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10885%3A6578
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-info-banner/src/BpkInfoBanner.tsx
+// component=BpkInfoBanner
+
+import figma from "figma"
+
+export default {
+  id: "BpkInfoBanner",
+  imports: [
+    "import BpkInfoBanner from '@skyscanner/backpack-web/bpk-component-info-banner';",
+  ],
+  example: figma.code`<BpkInfoBanner />`,
+}

--- a/packages/backpack-web/src/bpk-component-input/src/BpkInput.figma.ts
+++ b/packages/backpack-web/src/bpk-component-input/src/BpkInput.figma.ts
@@ -1,0 +1,37 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A5030
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-input/src/BpkInput.tsx
+// component=BpkInput
+
+import figma from "figma"
+
+const large = figma.selectedInstance.getEnum("Size", {
+  Default: false,
+  Large: true,
+})
+const dockedFirst = figma.selectedInstance.getEnum("Docking", {
+  Left: true,
+})
+const dockedMiddle = figma.selectedInstance.getEnum("Docking", {
+  Centre: true,
+})
+const dockedLast = figma.selectedInstance.getEnum("Docking", {
+  Right: true,
+})
+
+export default {
+  id: "BpkInput",
+  imports: [
+    "import BpkInput from '@skyscanner/backpack-web/bpk-component-input';",
+  ],
+  example: figma.code`<BpkInput id="input-id" name="" value=""${figma.helpers.react.renderProp(
+    "large",
+    large,
+  )}${figma.helpers.react.renderProp(
+    "dockedFirst",
+    dockedFirst,
+  )}${figma.helpers.react.renderProp(
+    "dockedMiddle",
+    dockedMiddle,
+  )}${figma.helpers.react.renderProp("dockedLast", dockedLast)}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBanner.figma.ts
+++ b/packages/backpack-web/src/bpk-component-inset-banner/src/BpkInsetBanner.figma.ts
@@ -1,0 +1,12 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10885%3A4440
+// component=BpkInsetBanner
+
+import figma from "figma"
+
+export default {
+  id: "BpkInsetBanner",
+  imports: [
+    "import { BpkInsetBanner } from '@skyscanner/backpack-web/bpk-component-inset-banner';",
+  ],
+  example: figma.code`<BpkInsetBanner />`,
+}

--- a/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.figma.ts
+++ b/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10885%3A8553
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.tsx
+// component=BpkJourneyArrow
+
+import figma from "figma"
+
+export default {
+  id: "BpkJourneyArrow",
+  imports: [
+    "import BpkJourneyArrow from '@skyscanner/backpack-web/bpk-component-journey-arrow';",
+  ],
+  example: figma.code`<BpkJourneyArrow stops={1}/>`,
+}

--- a/packages/backpack-web/src/bpk-component-label/src/BpkLabel.figma.ts
+++ b/packages/backpack-web/src/bpk-component-label/src/BpkLabel.figma.ts
@@ -1,0 +1,35 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A5124
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-label/src/BpkLabel.tsx
+// component=BpkLabel
+
+import figma from "figma"
+
+const required = figma.selectedInstance.getEnum("Required", {
+  True: true,
+  False: false,
+})
+const disabled = figma.selectedInstance.getEnum("State", {
+  Disabled: true,
+})
+const valid = figma.selectedInstance.getEnum("State", {
+  Invalid: false,
+  Default: undefined,
+})
+const children = figma.selectedInstance.findText("Label").__render__()
+
+export default {
+  id: "BpkLabel",
+  imports: [
+    "import BpkLabel from '@skyscanner/backpack-web/bpk-component-label';",
+  ],
+  example: figma.code`<BpkLabel htmlFor="input-id"${figma.helpers.react.renderProp(
+    "required",
+    required,
+  )}${figma.helpers.react.renderProp(
+    "disabled",
+    disabled,
+  )}${figma.helpers.react.renderProp("valid", valid)}>
+        ${figma.helpers.react.renderChildren(children)}
+      </BpkLabel>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-link/src/BpkLink.figma.ts
+++ b/packages/backpack-web/src/bpk-component-link/src/BpkLink.figma.ts
@@ -1,0 +1,28 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10885%3A9743
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-link/src/BpkLink.tsx
+// component=BpkLink
+
+import figma from "figma"
+
+const implicit = figma.selectedInstance.getEnum("Type", {
+  Implicit: true,
+})
+const children = figma.selectedInstance.getString("Text")
+const alternate = figma.selectedInstance.getEnum("Style", {
+  Default: false,
+  "On Contrast": true,
+})
+
+export default {
+  id: "BpkLink",
+  imports: [
+    "import BpkLink from '@skyscanner/backpack-web/bpk-component-link';",
+  ],
+  example: figma.code`<BpkLink href="#"${figma.helpers.react.renderProp(
+    "implicit",
+    implicit,
+  )}${figma.helpers.react.renderProp("alternate", alternate)}>
+        ${figma.helpers.react.renderChildren(children)}
+      </BpkLink>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-list/src/BpkList.figma.ts
+++ b/packages/backpack-web/src/bpk-component-list/src/BpkList.figma.ts
@@ -1,0 +1,18 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10885%3A10298
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-list/src/BpkList.tsx
+// component=BpkList
+
+import figma from "figma"
+
+export default {
+  id: "BpkList",
+  imports: [
+    "import BpkList from '@skyscanner/backpack-web/bpk-component-list';",
+    "import BpkListItem from '@skyscanner/backpack-web/bpk-component-list';",
+  ],
+  example: figma.code`<BpkList>
+        <BpkListItem>List item 1</BpkListItem>
+        <BpkListItem>List item 2</BpkListItem>
+        <BpkListItem>List item 3</BpkListItem>
+      </BpkList>`,
+}

--- a/packages/backpack-web/src/bpk-component-map/src/BpkPriceMarker.figma.ts
+++ b/packages/backpack-web/src/bpk-component-map/src/BpkPriceMarker.figma.ts
@@ -1,0 +1,29 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10908%3A1778
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-map/src/BpkPriceMarker.tsx
+// component=BpkPriceMarker
+
+import figma from "figma"
+
+const status = figma.selectedInstance.getEnum("State", {
+  Unselected: figma.helpers.react.identifier("MARKER_STATUSES.unselected"),
+  Selected: figma.helpers.react.identifier("MARKER_STATUSES.selected"),
+  "Pervious selected": figma.helpers.react.identifier(
+    "MARKER_STATUSES.previous_selected",
+  ),
+})
+const icon = figma.selectedInstance.getBoolean("Icon?", {
+  true: figma.helpers.react.jsxElement("<Icon />"),
+  false: undefined,
+})
+
+export default {
+  id: "BpkPriceMarker",
+  imports: [
+    "import BpkPriceMarker from '@skyscanner/backpack-web/bpk-component-map';",
+  ],
+  example: figma.code`<BpkPriceMarker accessibilityLabel="£370" position={{ latitude: 0.0, longitude: 0.0 }} label="£370"${figma.helpers.react.renderProp(
+    "status",
+    status,
+  )}${figma.helpers.react.renderProp("icon", icon)}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalFullScreen.figma.ts
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalFullScreen.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A24026
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-modal/src/BpkModal.tsx
+// component=BpkModal
+
+import figma from "figma"
+
+export default {
+  id: "BpkModal",
+  imports: [
+    "import BpkModal from '@skyscanner/backpack-web/bpk-component-modal';",
+  ],
+  example: figma.code`<BpkModal />`,
+}

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalOverlay.figma.ts
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalOverlay.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A24057
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-modal/src/BpkModal.tsx
+// component=BpkModal
+
+import figma from "figma"
+
+export default {
+  id: "BpkModal",
+  imports: [
+    "import BpkModal from '@skyscanner/backpack-web/bpk-component-modal';",
+  ],
+  example: figma.code`<BpkModal />`,
+}

--- a/packages/backpack-web/src/bpk-component-navigation-bar/src/BpkNavigationBar.figma.ts
+++ b/packages/backpack-web/src/bpk-component-navigation-bar/src/BpkNavigationBar.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10908%3A4628
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-navigation-bar/src/BpkNavigationBar.tsx
+// component=BpkNavigationBar
+
+import figma from "figma"
+
+export default {
+  id: "BpkNavigationBar",
+  imports: [
+    "import BpkNavigationBar from '@skyscanner/backpack-web/bpk-component-navigation-bar';",
+  ],
+  example: figma.code`<BpkNavigationBar />`,
+}

--- a/packages/backpack-web/src/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.figma.ts
+++ b/packages/backpack-web/src/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10908%3A10570
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-navigation-tab-group/src/BpkNavigationTabGroup.tsx
+// component=BpkNavigationTabGroup
+
+import figma from "figma"
+
+export default {
+  id: "BpkNavigationTabGroup",
+  imports: [
+    "import BpkNavigationTabGroup from '@skyscanner/backpack-web/bpk-component-navigation-tab-group';",
+  ],
+  example: figma.code`<BpkNavigationTabGroup />`,
+}

--- a/packages/backpack-web/src/bpk-component-nudger/src/BpkNudger.figma.ts
+++ b/packages/backpack-web/src/bpk-component-nudger/src/BpkNudger.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10908%3A14360
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-nudger/src/BpkNudger.tsx
+// component=BpkNudger
+
+import figma from "figma"
+
+export default {
+  id: "BpkNudger",
+  imports: [
+    "import BpkNudger from '@skyscanner/backpack-web/bpk-component-nudger';",
+  ],
+  example: figma.code`<BpkNudger />`,
+}

--- a/packages/backpack-web/src/bpk-component-overlay/src/BpkOverlay.figma.ts
+++ b/packages/backpack-web/src/bpk-component-overlay/src/BpkOverlay.figma.ts
@@ -1,0 +1,42 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10908%3A17397
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-overlay/src/BpkOverlay.tsx
+// component=BpkOverlay
+
+import figma from "figma"
+
+const style = figma.selectedInstance.getEnum("Style", {
+  High: figma.helpers.react.identifier("OVERLAY_TYPES.solidHigh"),
+  Medium: figma.helpers.react.identifier("OVERLAY_TYPES.solidMedium"),
+  Low: figma.helpers.react.identifier("OVERLAY_TYPES.solidLow"),
+  None: figma.helpers.react.identifier("OVERLAY_TYPES.off"),
+  "↓ Heavy": figma.helpers.react.identifier("OVERLAY_TYPES.heavyBottom"),
+  "↓ High": figma.helpers.react.identifier("OVERLAY_TYPES.bottomHigh"),
+  "↓ Medium": figma.helpers.react.identifier("OVERLAY_TYPES.bottomMedium"),
+  "↓ Low": figma.helpers.react.identifier("OVERLAY_TYPES.bottomLow"),
+  "↑ Heavy": figma.helpers.react.identifier("OVERLAY_TYPES.heavyTop"),
+  "↑ High": figma.helpers.react.identifier("OVERLAY_TYPES.topHigh"),
+  "↑ Medium": figma.helpers.react.identifier("OVERLAY_TYPES.topMedium"),
+  "↑ Low": figma.helpers.react.identifier("OVERLAY_TYPES.topLow"),
+  "← High": figma.helpers.react.identifier("OVERLAY_TYPES.leftHigh"),
+  "← Medium": figma.helpers.react.identifier("OVERLAY_TYPES.leftMedium"),
+  "← Low": figma.helpers.react.identifier("OVERLAY_TYPES.leftLow"),
+  "→ High": figma.helpers.react.identifier("OVERLAY_TYPES.rightHigh"),
+  "→ Medium": figma.helpers.react.identifier("OVERLAY_TYPES.rightMedium"),
+  "→ Low": figma.helpers.react.identifier("OVERLAY_TYPES.rightLow"),
+  "◻︎ Vignette": figma.helpers.react.identifier("OVERLAY_TYPES.vignette"),
+})
+
+export default {
+  id: "BpkOverlay",
+  imports: [
+    "import BpkImage from '@skyscanner/backpack-web/bpk-component-image';",
+    "import BpkOverlay, { OVERLAY_TYPES } from '@skyscanner/backpack-web/bpk-component-overlay';",
+  ],
+  example: figma.code`<BpkOverlay${figma.helpers.react.renderProp(
+    "overlayType",
+    style,
+  )}>
+        <BpkImage altText="altText here" aspectRatio={16 / 9} src="https://content.skyscnr.com/m/f8b42e98e2b79a6/original/Carousel-placeholder-3.jpg"/>
+      </BpkOverlay>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-page-indicator/src/BpkPageIndicator.figma.ts
+++ b/packages/backpack-web/src/bpk-component-page-indicator/src/BpkPageIndicator.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A18676
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-page-indicator/src/BpkPageIndicator.tsx
+// component=BpkPageIndicator
+
+import figma from "figma"
+
+export default {
+  id: "BpkPageIndicator",
+  imports: [
+    "import BpkPageIndicator from '@skyscanner/backpack-web/bpk-component-page-indicator';",
+  ],
+  example: figma.code`<BpkPageIndicator />`,
+}

--- a/packages/backpack-web/src/bpk-component-pagination/src/BpkPagination.figma.ts
+++ b/packages/backpack-web/src/bpk-component-pagination/src/BpkPagination.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A17734
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-pagination/src/BpkPagination.tsx
+// component=BpkPagination
+
+import figma from "figma"
+
+export default {
+  id: "BpkPagination",
+  imports: [
+    "import BpkPagination from '@skyscanner/backpack-web/bpk-component-pagination';",
+  ],
+  example: figma.code`<BpkPagination />`,
+}

--- a/packages/backpack-web/src/bpk-component-phone-input/src/BpkPhoneInput.figma.ts
+++ b/packages/backpack-web/src/bpk-component-phone-input/src/BpkPhoneInput.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A4835
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-phone-input/src/BpkPhoneInput.js
+// component=BpkPhoneInput
+
+import figma from "figma"
+
+export default {
+  id: "BpkPhoneInput",
+  imports: [
+    "import BpkPhoneInput from '@skyscanner/backpack-web/bpk-component-phone-input';",
+  ],
+  example: figma.code`<BpkPhoneInput />`,
+}

--- a/packages/backpack-web/src/bpk-component-popover/src/BpkPopover.figma.ts
+++ b/packages/backpack-web/src/bpk-component-popover/src/BpkPopover.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A21839
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-popover/src/BpkPopover.tsx
+// component=BpkPopover
+
+import figma from "figma"
+
+export default {
+  id: "BpkPopover",
+  imports: [
+    "import BpkPopover from '@skyscanner/backpack-web/bpk-component-popover';",
+  ],
+  example: figma.code`<BpkPopover />`,
+}

--- a/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.figma.ts
+++ b/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A20355
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.tsx
+// component=BpkPriceRange
+
+import figma from "figma"
+
+export default {
+  id: "BpkPriceRange",
+  imports: [
+    "import BpkPriceRange from '@skyscanner/backpack-web/bpk-component-price-range';",
+  ],
+  example: figma.code`<BpkPriceRange />`,
+}

--- a/packages/backpack-web/src/bpk-component-price/src/BpkPrice.figma.ts
+++ b/packages/backpack-web/src/bpk-component-price/src/BpkPrice.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A19302
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-price/src/BpkPrice.tsx
+// component=BpkPrice
+
+import figma from "figma"
+
+const price = figma.selectedInstance.getString("Price")
+const size = figma.selectedInstance.getEnum("Size", {
+  "X-Small": figma.helpers.react.identifier("SIZES.xsmall"),
+  Small: figma.helpers.react.identifier("SIZES.small"),
+  Medium: figma.helpers.react.identifier("SIZES.medium"),
+  Large: figma.helpers.react.identifier("SIZES.large"),
+})
+const align = figma.selectedInstance.getEnum("Alignment", {
+  Left: figma.helpers.react.identifier("ALIGNS.left"),
+  Right: figma.helpers.react.identifier("ALIGNS.right"),
+})
+const trailingText = figma.selectedInstance.getString("Trailing text")
+
+export default {
+  id: "BpkPrice",
+  imports: [
+    "import BpkPrice from '@skyscanner/backpack-web/bpk-component-price'",
+  ],
+  example: figma.code`<BpkPrice${figma.helpers.react.renderProp(
+    "price",
+    price,
+  )}${figma.helpers.react.renderProp(
+    "size",
+    size,
+  )}${figma.helpers.react.renderProp(
+    "align",
+    align,
+  )}${figma.helpers.react.renderProp("trailingText", trailingText)}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-progress/src/BpkProgress.figma.ts
+++ b/packages/backpack-web/src/bpk-component-progress/src/BpkProgress.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A48491
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-progress/src/BpkProgress.tsx
+// component=BpkProgress
+
+import figma from "figma"
+
+export default {
+  id: "BpkProgress",
+  imports: [
+    "import BpkProgress from '@skyscanner/backpack-web/bpk-component-progress';",
+  ],
+  example: figma.code`<BpkProgress />`,
+}

--- a/packages/backpack-web/src/bpk-component-radio/src/BpkRadio.figma.ts
+++ b/packages/backpack-web/src/bpk-component-radio/src/BpkRadio.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A4897
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-radio/src/BpkRadio.tsx
+// component=BpkRadio
+
+import figma from "figma"
+
+export default {
+  id: "BpkRadio",
+  imports: [
+    "import BpkRadio from '@skyscanner/backpack-web/bpk-component-radio';",
+  ],
+  example: figma.code`<BpkRadio />`,
+}

--- a/packages/backpack-web/src/bpk-component-rating/src/BpkRating.figma.ts
+++ b/packages/backpack-web/src/bpk-component-rating/src/BpkRating.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A25511
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-rating/src/BpkRating.tsx
+// component=BpkRating
+
+import figma from "figma"
+
+export default {
+  id: "BpkRating",
+  imports: [
+    "import BpkRating from '@skyscanner/backpack-web/bpk-component-rating';",
+  ],
+  example: figma.code`<BpkRating />`,
+}

--- a/packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.figma.ts
+++ b/packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.figma.ts
@@ -1,0 +1,35 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A28653
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.tsx
+// component=BpkSectionHeader
+
+import figma from "figma"
+
+const title = figma.selectedInstance.getString("Title")
+const description = figma.selectedInstance.getString("Subheading")
+const button = figma.selectedInstance.getBoolean("Button", {
+  true: figma.helpers.react.jsxElement(
+    "<BpkButton onClick={() => null}>action</BpkButton>",
+  ),
+})
+const style = figma.selectedInstance.getEnum("Style", {
+  Default: figma.helpers.react.identifier("SECTION_TYPES.default"),
+  "On Dark": figma.helpers.react.identifier("SECTION_TYPES.onDark"),
+})
+
+export default {
+  id: "BpkSectionHeader",
+  imports: [
+    "import BpkSectionHeader, { SECTION_TYPES } from '@skyscanner/backpack-web/bpk-component-section-header';",
+  ],
+  example: figma.code`<BpkSectionHeader${figma.helpers.react.renderProp(
+    "title",
+    title,
+  )}${figma.helpers.react.renderProp(
+    "description",
+    description,
+  )}${figma.helpers.react.renderProp(
+    "style",
+    style,
+  )}${figma.helpers.react.renderProp("button", button)}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-segmented-control/src/BpkSegmentedControlV2/BpkSegmentedControlV2.figma.ts
+++ b/packages/backpack-web/src/bpk-component-segmented-control/src/BpkSegmentedControlV2/BpkSegmentedControlV2.figma.ts
@@ -1,0 +1,43 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=17386-8546
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-segmented-control/src/BpkSegmentedControlV2/BpkSegmentedControlV2.tsx
+// component=BpkSegmentedControlV2.Root
+
+import figma from "figma"
+
+const type = figma.selectedInstance.getEnum("Style", {
+  "Canvas Default": figma.helpers.react.identifier(
+    "SEGMENT_TYPES_V2.CanvasDefault",
+  ),
+  "Canvas Contrast": figma.helpers.react.identifier(
+    "SEGMENT_TYPES_V2.CanvasContrast",
+  ),
+  "Surface Default": figma.helpers.react.identifier(
+    "SEGMENT_TYPES_V2.SurfaceDefault",
+  ),
+  "Surface Contrast": figma.helpers.react.identifier(
+    "SEGMENT_TYPES_V2.SurfaceContrast",
+  ),
+})
+
+export default {
+  id: "BpkSegmentedControlV2.Root",
+  imports: [
+    "import BpkSegmentedControlV2 from '@skyscanner/backpack-web/bpk-component-segmented-control';",
+  ],
+  example: figma.code`<BpkSegmentedControlV2.Root${figma.helpers.react.renderProp(
+    "type",
+    type,
+  )} defaultValue="option1" label="Select option">
+      <BpkSegmentedControlV2.Item value="option1">
+        <BpkSegmentedControlV2.ItemText>Option 1</BpkSegmentedControlV2.ItemText>
+        <BpkSegmentedControlV2.ItemControl />
+        <BpkSegmentedControlV2.ItemHiddenInput />
+      </BpkSegmentedControlV2.Item>
+      <BpkSegmentedControlV2.Item value="option2">
+        <BpkSegmentedControlV2.ItemText>Option 2</BpkSegmentedControlV2.ItemText>
+        <BpkSegmentedControlV2.ItemControl />
+        <BpkSegmentedControlV2.ItemHiddenInput />
+      </BpkSegmentedControlV2.Item>
+    </BpkSegmentedControlV2.Root>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-select/src/BpkSelect.figma.ts
+++ b/packages/backpack-web/src/bpk-component-select/src/BpkSelect.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A41076
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-select/src/BpkSelect.tsx
+// component=BpkSelect
+
+import figma from "figma"
+
+export default {
+  id: "BpkSelect",
+  imports: [
+    "import BpkSelect from '@skyscanner/backpack-web/bpk-component-select';",
+  ],
+  example: figma.code`<BpkSelect />`,
+}

--- a/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeletonBodyText.figma.ts
+++ b/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeletonBodyText.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A43052
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeleton.tsx
+// component=BpkSkeleton
+
+import figma from "figma"
+
+export default {
+  id: "BpkSkeleton",
+  imports: [
+    "import BpkSkeleton from '@skyscanner/backpack-web/bpk-component-skeleton';",
+  ],
+  example: figma.code`<BpkSkeleton />`,
+}

--- a/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeletonCircle.figma.ts
+++ b/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeletonCircle.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A43029
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeleton.tsx
+// component=BpkSkeleton
+
+import figma from "figma"
+
+export default {
+  id: "BpkSkeleton",
+  imports: [
+    "import BpkSkeleton from '@skyscanner/backpack-web/bpk-component-skeleton';",
+  ],
+  example: figma.code`<BpkSkeleton />`,
+}

--- a/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeletonHeadline.figma.ts
+++ b/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeletonHeadline.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A43017
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeleton.tsx
+// component=BpkSkeleton
+
+import figma from "figma"
+
+export default {
+  id: "BpkSkeleton",
+  imports: [
+    "import BpkSkeleton from '@skyscanner/backpack-web/bpk-component-skeleton';",
+  ],
+  example: figma.code`<BpkSkeleton />`,
+}

--- a/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeletonImage.figma.ts
+++ b/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeletonImage.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A43024
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-skeleton/src/BpkSkeleton.tsx
+// component=BpkSkeleton
+
+import figma from "figma"
+
+export default {
+  id: "BpkSkeleton",
+  imports: [
+    "import BpkSkeleton from '@skyscanner/backpack-web/bpk-component-skeleton';",
+  ],
+  example: figma.code`<BpkSkeleton />`,
+}

--- a/packages/backpack-web/src/bpk-component-skip-link/src/BpkSkipLink.figma.ts
+++ b/packages/backpack-web/src/bpk-component-skip-link/src/BpkSkipLink.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A43122
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-skip-link/src/BpkSkipLink.tsx
+// component=BpkSkipLink
+
+import figma from "figma"
+
+export default {
+  id: "BpkSkipLink",
+  imports: [
+    "import BpkSkipLink from '@skyscanner/backpack-web/bpk-component-skip-link';",
+  ],
+  example: figma.code`<BpkSkipLink />`,
+}

--- a/packages/backpack-web/src/bpk-component-slider/src/BpkSlider.figma.ts
+++ b/packages/backpack-web/src/bpk-component-slider/src/BpkSlider.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A43190
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-slider/src/BpkSlider.tsx
+// component=BpkSlider
+
+import figma from "figma"
+
+export default {
+  id: "BpkSlider",
+  imports: [
+    "import BpkSlider from '@skyscanner/backpack-web/bpk-component-slider';",
+  ],
+  example: figma.code`<BpkSlider />`,
+}

--- a/packages/backpack-web/src/bpk-component-snippet/src/BpkSnippetHorizontal.figma.ts
+++ b/packages/backpack-web/src/bpk-component-snippet/src/BpkSnippetHorizontal.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A46250
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-snippet/src/BpkSnippet.tsx
+// component=BpkSnippet
+
+import figma from "figma"
+
+export default {
+  id: "BpkSnippet",
+  imports: [
+    "import BpkSnippet from '@skyscanner/backpack-web/bpk-component-snippet';",
+  ],
+  example: figma.code`<BpkSnippet />`,
+}

--- a/packages/backpack-web/src/bpk-component-snippet/src/BpkSnippetVertical.figma.ts
+++ b/packages/backpack-web/src/bpk-component-snippet/src/BpkSnippetVertical.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A45702
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-snippet/src/BpkSnippet.tsx
+// component=BpkSnippet
+
+import figma from "figma"
+
+export default {
+  id: "BpkSnippet",
+  imports: [
+    "import BpkSnippet from '@skyscanner/backpack-web/bpk-component-snippet';",
+  ],
+  example: figma.code`<BpkSnippet />`,
+}

--- a/packages/backpack-web/src/bpk-component-spinner/src/BpkSpinner.figma.ts
+++ b/packages/backpack-web/src/bpk-component-spinner/src/BpkSpinner.figma.ts
@@ -1,0 +1,12 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A48523
+// component=BpkSpinner
+
+import figma from "figma"
+
+export default {
+  id: "BpkSpinner",
+  imports: [
+    "import { BpkSpinner } from '@skyscanner/backpack-web/bpk-component-spinner';",
+  ],
+  example: figma.code`<BpkSpinner />`,
+}

--- a/packages/backpack-web/src/bpk-component-split-input/src/BpkSplitInput.figma.ts
+++ b/packages/backpack-web/src/bpk-component-split-input/src/BpkSplitInput.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A4923
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-split-input/src/BpkSplitInput.tsx
+// component=BpkSplitInput
+
+import figma from "figma"
+
+export default {
+  id: "BpkSplitInput",
+  imports: [
+    "import BpkSplitInput from '@skyscanner/backpack-web/bpk-component-split-input';",
+  ],
+  example: figma.code`<BpkSplitInput />`,
+}

--- a/packages/backpack-web/src/bpk-component-star-rating/src/BpkInteractiveStarRating.figma.ts
+++ b/packages/backpack-web/src/bpk-component-star-rating/src/BpkInteractiveStarRating.figma.ts
@@ -1,0 +1,36 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A49221
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-star-rating/src/BpkInteractiveStarRating.tsx
+// component=BpkInteractiveStarRating
+
+import figma from "figma"
+
+const large = figma.selectedInstance.getEnum("Size", {
+  Large: true,
+})
+const extraLarge = figma.selectedInstance.getEnum("Size", {
+  "Extra-large": true,
+})
+const initialRating = figma.selectedInstance.getEnum("Rating", {
+  "1 star": 1,
+  "2 stars": 2,
+  "3 stars": 3,
+  "4 stars": 4,
+  "5 stars": 5,
+})
+
+export default {
+  id: "BpkInteractiveStarRating",
+  imports: [
+    "import BpkInteractiveStarRating from '@skyscanner/backpack-web/bpk-component-star-rating'",
+  ],
+  example: figma.code`<BpkInteractiveStarRating getStarLabel={(rating: number, maxRating: number) => \`${rating} out of ${maxRating} stars\`} id="uniqueId" 
+// eslint-disable-next-line no-console
+onRatingSelect={(rating: number) => console.log(rating)}${figma.helpers.react.renderProp(
+    "large",
+    large,
+  )}${figma.helpers.react.renderProp(
+    "extraLarge",
+    extraLarge,
+  )}${figma.helpers.react.renderProp("rating", initialRating)}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-star-rating/src/BpkStarRating.figma.ts
+++ b/packages/backpack-web/src/bpk-component-star-rating/src/BpkStarRating.figma.ts
@@ -1,0 +1,40 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A49089
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-star-rating/src/BpkStarRating.tsx
+// component=BpkStarRating
+
+import figma from "figma"
+
+const large = figma.selectedInstance.getEnum("Size", {
+  Large: true,
+})
+const rating = figma.selectedInstance.getEnum("Rating", {
+  "1 star": 1,
+  "2 stars": 2,
+  "3 stars": 3,
+  "3.5 stars": 3.5,
+  "4 stars": 4,
+  "5 stars": 5,
+})
+const ratingLabel = figma.selectedInstance.getEnum("Rating", {
+  "1 star": "Rated 1 star out of 5",
+  "2 stars": "Rated 2 stars out of 5",
+  "3 stars": "Rated 3 stars out of 5",
+  "3.5 stars": "Rated 3.5 stars out of 5",
+  "4 stars": "Rated 4 stars out of 5",
+  "5 stars": "Rated 5 stars out of 5",
+})
+
+export default {
+  id: "BpkStarRating",
+  imports: [
+    "import BpkStarRating from '@skyscanner/backpack-web/bpk-component-star-rating';",
+  ],
+  example: figma.code`<BpkStarRating${figma.helpers.react.renderProp(
+    "ratingLabel",
+    ratingLabel,
+  )}${figma.helpers.react.renderProp(
+    "large",
+    large,
+  )}${figma.helpers.react.renderProp("rating", rating)}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-star-rating/src/BpkStarRating_1.figma.ts
+++ b/packages/backpack-web/src/bpk-component-star-rating/src/BpkStarRating_1.figma.ts
@@ -1,0 +1,41 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A49171
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-star-rating/src/BpkStarRating.tsx
+// component=BpkStarRating
+
+import figma from "figma"
+
+const large = figma.selectedInstance.getEnum("Size", {
+  Large: true,
+})
+const hotelRating = figma.selectedInstance.getEnum("Rating", {
+  "1 star": 1,
+  "2 star": 2,
+  "3 star": 3,
+  "4 star": 4,
+  "5 star": 5,
+})
+const hotelRatingLabel = figma.selectedInstance.getEnum("Rating", {
+  "1 star": "1 star hotel",
+  "2 star": "2 star hotel",
+  "3 star": "3 star hotel",
+  "4 star": "4 star hotel",
+  "5 star": "5 star hotel",
+})
+
+export default {
+  id: "BpkStarRating",
+  imports: [
+    "import BpkStarRating from '@skyscanner/backpack-web/bpk-component-star-rating';",
+  ],
+  example: figma.code`<BpkStarRating${figma.helpers.react.renderProp(
+    "ratingLabel",
+    hotelRatingLabel,
+  )}${figma.helpers.react.renderProp(
+    "large",
+    large,
+  )}${figma.helpers.react.renderProp(
+    "rating",
+    hotelRating,
+  )}${figma.helpers.react.renderProp("maxRating", hotelRating)}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-swap-button/src/BpkSwapButton.figma.ts
+++ b/packages/backpack-web/src/bpk-component-swap-button/src/BpkSwapButton.figma.ts
@@ -1,0 +1,29 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A50522
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-swap-button/src/BpkSwapButton.tsx
+// component=BpkSwapButton
+
+import figma from "figma"
+
+const swapButtonStyle = figma.selectedInstance.getEnum("Style", {
+  "Surface Contrast": figma.helpers.react.identifier(
+    "SWAPBUTTON_STYLES.surfaceContrast",
+  ),
+  "Canvas Contrast": figma.helpers.react.identifier(
+    "SWAPBUTTON_STYLES.canvasContrast",
+  ),
+  "Canvas Default": figma.helpers.react.identifier(
+    "SWAPBUTTON_STYLES.canvasDefault",
+  ),
+})
+
+export default {
+  id: "BpkSwapButton",
+  imports: [
+    "import BpkSwapButton, { SWAPBUTTON_STYLES } from '@skyscanner/backpack-web/bpk-component-swap-button';",
+  ],
+  example: figma.code`<BpkSwapButton ariaLabel="Swap origin and destination" onClick={() => { }}${figma.helpers.react.renderProp(
+    "swapButtonStyle",
+    swapButtonStyle,
+  )}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-switch/src/BpkSwitch.figma.ts
+++ b/packages/backpack-web/src/bpk-component-switch/src/BpkSwitch.figma.ts
@@ -1,0 +1,26 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A51298
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-switch/src/BpkSwitch.tsx
+// component=BpkSwitch
+
+import figma from "figma"
+
+const size = figma.selectedInstance.getEnum("Size", {
+  Default: false,
+  Small: true,
+})
+const state = figma.selectedInstance.getEnum("State", {
+  On: true,
+  Off: false,
+})
+
+export default {
+  id: "BpkSwitch",
+  imports: [
+    "import BpkSwitch from '@skyscanner/backpack-web/bpk-component-switch';",
+  ],
+  example: figma.code`<BpkSwitch ariaLabel="Activate Backpack"${figma.helpers.react.renderProp(
+    "small",
+    size,
+  )}${figma.helpers.react.renderProp("checked", state)}/>`,
+  metadata: { nestable: true },
+}

--- a/packages/backpack-web/src/bpk-component-table/src/BpkTable.figma.ts
+++ b/packages/backpack-web/src/bpk-component-table/src/BpkTable.figma.ts
@@ -1,0 +1,31 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A52693
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-table/src/BpkTable.tsx
+// component=BpkTable
+
+import figma from "figma"
+
+export default {
+  id: "BpkTable",
+  imports: [
+    "import BpkTable from '@skyscanner/backpack-web/bpk-component-table';",
+    "import BpkTableBody from '@skyscanner/backpack-web/bpk-component-table';",
+    "import BpkTableCell from '@skyscanner/backpack-web/bpk-component-table';",
+    "import BpkTableHead from '@skyscanner/backpack-web/bpk-component-table';",
+    "import BpkTableHeadCell from '@skyscanner/backpack-web/bpk-component-table';",
+    "import BpkTableRow from '@skyscanner/backpack-web/bpk-component-table';",
+  ],
+  example: figma.code`<BpkTable>
+        <BpkTableHead>
+          <BpkTableRow>
+            <BpkTableHeadCell>Column 1</BpkTableHeadCell>
+            <BpkTableHeadCell>Column 2</BpkTableHeadCell>
+          </BpkTableRow>
+        </BpkTableHead>
+        <BpkTableBody>
+          <BpkTableRow>
+            <BpkTableCell>Cell 1</BpkTableCell>
+            <BpkTableCell>Cell 2</BpkTableCell>
+          </BpkTableRow>
+        </BpkTableBody>
+      </BpkTable>`,
+}

--- a/packages/backpack-web/src/bpk-component-textarea/src/BpkTextarea.figma.ts
+++ b/packages/backpack-web/src/bpk-component-textarea/src/BpkTextarea.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10872%3A4843
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-textarea/src/BpkTextarea.tsx
+// component=BpkTextarea
+
+import figma from "figma"
+
+export default {
+  id: "BpkTextarea",
+  imports: [
+    "import BpkTextarea from '@skyscanner/backpack-web/bpk-component-textarea';",
+  ],
+  example: figma.code`<BpkTextarea />`,
+}

--- a/packages/backpack-web/src/bpk-component-ticket/src/BpkTicket.figma.ts
+++ b/packages/backpack-web/src/bpk-component-ticket/src/BpkTicket.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A51477
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-ticket/src/BpkTicket.js
+// component=BpkTicket
+
+import figma from "figma"
+
+export default {
+  id: "BpkTicket",
+  imports: [
+    "import BpkTicket from '@skyscanner/backpack-web/bpk-component-ticket';",
+  ],
+  example: figma.code`<BpkTicket />`,
+}

--- a/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.figma.ts
+++ b/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.figma.ts
@@ -1,0 +1,13 @@
+// url=https://www.figma.com/design/KXf2gHNLDe2cXWUoHl4cTX/Backpack%E2%80%A8Foundations---Components?node-id=10911%3A23996
+// source=https://github.com/Skyscanner/backpack/blob/main/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.tsx
+// component=BpkTooltip
+
+import figma from "figma"
+
+export default {
+  id: "BpkTooltip",
+  imports: [
+    "import BpkTooltip from '@skyscanner/backpack-web/bpk-component-tooltip';",
+  ],
+  example: figma.code`<BpkTooltip />`,
+}


### PR DESCRIPTION
## Summary

Adds [Figma Code Connect](https://www.figma.com/code-connect-docs/) mapping files (`*.figma.ts`) across the component and icon packages, connecting Figma components to their Backpack code components so designers see real code snippets in Figma Dev Mode. Also bumps `@figma/code-connect` to `^1.4.8` and adds `*.figma.ts` to `.eslintignore` since these files are generated.

These are tooling/metadata files only — no runtime component code, public APIs, or styles change, and nothing ships to consumers.

- [ ] Ensure the PR title includes the name of the component you are changing — N/A, affects Code Connect mappings across all components
- [ ] `README.md` (If you have created a new component) — N/A, no new component
- [ ] Component `README.md` — N/A
- [ ] Tests — N/A, generated mapping files
- [ ] Accessibility tests — N/A, no UI changes
- [ ] Storybook examples created/updated — N/A, no UI changes
- [ ] Migration guides — N/A, no breaking changes

`skip-changelog` — generated Code Connect metadata, no consumer-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
