### PR TITLE
[BpkText][BpkPrice] Add dark mode support and strikethrough prop

### DIFF
--- a/packages/backpack-web/src/bpk-component-price/src/BpkPrice-test.tsx
+++ b/packages/backpack-web/src/bpk-component-price/src/BpkPrice-test.tsx
@@ -105,7 +105,10 @@ describe.each([
       />,
     );
 
-    expect(screen.getByText(previousPrice)).toHaveClass(expectedDefaultClass);
+    const previousPriceEl = screen.getByText(previousPrice);
+    expect(previousPriceEl).toHaveClass(expectedDefaultClass);
+    expect(previousPriceEl).toHaveClass('bpk-text--text-error');
+    expect(previousPriceEl).toHaveClass('bpk-text--strikethrough');
   });
 
   it('should render previous price and leading text separated by a separator', () => {

--- a/packages/backpack-web/src/bpk-component-price/src/BpkPrice-test.tsx
+++ b/packages/backpack-web/src/bpk-component-price/src/BpkPrice-test.tsx
@@ -105,8 +105,6 @@ describe.each([
       />,
     );
 
-    const previous = container.querySelector('.bpk-price__previous-price');
-    expect(previous).toHaveTextContent(previousPrice);
     expect(screen.getByText(previousPrice)).toHaveClass(expectedDefaultClass);
   });
 

--- a/packages/backpack-web/src/bpk-component-price/src/BpkPrice.module.scss
+++ b/packages/backpack-web/src/bpk-component-price/src/BpkPrice.module.scss
@@ -21,7 +21,6 @@
 .bpk-price {
   display: flex;
   flex-direction: column;
-  color: tokens.$bpk-text-secondary-day;
 
   &--right {
     align-items: flex-end;
@@ -35,12 +34,6 @@
       display: flex;
       justify-content: flex-end;
     }
-  }
-
-  &__previous-price {
-    display: flex;
-    color: tokens.$bpk-text-error-day;
-    text-decoration-line: line-through;
   }
 
   &__separator {
@@ -58,7 +51,6 @@
 
   &__price {
     display: contents;
-    color: tokens.$bpk-text-primary-day;
     word-break: break-all;
   }
 

--- a/packages/backpack-web/src/bpk-component-price/src/BpkPrice.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-price/src/BpkPrice.stories.tsx
@@ -366,6 +366,7 @@ const MixedExample = () => (
 const meta = {
   title: 'bpk-component-price',
   component: BpkPrice,
+  tags: ['dark-mode-compatible'],
 } satisfies Meta;
 
 export default meta;

--- a/packages/backpack-web/src/bpk-component-price/src/BpkPrice.tsx
+++ b/packages/backpack-web/src/bpk-component-price/src/BpkPrice.tsx
@@ -18,7 +18,7 @@
 
 import type { HTMLAttributes, ReactNode } from 'react';
 
-import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
+import BpkText, { TEXT_STYLES, TEXT_COLORS } from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
 
 import { SIZES, ALIGNS } from './common-types';
@@ -92,7 +92,7 @@ const BpkPrice = ({
       return null;
     }
     const textNode = (
-      <BpkText textStyle={defaultTextStyle} tagName="span">
+      <BpkText textStyle={defaultTextStyle} tagName="span" color={TEXT_COLORS.textSecondary}>
         {trailingText}
       </BpkText>
     );
@@ -122,21 +122,19 @@ const BpkPrice = ({
         )}
       >
         {previousPrice && (
-          <span className={getClassName('bpk-price__previous-price')}>
-            <BpkText textStyle={defaultTextStyle} tagName="span">
-              {previousPrice}
-            </BpkText>
-          </span>
+          <BpkText textStyle={defaultTextStyle} tagName="span" color={TEXT_COLORS.textError} strikethrough>
+            {previousPrice}
+          </BpkText>
         )}
         {previousPrice && leadingText && (
           <span className={getClassName('bpk-price__separator')}>
-            <BpkText textStyle={defaultTextStyle} tagName="span">
+            <BpkText textStyle={defaultTextStyle} tagName="span" color={TEXT_COLORS.textSecondary}>
               &#67871;
             </BpkText>
           </span>
         )}
         {leadingText && (
-          <BpkText textStyle={defaultTextStyle} tagName="span">
+          <BpkText textStyle={defaultTextStyle} tagName="span" color={TEXT_COLORS.textSecondary}>
             {leadingText}
           </BpkText>
         )}
@@ -153,6 +151,7 @@ const BpkPrice = ({
           <BpkText
             textStyle={priceTextStyle}
             tagName="span"
+            color={TEXT_COLORS.textPrimary}
             {...dataAttributes}
           >
             {price}

--- a/packages/backpack-web/src/bpk-component-text/README.md
+++ b/packages/backpack-web/src/bpk-component-text/README.md
@@ -80,6 +80,21 @@ export default () => (
 );
 ```
 
+### Strikethrough Prop
+
+The `strikethrough` prop renders text with a line through it. It defaults to `false`. When combined with the `color` prop, both the text and the decoration line use the same color, ensuring visual consistency — including in dark mode.
+
+```javascript
+import BpkText, { TEXT_COLORS } from '@skyscanner/backpack-web/bpk-component-text';
+
+export default () => (
+  <BpkText strikethrough>Struck-through text</BpkText>
+  <BpkText color={TEXT_COLORS.textError} strikethrough>
+    Struck-through error text
+  </BpkText>
+);
+```
+
 ### Color Prop
 
 The `color` prop allows you to set the text color directly rather override by  `className`. It uses predefined `TEXT_COLORS` tokens to ensure ux consistency with the design system.

--- a/packages/backpack-web/src/bpk-component-text/src/BpkText.module.scss
+++ b/packages/backpack-web/src/bpk-component-text/src/BpkText.module.scss
@@ -172,6 +172,10 @@ $text-colors: (
     }
   }
 
+  &--strikethrough {
+    text-decoration-line: line-through;
+  }
+
   $text-aligns: 'start', 'end', 'center', 'justify';
 
   @each $align in $text-aligns {

--- a/packages/backpack-web/src/bpk-component-text/src/BpkText.module.scss
+++ b/packages/backpack-web/src/bpk-component-text/src/BpkText.module.scss
@@ -173,7 +173,7 @@ $text-colors: (
   }
 
   &--strikethrough {
-    text-decoration-line: line-through;
+    text-decoration: line-through;
   }
 
   $text-aligns: 'start', 'end', 'center', 'justify';

--- a/packages/backpack-web/src/bpk-component-text/src/BpkText.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-text/src/BpkText.stories.tsx
@@ -195,6 +195,20 @@ const ColorPropExample = () => (
   </div>
 );
 
+const StrikethroughExample = () => (
+  <div>
+    <BpkText tagName="p" strikethrough>
+      Plain strikethrough text
+    </BpkText>
+    <BpkText tagName="p" color={TEXT_COLORS.textError} strikethrough>
+      Strikethrough with textError color
+    </BpkText>
+    <BpkText tagName="p" color={TEXT_COLORS.textSecondary} strikethrough>
+      Strikethrough with textSecondary color
+    </BpkText>
+  </div>
+);
+
 const MixedExample = () => (
   <div>
     <HeroStylesExample />
@@ -203,6 +217,7 @@ const MixedExample = () => (
     <LabelStylesExample />
     <LarkenStylesExample />
     <ColorPropExample />
+    <StrikethroughExample />
   </div>
 );
 
@@ -268,6 +283,10 @@ export const TextAlignProp = {
 
 export const ColorProp = {
   render: () => <ColorPropExample />,
+};
+
+export const Strikethrough = {
+  render: () => <StrikethroughExample />,
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-text/src/BpkText.tsx
+++ b/packages/backpack-web/src/bpk-component-text/src/BpkText.tsx
@@ -100,6 +100,7 @@ type Props = {
   className?: string | null;
   color?: TextColor | null;
   textAlign?: TextAlign | null;
+  strikethrough?: boolean;
   id?: string;
   [rest: string]: any;
 };
@@ -108,6 +109,7 @@ const BpkText = ({
   children,
   className = null,
   color = null,
+  strikethrough = false,
   tagName: TagName = 'span',
   textAlign = null,
   textStyle = TEXT_STYLES.bodyDefault,
@@ -118,6 +120,7 @@ const BpkText = ({
     `bpk-text--${textStyle}`,
     color ? `bpk-text--${color}` : '',
     textAlign ? `bpk-text--align-${textAlign}` : '',
+    strikethrough ? 'bpk-text--strikethrough' : '',
     className,
   );
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

`BpkPrice` was not supporting dark mode because it set text colours via hardcoded SASS day tokens in SCSS rather than delegating to `BpkText`'s CSS custom property system. This PR fixes that by passing the appropriate `color` prop to each `BpkText` instance in `BpkPrice`, and removes the now-redundant colour rules from `BpkPrice.module.scss`.

A `strikethrough` boolean prop is also added to `BpkText` so that `text-decoration-line` and `color` always live on the same element — preventing the strikethrough line from desyncing from the text colour (as was the case with `previousPrice` in `BpkPrice`).

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here