### PR TITLE
[bpk-component-ai-blurb] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-ai-blurb/src/BpkAiBlurb.module.scss
+++ b/packages/backpack-web/src/bpk-component-ai-blurb/src/BpkAiBlurb.module.scss
@@ -22,10 +22,10 @@
 .bpk-ai-blurb {
   display: flex;
   flex-direction: column;
-  gap: tokens.bpk-spacing-md();
+  gap: var(--bpk-spacing-md, tokens.bpk-spacing-md());
 
   &__header {
-    color: tokens.$bpk-text-secondary-day;
+    color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
 
     // Apply secondary colour to the AI spark icon SVG
     svg {
@@ -42,7 +42,7 @@
     margin: 0;
     flex-wrap: wrap;
     align-items: baseline;
-    gap: 0 tokens.bpk-spacing-sm();
+    gap: 0 var(--bpk-spacing-sm, tokens.bpk-spacing-sm());
 
     @include typography.bpk-caption;
   }
@@ -50,7 +50,7 @@
   &__ellipsis {
     display: inline;
     vertical-align: baseline;
-    margin-inline-start: tokens.bpk-spacing-sm();
+    margin-inline-start: var(--bpk-spacing-sm, tokens.bpk-spacing-sm());
 
     &-dot {
       display: inline;


### PR DESCRIPTION
## Summary

- Migrates bare SASS tokens in `BpkAiBlurb.module.scss` to the `var(--css-var, sass-fallback)` pattern
- Tokens migrated: `$bpk-text-secondary-day`, `bpk-spacing-md()`, `bpk-spacing-sm()` (×2)
- Enables CSS custom property overrides for theming while preserving SASS token fallbacks

Closes #4794

🤖 Generated with [Claude Code](https://claude.com/claude-code)