### PR TITLE
[bpk-component-section-header] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.module.scss
+++ b/packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.module.scss
@@ -31,11 +31,11 @@
     flex-direction: column;
 
     &--default {
-      color: tokens.$bpk-text-primary-day;
+      color: var(--bpk-text-primary, tokens.$bpk-text-primary-day);
     }
 
     &--on-dark {
-      color: tokens.$bpk-text-on-dark-day;
+      color: var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day);
     }
   }
 

--- a/packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.stories.module.scss
@@ -22,7 +22,10 @@
   &__on-dark {
     margin-top: tokens.bpk-spacing-lg();
     padding: tokens.bpk-spacing-base();
-    background-color: var(--bpk-surface-contrast, tokens.$bpk-surface-contrast-day);
+    background-color: var(
+      --bpk-surface-contrast,
+      tokens.$bpk-surface-contrast-day
+    );
   }
 
   &__mixed {

--- a/packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.stories.module.scss
@@ -22,7 +22,7 @@
   &__on-dark {
     margin-top: tokens.bpk-spacing-lg();
     padding: tokens.bpk-spacing-base();
-    background-color: tokens.$bpk-surface-contrast-day;
+    background-color: var(--bpk-surface-contrast, tokens.$bpk-surface-contrast-day);
   }
 
   &__mixed {


### PR DESCRIPTION
## What did you change?

Migrated bare SASS token references in `bpk-component-section-header` SCSS files to CSS custom properties with SASS fallbacks, enabling light/dark mode theming support.

### Token replacements

| Before | After |
|--------|-------|
| `tokens.$bpk-text-primary-day` | `var(--bpk-text-primary, tokens.$bpk-text-primary-day)` |
| `tokens.$bpk-text-on-dark-day` | `var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day)` |
| `tokens.$bpk-surface-contrast-day` | `var(--bpk-surface-contrast, tokens.$bpk-surface-contrast-day)` |

### Files changed

- `packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.module.scss`
- `packages/backpack-web/src/bpk-component-section-header/src/BpkSectionHeader.stories.module.scss`

Closes #4796

🤖 Generated with [Claude Code](https://claude.ai/claude-code)