### PR TITLE
[bpk-component-fieldset] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-fieldset/src/BpkFieldset.module.scss
+++ b/packages/backpack-web/src/bpk-component-fieldset/src/BpkFieldset.module.scss
@@ -26,13 +26,13 @@
 
   &__description {
     display: block;
-    margin-top: tokens.bpk-spacing-md();
-    color: tokens.$bpk-text-secondary-day;
+    margin-top: var(--bpk-spacing-md, tokens.bpk-spacing-md());
+    color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
 
     @include typography.bpk-caption;
   }
 
   &__label {
-    margin-bottom: tokens.bpk-spacing-sm();
+    margin-bottom: var(--bpk-spacing-sm, tokens.bpk-spacing-sm());
   }
 }

--- a/packages/backpack-web/src/bpk-component-fieldset/src/BpkFieldset.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-fieldset/src/BpkFieldset.stories.module.scss
@@ -25,12 +25,12 @@
   }
 
   &__fieldset {
-    margin-right: tokens.bpk-spacing-sm();
+    margin-right: var(--bpk-spacing-sm, tokens.bpk-spacing-sm());
     flex: 1;
 
     @include utils.bpk-rtl {
       margin-right: 0;
-      margin-left: tokens.bpk-spacing-sm();
+      margin-left: var(--bpk-spacing-sm, tokens.bpk-spacing-sm());
     }
   }
 


### PR DESCRIPTION
## Summary

- Wraps bare SASS tokens in `BpkFieldset.module.scss` with CSS custom property `var()` calls for light/dark theme support
- Migrates `tokens.$bpk-text-secondary-day` → `var(--bpk-text-secondary, tokens.$bpk-text-secondary-day)`
- Migrates spacing functions `tokens.bpk-spacing-md()` and `tokens.bpk-spacing-sm()` to use `var(--bpk-spacing-md, ...)` and `var(--bpk-spacing-sm, ...)` respectively
- Applies same spacing migration to `BpkFieldset.stories.module.scss`

Closes #4797

## Test plan

- [ ] All existing Jest tests pass (16 tests, 15 snapshots)
- [ ] Stylelint passes
- [ ] No bare `tokens.$bpk-*-day` or `tokens.bpk-spacing-*()` remain in the fieldset SCSS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)