### PR TITLE
feat(BpkCheckboxV2): add fullWidth prop to Root

### DIFF
--- a/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2.module.scss
+++ b/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2.module.scss
@@ -36,6 +36,10 @@
   &[data-disabled] {
     cursor: not-allowed;
   }
+
+  &--full-width {
+    width: 100%;
+  }
 }
 
 // Control — the visual 20×20 checkbox box

--- a/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2.stories.tsx
@@ -238,6 +238,41 @@ const ComposedHertzExample = () => (
   </BpkProvider>
 );
 
+const FullWidthExample = () => (
+  <BpkProvider>
+    <div style={{ width: '300px', border: '1px dashed #ccc', padding: '16px' }}>
+      <BpkFlex direction="column" gap={BpkSpacing.Base}>
+        <BpkCheckboxV2.Root fullWidth>
+          <BpkCheckboxV2.Control>
+            <BpkCheckboxV2.Indicator />
+          </BpkCheckboxV2.Control>
+          <BpkCheckboxV2.Label>Stretch to container width</BpkCheckboxV2.Label>
+          <BpkCheckboxV2.HiddenInput />
+        </BpkCheckboxV2.Root>
+        <BpkCheckboxV2.Root fullWidth defaultChecked>
+          <BpkCheckboxV2.Control>
+            <BpkCheckboxV2.Indicator />
+          </BpkCheckboxV2.Control>
+          <BpkFlex direction="column">
+            <BpkCheckboxV2.Label>Price alerts</BpkCheckboxV2.Label>
+            <BpkCheckboxV2.Description>
+              We&apos;ll email you about price drops.
+            </BpkCheckboxV2.Description>
+          </BpkFlex>
+          <BpkCheckboxV2.HiddenInput />
+        </BpkCheckboxV2.Root>
+        <BpkCheckboxV2.Root fullWidth disabled>
+          <BpkCheckboxV2.Control>
+            <BpkCheckboxV2.Indicator />
+          </BpkCheckboxV2.Control>
+          <BpkCheckboxV2.Label>Disabled full-width</BpkCheckboxV2.Label>
+          <BpkCheckboxV2.HiddenInput />
+        </BpkCheckboxV2.Root>
+      </BpkFlex>
+    </div>
+  </BpkProvider>
+);
+
 const MixedExample = () => (
   <BpkProvider>
     <BpkFlex gap={BpkSpacing.Base} direction="column">
@@ -250,6 +285,7 @@ const MixedExample = () => (
       <IndeterminateExample />
       <InvalidExample />
       <ThemedExample />
+      <FullWidthExample />
     </BpkFlex>
   </BpkProvider>
 );
@@ -306,6 +342,10 @@ export const ComposedHertz = {
 
 export const InsideDrawer = {
   render: () => <InsideDrawerExample />,
+};
+
+export const FullWidth = {
+  render: () => <FullWidthExample />,
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Root.tsx
+++ b/packages/backpack-web/src/bpk-component-checkbox/src/BpkCheckboxV2/BpkCheckboxV2Root.tsx
@@ -35,6 +35,7 @@ export type BpkCheckboxV2RootProps = {
   'data-testid'?: string;
   defaultChecked?: BpkCheckboxV2CheckedState;
   disabled?: boolean;
+  fullWidth?: boolean;
   id?: string;
   invalid?: boolean;
   name?: string;
@@ -51,6 +52,7 @@ const BpkCheckboxV2Root = forwardRef<HTMLLabelElement, BpkCheckboxV2RootProps>(
       'data-testid': dataTestId,
       defaultChecked,
       disabled = false,
+      fullWidth = false,
       id,
       invalid = false,
       name,
@@ -62,7 +64,9 @@ const BpkCheckboxV2Root = forwardRef<HTMLLabelElement, BpkCheckboxV2RootProps>(
   ) => (
     <Checkbox.Root
       ref={ref}
-      className={getClassName('bpk-checkbox-v2')}
+      className={getClassName('bpk-checkbox-v2', {
+        'bpk-checkbox-v2--full-width': fullWidth,
+      })}
       checked={checked}
       data-testid={dataTestId}
       defaultChecked={defaultChecked}


### PR DESCRIPTION
## Summary

- Adds opt-in `fullWidth?: boolean` prop to `BpkCheckboxV2.Root`
- When `true`, applies `bpk-checkbox-v2--full-width` modifier → `width: 100%`
- Default `inline-flex` display **unchanged** — zero breaking changes for existing consumers (Overlay, carhire-homepage)
- Adds `FullWidth` Storybook story with unchecked / checked+description / disabled variants inside a constrained container

## Why not change `inline-flex` → `flex` globally?

Searched Skyscanner org — found two external consumers using `BpkCheckboxV2.Root` in contexts that would break if the root became block-level. An opt-in prop avoids all regressions.

## Test plan

- [ ] `BpkCheckboxV2-test` — 17 tests pass, snapshots unchanged
- [ ] Lint clean (lint-staged passed on commit)
- [ ] Storybook: `FullWidth` story renders at 300px container, all three variants fill width
- [ ] Existing stories unaffected