### PR TITLE
[bpk-component-nudger] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-nudger/src/BpkNudger.module.scss
+++ b/packages/backpack-web/src/bpk-component-nudger/src/BpkNudger.module.scss
@@ -29,7 +29,7 @@
     display: inline-block;
     padding: tokens.bpk-spacing-md() 0;
     border: none;
-    color: tokens.$bpk-text-primary-day;
+    color: var(--bpk-text-primary, tokens.$bpk-text-primary-day);
     text-align: center;
     vertical-align: middle;
 
@@ -48,7 +48,7 @@
 
     &--secondary-on-dark {
       background-color: transparent;
-      color: tokens.$bpk-text-on-dark-day;
+      color: var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day);
     }
 
     &--numeric {
@@ -75,7 +75,7 @@
     }
 
     &--subtitle {
-      color: tokens.$bpk-text-secondary-day;
+      color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
     }
   }
 }

--- a/packages/backpack-web/src/bpk-component-nudger/src/BpkNudger.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-nudger/src/BpkNudger.stories.module.scss
@@ -19,7 +19,7 @@
 @use '../../bpk-mixins/tokens';
 
 .bpk-nudger-secondary-on-dark {
-  color: tokens.$bpk-text-on-dark-day;
+  color: var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day);
 }
 
 .bpk-nudger-configurable {


### PR DESCRIPTION
## Summary

- Migrates bare SASS tokens in `bpk-component-nudger` to `var()` with SASS fallbacks for light/dark mode support
- `tokens.$bpk-text-primary-day` → `var(--bpk-text-primary, tokens.$bpk-text-primary-day)`
- `tokens.$bpk-text-secondary-day` → `var(--bpk-text-secondary, tokens.$bpk-text-secondary-day)`
- `tokens.$bpk-text-on-dark-day` → `var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day)` (in both `BpkNudger.module.scss` and `BpkNudger.stories.module.scss`)

Closes #4798

## Test plan

- [ ] All 15 existing nudger tests pass
- [ ] Visual appearance unchanged in light mode (SASS fallbacks preserve existing values)
- [ ] Component responds correctly to theme CSS vars in dark mode