### PR TITLE
[bpk-scrim-utils] Pin tabbable to 6.3.0 to fix Safari 16.0-16.3 modal crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41998,7 +41998,7 @@
         "react-table": "^7.8.0",
         "react-virtualized-auto-sizer": "1.0.20",
         "react-window": "^1.8.7",
-        "tabbable": "^6.4.0"
+        "tabbable": "6.3.0"
       },
       "peerDependencies": {
         "date-fns": "3.3.1 - 4",
@@ -42016,6 +42016,12 @@
           "optional": true
         }
       }
+    },
+    "packages/backpack-web/node_modules/tabbable": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.3.0.tgz",
+      "integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
+      "license": "MIT"
     }
   }
 }

--- a/packages/backpack-web/package.json
+++ b/packages/backpack-web/package.json
@@ -59,7 +59,7 @@
     "@react-google-maps/api": "^2.19.3",
     "@skyscanner/bpk-foundations-web": "^24.6.0",
     "@skyscanner/bpk-svgs": "^20.14.0",
-    "tabbable": "^6.4.0",
+    "tabbable": "6.3.0",
     "d3-path": "^3.1.0",
     "d3-scale": "^4.0.2",
     "downshift": "^9.0.10",


### PR DESCRIPTION
## Summary

`bpk-scrim-utils/focusScope.ts` calls `tabbable(element)` when a modal opens to find the first focusable element.

`tabbable@6.4.0` re-enabled a `querySelectorAll` fast-path using the CSS Selectors Level 4 syntax `:not([inert] *)`. This syntax is only supported from **Safari 16.4+**, so **Safari 16.0–16.3 throws a `SyntaxError`** immediately when any modal/picker opens (DestinationPicker, OriginPicker, CabinClassTraveller etc.). The call has no surrounding `try/catch`, so the crash is unrecoverable.

This was introduced in #4400, which migrated from the archived `a11y-focus-scope` package and bumped `tabbable` from v1 to `^6.4.0`.

## Fix

Pin `tabbable` to exact **`6.3.0`** in `backpack-web/package.json`. `6.3.x` uses manual DOM traversal instead of the CSS selector fast-path — functionally identical, no behaviour change.

> Note: the linked issue mentions "6.3.1", but that version does not exist on npm (`6.3.0` → `6.4.0`). `6.3.0` is the last release before the fast-path was re-introduced.

## Upstream confirmation

The same root cause is tracked upstream in [focus-trap/tabbable#1988](https://github.com/focus-trap/tabbable/issues/1988) (reported for Samsung Internet ≤14, same `:not([inert] *)` / Selectors Level 4 limitation). The selector was originally added in 6.1.0, removed in 6.1.1 for the exact same crash, then re-introduced in 6.4.0.

The tabbable maintainer has stated they **will not revert this upstream** and instead recommends consumers **"use the previous version that doesn't have the change, and then use an override"** — which is exactly what this PR does.

We do not need an npm `override` here: `@floating-ui/react`'s transitive `tabbable@6.4.0` stays at the top level (it never goes through the modal focus-scope path), while `backpack-web` resolves its own nested `tabbable@6.3.0` for `focusScope.ts`.

---

- [x] The PR title includes the name of the component being changed
- [ ] `README.md` (If you have created a new component) — n/a
- [x] Component `README.md` — n/a (internal utility, no API change)
- [x] Tests — no behaviour change; existing `focusScope-test.ts` covers the scoping logic
- [ ] Accessibility tests — n/a (no behaviour change)
- [ ] Storybook examples created/updated — n/a
- [ ] Migration guide — n/a (no breaking change)