### PR TITLE
[bpk-component-spinner] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-spinner/src/BpkSpinner.module.scss
+++ b/packages/backpack-web/src/bpk-component-spinner/src/BpkSpinner.module.scss
@@ -18,7 +18,6 @@
 
 @use '../../bpk-mixins/tokens';
 @use '../../bpk-mixins/spinners';
-@use '../../bpk-mixins/utils';
 
 .bpk-spinner {
   display: block;
@@ -27,19 +26,15 @@
 
   &--primary {
     // Post colour adoption/rollout we will require to move the 'primary' style to be the same as dark and make dark (moving to primary/defautl) and light the only options
-    @include utils.bpk-themeable-property(
-      fill,
-      --bpk-spinner-primary-color,
-      tokens.$bpk-core-accent-day
-    );
+    fill: var(--bpk-core-accent, tokens.$bpk-core-accent-day);
   }
 
   &--light {
-    fill: tokens.$bpk-text-on-dark-day;
+    fill: var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day);
   }
 
   &--dark {
-    fill: tokens.$bpk-text-primary-day;
+    fill: var(--bpk-text-primary, tokens.$bpk-text-primary-day);
   }
 
   &--large {

--- a/packages/backpack-web/src/bpk-component-spinner/src/SpinnerLayout.story-helpers.module.scss
+++ b/packages/backpack-web/src/bpk-component-spinner/src/SpinnerLayout.story-helpers.module.scss
@@ -25,11 +25,14 @@
 
   &__spinner {
     display: flex;
-    padding: tokens.bpk-spacing-lg();
+    padding: var(--bpk-spacing-lg, tokens.bpk-spacing-lg());
     justify-content: center;
 
     &--light {
-      background-color: tokens.$bpk-surface-contrast-day;
+      background-color: var(
+        --bpk-surface-contrast,
+        tokens.$bpk-surface-contrast-day
+      );
 
       @include radii.bpk-border-radius-xs;
     }


### PR DESCRIPTION
## Summary

- Replaces bare SASS tokens in `BpkSpinner.module.scss` and `SpinnerLayout.story-helpers.module.scss` with `var()` declarations and SASS fallbacks
- Removes the legacy `bpk-themeable-property` mixin call from the `--primary` variant, replacing it with `var(--bpk-core-accent, tokens.$bpk-core-accent-day)`
- Removes now-unused `@use '../../bpk-mixins/utils'` import

### Token replacements

| Before | After |
|--------|-------|
| `tokens.$bpk-core-accent-day` | `var(--bpk-core-accent, tokens.$bpk-core-accent-day)` |
| `tokens.$bpk-text-on-dark-day` | `var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day)` |
| `tokens.$bpk-text-primary-day` | `var(--bpk-text-primary, tokens.$bpk-text-primary-day)` |
| `tokens.$bpk-surface-contrast-day` | `var(--bpk-surface-contrast, tokens.$bpk-surface-contrast-day)` |
| `tokens.bpk-spacing-lg()` | `var(--bpk-spacing-lg, tokens.bpk-spacing-lg())` |

Closes #4802

🤖 Generated with [Claude Code](https://claude.com/claude-code)