### PR TITLE
Add CI check that validates CSS vars in changed files exist in base.css

### DIFF
--- a/.github/workflows/css-var-check.yml
+++ b/.github/workflows/css-var-check.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Check CSS vars
         id: check
@@ -65,8 +67,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const marker = process.env.COMMENT_MARKER;
-            const rawOutput = ${{ toJSON(steps.check.outputs.output) }};
-            const exitCode = parseInt(${{ toJSON(steps.check.outputs.exit_code) }}, 10);
+            const rawOutput = process.env.CHECK_OUTPUT;
             const skipLabel = context.payload.pull_request.labels
               .some(l => l.name === 'skip-css-var-check');
 
@@ -114,12 +115,14 @@ jobs:
             }
         env:
           COMMENT_MARKER: ${{ env.COMMENT_MARKER }}
+          CHECK_OUTPUT: ${{ steps.check.outputs.output }}
 
       - name: Fail if violations found and label not set
         if: steps.check.outputs.exit_code != '0'
+        env:
+          HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-css-var-check') }}
         run: |
-          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
-          if echo "$LABELS" | grep -q 'skip-css-var-check'; then
+          if [ "$HAS_SKIP_LABEL" = "true" ]; then
             echo "skip-css-var-check label is set — allowing merge despite violations."
             exit 0
           fi

--- a/.github/workflows/css-var-check.yml
+++ b/.github/workflows/css-var-check.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: css-var-check-${{ github.head_ref || github.run_id }}
+  group: css-var-check-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 defaults:
@@ -58,7 +58,12 @@ jobs:
           OUTPUT=$(node scripts/npm/check-css-vars.js --json)
           EXIT_CODE=$?
           set -e
