### PR TITLE
[bpk-component-table] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-table/src/BpkTable.module.scss
+++ b/packages/backpack-web/src/bpk-component-table/src/BpkTable.module.scss
@@ -25,7 +25,7 @@
   &__body {
     &--striped {
       tr:nth-child(even) {
-        background-color: tokens.$bpk-canvas-contrast-day;
+        background-color: var(--bpk-canvas-contrast, tokens.$bpk-canvas-contrast-day);
       }
     }
   }

--- a/packages/backpack-web/src/bpk-component-table/src/BpkTable.module.scss
+++ b/packages/backpack-web/src/bpk-component-table/src/BpkTable.module.scss
@@ -25,7 +25,10 @@
   &__body {
     &--striped {
       tr:nth-child(even) {
-        background-color: var(--bpk-canvas-contrast, tokens.$bpk-canvas-contrast-day);
+        background-color: var(
+          --bpk-canvas-contrast,
+          tokens.$bpk-canvas-contrast-day
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

- Replaces bare `tokens.$bpk-canvas-contrast-day` with `var(--bpk-canvas-contrast, tokens.$bpk-canvas-contrast-day)` in `BpkTable.module.scss`
- Enables the striped table row background to respond to light/dark theme switching via CSS custom properties
- SCSS-only change; no `.tsx`/`.ts` files touched

Closes #4799

🤖 Generated with [Claude Code](https://claude.com/claude-code)