### PR TITLE
[BpkModal] Fix focus trap broken by React 19 ref injection

### DIFF
--- a/packages/backpack-web/src/bpk-react-utils/src/TransitionInitialMount-test.tsx
+++ b/packages/backpack-web/src/bpk-react-utils/src/TransitionInitialMount-test.tsx
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import { createRef } from 'react';
+
 import { render } from '@testing-library/react';
 
 import TransitionInitialMount from './TransitionInitialMount';
@@ -33,5 +35,35 @@ describe('TransitionInitialMount', () => {
     );
 
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("should preserve the child's own ref when injecting nodeRef", () => {
+    // Regression: cloneElement used to overwrite the child ref with nodeRef,
+    // which broke focus trapping in BpkModal/BpkDialog (the dialogRef from
+    // withScrim never fired). See backpack#4701.
+    const callbackRef = jest.fn();
+    const objectRef = createRef<HTMLElement>();
+
+    render(
+      <TransitionInitialMount
+        appearClassName="block--appear"
+        appearActiveClassName="block--appear-active"
+        transitionTimeout={250}
+      >
+        <section ref={callbackRef}>callback ref child</section>
+      </TransitionInitialMount>,
+    );
+    expect(callbackRef).toHaveBeenCalledWith(expect.any(HTMLElement));
+
+    render(
+      <TransitionInitialMount
+        appearClassName="block--appear"
+        appearActiveClassName="block--appear-active"
+        transitionTimeout={250}
+      >
+        <section ref={objectRef}>object ref child</section>
+      </TransitionInitialMount>,
+    );
+    expect(objectRef.current).toBeInstanceOf(HTMLElement);
   });
 });

--- a/packages/backpack-web/src/bpk-react-utils/src/TransitionInitialMount-test.tsx
+++ b/packages/backpack-web/src/bpk-react-utils/src/TransitionInitialMount-test.tsx
@@ -17,12 +17,35 @@
  */
 
 import { createRef } from 'react';
+import type { ReactNode, RefObject } from 'react';
 
 import { render } from '@testing-library/react';
 
 import TransitionInitialMount from './TransitionInitialMount';
 
