### PR TITLE
[bpk-component-mobile-scroll-container] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-mobile-scroll-container/src/BpkMobileScrollContainer.stories.module.scss
@@ -22,13 +22,13 @@
 .bpk-stories-mobile-scroll-container {
   &__leading-indicator {
     @include scroll-indicators.bpk-scroll-indicator-left(
-      tokens.$bpk-core-accent-day
+      var(--bpk-core-accent, tokens.$bpk-core-accent-day)
     );
   }
 
   &__trailing-indicator {
     @include scroll-indicators.bpk-scroll-indicator-right(
-      tokens.$bpk-core-accent-day
+      var(--bpk-core-accent, tokens.$bpk-core-accent-day)
     );
   }
 }
@@ -42,10 +42,16 @@
     height: tokens.bpk-spacing-xxl() * 5;
     justify-content: center;
     align-items: center;
-    background-color: tokens.$bpk-canvas-contrast-day;
+    background-color: var(
+      --bpk-canvas-contrast,
+      tokens.$bpk-canvas-contrast-day
+    );
 
     &--alternate {
-      background-color: tokens.$bpk-surface-highlight-day;
+      background-color: var(
+        --bpk-surface-highlight,
+        tokens.$bpk-surface-highlight-day
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

- Migrates bare SASS token references in `BpkMobileScrollContainer.stories.module.scss` to CSS custom properties with SASS fallbacks
- Replaces `tokens.$bpk-core-accent-day` → `var(--bpk-core-accent, tokens.$bpk-core-accent-day)` (×2, passed as mixin args)
- Replaces `tokens.$bpk-canvas-contrast-day` → `var(--bpk-canvas-contrast, tokens.$bpk-canvas-contrast-day)`
- Replaces `tokens.$bpk-surface-highlight-day` → `var(--bpk-surface-highlight, tokens.$bpk-surface-highlight-day)`

Closes #4801

## Test plan

- [x] All existing tests pass (`npx jest bpk-component-mobile-scroll-container --passWithNoTests`)
- [x] No bare `tokens.$bpk-*-day` remain (spacing arithmetic expressions are intentionally kept as-is since `var()` does not support arithmetic)
- [x] SCSS only — no `.tsx`/`.ts` files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)