-          echo "output=$OUTPUT" >> "$GITHUB_OUTPUT"
+          # Use heredoc syntax so JSON with special characters is passed safely
+          {
+            echo "output<<__EOF__"
+            echo "$OUTPUT"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
       - name: Post or update PR comment

--- a/.github/workflows/css-var-check.yml
+++ b/.github/workflows/css-var-check.yml
@@ -1,0 +1,127 @@
+name: CSS var check
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+    branches: [main]
+
+concurrency:
+  group: css-var-check-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+permissions: {}
+
+env:
+  CACHE_NAME: node-modules-cache-v2
+  # Marker so we can find-and-update our own comment across pushes
+  COMMENT_MARKER: "<!-- css-var-check -->"
+
+jobs:
+  css-var-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Restore NPM Cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: node_modules/
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
+
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Check CSS vars
+        id: check
+        run: |
+          set +e
+          OUTPUT=$(node scripts/npm/check-css-vars.js --json)
+          EXIT_CODE=$?
+          set -e
+          echo "output=$OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const marker = process.env.COMMENT_MARKER;
+            const rawOutput = ${{ toJSON(steps.check.outputs.output) }};
+            const exitCode = parseInt(${{ toJSON(steps.check.outputs.exit_code) }}, 10);
+            const skipLabel = context.payload.pull_request.labels
+              .some(l => l.name === 'skip-css-var-check');
+
+            let parsed;
+            try { parsed = JSON.parse(rawOutput); } catch { parsed = { violations: [] }; }
+
+            const { violations = [] } = parsed;
+
+            let body;
+            if (violations.length === 0) {
+              body = `${marker}\n### CSS var check ✅\n\nNo undefined CSS vars found in changed lines.`;
+            } else {
+              const rows = violations
+                .map(v => `| \`${v.varName}\` | \`${v.file}:${v.line}\` |`)
+                .join('\n');
+              const table = `| Variable | Location |\n|---|---|\n${rows}`;
+              const skipNote = skipLabel
+                ? '\n\n> ⚠️ **skip-css-var-check** label is set — CI will not fail, but these vars are still missing from base.css.'
+                : '\n\n> Add the **skip-css-var-check** label to bypass the CI failure.';
+              body = `${marker}\n### CSS var check ❌\n\n${violations.length} CSS var(s) used in new/changed lines are not defined in \`base.css\`:\n\n${table}${skipNote}`;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+        env:
+          COMMENT_MARKER: ${{ env.COMMENT_MARKER }}
+
+      - name: Fail if violations found and label not set
+        if: steps.check.outputs.exit_code != '0'
+        run: |
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q 'skip-css-var-check'; then
+            echo "skip-css-var-check label is set — allowing merge despite violations."
+            exit 0
+          fi
+          echo "CSS var violations found. Add the 'skip-css-var-check' label to bypass."
+          exit 1

--- a/scripts/npm/check-css-vars.js
+++ b/scripts/npm/check-css-vars.js
@@ -18,13 +18,14 @@
 
 /* eslint-disable no-console */
 
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
+const path = require('path');
 
 const BASE_CSS = 'packages/backpack-web/src/bpk-stylesheets/base.css';
 
-// Only check these source extensions; skip compiled .module.css outputs
-const SOURCE_GLOB = ['*.scss', '*.tsx', '*.ts', '*.js', '*.jsx'];
+// Allowlisted source extensions — everything else is skipped
+const SOURCE_EXTENSIONS = new Set(['.scss', '.tsx', '.ts', '.js', '.jsx']);
 // Skip compiled CSS module outputs and node_modules
 const SKIP_REGEX = /(\bnode_modules\b|\.module\.css$)/;
 
@@ -40,29 +41,41 @@ function extractDefinedVars(cssPath) {
   return defined;
 }
 
+function isCheckedFile(filePath) {
+  if (SKIP_REGEX.test(filePath)) return false;
+  return SOURCE_EXTENSIONS.has(path.extname(filePath));
+}
+
 // Parse added lines from a unified diff, returning { file, line, content }[]
 function parseAddedLines(diff) {
   const results = [];
   let currentFile = null;
   let currentNewLine = 0;
+  let insideHunk = false;
 
   for (const line of diff.split('\n')) {
     if (line.startsWith('+++ b/')) {
-      currentFile = line.slice(6);
-      if (SKIP_REGEX.test(currentFile)) currentFile = null;
+      currentFile = isCheckedFile(line.slice(6)) ? line.slice(6) : null;
+      insideHunk = false;
     } else if (line.startsWith('@@ ')) {
       const lineMatch = line.match(/\+(\d+)/);
       if (lineMatch) currentNewLine = parseInt(lineMatch[1], 10) - 1;
+      insideHunk = true;
+    } else if (!insideHunk) {
+      // skip diff header lines before the first hunk
+    } else if (line.startsWith('\\')) {
+      // meta line e.g. "\ No newline at end of file" — do not advance counter
     } else if (line.startsWith('+') && !line.startsWith('+++')) {
       currentNewLine += 1;
       if (currentFile) {
         results.push({
+          content: line.slice(1),
           file: currentFile,
           line: currentNewLine,
-          content: line.slice(1),
         });
       }
     } else if (!line.startsWith('-')) {
+      // context line
       currentNewLine += 1;
     }
   }
@@ -70,16 +83,34 @@ function parseAddedLines(diff) {
   return results;
 }
 
+// Use :(glob) pathspecs so nested files are matched at any depth.
+// We still filter by extension in JS (isCheckedFile) as an extra safety net.
+// spawnSync with an args array bypasses the shell so :(glob) is passed
+// directly to git without shell-quoting issues.
+const DIFF_PATHSPECS = [
+  ':(glob)**/*.scss',
+  ':(glob)**/*.tsx',
+  ':(glob)**/*.ts',
+  ':(glob)**/*.js',
+  ':(glob)**/*.jsx',
+];
+
 function getDiff() {
-  try {
-    const globs = SOURCE_GLOB.map((g) => `"${g}"`).join(' ');
-    return execSync(
-      `git diff origin/main --unified=0 --diff-filter=ACMR -- ${globs}`,
-      { encoding: 'utf8' },
-    );
-  } catch {
-    return '';
-  }
+  const result = spawnSync(
+    'git',
+    [
+      'diff',
+      'origin/main',
+      '--unified=0',
+      '--diff-filter=ACMR',
+      '--',
+      ...DIFF_PATHSPECS,
+    ],
+    { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(result.stderr || 'git diff failed');
+  return result.stdout;
 }
 
 function findViolations(addedLines, definedVars) {
@@ -111,7 +142,17 @@ if (!fs.existsSync(BASE_CSS)) {
 }
 
 const definedVars = extractDefinedVars(BASE_CSS);
-const diff = getDiff();
+
+let diff;
+try {
+  diff = getDiff();
+} catch (err) {
+  const msg = `git diff failed: ${err.message}`;
+  if (useJson) console.log(JSON.stringify({ error: msg, violations: [] }));
+  else console.error(msg);
+  process.exit(1);
+}
+
 const addedLines = parseAddedLines(diff);
 const violations = findViolations(addedLines, definedVars);
 

--- a/scripts/npm/check-css-vars.js
+++ b/scripts/npm/check-css-vars.js
@@ -1,0 +1,132 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-console */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+const BASE_CSS = 'packages/backpack-web/src/bpk-stylesheets/base.css';
+
+// Only check these source extensions; skip compiled .module.css outputs
+const SOURCE_GLOB = ['*.scss', '*.tsx', '*.ts', '*.js', '*.jsx'];
+// Skip compiled CSS module outputs and node_modules
+const SKIP_REGEX = /(\bnode_modules\b|\.module\.css$)/;
+
+function extractDefinedVars(cssPath) {
+  const content = fs.readFileSync(cssPath, 'utf8');
+  const defined = new Set();
+  const re = /(--bpk-[a-z0-9-]+)\s*:/g;
+  let m = re.exec(content);
+  while (m !== null) {
+    defined.add(m[1]);
+    m = re.exec(content);
+  }
+  return defined;
+}
+
+// Parse added lines from a unified diff, returning { file, line, content }[]
+function parseAddedLines(diff) {
+  const results = [];
+  let currentFile = null;
+  let currentNewLine = 0;
+
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++ b/')) {
+      currentFile = line.slice(6);
+      if (SKIP_REGEX.test(currentFile)) currentFile = null;
+    } else if (line.startsWith('@@ ')) {
+      const lineMatch = line.match(/\+(\d+)/);
+      if (lineMatch) currentNewLine = parseInt(lineMatch[1], 10) - 1;
+    } else if (line.startsWith('+') && !line.startsWith('+++')) {
+      currentNewLine += 1;
+      if (currentFile) {
+        results.push({
+          file: currentFile,
+          line: currentNewLine,
+          content: line.slice(1),
+        });
+      }
+    } else if (!line.startsWith('-')) {
+      currentNewLine += 1;
+    }
+  }
+
+  return results;
+}
+
+function getDiff() {
+  try {
+    const globs = SOURCE_GLOB.map((g) => `"${g}"`).join(' ');
+    return execSync(
+      `git diff origin/main --unified=0 --diff-filter=ACMR -- ${globs}`,
+      { encoding: 'utf8' },
+    );
+  } catch {
+    return '';
+  }
+}
+
+function findViolations(addedLines, definedVars) {
+  const violations = [];
+  const re = /var\((--bpk-[a-z0-9-]+)/g;
+
+  for (const { content, file, line } of addedLines) {
+    re.lastIndex = 0;
+    let m = re.exec(content);
+    while (m !== null) {
+      const varName = m[1];
+      if (!definedVars.has(varName)) {
+        violations.push({ file, line, varName });
+      }
+      m = re.exec(content);
+    }
+  }
+
+  return violations;
+}
+
+const useJson = process.argv.includes('--json');
+
+if (!fs.existsSync(BASE_CSS)) {
+  const msg = `Could not find base.css at ${BASE_CSS}`;
+  if (useJson) console.log(JSON.stringify({ error: msg, violations: [] }));
+  else console.error(msg);
+  process.exit(1);
+}
+
+const definedVars = extractDefinedVars(BASE_CSS);
+const diff = getDiff();
+const addedLines = parseAddedLines(diff);
+const violations = findViolations(addedLines, definedVars);
+
+if (useJson) {
+  console.log(JSON.stringify({ violations }));
+} else if (violations.length === 0) {
+  console.log('All CSS vars in changed lines are defined in base.css. 👍');
+} else {
+  console.log(
+    `Found ${violations.length} CSS var(s) used in new lines but not defined in base.css:\n`,
+  );
+  violations.forEach(({ file, line, varName }) => {
+    console.log(`  ${file}:${line}  ${varName}`);
+  });
+  console.log('');
+}
+
+process.exit(violations.length > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Adds `scripts/npm/check-css-vars.js` — scans **only added lines** in changed `.scss`/`.tsx`/`.ts`/`.js`/`.jsx` files for `var(--bpk-*)` usage not defined in `bpk-stylesheets/base.css`
- Adds `.github/workflows/css-var-check.yml` — standalone PR workflow that posts or **amends a single comment** per PR with ✅/❌ results
- Hard-fails CI on violations; escape hatch via the `skip-css-var-check` label (re-runs instantly on label events, no re-push needed)

## Test plan

- [ ] Open a PR that adds `var(--bpk-does-not-exist, fallback)` in a `.scss` file → comment should appear with ❌ table and CI should fail
- [ ] Apply `skip-css-var-check` label → workflow re-runs, comment updates with warning note, CI passes
- [ ] Remove the violation → next push updates comment to ✅ and CI passes
- [ ] Open a PR with no CSS var changes → comment shows ✅ immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)