### PR TITLE
[bpk-component-infinite-scroll] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-infinite-scroll/src/BpkInfiniteScroll.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-infinite-scroll/src/BpkInfiniteScroll.stories.module.scss
@@ -33,14 +33,8 @@
       height: tokens.bpk-spacing-xxl() * 2;
       justify-content: center;
       align-items: center;
-      background-color: var(
-        --bpk-canvas-contrast,
-        tokens.$bpk-canvas-contrast-day
-      );
-      color: var(
-        --bpk-text-secondary,
-        tokens.$bpk-text-secondary-day
-      );
+      background-color: var(--bpk-canvas-contrast, tokens.$bpk-canvas-contrast-day);
+      color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
     }
   }
 

--- a/packages/backpack-web/src/bpk-component-infinite-scroll/src/BpkInfiniteScroll.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-infinite-scroll/src/BpkInfiniteScroll.stories.module.scss
@@ -33,7 +33,10 @@
       height: tokens.bpk-spacing-xxl() * 2;
       justify-content: center;
       align-items: center;
-      background-color: var(--bpk-canvas-contrast, tokens.$bpk-canvas-contrast-day);
+      background-color: var(
+        --bpk-canvas-contrast,
+        tokens.$bpk-canvas-contrast-day
+      );
       color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
     }
   }

--- a/packages/backpack-web/src/bpk-component-infinite-scroll/src/BpkInfiniteScroll.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-infinite-scroll/src/BpkInfiniteScroll.stories.module.scss
@@ -33,8 +33,14 @@
       height: tokens.bpk-spacing-xxl() * 2;
       justify-content: center;
       align-items: center;
-      background-color: var(--bpk-canvas-contrast, tokens.$bpk-canvas-contrast-day);
-      color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
+      background-color: var(
+        --bpk-canvas-contrast,
+        tokens.$bpk-canvas-contrast-day
+      );
+      color: var(
+        --bpk-text-secondary,
+        tokens.$bpk-text-secondary-day
+      );
     }
   }
 

--- a/packages/backpack-web/src/bpk-component-infinite-scroll/src/BpkInfiniteScroll.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-infinite-scroll/src/BpkInfiniteScroll.stories.module.scss
@@ -33,8 +33,8 @@
       height: tokens.bpk-spacing-xxl() * 2;
       justify-content: center;
       align-items: center;
-      background-color: tokens.$bpk-canvas-contrast-day;
-      color: tokens.$bpk-text-secondary-day;
+      background-color: var(--bpk-canvas-contrast, tokens.$bpk-canvas-contrast-day);
+      color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
     }
   }
 


### PR DESCRIPTION
## Summary

- Migrates bare SASS tokens in `BpkInfiniteScroll.stories.module.scss` to CSS custom properties with SASS fallbacks
- `tokens.$bpk-canvas-contrast-day` → `var(--bpk-canvas-contrast, tokens.$bpk-canvas-contrast-day)`
- `tokens.$bpk-text-secondary-day` → `var(--bpk-text-secondary, tokens.$bpk-text-secondary-day)`

Closes #4800

## Test plan

- [x] All existing tests pass (`npx jest packages/backpack-web/src/bpk-component-infinite-scroll --passWithNoTests`)
- [x] No bare `tokens.$bpk-*-day` tokens remain outside of `var()` fallbacks
- [x] SCSS files only — no `.tsx` or `.ts` files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)