### PR TITLE
[bpk-component-section-list] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListItem.module.scss
+++ b/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListItem.module.scss
@@ -24,7 +24,7 @@
 
   display: flex;
   width: 100%;
-  min-height: calc(var(--bpk-spacing-xl, tokens.bpk-spacing-xl()) * 2);
+  min-height: tokens.bpk-spacing-xl() * 2;
   padding: var(--bpk-spacing-md, tokens.bpk-spacing-md())
     var(--bpk-spacing-base, tokens.bpk-spacing-base());
   justify-content: space-between;

--- a/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListItem.module.scss
+++ b/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListItem.module.scss
@@ -24,7 +24,7 @@
 
   display: flex;
   width: 100%;
-  min-height: tokens.bpk-spacing-xl() * 2;
+  min-height: calc(var(--bpk-spacing-xl, tokens.bpk-spacing-xl()) * 2);
   padding: var(--bpk-spacing-md, tokens.bpk-spacing-md())
     var(--bpk-spacing-base, tokens.bpk-spacing-base());
   justify-content: space-between;

--- a/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListItem.module.scss
+++ b/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListItem.module.scss
@@ -25,15 +25,15 @@
   display: flex;
   width: 100%;
   min-height: tokens.bpk-spacing-xl() * 2;
-  padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
+  padding: var(--bpk-spacing-md, tokens.bpk-spacing-md()) var(--bpk-spacing-base, tokens.bpk-spacing-base());
   justify-content: space-between;
   align-items: center;
   border: none;
-  background-color: tokens.$bpk-surface-default-day;
-  color: tokens.$bpk-text-primary-day;
+  background-color: var(--bpk-surface-default, tokens.$bpk-surface-default-day);
+  color: var(--bpk-text-primary, tokens.$bpk-text-primary-day);
   text-decoration: none;
 
-  @include borders.bpk-border-bottom-sm(tokens.$bpk-line-day);
+  @include borders.bpk-border-bottom-sm(var(--bpk-other-line-default, tokens.$bpk-line-day));
 
   &--interactive {
     cursor: pointer;
@@ -41,14 +41,14 @@
 
   &__chevron {
     display: contents;
-    fill: tokens.$bpk-text-secondary-day;
+    fill: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
 
     #{$root}:hover & {
-      fill: tokens.$bpk-text-primary-day;
+      fill: var(--bpk-text-primary, tokens.$bpk-text-primary-day);
     }
 
     #{$root}:active & {
-      fill: tokens.$bpk-text-primary-day;
+      fill: var(--bpk-text-primary, tokens.$bpk-text-primary-day);
     }
   }
 }

--- a/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListItem.module.scss
+++ b/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListItem.module.scss
@@ -25,7 +25,8 @@
   display: flex;
   width: 100%;
   min-height: tokens.bpk-spacing-xl() * 2;
-  padding: var(--bpk-spacing-md, tokens.bpk-spacing-md()) var(--bpk-spacing-base, tokens.bpk-spacing-base());
+  padding: var(--bpk-spacing-md, tokens.bpk-spacing-md())
+    var(--bpk-spacing-base, tokens.bpk-spacing-base());
   justify-content: space-between;
   align-items: center;
   border: none;
@@ -33,7 +34,9 @@
   color: var(--bpk-text-primary, tokens.$bpk-text-primary-day);
   text-decoration: none;
 
-  @include borders.bpk-border-bottom-sm(var(--bpk-other-line-default, tokens.$bpk-line-day));
+  @include borders.bpk-border-bottom-sm(
+    var(--bpk-other-line-default, tokens.$bpk-line-day)
+  );
 
   &--interactive {
     cursor: pointer;

--- a/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListSection.module.scss
+++ b/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListSection.module.scss
@@ -26,8 +26,12 @@
   &__header {
     display: flex;
     min-height: var(--bpk-spacing-xl, tokens.bpk-spacing-xl());
-    padding: var(--bpk-spacing-md, tokens.bpk-spacing-md()) var(--bpk-spacing-base, tokens.bpk-spacing-base());
+    padding: var(--bpk-spacing-md, tokens.bpk-spacing-md())
+      var(--bpk-spacing-base, tokens.bpk-spacing-base());
     align-items: center;
-    background-color: var(--bpk-surface-highlight, tokens.$bpk-surface-highlight-day);
+    background-color: var(
+      --bpk-surface-highlight,
+      tokens.$bpk-surface-highlight-day
+    );
   }
 }

--- a/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListSection.module.scss
+++ b/packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListSection.module.scss
@@ -25,9 +25,9 @@
 
   &__header {
     display: flex;
-    min-height: tokens.bpk-spacing-xl();
-    padding: tokens.bpk-spacing-md() tokens.bpk-spacing-base();
+    min-height: var(--bpk-spacing-xl, tokens.bpk-spacing-xl());
+    padding: var(--bpk-spacing-md, tokens.bpk-spacing-md()) var(--bpk-spacing-base, tokens.bpk-spacing-base());
     align-items: center;
-    background-color: tokens.$bpk-surface-highlight-day;
+    background-color: var(--bpk-surface-highlight, tokens.$bpk-surface-highlight-day);
   }
 }


### PR DESCRIPTION
## Summary

Migrates `bpk-component-section-list` SCSS files to use CSS custom properties with SASS token fallbacks, enabling light/dark mode theming via the CSS custom properties system.

### Token replacements applied

- `tokens.$bpk-line-day` → `var(--bpk-other-line-default, tokens.$bpk-line-day)`
- `tokens.$bpk-surface-default-day` → `var(--bpk-surface-default, tokens.$bpk-surface-default-day)`
- `tokens.$bpk-surface-highlight-day` → `var(--bpk-surface-highlight, tokens.$bpk-surface-highlight-day)`
- `tokens.$bpk-text-primary-day` → `var(--bpk-text-primary, tokens.$bpk-text-primary-day)`
- `tokens.$bpk-text-secondary-day` → `var(--bpk-text-secondary, tokens.$bpk-text-secondary-day)`
- Spacing tokens wrapped in `var(--bpk-spacing-*, tokens.bpk-spacing-*())`

**Note:** `tokens.bpk-spacing-xl() * 2` (arithmetic expression) intentionally left unwrapped — `var()` cannot participate in SASS arithmetic.

## Files changed

- `packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListSection.module.scss`
- `packages/backpack-web/src/bpk-component-section-list/src/BpkSectionListItem.module.scss`

Closes #4804

🤖 Generated with [Claude Code](https://claude.com/claude-code)