+// Capture the nodeRef CSSTransition is given so we can assert it points at the
+// child node. The real CSSTransition drives its appear animation through a
+// DOM/raf pipeline jsdom does not run, so we render the children directly.
+let capturedNodeRef: RefObject<HTMLElement | null> | null = null;
+jest.mock('react-transition-group/CSSTransition', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    nodeRef,
+  }: {
+    children: ReactNode;
+    nodeRef: RefObject<HTMLElement | null>;
+  }) => {
+    capturedNodeRef = nodeRef;
+    return children;
+  },
+}));
+
 describe('TransitionInitialMount', () => {
+  beforeEach(() => {
+    capturedNodeRef = null;
+  });
+
   it('should render correctly', () => {
     const { asFragment } = render(
       <TransitionInitialMount
@@ -65,5 +88,26 @@ describe('TransitionInitialMount', () => {
       </TransitionInitialMount>,
     );
     expect(objectRef.current).toBeInstanceOf(HTMLElement);
+  });
+
+  it('should populate the nodeRef that CSSTransition uses to drive the animation', () => {
+    // Covers the nodeRef side of the merged ref. CSSTransition reads nodeRef
+    // to drive the appear animation; that animation relies on a real DOM/raf
+    // pipeline jsdom cannot run, so we instead assert CSSTransition is handed a
+    // nodeRef pointing at the child node. Deleting `nodeRef.current = node`
+    // would null this and fail the test, where a snapshot test would not.
+    const { container } = render(
+      <TransitionInitialMount
+        appearClassName="my-appear"
+        appearActiveClassName="my-appear-active"
+        transitionTimeout={250}
+      >
+        <section>child</section>
+      </TransitionInitialMount>,
+    );
+
+    const section = container.querySelector('section');
+    expect(capturedNodeRef).not.toBeNull();
+    expect(capturedNodeRef?.current).toBe(section);
   });
 });

--- a/packages/backpack-web/src/bpk-react-utils/src/TransitionInitialMount.tsx
+++ b/packages/backpack-web/src/bpk-react-utils/src/TransitionInitialMount.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { cloneElement, useCallback, useRef } from 'react';
+import { cloneElement, useCallback, useRef, version } from 'react';
 import type { MutableRefObject, ReactElement, Ref } from 'react';
 
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
@@ -31,23 +31,31 @@ type Props = {
   appearClassName: string;
   appearActiveClassName: string;
   transitionTimeout: number;
-  // Must be a single ReactElement that accepts a ref — React 19 removed the
-  // findDOMNode fallback in react-transition-group@4, so we inject a nodeRef
-  // into the child via cloneElement. A plain string/fragment cannot accept a
-  // ref and would crash at runtime, so the type is narrowed accordingly.
+  // Must be a single ReactElement that forwards a ref to a DOM node — React 19
+  // removed the findDOMNode fallback in react-transition-group@4, so we inject
+  // a nodeRef into the child via cloneElement. The child therefore has to be a
+  // DOM element (e.g. <section>), a class component, or a forwardRef component;
+  // a plain string/fragment or a function component that drops the ref cannot
+  // receive nodeRef, so CSSTransition would have no node to animate.
   // `Ref` (not `RefObject`) so the merged callback ref we inject is assignable.
   children: ReactElement<{ ref?: Ref<HTMLElement> }>;
 };
 
-const assignRef = (ref: Ref<HTMLElement> | undefined, node: HTMLElement | null) => {
-  if (!ref) {
+// Assigns a node to the child's own ref, supporting both callback refs and
+// object refs (e.g. createRef). nodeRef is handled separately below since it is
+// always an object ref we own.
+const assignChildRef = (
+  childRef: Ref<HTMLElement> | undefined,
+  node: HTMLElement | null,
+) => {
+  if (!childRef) {
     return;
   }
-  if (typeof ref === 'function') {
-    ref(node);
+  if (typeof childRef === 'function') {
+    childRef(node);
   } else {
     // eslint-disable-next-line no-param-reassign
-    (ref as MutableRefObject<HTMLElement | null>).current = node;
+    (childRef as MutableRefObject<HTMLElement | null>).current = node;
   }
 };
 
@@ -59,15 +67,16 @@ const TransitionInitialMount = ({
   children,
   transitionTimeout,
 }: Props) => {
-  const nodeRef = useRef<HTMLElement>(null);
+  const nodeRef = useRef<HTMLElement | null>(null);
   // Read the child's own ref so injecting nodeRef does not clobber it.
-  // React 19 exposes ref as a normal prop (children.props.ref); React 18 keeps
-  // it on the element itself (children.ref). Check props.ref FIRST so that on
-  // React 19 we never touch element.ref (which logs a deprecation warning).
-  const childProps = children.props as { ref?: Ref<HTMLElement> };
-  const childRef =
-    childProps.ref ??
-    (children as ReactElement & { ref?: Ref<HTMLElement> }).ref;
+  // React 19 exposes ref as a normal prop (children.props.ref) and logs a
+  // deprecation warning if you read element.ref; React 18 keeps it on the
+  // element itself. Pick the source by major version so we never touch
+  // element.ref on React 19, even when the child has no ref of its own.
+  const isReact19OrLater = parseInt(version, 10) >= 19;
+  const childRef = isReact19OrLater
+    ? (children.props as { ref?: Ref<HTMLElement> }).ref
+    : (children as ReactElement & { ref?: Ref<HTMLElement> }).ref;
 
   // Compose the nodeRef CSSTransition needs with any ref the child already has,
   // so injecting nodeRef does not clobber the child's own ref (e.g. the
@@ -76,8 +85,8 @@ const TransitionInitialMount = ({
   // only re-run when nodeRef or the child's ref actually changes.
   const mergedRef = useCallback(
     (node: HTMLElement | null) => {
-      assignRef(nodeRef, node);
-      assignRef(childRef, node);
+      nodeRef.current = node;
+      assignChildRef(childRef, node);
     },
     [childRef],
   );

--- a/packages/backpack-web/src/bpk-react-utils/src/TransitionInitialMount.tsx
+++ b/packages/backpack-web/src/bpk-react-utils/src/TransitionInitialMount.tsx
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-import { cloneElement, useRef } from 'react';
-import type { ReactElement, RefObject } from 'react';
+import { cloneElement, useCallback, useRef } from 'react';
+import type { MutableRefObject, ReactElement, Ref } from 'react';
 
 // @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
 import assign from 'object-assign';
@@ -35,7 +35,20 @@ type Props = {
   // findDOMNode fallback in react-transition-group@4, so we inject a nodeRef
   // into the child via cloneElement. A plain string/fragment cannot accept a
   // ref and would crash at runtime, so the type is narrowed accordingly.
-  children: ReactElement<{ ref?: RefObject<HTMLElement | null> }>;
+  // `Ref` (not `RefObject`) so the merged callback ref we inject is assignable.
+  children: ReactElement<{ ref?: Ref<HTMLElement> }>;
+};
+
+const assignRef = (ref: Ref<HTMLElement> | undefined, node: HTMLElement | null) => {
+  if (!ref) {
+    return;
+  }
+  if (typeof ref === 'function') {
+    ref(node);
+  } else {
+    // eslint-disable-next-line no-param-reassign
+    (ref as MutableRefObject<HTMLElement | null>).current = node;
+  }
 };
 
 // TODO: revisit the cloneElement pattern when react-transition-group v5 ships;
@@ -47,6 +60,28 @@ const TransitionInitialMount = ({
   transitionTimeout,
 }: Props) => {
   const nodeRef = useRef<HTMLElement>(null);
+  // Read the child's own ref so injecting nodeRef does not clobber it.
+  // React 19 exposes ref as a normal prop (children.props.ref); React 18 keeps
+  // it on the element itself (children.ref). Check props.ref FIRST so that on
+  // React 19 we never touch element.ref (which logs a deprecation warning).
+  const childProps = children.props as { ref?: Ref<HTMLElement> };
+  const childRef =
+    childProps.ref ??
+    (children as ReactElement & { ref?: Ref<HTMLElement> }).ref;
+
+  // Compose the nodeRef CSSTransition needs with any ref the child already has,
+  // so injecting nodeRef does not clobber the child's own ref (e.g. the
+  // `dialogRef` used by withScrim to scope focus inside BpkModal/BpkDialog).
+  // Memoised so the callback ref keeps a stable identity across renders and is
+  // only re-run when nodeRef or the child's ref actually changes.
+  const mergedRef = useCallback(
+    (node: HTMLElement | null) => {
+      assignRef(nodeRef, node);
+      assignRef(childRef, node);
+    },
+    [childRef],
+  );
+
   return (
     <CSSTransition
       nodeRef={nodeRef}
@@ -58,7 +93,7 @@ const TransitionInitialMount = ({
       appear
       timeout={{ exit: 0, enter: 0, appear: transitionTimeout }}
     >
-      {cloneElement(children, { ref: nodeRef })}
+      {cloneElement(children, { ref: mergedRef })}
     </CSSTransition>
   );
 };


### PR DESCRIPTION
## Summary

`TransitionInitialMount` injected a `nodeRef` into its child via `cloneElement(children, { ref: nodeRef })`, which **overwrote** the child's existing ref.

`BpkModalInner` / `BpkDialogInner` render `<section ref={dialogRef}>`, where `dialogRef` comes from the `withScrim` HOC and is used to scope focus. With the ref clobbered, `dialogRef` never fired → `withScrim.dialogElement` stayed `undefined` → `focusScope.scopeFocus()` was never called → no focus trap → **Tab escapes the modal** (the failing E2E for the mobile datepicker in global-components, backpack#4701).

This was a regression from the React 19 migration, which switched `TransitionInitialMount` to the `nodeRef` + `cloneElement` pattern (react-transition-group@4 removed the `findDOMNode` fallback).

## Fix

Merge `nodeRef` with the child's own ref instead of overwriting it:

- A memoised callback ref (`useCallback`, keyed on the child ref) keeps a **stable identity** across renders, so the child's callback ref isn't churned every render.
- The child ref is read from `props.ref` first (React 19) then `element.ref` (React 18), so it keeps working across the upcoming React 19 upgrade — no silent re-break.

## Scope

| Consumer | Child of `TransitionInitialMount` | Affected? |
|---|---|---|
| `BpkModalInner` | `<section ref={dialogRef}>` | ✅ fixed |
| `BpkDialogInner` | `<section ref={dialogRef}>` | ✅ fixed |
| `BpkScrim` | `<div>` (no ref) | unaffected |
| `BpkTooltip` / `BpkPopover` | `<section>` (uses floating-ui `FloatingFocusManager`, no `dialogRef`) | unaffected |

## Testing

<img width="825" height="684" alt="image" src="https://github.com/user-attachments/assets/6eaf6449-b4e6-47cb-91c3-2a02dff56075" />


- New regression test in `TransitionInitialMount-test.tsx` asserting both callback-ref and object-ref children still receive the DOM node.
- All `TransitionInitialMount` / `withScrim` / `BpkModal` / `BpkDialog` suites pass (117 tests).
- `npm run lint` + `tsc --noEmit` clean.

---

Remember to include the following changes:

- [x] Tests
- [x] Accessibility tests
    - The following checks were performed:
        - [x] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/) — Tab is now trapped inside the modal again
- [ ] Storybook examples created/updated — n/a, no API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)