### PR TITLE
[bpk-component-card-list] Migrate SCSS tokens to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.stories.module.scss
@@ -20,7 +20,7 @@
 
 .bpk-destination {
   img {
-    border-radius: tokens.$bpk-border-radius-md tokens.$bpk-border-radius-md 0 0;
+    border-radius: var(--bpk-radius-md, tokens.$bpk-border-radius-md) var(--bpk-radius-md, tokens.$bpk-border-radius-md) 0 0;
     overflow: hidden;
   }
 

--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.stories.module.scss
@@ -20,7 +20,8 @@
 
 .bpk-destination {
   img {
-    border-radius: var(--bpk-radius-md, tokens.$bpk-border-radius-md) var(--bpk-radius-md, tokens.$bpk-border-radius-md) 0 0;
+    border-radius: var(--bpk-radius-md, tokens.$bpk-border-radius-md)
+      var(--bpk-radius-md, tokens.$bpk-border-radius-md) 0 0;
     overflow: hidden;
   }
 


### PR DESCRIPTION
## Summary

- Replaces bare `tokens.$bpk-border-radius-md` with `var(--bpk-radius-md, tokens.$bpk-border-radius-md)` in `BpkCardList.stories.module.scss`
- Enables theming via CSS custom properties while preserving the SASS token as a fallback
- Only SCSS files were modified; no `.tsx`/`.ts` files touched

Closes #4805

## Test plan

- [ ] All 60 existing tests pass (`npm run jest packages/backpack-web/src/bpk-component-card-list`)
- [ ] Visual regression: component renders identically (fallback value unchanged)
- [ ] CSS var override applied at runtime changes border radius as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)