### PR TITLE
[BpkLayout][CLOV-1823] Add layout positioning and spacing token support

### DIFF
--- a/packages/backpack-web/src/bpk-component-layout/README.md
+++ b/packages/backpack-web/src/bpk-component-layout/README.md
@@ -103,16 +103,18 @@ BpkVessel accepts **all React.HTMLAttributes** to maximize migration flexibility
 
 The layout API is intentionally limited and strongly typed. The main groups are:
 
-- **Spacing** – `padding`, `margin`, logical props (`marginStart`, `marginEnd`, `paddingInline`), `gap`:
-  - Values: `BpkSpacing` tokens (`BpkSpacing.XS`, `BpkSpacing.SM`, `BpkSpacing.MD`, …) or percentages (e.g. `'50%'`).
+- **Spacing** – `padding`, `margin`, logical props (`marginStart`, `marginEnd`, `paddingInline`), `gap`, `scrollMarginTop`, `scrollMarginBottom`:
+  - Values: `BpkSpacing` tokens (`BpkSpacing.XS`, `BpkSpacing.SM`, `BpkSpacing.MD`, …, `BpkSpacing.XXXL`) or percentages (e.g. `'50%'`).
+  - `scrollMarginTop`/`scrollMarginBottom` control the scroll snap margin for the element.
 - **Flex gaps** – `BpkFlex` supports `gap`, `rowGap`, and `columnGap` for shared or independent flex row/column spacing.
   - Values: `BpkSpacing` tokens (`BpkSpacing.SM`, `BpkSpacing.LG`, …) or percentages.
 - **Size** – `width`, `height`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight`:
   - Values: rem strings (e.g. `'6rem'`), percentages (e.g. `'50%'`) or semantic values (`'auto' | 'full' | 'fit-content'`).
 - **Position keyword** – `position`:
   - Values: `'static' | 'relative' | 'absolute' | 'fixed' | 'sticky'`. Supports responsive overrides.
-- **Position offsets** – `top`, `right`, `bottom`, `left`:
-  - Values: rem strings (e.g. `'1rem'`), percentages (e.g. `'50%'`), or bare `'0'` (no unit required). Supports responsive overrides.
+- **Position offsets** – `top`, `right`, `bottom`, `left`, `insetInlineStart`, `insetInlineEnd`:
+  - Values: rem strings (e.g. `'1rem'`), percentages (e.g. `'50%'`), bare `'0'`, or **BPK spacing tokens** (e.g. `BpkSpacing.Base`). Supports responsive overrides.
+  - `insetInlineStart`/`insetInlineEnd` are the RTL-safe logical equivalents of `left`/`right`.
 - **Overflow** – `overflow`, `overflowX`, `overflowY`:
   - Values: `'visible' | 'hidden' | 'scroll' | 'auto' | 'clip'`. All three support responsive overrides. Use `overflowX`/`overflowY` for per-axis control (e.g. `overflowX="hidden"` + `overflowY="auto"`).
 - **Stacking context** – `zIndex`:
@@ -137,6 +139,7 @@ In addition, `BpkBox` exposes a **minimal interaction and accessibility surface*
 - `tabIndex`, `role` – make containers focusable and assign ARIA roles (e.g. `role="region"`, `role="button"`).
 - `id` – useful for `aria-labelledby`/`aria-describedby` cross-references.
 - All `aria-*` props – forwarded directly to the DOM element for full ARIA attribute support.
+- `pointerEvents` (`'none' | 'auto'`) – controls mouse/touch hit-testing. Use `'none'` for click-through overlays; `'auto'` explicitly restores interaction. Available on all layout components.
 
 Layout primitives expose this event surface only where the underlying rendered element supports it.
 
@@ -253,6 +256,8 @@ In particular:
 
 `alignSelf`, `justifySelf`, `gridColumn`, and `gridRow` also support Backpack responsive breakpoint objects.
 
+`BpkFlex` exposes `shrink` and `flexShrink` as aliases for CSS `flex-shrink` (both accept responsive values; `shrink` takes precedence if both are provided).
+
 > **Note:** `justifySelf`, `gridColumn`, and `gridRow` only take effect when `BpkFlex` is a child of a **grid** parent. In a flex parent, `justify-self`/`grid-*` are ignored by CSS (main-axis alignment there is controlled by the parent's `justify` or a child `margin: auto`). `alignSelf` works in both flex and grid parents. These props mirror the equivalent `BpkBox` placement props.
 
 ## Constraints and design principles
@@ -265,7 +270,8 @@ To keep layout predictable, performant and consistent with Backpack:
 - **Tokenised colors only** – `color` and `backgroundColor` are supported but must use Backpack tokens (`TEXT_COLORS` / `BACKGROUND_COLORS`); raw CSS values and Chakra color props (`borderColor`, `borderWidth`, `borderRadius`, `boxShadow`) are not exposed.
 - **No composite border shorthands** – props like `border`, `borderX`, `borderInline`, `borderBlock` are not supported.
 - **No typography props** – font family/size/line height/etc. should come from dedicated text components, not from layout primitives.
-- **No transition/transform props** – layout components are purely structural; animations and transforms should live in higher‑level components.
+- **No transition props** – layout components are purely structural; CSS transitions should live in higher‑level components or CSS classes.
+- **`transform` on BpkBox only** – `BpkBox` supports a `transform?: string` prop (e.g. `translateX(16px)`, `rotate(10deg)`). Other layout primitives (`BpkFlex`, `BpkGrid`, `BpkStack`) do not expose `transform`.
 - **Token‑driven spacing** – spacing props only accept Backpack spacing tokens (or percentages) to keep design consistent and avoid magic numbers.
 - **Breakpoint‑driven responsiveness** – responsive overrides must use Backpack breakpoint keys in object form; array syntax is intentionally disabled.
 
@@ -276,7 +282,11 @@ This package includes Storybook examples under `examples/bpk-component-layout` s
 - Basic spacing
 - RTL‑friendly spacing (`marginInline`, `paddingInline`)
 - Size props
-- Position keyword (`position`) and offset props (`top/right/bottom/left`)
+- Position keyword (`position`) and offset props (`top/right/bottom/left`, `insetInlineStart/End`)
+- Logical position offsets with BPK spacing tokens
+- Scroll snap margins (`scrollMarginTop`, `scrollMarginBottom`)
+- CSS `transform` on BpkBox
+- `pointerEvents` for click-through overlays
 - Overflow props (`overflow`, `overflowX`, `overflowY`)
 - Stacking context (`zIndex`)
 - Accessibility props (`id`, `aria-label`, `aria-labelledby`)

--- a/packages/backpack-web/src/bpk-component-layout/README.md
+++ b/packages/backpack-web/src/bpk-component-layout/README.md
@@ -103,18 +103,18 @@ BpkVessel accepts **all React.HTMLAttributes** to maximize migration flexibility
 
 The layout API is intentionally limited and strongly typed. The main groups are:
 
-- **Spacing** – `padding`, `margin`, logical props (`marginStart`, `marginEnd`, `paddingInline`), `gap`, `scrollMarginTop`, `scrollMarginBottom`:
+- **Spacing** – `padding`, `margin`, logical props (`marginStart`, `marginEnd`, `paddingInline`), `gap`:
   - Values: `BpkSpacing` tokens (`BpkSpacing.XS`, `BpkSpacing.SM`, `BpkSpacing.MD`, …, `BpkSpacing.XXXL`) or percentages (e.g. `'50%'`).
-  - `scrollMarginTop`/`scrollMarginBottom` control the scroll snap margin for the element.
 - **Flex gaps** – `BpkFlex` supports `gap`, `rowGap`, and `columnGap` for shared or independent flex row/column spacing.
   - Values: `BpkSpacing` tokens (`BpkSpacing.SM`, `BpkSpacing.LG`, …) or percentages.
 - **Size** – `width`, `height`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight`:
   - Values: rem strings (e.g. `'6rem'`), percentages (e.g. `'50%'`) or semantic values (`'auto' | 'full' | 'fit-content'`).
 - **Position keyword** – `position`:
   - Values: `'static' | 'relative' | 'absolute' | 'fixed' | 'sticky'`. Supports responsive overrides.
-- **Position offsets** – `top`, `right`, `bottom`, `left`, `insetInlineStart`, `insetInlineEnd`:
-  - Values: rem strings (e.g. `'1rem'`), percentages (e.g. `'50%'`), bare `'0'`, or **BPK spacing tokens** (e.g. `BpkSpacing.Base`). Supports responsive overrides.
+- **Position offsets** – `top`, `right`, `bottom`, `left`, `insetInlineStart`, `insetInlineEnd`, `scrollMarginTop`, `scrollMarginBottom`:
+  - Values: rem strings (e.g. `'1rem'`), percentages (e.g. `'50%'`), bare `'0'`, or **BPK spacing tokens** (e.g. `BpkSpacing.Base`). `top/right/bottom/left/insetInline*` support responsive overrides; `scrollMargin*` are scalar only.
   - `insetInlineStart`/`insetInlineEnd` are the RTL-safe logical equivalents of `left`/`right`.
+  - `scrollMarginTop`/`scrollMarginBottom` offset the scroll snap position, typically matching a sticky header height (e.g. `scrollMarginTop="3.5rem"`).
 - **Overflow** – `overflow`, `overflowX`, `overflowY`:
   - Values: `'visible' | 'hidden' | 'scroll' | 'auto' | 'clip'`. All three support responsive overrides. Use `overflowX`/`overflowY` for per-axis control (e.g. `overflowX="hidden"` + `overflowY="auto"`).
 - **Stacking context** – `zIndex`:

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
@@ -491,105 +491,94 @@ describe('BpkBox', () => {
   });
 
   describe('transform prop (BpkBox only)', () => {
-    it('renders with a CSS transform string', () => {
+    it('applies the CSS transform to the DOM element', () => {
       const { container } = render(
         <BpkProvider>
           <BpkBox transform="translateX(10px)">Transformed</BpkBox>
         </BpkProvider>,
       );
-      expect(container.querySelector('div')).toBeInTheDocument();
+      expect(container.querySelector('div')).toHaveStyle('transform: translateX(10px)');
     });
 
-    it('produces different output with and without transform', () => {
+    it('applies a different transform value than no transform', () => {
       const { container: withTransform } = render(
         <BpkProvider>
           <BpkBox transform="rotate(45deg)">Rotated</BpkBox>
         </BpkProvider>,
       );
-      const { container: withoutTransform } = render(
-        <BpkProvider>
-          <BpkBox>No transform</BpkBox>
-        </BpkProvider>,
-      );
-      expect(withTransform.querySelector('div')?.className).not.toBe(
-        withoutTransform.querySelector('div')?.className,
-      );
+      expect(withTransform.querySelector('div')).toHaveStyle('transform: rotate(45deg)');
     });
   });
 
   describe('pointerEvents prop', () => {
-    it('renders with pointerEvents="none"', () => {
+    it('applies pointer-events: none to the DOM element', () => {
       const { container } = render(
         <BpkProvider>
           <BpkBox pointerEvents="none">Overlay</BpkBox>
         </BpkProvider>,
       );
-      expect(container.querySelector('div')).toBeInTheDocument();
+      expect(container.querySelector('div')).toHaveStyle('pointer-events: none');
     });
 
-    it('produces different output with pointerEvents="none" vs default', () => {
-      const { container: withNone } = render(
-        <BpkProvider>
-          <BpkBox pointerEvents="none">Click-through</BpkBox>
-        </BpkProvider>,
-      );
-      const { container: withAuto } = render(
+    it('applies pointer-events: auto to the DOM element', () => {
+      const { container } = render(
         <BpkProvider>
           <BpkBox pointerEvents="auto">Interactive</BpkBox>
         </BpkProvider>,
       );
-      expect(withNone.querySelector('div')?.className).not.toBe(
-        withAuto.querySelector('div')?.className,
-      );
+      expect(container.querySelector('div')).toHaveStyle('pointer-events: auto');
     });
   });
 
   describe('insetInlineStart / insetInlineEnd props', () => {
-    it('renders with a spacing token for insetInlineStart', () => {
+    it('applies inset-inline-start from a BPK spacing token (resolves to rem)', () => {
       const { container } = render(
         <BpkProvider>
           <BpkBox position="absolute" insetInlineStart={BpkSpacing.Base}>Content</BpkBox>
         </BpkProvider>,
       );
-      expect(container.querySelector('div')).toBeInTheDocument();
+      // BpkSpacing.Base = 1rem
+      expect(container.querySelector('div')).toHaveStyle('inset-inline-start: 1rem');
     });
 
-    it('renders with a raw rem value for insetInlineEnd', () => {
+    it('applies inset-inline-end from a raw rem value', () => {
       const { container } = render(
         <BpkProvider>
           <BpkBox position="absolute" insetInlineEnd="1.5rem">Content</BpkBox>
         </BpkProvider>,
       );
-      expect(container.querySelector('div')).toBeInTheDocument();
+      expect(container.querySelector('div')).toHaveStyle('inset-inline-end: 1.5rem');
     });
   });
 
   describe('scrollMarginTop / scrollMarginBottom props', () => {
-    it('renders with scrollMarginTop using a spacing token', () => {
+    it('applies scroll-margin-top from a BPK spacing token (resolves to rem)', () => {
       const { container } = render(
         <BpkProvider>
           <BpkBox scrollMarginTop={BpkSpacing.XXXL}>Scroll target</BpkBox>
         </BpkProvider>,
       );
-      expect(container.querySelector('div')).toBeInTheDocument();
+      // BpkSpacing.XXXL = 4rem
+      expect(container.querySelector('div')).toHaveStyle('scroll-margin-top: 4rem');
     });
 
-    it('renders with scrollMarginBottom using a spacing token', () => {
+    it('applies scroll-margin-bottom from a BPK spacing token', () => {
       const { container } = render(
         <BpkProvider>
           <BpkBox scrollMarginBottom={BpkSpacing.MD}>Scroll target</BpkBox>
         </BpkProvider>,
       );
-      expect(container.querySelector('div')).toBeInTheDocument();
+      // BpkSpacing.MD = .5rem
+      expect(container.querySelector('div')).toHaveStyle('scroll-margin-bottom: .5rem');
     });
 
-    it('renders with scrollMarginTop using a raw rem value (e.g. sticky-header height)', () => {
+    it('applies scroll-margin-top from a raw rem value (sticky-header height)', () => {
       const { container } = render(
         <BpkProvider>
           <BpkBox scrollMarginTop="3.5rem">Scroll target</BpkBox>
         </BpkProvider>,
       );
-      expect(container.querySelector('div')).toBeInTheDocument();
+      expect(container.querySelector('div')).toHaveStyle('scroll-margin-top: 3.5rem');
     });
   });
 

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
@@ -490,4 +490,98 @@ describe('BpkBox', () => {
     });
   });
 
+  describe('transform prop (BpkBox only)', () => {
+    it('renders with a CSS transform string', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox transform="translateX(10px)">Transformed</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+
+    it('produces different output with and without transform', () => {
+      const { container: withTransform } = render(
+        <BpkProvider>
+          <BpkBox transform="rotate(45deg)">Rotated</BpkBox>
+        </BpkProvider>,
+      );
+      const { container: withoutTransform } = render(
+        <BpkProvider>
+          <BpkBox>No transform</BpkBox>
+        </BpkProvider>,
+      );
+      expect(withTransform.querySelector('div')?.className).not.toBe(
+        withoutTransform.querySelector('div')?.className,
+      );
+    });
+  });
+
+  describe('pointerEvents prop', () => {
+    it('renders with pointerEvents="none"', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox pointerEvents="none">Overlay</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+
+    it('produces different output with pointerEvents="none" vs default', () => {
+      const { container: withNone } = render(
+        <BpkProvider>
+          <BpkBox pointerEvents="none">Click-through</BpkBox>
+        </BpkProvider>,
+      );
+      const { container: withAuto } = render(
+        <BpkProvider>
+          <BpkBox pointerEvents="auto">Interactive</BpkBox>
+        </BpkProvider>,
+      );
+      expect(withNone.querySelector('div')?.className).not.toBe(
+        withAuto.querySelector('div')?.className,
+      );
+    });
+  });
+
+  describe('insetInlineStart / insetInlineEnd props', () => {
+    it('renders with a spacing token for insetInlineStart', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox position="absolute" insetInlineStart={BpkSpacing.Base}>Content</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+
+    it('renders with a raw rem value for insetInlineEnd', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox position="absolute" insetInlineEnd="1.5rem">Content</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+  });
+
+  describe('scrollMarginTop / scrollMarginBottom props', () => {
+    it('renders with scrollMarginTop using a spacing token', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox scrollMarginTop={BpkSpacing.XXXL}>Scroll target</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+
+    it('renders with scrollMarginBottom using a spacing token', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox scrollMarginBottom={BpkSpacing.MD}>Scroll target</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+  });
+
 });

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox-test.tsx
@@ -582,6 +582,15 @@ describe('BpkBox', () => {
       );
       expect(container.querySelector('div')).toBeInTheDocument();
     });
+
+    it('renders with scrollMarginTop using a raw rem value (e.g. sticky-header height)', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkBox scrollMarginTop="3.5rem">Scroll target</BpkBox>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
   });
 
 });

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
@@ -714,3 +714,196 @@ const DirExample = () => (
 export const Dir = {
   render: () => <DirExample />,
 };
+
+/**
+ * Transform example – demonstrates the `transform` prop on BpkBox for translate, rotate, and scale.
+ *
+ * @returns {JSX.Element} Boxes with CSS transform applied.
+ */
+const TransformExample = () => (
+  <LayoutWrapper>
+    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+      <BpkText textStyle={TEXT_STYLES.label2}>translateX(16px) — horizontal shift</BpkText>
+      <BpkBox
+        transform="translateX(16px)"
+        padding={BpkSpacing.SM}
+        marginTop={BpkSpacing.SM}
+        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+      >
+        <BpkText>Shifted 16px to the right</BpkText>
+      </BpkBox>
+    </BpkBox>
+
+    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+      <BpkText textStyle={TEXT_STYLES.label2}>rotate(10deg) — slight rotation</BpkText>
+      <BpkBox
+        transform="rotate(10deg)"
+        padding={BpkSpacing.SM}
+        marginTop={BpkSpacing.SM}
+        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+      >
+        <BpkText>Rotated 10 degrees</BpkText>
+      </BpkBox>
+    </BpkBox>
+
+    <BpkBox padding={BpkSpacing.SM}>
+      <BpkText textStyle={TEXT_STYLES.label2}>scale(0.8) — scaled down</BpkText>
+      <BpkBox
+        transform="scale(0.8)"
+        padding={BpkSpacing.SM}
+        marginTop={BpkSpacing.SM}
+        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+      >
+        <BpkText>Scaled to 80%</BpkText>
+      </BpkBox>
+    </BpkBox>
+  </LayoutWrapper>
+);
+
+export const Transform = {
+  render: () => <TransformExample />,
+};
+
+/**
+ * PointerEvents example – demonstrates `pointerEvents="none"` for click-through overlays
+ * and `pointerEvents="auto"` for restoring interaction.
+ *
+ * @returns {JSX.Element} A stacked overlay with pointer-events control.
+ */
+const PointerEventsExample = () => {
+  const [clicked, setClicked] = useState(false);
+  return (
+    <LayoutWrapper>
+      <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+        <BpkText textStyle={TEXT_STYLES.label2}>pointerEvents=&quot;none&quot; — overlay passes clicks through</BpkText>
+        <BpkBox position="relative" width="14rem" height="5rem" marginTop={BpkSpacing.SM}>
+          <BpkBox
+            position="absolute"
+            top="0"
+            left="0"
+            width="14rem"
+            height="5rem"
+            padding={BpkSpacing.SM}
+            backgroundColor={BACKGROUND_COLORS.surfaceDefault}
+            role="button"
+            tabIndex={0}
+            onClick={() => setClicked(true)}
+          >
+            <BpkText>{clicked ? 'Clicked!' : 'Click me (underneath)'}</BpkText>
+          </BpkBox>
+          <BpkBox
+            position="absolute"
+            top="0"
+            left="0"
+            width="14rem"
+            height="5rem"
+            backgroundColor={BACKGROUND_COLORS.surfaceHighlight}
+            opacity={0.5}
+            pointerEvents="none"
+          />
+        </BpkBox>
+      </BpkBox>
+
+      <BpkBox padding={BpkSpacing.SM}>
+        <BpkText textStyle={TEXT_STYLES.label2}>pointerEvents=&quot;auto&quot; — explicit restore of interaction</BpkText>
+        <BpkBox
+          pointerEvents="auto"
+          padding={BpkSpacing.SM}
+          marginTop={BpkSpacing.SM}
+          backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+          role="button"
+          tabIndex={0}
+        >
+          <BpkText>Fully interactive (pointerEvents=&quot;auto&quot;)</BpkText>
+        </BpkBox>
+      </BpkBox>
+    </LayoutWrapper>
+  );
+};
+
+export const PointerEvents = {
+  render: () => <PointerEventsExample />,
+};
+
+/**
+ * InsetInline example – demonstrates `insetInlineStart` and `insetInlineEnd` with
+ * BPK spacing tokens for RTL-safe absolute positioning.
+ *
+ * @returns {JSX.Element} Relative box with children positioned via logical inset props.
+ */
+const InsetInlineExample = () => (
+  <LayoutWrapper>
+    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+      <BpkText textStyle={TEXT_STYLES.label2}>insetInlineStart + insetInlineEnd with BPK spacing tokens (LTR)</BpkText>
+      <BpkBox position="relative" height="5rem" backgroundColor={BACKGROUND_COLORS.surfaceDefault} marginTop={BpkSpacing.SM}>
+        <BpkBox
+          position="absolute"
+          top="0"
+          insetInlineStart={BpkSpacing.Base}
+          insetInlineEnd={BpkSpacing.Base}
+          height="2rem"
+          backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+          padding={BpkSpacing.SM}
+        >
+          <BpkText>insetInlineStart=Base, insetInlineEnd=Base</BpkText>
+        </BpkBox>
+      </BpkBox>
+    </BpkBox>
+
+    <BpkBox padding={BpkSpacing.SM}>
+      <BpkText textStyle={TEXT_STYLES.label2}>Same layout in RTL — start/end swap automatically</BpkText>
+      <BpkBox dir="rtl" position="relative" height="5rem" backgroundColor={BACKGROUND_COLORS.surfaceDefault} marginTop={BpkSpacing.SM}>
+        <BpkBox
+          position="absolute"
+          top="0"
+          insetInlineStart={BpkSpacing.Base}
+          insetInlineEnd={BpkSpacing.XXXL}
+          height="2rem"
+          backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+          padding={BpkSpacing.SM}
+        >
+          <BpkText>insetInlineStart=Base, insetInlineEnd=XXXL (RTL)</BpkText>
+        </BpkBox>
+      </BpkBox>
+    </BpkBox>
+  </LayoutWrapper>
+);
+
+export const InsetInline = {
+  render: () => <InsetInlineExample />,
+};
+
+/**
+ * SpacingXXXL example – demonstrates the new `bpk-spacing-xxxl` (4rem / 64px) token.
+ *
+ * @returns {JSX.Element} A box using the xxxl spacing token for padding and margin.
+ */
+const SpacingXXXLExample = () => (
+  <LayoutWrapper>
+    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+      <BpkText textStyle={TEXT_STYLES.label2}>BpkSpacing.XXXL (4rem / 64px) as padding</BpkText>
+      <BpkBox
+        padding={BpkSpacing.XXXL}
+        marginTop={BpkSpacing.SM}
+        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+      >
+        <BpkText>64px padding on all sides</BpkText>
+      </BpkBox>
+    </BpkBox>
+
+    <BpkBox padding={BpkSpacing.SM}>
+      <BpkText textStyle={TEXT_STYLES.label2}>XXXL as top margin</BpkText>
+      <BpkBox
+        marginTop={BpkSpacing.XXXL}
+        padding={BpkSpacing.SM}
+        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+      >
+        <BpkText>64px top margin</BpkText>
+      </BpkBox>
+    </BpkBox>
+  </LayoutWrapper>
+);
+
+export const SpacingXXXL = {
+  render: () => <SpacingXXXLExample />,
+};

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
@@ -41,6 +41,16 @@ const SpacingExample = () => (
     <BpkBox padding={BpkSpacing.MD} margin={BpkSpacing.MD}>
       Default box with padding and margin using Backpack spacing tokens.
     </BpkBox>
+    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+      <BpkText textStyle={TEXT_STYLES.label2}>BpkSpacing.XXXL (4rem / 64px)</BpkText>
+      <BpkBox
+        padding={BpkSpacing.XXXL}
+        marginTop={BpkSpacing.SM}
+        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+      >
+        <BpkText>64px padding on all sides</BpkText>
+      </BpkBox>
+    </BpkBox>
   </LayoutWrapper>
 );
 
@@ -738,14 +748,14 @@ const TransformExample = () => (
 
     {/* Extra bottom margin because rotate extends the visual bounding box beyond the layout footprint */}
     <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.XXXL}>
-      <BpkText textStyle={TEXT_STYLES.label2}>rotate(10deg) — slight rotation</BpkText>
+      <BpkText textStyle={TEXT_STYLES.label2}>rotate(5deg) — slight rotation</BpkText>
       <BpkBox minHeight="4rem" marginTop={BpkSpacing.SM}>
         <BpkBox
-          transform="rotate(10deg)"
+          transform="rotate(5deg)"
           padding={BpkSpacing.SM}
           backgroundColor={BACKGROUND_COLORS.surfaceElevated}
         >
-          <BpkText>Rotated 10 degrees</BpkText>
+          <BpkText>Rotated 5 degrees</BpkText>
         </BpkBox>
       </BpkBox>
     </BpkBox>
@@ -770,47 +780,35 @@ export const Transform = {
 };
 
 /**
- * PointerEvents example – demonstrates `pointerEvents="none"` for click-through overlays
- * and `pointerEvents="auto"` for restoring interaction.
+ * PointerEvents example – demonstrates the `pointerEvents` prop.
+ * pointerEvents="none" makes a box non-interactive (clicks pass through to elements behind it).
+ * pointerEvents="auto" restores interaction explicitly.
  *
- * @returns {JSX.Element} A stacked overlay with pointer-events control.
+ * @returns {JSX.Element} Two boxes with different pointerEvents values.
  */
 const PointerEventsExample = () => {
-  const [clicked, setClicked] = useState(false);
+  const [clickedNone, setClickedNone] = useState(false);
+  const [clickedAuto, setClickedAuto] = useState(false);
   return (
     <LayoutWrapper>
       <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
-        <BpkText textStyle={TEXT_STYLES.label2}>pointerEvents=&quot;none&quot; — overlay passes clicks through</BpkText>
-        <BpkBox position="relative" width="24rem" height="5rem" marginTop={BpkSpacing.SM}>
-          <BpkBox
-            position="absolute"
-            top="0"
-            left="0"
-            width="24rem"
-            height="5rem"
-            padding={BpkSpacing.SM}
-            backgroundColor={BACKGROUND_COLORS.surfaceDefault}
-            role="button"
-            tabIndex={0}
-            onClick={() => setClicked(true)}
-          >
-            <BpkText>{clicked ? 'Clicked!' : 'Click me (underneath)'}</BpkText>
-          </BpkBox>
-          <BpkBox
-            position="absolute"
-            top="0"
-            left="0"
-            width="24rem"
-            height="5rem"
-            backgroundColor={BACKGROUND_COLORS.surfaceHighlight}
-            opacity={0.5}
-            pointerEvents="none"
-          />
+        <BpkText textStyle={TEXT_STYLES.label2}>pointerEvents=&quot;none&quot; — box does not receive clicks</BpkText>
+        <BpkBox
+          pointerEvents="none"
+          padding={BpkSpacing.SM}
+          marginTop={BpkSpacing.SM}
+          backgroundColor={BACKGROUND_COLORS.surfaceHighlight}
+          opacity={0.6}
+          role="button"
+          tabIndex={0}
+          onClick={() => setClickedNone(true)}
+        >
+          <BpkText>{clickedNone ? 'You clicked (pointerEvents=none should prevent this)' : 'Try clicking — pointer events are disabled'}</BpkText>
         </BpkBox>
       </BpkBox>
 
       <BpkBox padding={BpkSpacing.SM}>
-        <BpkText textStyle={TEXT_STYLES.label2}>pointerEvents=&quot;auto&quot; — explicit restore of interaction</BpkText>
+        <BpkText textStyle={TEXT_STYLES.label2}>pointerEvents=&quot;auto&quot; — box receives clicks normally</BpkText>
         <BpkBox
           pointerEvents="auto"
           padding={BpkSpacing.SM}
@@ -818,8 +816,9 @@ const PointerEventsExample = () => {
           backgroundColor={BACKGROUND_COLORS.surfaceElevated}
           role="button"
           tabIndex={0}
+          onClick={() => setClickedAuto((v) => !v)}
         >
-          <BpkText>Fully interactive (pointerEvents=&quot;auto&quot;)</BpkText>
+          <BpkText>{clickedAuto ? 'Clicked!' : 'Click me — pointer events are active'}</BpkText>
         </BpkBox>
       </BpkBox>
     </LayoutWrapper>
@@ -878,37 +877,3 @@ export const InsetInline = {
   render: () => <InsetInlineExample />,
 };
 
-/**
- * SpacingXXXL example – demonstrates the new `bpk-spacing-xxxl` (4rem / 64px) token.
- *
- * @returns {JSX.Element} A box using the xxxl spacing token for padding and margin.
- */
-const SpacingXXXLExample = () => (
-  <LayoutWrapper>
-    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
-      <BpkText textStyle={TEXT_STYLES.label2}>BpkSpacing.XXXL (4rem / 64px) as padding</BpkText>
-      <BpkBox
-        padding={BpkSpacing.XXXL}
-        marginTop={BpkSpacing.SM}
-        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
-      >
-        <BpkText>64px padding on all sides</BpkText>
-      </BpkBox>
-    </BpkBox>
-
-    <BpkBox padding={BpkSpacing.SM}>
-      <BpkText textStyle={TEXT_STYLES.label2}>XXXL as top margin</BpkText>
-      <BpkBox
-        marginTop={BpkSpacing.XXXL}
-        padding={BpkSpacing.SM}
-        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
-      >
-        <BpkText>64px top margin</BpkText>
-      </BpkBox>
-    </BpkBox>
-  </LayoutWrapper>
-);
-
-export const SpacingXXXL = {
-  render: () => <SpacingXXXLExample />,
-};

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkBox.stories.tsx
@@ -722,39 +722,44 @@ export const Dir = {
  */
 const TransformExample = () => (
   <LayoutWrapper>
-    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.XL}>
       <BpkText textStyle={TEXT_STYLES.label2}>translateX(16px) — horizontal shift</BpkText>
-      <BpkBox
-        transform="translateX(16px)"
-        padding={BpkSpacing.SM}
-        marginTop={BpkSpacing.SM}
-        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
-      >
-        <BpkText>Shifted 16px to the right</BpkText>
+      {/* Extra minHeight gives visual room for the shifted box */}
+      <BpkBox minHeight="3rem" marginTop={BpkSpacing.SM}>
+        <BpkBox
+          transform="translateX(16px)"
+          padding={BpkSpacing.SM}
+          backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+        >
+          <BpkText>Shifted 16px to the right</BpkText>
+        </BpkBox>
       </BpkBox>
     </BpkBox>
 
-    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+    {/* Extra bottom margin because rotate extends the visual bounding box beyond the layout footprint */}
+    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.XXXL}>
       <BpkText textStyle={TEXT_STYLES.label2}>rotate(10deg) — slight rotation</BpkText>
-      <BpkBox
-        transform="rotate(10deg)"
-        padding={BpkSpacing.SM}
-        marginTop={BpkSpacing.SM}
-        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
-      >
-        <BpkText>Rotated 10 degrees</BpkText>
+      <BpkBox minHeight="4rem" marginTop={BpkSpacing.SM}>
+        <BpkBox
+          transform="rotate(10deg)"
+          padding={BpkSpacing.SM}
+          backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+        >
+          <BpkText>Rotated 10 degrees</BpkText>
+        </BpkBox>
       </BpkBox>
     </BpkBox>
 
     <BpkBox padding={BpkSpacing.SM}>
       <BpkText textStyle={TEXT_STYLES.label2}>scale(0.8) — scaled down</BpkText>
-      <BpkBox
-        transform="scale(0.8)"
-        padding={BpkSpacing.SM}
-        marginTop={BpkSpacing.SM}
-        backgroundColor={BACKGROUND_COLORS.surfaceElevated}
-      >
-        <BpkText>Scaled to 80%</BpkText>
+      <BpkBox minHeight="3rem" marginTop={BpkSpacing.SM}>
+        <BpkBox
+          transform="scale(0.8)"
+          padding={BpkSpacing.SM}
+          backgroundColor={BACKGROUND_COLORS.surfaceElevated}
+        >
+          <BpkText>Scaled to 80%</BpkText>
+        </BpkBox>
       </BpkBox>
     </BpkBox>
   </LayoutWrapper>
@@ -776,12 +781,12 @@ const PointerEventsExample = () => {
     <LayoutWrapper>
       <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
         <BpkText textStyle={TEXT_STYLES.label2}>pointerEvents=&quot;none&quot; — overlay passes clicks through</BpkText>
-        <BpkBox position="relative" width="14rem" height="5rem" marginTop={BpkSpacing.SM}>
+        <BpkBox position="relative" width="24rem" height="5rem" marginTop={BpkSpacing.SM}>
           <BpkBox
             position="absolute"
             top="0"
             left="0"
-            width="14rem"
+            width="24rem"
             height="5rem"
             padding={BpkSpacing.SM}
             backgroundColor={BACKGROUND_COLORS.surfaceDefault}
@@ -795,7 +800,7 @@ const PointerEventsExample = () => {
             position="absolute"
             top="0"
             left="0"
-            width="14rem"
+            width="24rem"
             height="5rem"
             backgroundColor={BACKGROUND_COLORS.surfaceHighlight}
             opacity={0.5}

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
@@ -223,73 +223,52 @@ describe('BpkFlex', () => {
   });
 
   describe('flexShrink prop', () => {
-    it('renders with flexShrink=0 (direct CSS prop alias)', () => {
+    it('applies flex-shrink: 0 via the flexShrink prop alias', () => {
       const { container } = render(
         <BpkProvider>
           <BpkFlex flexShrink={0}>Fixed-size item</BpkFlex>
         </BpkProvider>,
       );
-      expect(container.querySelector('div')).toBeInTheDocument();
+      expect(container.querySelector('div')).toHaveStyle('flex-shrink: 0');
     });
 
-    it('produces different output with flexShrink=0 vs flexShrink=1', () => {
-      const { container: noShrink } = render(
-        <BpkProvider>
-          <BpkFlex flexShrink={0}>Fixed</BpkFlex>
-        </BpkProvider>,
-      );
-      const { container: defaultShrink } = render(
+    it('applies flex-shrink: 1 via the flexShrink prop alias', () => {
+      const { container } = render(
         <BpkProvider>
           <BpkFlex flexShrink={1}>Shrinkable</BpkFlex>
         </BpkProvider>,
       );
-      expect(noShrink.querySelector('div')?.className).not.toBe(
-        defaultShrink.querySelector('div')?.className,
-      );
+      expect(container.querySelector('div')).toHaveStyle('flex-shrink: 1');
     });
 
     it('shrink prop takes precedence over flexShrink when both are provided', () => {
       const { container: shrinkWins } = render(
         <BpkProvider>
-          <BpkFlex shrink={0} flexShrink={1}>Should be shrink=0</BpkFlex>
+          <BpkFlex shrink={0} flexShrink={1}>Should be flex-shrink: 0</BpkFlex>
         </BpkProvider>,
       );
-      const { container: flexShrinkAlone } = render(
-        <BpkProvider>
-          <BpkFlex flexShrink={0}>flexShrink=0</BpkFlex>
-        </BpkProvider>,
-      );
-      // Both should produce the same output since the effective value is 0 in both cases
-      expect(shrinkWins.querySelector('div')?.className).toBe(
-        flexShrinkAlone.querySelector('div')?.className,
-      );
+      // shrink=0 wins over flexShrink=1
+      expect(shrinkWins.querySelector('div')).toHaveStyle('flex-shrink: 0');
     });
   });
 
   describe('pointerEvents prop', () => {
-    it('renders with pointerEvents="none"', () => {
+    it('applies pointer-events: none to the DOM element', () => {
       const { container } = render(
         <BpkProvider>
           <BpkFlex pointerEvents="none">Click-through overlay</BpkFlex>
         </BpkProvider>,
       );
-      expect(container.querySelector('div')).toBeInTheDocument();
+      expect(container.querySelector('div')).toHaveStyle('pointer-events: none');
     });
 
-    it('produces different output with pointerEvents="none" vs "auto"', () => {
-      const { container: withNone } = render(
+    it('applies pointer-events: auto to the DOM element', () => {
+      const { container } = render(
         <BpkProvider>
-          <BpkFlex pointerEvents="none">None</BpkFlex>
+          <BpkFlex pointerEvents="auto">Interactive</BpkFlex>
         </BpkProvider>,
       );
-      const { container: withAuto } = render(
-        <BpkProvider>
-          <BpkFlex pointerEvents="auto">Auto</BpkFlex>
-        </BpkProvider>,
-      );
-      expect(withNone.querySelector('div')?.className).not.toBe(
-        withAuto.querySelector('div')?.className,
-      );
+      expect(container.querySelector('div')).toHaveStyle('pointer-events: auto');
     });
   });
 });

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex-test.tsx
@@ -221,4 +221,75 @@ describe('BpkFlex', () => {
     );
     expect(container.querySelector('div')).toBeInTheDocument();
   });
+
+  describe('flexShrink prop', () => {
+    it('renders with flexShrink=0 (direct CSS prop alias)', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkFlex flexShrink={0}>Fixed-size item</BpkFlex>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+
+    it('produces different output with flexShrink=0 vs flexShrink=1', () => {
+      const { container: noShrink } = render(
+        <BpkProvider>
+          <BpkFlex flexShrink={0}>Fixed</BpkFlex>
+        </BpkProvider>,
+      );
+      const { container: defaultShrink } = render(
+        <BpkProvider>
+          <BpkFlex flexShrink={1}>Shrinkable</BpkFlex>
+        </BpkProvider>,
+      );
+      expect(noShrink.querySelector('div')?.className).not.toBe(
+        defaultShrink.querySelector('div')?.className,
+      );
+    });
+
+    it('shrink prop takes precedence over flexShrink when both are provided', () => {
+      const { container: shrinkWins } = render(
+        <BpkProvider>
+          <BpkFlex shrink={0} flexShrink={1}>Should be shrink=0</BpkFlex>
+        </BpkProvider>,
+      );
+      const { container: flexShrinkAlone } = render(
+        <BpkProvider>
+          <BpkFlex flexShrink={0}>flexShrink=0</BpkFlex>
+        </BpkProvider>,
+      );
+      // Both should produce the same output since the effective value is 0 in both cases
+      expect(shrinkWins.querySelector('div')?.className).toBe(
+        flexShrinkAlone.querySelector('div')?.className,
+      );
+    });
+  });
+
+  describe('pointerEvents prop', () => {
+    it('renders with pointerEvents="none"', () => {
+      const { container } = render(
+        <BpkProvider>
+          <BpkFlex pointerEvents="none">Click-through overlay</BpkFlex>
+        </BpkProvider>,
+      );
+      expect(container.querySelector('div')).toBeInTheDocument();
+    });
+
+    it('produces different output with pointerEvents="none" vs "auto"', () => {
+      const { container: withNone } = render(
+        <BpkProvider>
+          <BpkFlex pointerEvents="none">None</BpkFlex>
+        </BpkProvider>,
+      );
+      const { container: withAuto } = render(
+        <BpkProvider>
+          <BpkFlex pointerEvents="auto">Auto</BpkFlex>
+        </BpkProvider>,
+      );
+      expect(withNone.querySelector('div')?.className).not.toBe(
+        withAuto.querySelector('div')?.className,
+      );
+    });
+  });
 });

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.stories.tsx
@@ -280,3 +280,86 @@ export const Color = {
 export const LayoutProps = {
   render: () => <BpkFlexLayoutPropsExample />,
 };
+
+/**
+ * FlexShrink example – demonstrates the `shrink` prop for controlling how flex items shrink.
+ *
+ * @returns {JSX.Element} A flex container where children have different shrink values.
+ */
+const BpkFlexShrinkExample = () => (
+  <LayoutWrapper>
+    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+      <BpkText textStyle={TEXT_STYLES.label2}>shrink=0 — item refuses to shrink below its natural size</BpkText>
+      <BpkFlex gap={BpkSpacing.SM} width="20rem" marginTop={BpkSpacing.SM}>
+        <BpkFlex shrink={0} width="14rem" padding={BpkSpacing.SM} backgroundColor={BACKGROUND_COLORS.surfaceElevated}>
+          <BpkText>shrink=0 (fixed)</BpkText>
+        </BpkFlex>
+        <BpkBox width="100%" padding={BpkSpacing.SM} backgroundColor={BACKGROUND_COLORS.surfaceDefault}>
+          <BpkText>flexible</BpkText>
+        </BpkBox>
+      </BpkFlex>
+    </BpkBox>
+
+    <BpkBox padding={BpkSpacing.SM}>
+      <BpkText textStyle={TEXT_STYLES.label2}>shrink=1 (default) — item shrinks proportionally</BpkText>
+      <BpkFlex gap={BpkSpacing.SM} width="20rem" marginTop={BpkSpacing.SM}>
+        <BpkFlex shrink={1} width="14rem" padding={BpkSpacing.SM} backgroundColor={BACKGROUND_COLORS.surfaceElevated}>
+          <BpkText>shrink=1</BpkText>
+        </BpkFlex>
+        <BpkBox width="100%" padding={BpkSpacing.SM} backgroundColor={BACKGROUND_COLORS.surfaceDefault}>
+          <BpkText>flexible</BpkText>
+        </BpkBox>
+      </BpkFlex>
+    </BpkBox>
+  </LayoutWrapper>
+);
+
+export const FlexShrink = {
+  render: () => <BpkFlexShrinkExample />,
+};
+
+/**
+ * PointerEvents example – demonstrates `pointerEvents="none"` for a click-through overlay on BpkFlex.
+ *
+ * @returns {JSX.Element} A flex overlay that passes clicks through to the content underneath.
+ */
+const BpkFlexPointerEventsExample = () => (
+  <LayoutWrapper>
+    <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
+      <BpkText textStyle={TEXT_STYLES.label2}>pointerEvents=&quot;none&quot; — flex overlay passes clicks through</BpkText>
+      <BpkBox position="relative" width="16rem" height="5rem" marginTop={BpkSpacing.SM}>
+        <BpkFlex
+          position="absolute"
+          top="0"
+          left="0"
+          width="16rem"
+          height="5rem"
+          align="center"
+          padding={BpkSpacing.SM}
+          backgroundColor={BACKGROUND_COLORS.surfaceDefault}
+        >
+          <BpkText>Content underneath</BpkText>
+        </BpkFlex>
+        <BpkFlex
+          position="absolute"
+          top="0"
+          left="0"
+          width="16rem"
+          height="5rem"
+          align="center"
+          justify="flex-end"
+          padding={BpkSpacing.SM}
+          backgroundColor={BACKGROUND_COLORS.surfaceHighlight}
+          opacity={0.6}
+          pointerEvents="none"
+        >
+          <BpkText>Overlay (non-interactive)</BpkText>
+        </BpkFlex>
+      </BpkBox>
+    </BpkBox>
+  </LayoutWrapper>
+);
+
+export const FlexPointerEvents = {
+  render: () => <BpkFlexPointerEventsExample />,
+};

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.stories.tsx
@@ -327,12 +327,12 @@ const BpkFlexPointerEventsExample = () => (
   <LayoutWrapper>
     <BpkBox padding={BpkSpacing.SM} marginBottom={BpkSpacing.MD}>
       <BpkText textStyle={TEXT_STYLES.label2}>pointerEvents=&quot;none&quot; — flex overlay passes clicks through</BpkText>
-      <BpkBox position="relative" width="16rem" height="5rem" marginTop={BpkSpacing.SM}>
+      <BpkBox position="relative" width="26rem" height="5rem" marginTop={BpkSpacing.SM}>
         <BpkFlex
           position="absolute"
           top="0"
           left="0"
-          width="16rem"
+          width="26rem"
           height="5rem"
           align="center"
           padding={BpkSpacing.SM}
@@ -344,7 +344,7 @@ const BpkFlexPointerEventsExample = () => (
           position="absolute"
           top="0"
           left="0"
-          width="16rem"
+          width="26rem"
           height="5rem"
           align="center"
           justify="flex-end"

--- a/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.tsx
+++ b/packages/backpack-web/src/bpk-component-layout/src/BpkFlex.tsx
@@ -32,7 +32,7 @@ import STYLES from './BpkLayout.module.scss';
 const getClassName = cssModules(STYLES);
 
 export const BpkFlex = forwardRef<HTMLDivElement, BpkFlexProps>(
-  ({ align, backgroundColor, basis, children, color, direction, grow, inline, justify, shrink, textStyle, wrap, ...props }, ref) => {
+  ({ align, backgroundColor, basis, children, color, direction, flexShrink, grow, inline, justify, shrink, textStyle, wrap, ...props }, ref) => {
     const processedProps = processBpkComponentProps(props, {
       component: 'BpkFlex',
       responsiveProps: {
@@ -42,7 +42,7 @@ export const BpkFlex = forwardRef<HTMLDivElement, BpkFlexProps>(
         alignItems: align,
         flexWrap: wrap,
         flexGrow: grow,
-        flexShrink: shrink,
+        flexShrink: shrink ?? flexShrink,
         flexBasis: basis,
       },
     });

--- a/packages/backpack-web/src/bpk-component-layout/src/commonProps.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/commonProps.ts
@@ -84,11 +84,18 @@ export interface BpkSpacingProps {
   maxWidth?: BpkResponsiveValue<BpkSizeValue>;
   maxHeight?: BpkResponsiveValue<BpkSizeValue>;
 
-  // Position props (use rem values or percentages)
+  // Position props (use rem values, percentages, or BPK spacing tokens)
   top?: BpkResponsiveValue<BpkPositionValue>;
   right?: BpkResponsiveValue<BpkPositionValue>;
   bottom?: BpkResponsiveValue<BpkPositionValue>;
   left?: BpkResponsiveValue<BpkPositionValue>;
+  // CSS logical position props — RTL-safe equivalents of left/right
+  insetInlineStart?: BpkResponsiveValue<BpkPositionValue>;
+  insetInlineEnd?: BpkResponsiveValue<BpkPositionValue>;
+
+  // Scroll snap margin props — space between the scroll container's snap point and the element
+  scrollMarginTop?: BpkResponsiveValue<BpkSpacingValue>;
+  scrollMarginBottom?: BpkResponsiveValue<BpkSpacingValue>;
 }
 
 /**
@@ -144,6 +151,9 @@ export interface BpkCommonLayoutProps extends BpkSpacingProps, AriaAttributes {
   // Opacity — CSS opacity value (0–1)
   opacity?: number;
 
+  // CSS pointer-events — use 'none' for click-through overlays, 'auto' to restore interaction
+  pointerEvents?: 'none' | 'auto';
+
   // Text direction — for embedding bidirectional content within a page
   dir?: 'ltr' | 'rtl' | 'auto';
 
@@ -194,12 +204,12 @@ export interface BpkCommonLayoutProps extends BpkSpacingProps, AriaAttributes {
   borderX?: never;
   borderY?: never;
 
-  // Explicitly exclude transition & transform related props for performance reasons
+  // Explicitly exclude transition-related props — apply animations via CSS classes instead
   transition?: never;
   transitionProperty?: never;
   transitionDuration?: never;
   transitionTimingFunction?: never;
   transitionDelay?: never;
-  transform?: never;
+  // transform is excluded here so BpkBox can opt-in via its own specific props
   transformOrigin?: never;
 }

--- a/packages/backpack-web/src/bpk-component-layout/src/commonProps.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/commonProps.ts
@@ -93,9 +93,12 @@ export interface BpkSpacingProps {
   insetInlineStart?: BpkResponsiveValue<BpkPositionValue>;
   insetInlineEnd?: BpkResponsiveValue<BpkPositionValue>;
 
-  // Scroll snap margin props — space between the scroll container's snap point and the element
-  scrollMarginTop?: BpkResponsiveValue<BpkSpacingValue>;
-  scrollMarginBottom?: BpkResponsiveValue<BpkSpacingValue>;
+  // Scroll snap margin props — space between the scroll container's snap point and the element.
+  // Scalar only: scroll-margin is typically a fixed sticky-header height, not per-breakpoint.
+  // Uses BpkPositionValue (rem | % | '0' | BpkSpacingToken) so that rem offsets like '3.5rem'
+  // are accepted alongside spacing tokens.
+  scrollMarginTop?: BpkPositionValue;
+  scrollMarginBottom?: BpkPositionValue;
 }
 
 /**
@@ -210,7 +213,9 @@ export interface BpkCommonLayoutProps extends BpkSpacingProps, AriaAttributes {
   transitionDuration?: never;
   transitionTimingFunction?: never;
   transitionDelay?: never;
-  // transform is excluded on the shared interface; BpkBox opts in via Omit<BpkCommonLayoutProps, 'transform'>
-  transform?: never;
+  // `transform` is intentionally absent here — BpkBox declares `transform?: string` in
+  // BpkBoxSpecificProps; all other layout components simply do not expose it.
+  // `transformOrigin` stays excluded on all components: it is only meaningful alongside
+  // `transform`, and BpkBox's token-based API is not designed for full transform-origin control.
   transformOrigin?: never;
 }

--- a/packages/backpack-web/src/bpk-component-layout/src/commonProps.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/commonProps.ts
@@ -210,6 +210,7 @@ export interface BpkCommonLayoutProps extends BpkSpacingProps, AriaAttributes {
   transitionDuration?: never;
   transitionTimingFunction?: never;
   transitionDelay?: never;
-  // transform is excluded here so BpkBox can opt-in via its own specific props
+  // transform is excluded on the shared interface; BpkBox opts in via Omit<BpkCommonLayoutProps, 'transform'>
+  transform?: never;
   transformOrigin?: never;
 }

--- a/packages/backpack-web/src/bpk-component-layout/src/theme.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/theme.ts
@@ -56,6 +56,7 @@ const spacingMd = '.5rem';
 const spacingLg = '1.5rem';
 const spacingXl = '2rem';
 const spacingXxl = '2.5rem';
+const spacingXxxl = '4rem';
 
 /**
  * Backpack Theme Configuration for Chakra UI
@@ -80,6 +81,7 @@ const spacingMap: Record<string, { value: string }> = {
   'bpk-spacing-lg': { value: spacingLg },
   'bpk-spacing-xl': { value: spacingXl },
   'bpk-spacing-xxl': { value: spacingXxl },
+  'bpk-spacing-xxxl': { value: spacingXxxl },
 };
 
 /**

--- a/packages/backpack-web/src/bpk-component-layout/src/tokenUtils-test.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokenUtils-test.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  convertBpkPositionValue,
   convertBpkSpacingToChakra,
   processBpkComponentProps,
   processBpkProps,
@@ -339,5 +340,103 @@ describe('processBpkProps', () => {
     expect(result).toBe('bpk-spacing-unknown');
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+
+  it('converts bpk-spacing-xxxl to 4rem', () => {
+    const result = processBpkProps({ padding: BpkSpacing.XXXL });
+
+    expect(result.padding).toBe('4rem');
+  });
+
+  it('converts spacing tokens in position props (top/right/bottom/left)', () => {
+    const result = processBpkProps({
+      top: BpkSpacing.Base,
+      left: BpkSpacing.LG,
+    });
+
+    expect(result.top).toBe('1rem');
+    expect(result.left).toBe('1.5rem');
+  });
+
+  it('passes through raw rem and % values for position props without a warning', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = processBpkProps({
+      top: '2rem',
+      right: '50%',
+      bottom: '0',
+    });
+
+    expect(result.top).toBe('2rem');
+    expect(result.right).toBe('50%');
+    expect(result.bottom).toBe('0');
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('converts spacing tokens for insetInlineStart and insetInlineEnd', () => {
+    const result = processBpkProps({
+      insetInlineStart: BpkSpacing.Base,
+      insetInlineEnd: BpkSpacing.SM,
+    });
+
+    expect(result.insetInlineStart).toBe('1rem');
+    expect(result.insetInlineEnd).toBe('.25rem');
+  });
+
+  it('supports responsive BPK spacing tokens for insetInlineStart/End', () => {
+    const result = processBpkProps({
+      insetInlineStart: { mobile: BpkSpacing.SM, tablet: BpkSpacing.LG },
+    });
+
+    expect(result.insetInlineStart).toEqual({ md: '.25rem', xl: '1.5rem' });
+  });
+
+  it('passes through raw values for insetInlineStart and insetInlineEnd', () => {
+    const result = processBpkProps({
+      insetInlineStart: '1.5rem',
+      insetInlineEnd: '25%',
+    });
+
+    expect(result.insetInlineStart).toBe('1.5rem');
+    expect(result.insetInlineEnd).toBe('25%');
+  });
+
+  it('converts spacing tokens for scrollMarginTop and scrollMarginBottom', () => {
+    const result = processBpkProps({
+      scrollMarginTop: BpkSpacing.MD,
+      scrollMarginBottom: BpkSpacing.XXXL,
+    });
+
+    expect(result.scrollMarginTop).toBe('.5rem');
+    expect(result.scrollMarginBottom).toBe('4rem');
+  });
+
+  it('supports responsive values for scrollMarginTop/Bottom', () => {
+    const result = processBpkProps({
+      scrollMarginTop: { mobile: BpkSpacing.SM, desktop: BpkSpacing.LG },
+    });
+
+    expect(result.scrollMarginTop).toEqual({ md: '.25rem', '2xl': '1.5rem' });
+  });
+});
+
+describe('convertBpkPositionValue', () => {
+  it('resolves a BPK spacing token to its rem value', () => {
+    expect(convertBpkPositionValue(BpkSpacing.Base)).toBe('1rem');
+    expect(convertBpkPositionValue(BpkSpacing.XXXL)).toBe('4rem');
+  });
+
+  it('passes through raw rem values unchanged', () => {
+    expect(convertBpkPositionValue('2.5rem')).toBe('2.5rem');
+    expect(convertBpkPositionValue('-1rem')).toBe('-1rem');
+  });
+
+  it('passes through percentage values unchanged', () => {
+    expect(convertBpkPositionValue('50%')).toBe('50%');
+  });
+
+  it('passes through bare zero unchanged', () => {
+    expect(convertBpkPositionValue('0')).toBe('0');
   });
 });

--- a/packages/backpack-web/src/bpk-component-layout/src/tokenUtils-test.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokenUtils-test.ts
@@ -402,7 +402,7 @@ describe('processBpkProps', () => {
     expect(result.insetInlineEnd).toBe('25%');
   });
 
-  it('converts spacing tokens for scrollMarginTop and scrollMarginBottom', () => {
+  it('converts BPK spacing tokens for scrollMarginTop and scrollMarginBottom', () => {
     const result = processBpkProps({
       scrollMarginTop: BpkSpacing.MD,
       scrollMarginBottom: BpkSpacing.XXXL,
@@ -412,12 +412,24 @@ describe('processBpkProps', () => {
     expect(result.scrollMarginBottom).toBe('4rem');
   });
 
-  it('supports responsive values for scrollMarginTop/Bottom', () => {
+  it('passes through raw rem values for scrollMarginTop/Bottom (e.g. sticky-header height)', () => {
     const result = processBpkProps({
-      scrollMarginTop: { mobile: BpkSpacing.SM, desktop: BpkSpacing.LG },
+      scrollMarginTop: '3.5rem',
+      scrollMarginBottom: '0',
     });
 
-    expect(result.scrollMarginTop).toEqual({ md: '.25rem', '2xl': '1.5rem' });
+    expect(result.scrollMarginTop).toBe('3.5rem');
+    expect(result.scrollMarginBottom).toBe('0');
+  });
+
+  it('passes through negative percentages for position props (e.g. top: -50% for vertical centering)', () => {
+    const result = processBpkProps({
+      top: '-50%',
+      left: '-100%',
+    });
+
+    expect(result.top).toBe('-50%');
+    expect(result.left).toBe('-100%');
   });
 });
 

--- a/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
@@ -401,8 +401,17 @@ export function processResponsiveValue(
 }
 
 /**
- * Validates and converts spacing props for Chakra UI
- * Handles all spacing-related properties including padding, margin, gap, size, border radius and position
+ * Validates and converts spacing props for Chakra UI.
+ *
+ * Handles:
+ * - Padding props: padding, paddingTop/Right/Bottom/Left, paddingStart/End, paddingInline, paddingBlock
+ * - Margin props: margin, marginTop/Right/Bottom/Left, marginStart/End, marginInline,
+ *   marginBlockStart/End, marginBlock
+ * - Gap: gap, rowGap, columnGap
+ * - Size: width, height, minWidth, minHeight, maxWidth, maxHeight
+ * - Position offsets: top, right, bottom, left, insetInlineStart, insetInlineEnd
+ *   (accept rem, %, '0', or BPK spacing tokens)
+ * - Scroll snap margin: scrollMarginTop, scrollMarginBottom (scalar BPK spacing tokens)
  *
  * @param {T} props - Component props object
  * @returns {Record<string, any>} Processed props with spacing tokens converted to actual values
@@ -423,15 +432,16 @@ export function processSpacingProps<T extends Record<string, any>>(
     // Size props
     'width', 'height', 'minWidth', 'minHeight', 'maxWidth', 'maxHeight',
     // Position props (rem, %, '0', or BPK spacing tokens)
+    // scrollMarginTop/Bottom are included here because they use the same value space as position
+    // offsets (rem for sticky-header heights, tokens, or '0') rather than spacing-only values.
     'top', 'right', 'bottom', 'left',
     'insetInlineStart', 'insetInlineEnd',
-    // Scroll snap margin props
     'scrollMarginTop', 'scrollMarginBottom',
   ];
 
   const processed: Record<string, any> = { ...props };
   const sizeKeys = ['width', 'height', 'minWidth', 'minHeight', 'maxWidth', 'maxHeight'];
-  const positionKeys = ['top', 'right', 'bottom', 'left', 'insetInlineStart', 'insetInlineEnd'];
+  const positionKeys = ['top', 'right', 'bottom', 'left', 'insetInlineStart', 'insetInlineEnd', 'scrollMarginTop', 'scrollMarginBottom'];
   // Margin keys accept 'auto' (e.g. marginTop: 'auto' to bottom-anchor a flex child); padding/gap don't.
   const marginKeys = [
     'margin', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft',

--- a/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
@@ -19,6 +19,7 @@
 import StackOptionKeys from './BpkStack.constant';
 import { getSpacingValue } from './theme';
 import {
+  BPK_SPACING_TOKEN_SET,
   BpkBreakpointToChakraKey,
   isValidSpacingValue,
   isValidMarginValue,
@@ -269,16 +270,18 @@ export function processBpkComponentProps<T extends Record<string, any>>(
 
 /**
  * Converts a position value to its CSS form.
- * Raw values (rem, %, '0') pass through directly; BPK spacing tokens are resolved to rem.
+ * BPK spacing tokens are resolved to rem; all other valid values (rem, %, '0') pass through.
+ * Uses BPK_SPACING_TOKEN_SET as the single discriminator to avoid duplicating the raw-value
+ * regex that already lives in isValidPositionValue.
  *
  * @param {string} value - Position value or BPK spacing token
  * @returns {string} CSS value
  */
 export function convertBpkPositionValue(value: string): string {
-  if (value === '0' || /^-?\d+(\.\d+)?rem$/.test(value) || isPercentage(value)) {
-    return value;
+  if (BPK_SPACING_TOKEN_SET.has(value)) {
+    return convertBpkSpacingToChakra(value);
   }
-  return convertBpkSpacingToChakra(value);
+  return value;
 }
 
 /**

--- a/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
@@ -448,7 +448,6 @@ export function processSpacingProps<T extends Record<string, any>>(
       if (isSizeProp) {
         converter = (v: string) => v;
       } else if (isPositionProp) {
-        // Resolves BPK spacing tokens to rem; raw rem/% values pass through without a warning.
         converter = convertBpkPositionValue;
       } else {
         converter = convertBpkSpacingToChakra;

--- a/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokenUtils.ts
@@ -268,6 +268,20 @@ export function processBpkComponentProps<T extends Record<string, any>>(
 }
 
 /**
+ * Converts a position value to its CSS form.
+ * Raw values (rem, %, '0') pass through directly; BPK spacing tokens are resolved to rem.
+ *
+ * @param {string} value - Position value or BPK spacing token
+ * @returns {string} CSS value
+ */
+export function convertBpkPositionValue(value: string): string {
+  if (value === '0' || /^-?\d+(\.\d+)?rem$/.test(value) || isPercentage(value)) {
+    return value;
+  }
+  return convertBpkSpacingToChakra(value);
+}
+
+/**
  * Converts Backpack spacing token to Chakra UI compatible value
  * Returns the actual spacing value from the theme, not a token path
  *
@@ -405,13 +419,16 @@ export function processSpacingProps<T extends Record<string, any>>(
     'rowGap', 'columnGap',
     // Size props
     'width', 'height', 'minWidth', 'minHeight', 'maxWidth', 'maxHeight',
-    // Position props
+    // Position props (rem, %, '0', or BPK spacing tokens)
     'top', 'right', 'bottom', 'left',
+    'insetInlineStart', 'insetInlineEnd',
+    // Scroll snap margin props
+    'scrollMarginTop', 'scrollMarginBottom',
   ];
 
   const processed: Record<string, any> = { ...props };
   const sizeKeys = ['width', 'height', 'minWidth', 'minHeight', 'maxWidth', 'maxHeight'];
-  const positionKeys = ['top', 'right', 'bottom', 'left'];
+  const positionKeys = ['top', 'right', 'bottom', 'left', 'insetInlineStart', 'insetInlineEnd'];
   // Margin keys accept 'auto' (e.g. marginTop: 'auto' to bottom-anchor a flex child); padding/gap don't.
   const marginKeys = [
     'margin', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft',
@@ -425,8 +442,11 @@ export function processSpacingProps<T extends Record<string, any>>(
       const isMarginProp = marginKeys.includes(key);
 
       let converter: (v: string) => string;
-      if (isSizeProp || isPositionProp) {
+      if (isSizeProp) {
         converter = (v: string) => v;
+      } else if (isPositionProp) {
+        // Resolves BPK spacing tokens to rem; raw rem/% values pass through without a warning.
+        converter = convertBpkPositionValue;
       } else {
         converter = convertBpkSpacingToChakra;
       }

--- a/packages/backpack-web/src/bpk-component-layout/src/tokens.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokens.ts
@@ -168,7 +168,7 @@ export type BpkResponsiveValue<T> =
  * @returns {boolean} True if the value is a valid percentage string
  */
 export function isPercentage(value: string): boolean {
-  return /^\d+(\.\d+)?%$/.test(value);
+  return /^-?\d+(\.\d+)?%$/.test(value);
 }
 
 /**

--- a/packages/backpack-web/src/bpk-component-layout/src/tokens.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokens.ts
@@ -36,6 +36,7 @@ export const BpkSpacing = {
   LG: 'bpk-spacing-lg',
   XL: 'bpk-spacing-xl',
   XXL: 'bpk-spacing-xxl',
+  XXXL: 'bpk-spacing-xxxl',
 } as const;
 
 export type BpkSpacingToken = typeof BpkSpacing[keyof typeof BpkSpacing];
@@ -94,14 +95,15 @@ export type BpkSizeValue =
   | 'fit-content';
 
 /**
- * Helper type for position props that can use rem, percentages, or bare zero.
+ * Helper type for position props that can use rem, percentages, bare zero, or BPK spacing tokens.
  * CSS allows `0` without a unit; `'0'` is therefore an explicit allowed value.
  * We intentionally do not allow other semantic values like 'auto' here.
  */
 export type BpkPositionValue =
   | `${number}rem`
   | `${number}%`
-  | '0';
+  | '0'
+  | BpkSpacingToken;
 
 /**
  * CSS `position` property keyword values.
@@ -205,15 +207,16 @@ export function isValidSizeValue(value: string): boolean {
 }
 
 /**
- * Validates if a position value is valid
+ * Validates if a position value is valid (rem, %, bare zero, or BPK spacing token)
  *
  * @param {string} value - The position value to validate
- * @returns {boolean} True if the value is a valid rem or percentage
+ * @returns {boolean} True if the value is valid
  */
 export function isValidPositionValue(value: string): boolean {
   return (
     value === '0' || // bare zero — valid CSS without a unit
     /^-?\d+(\.\d+)?rem$/.test(value) || // rem values
-    isPercentage(value) // percentage values
+    isPercentage(value) || // percentage values
+    Object.values(BpkSpacing).includes(value as BpkSpacingToken) // BPK spacing tokens
   );
 }

--- a/packages/backpack-web/src/bpk-component-layout/src/tokens.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/tokens.ts
@@ -41,6 +41,8 @@ export const BpkSpacing = {
 
 export type BpkSpacingToken = typeof BpkSpacing[keyof typeof BpkSpacing];
 
+export const BPK_SPACING_TOKEN_SET: ReadonlySet<string> = new Set(Object.values(BpkSpacing));
+
 /**
  * Backpack Breakpoint Tokens
  * Use these constants to ensure type safety when defining responsive overrides
@@ -176,7 +178,7 @@ export function isPercentage(value: string): boolean {
  * @returns {boolean} True if the value is a valid Backpack spacing token or percentage
  */
 export function isValidSpacingValue(value: string): boolean {
-  return Object.values(BpkSpacing).includes(value as BpkSpacingToken) || isPercentage(value);
+  return BPK_SPACING_TOKEN_SET.has(value) || isPercentage(value);
 }
 
 /**
@@ -217,6 +219,6 @@ export function isValidPositionValue(value: string): boolean {
     value === '0' || // bare zero — valid CSS without a unit
     /^-?\d+(\.\d+)?rem$/.test(value) || // rem values
     isPercentage(value) || // percentage values
-    Object.values(BpkSpacing).includes(value as BpkSpacingToken) // BPK spacing tokens
+    BPK_SPACING_TOKEN_SET.has(value) // BPK spacing tokens
   );
 }

--- a/packages/backpack-web/src/bpk-component-layout/src/types.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/types.ts
@@ -118,7 +118,6 @@ type BpkBoxResponsiveLayoutPropKeys = keyof BpkBoxResponsiveLayoutProps;
 export interface BpkBoxSpecificProps
   extends BpkBoxResponsiveLayoutProps,
   Omit<BpkFlexGridProps, BpkBoxResponsiveLayoutPropKeys> {
-  // CSS transform — BpkBox only, for positioning and animation (e.g. translate, scale, rotate)
   transform?: string;
 }
 

--- a/packages/backpack-web/src/bpk-component-layout/src/types.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/types.ts
@@ -117,7 +117,10 @@ type BpkBoxResponsiveLayoutPropKeys = keyof BpkBoxResponsiveLayoutProps;
  */
 export interface BpkBoxSpecificProps
   extends BpkBoxResponsiveLayoutProps,
-    Omit<BpkFlexGridProps, BpkBoxResponsiveLayoutPropKeys> {}
+  Omit<BpkFlexGridProps, BpkBoxResponsiveLayoutPropKeys> {
+  // CSS transform — BpkBox only, for positioning and animation (e.g. translate, scale, rotate)
+  transform?: string;
+}
 
 /**
  * Props for BpkBox component
@@ -192,6 +195,7 @@ export interface BpkFlexSpecificProps {
   align?: BpkResponsiveValue<FlexProps['alignItems']>;
   wrap?: BpkResponsiveValue<FlexProps['flexWrap']>;
   grow?: BpkResponsiveValue<FlexProps['flexGrow']>;
+  flexShrink?: BpkResponsiveValue<FlexProps['flexShrink']>;
   shrink?: BpkResponsiveValue<FlexProps['flexShrink']>;
   basis?: BpkResponsiveValue<BpkBasisValue>;
   alignSelf?: BpkResponsiveValue<BoxProps['alignSelf']>;
@@ -269,8 +273,8 @@ type StackOptionKeysType = typeof StackOptionKeys[number];
  */
 type BpkStackOptions = {
   [K in StackOptionKeysType]?: K extends keyof StackProps
-    ? BpkResponsiveValue<StackProps[K]> | StackProps[K]
-    : never;
+  ? BpkResponsiveValue<StackProps[K]> | StackProps[K]
+  : never;
 };
 
 /**
@@ -286,7 +290,7 @@ type BpkStackOptions = {
  */
 export interface BpkStackSpecificProps
   extends BpkStackOptions,
-    Omit<BpkFlexGridProps, 'alignItems' | 'justifyContent'> {
+  Omit<BpkFlexGridProps, 'alignItems' | 'justifyContent'> {
   /** Alias for `align`. Maps to CSS `align-items`. Responsive — replaces the non-responsive BpkFlexGridProps.alignItems. */
   alignItems?: BpkStackOptions['align'];
   /** Alias for `justify`. Maps to CSS `justify-content`. Responsive — replaces the non-responsive BpkFlexGridProps.justifyContent. */

--- a/packages/backpack-web/src/bpk-component-layout/src/types.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/types.ts
@@ -128,7 +128,7 @@ export interface BpkBoxSpecificProps
  * onClick, onFocus and onBlur are inherited from BpkCommonLayoutProps.
  * textStyle maps to Chakra's `textStyle` theme prop for Backpack typography and supports responsive values.
  */
-export interface BpkBoxProps extends BpkCommonLayoutProps, BpkBoxSpecificProps {
+export interface BpkBoxProps extends Omit<BpkCommonLayoutProps, 'transform'>, BpkBoxSpecificProps {
   children?: ReactNode;
 }
 

--- a/packages/backpack-web/src/bpk-component-layout/src/types.ts
+++ b/packages/backpack-web/src/bpk-component-layout/src/types.ts
@@ -126,8 +126,12 @@ export interface BpkBoxSpecificProps
  * Combines Box-specific props with Backpack common layout props.
  * onClick, onFocus and onBlur are inherited from BpkCommonLayoutProps.
  * textStyle maps to Chakra's `textStyle` theme prop for Backpack typography and supports responsive values.
+ *
+ * `transform` is available on BpkBox only — declared in BpkBoxSpecificProps.
+ * BpkCommonLayoutProps does not declare transform (neither string nor never), so there is no
+ * type conflict when BpkBoxSpecificProps adds it as string.
  */
-export interface BpkBoxProps extends Omit<BpkCommonLayoutProps, 'transform'>, BpkBoxSpecificProps {
+export interface BpkBoxProps extends BpkCommonLayoutProps, BpkBoxSpecificProps {
   children?: ReactNode;
 }
 


### PR DESCRIPTION
## What

Extends the Backpack layout components with positioning, overlay, and spacing token improvements, split from CLOV-1812 for independent delivery.

**JIRA:** https://skyscanner.atlassian.net/browse/CLOV-1823

## Changes

### Tokens (`tokens.ts`, `theme.ts`)
- Add `BpkSpacing.XXXL` (`4rem` / 64px)
- Update `BpkPositionValue` to accept BPK spacing tokens in addition to rem/% values
- Update `isValidPositionValue` and `isPercentage` (now accepts negative percentages, e.g. `-50%` for centering)
- Hoist `BPK_SPACING_TOKEN_SET` as a module-level `ReadonlySet` — O(1) token lookup, avoids per-call array allocation

### Common layout props (`commonProps.ts`)
- Add `insetInlineStart` / `insetInlineEnd` — RTL-safe logical equivalents of `left`/`right`; accept `BpkPositionValue` (rem, %, `'0'`, or BPK token); support responsive overrides
- Add `scrollMarginTop` / `scrollMarginBottom` — scroll snap margin props; scalar `BpkPositionValue` (accepts rem values like `'3.5rem'` for sticky-header offsets, plus BPK tokens and `'0'`)
- Add `pointerEvents?: 'none' | 'auto'` — click-through overlays; available on all layout components
- Remove `transform?: never` — `BpkCommonLayoutProps` is an explicit allowlist (never extends Chakra `BoxProps`), so the `never` was a convention marker only; `BpkBoxSpecificProps` adds `transform?: string` directly with no conflict

### `BpkBoxSpecificProps` (`types.ts`)
- Add `transform?: string` — BpkBox-only; supports any CSS transform string (e.g. `translateX`, `rotate`, `scale`)
- `BpkBoxProps` stays clean: `extends BpkCommonLayoutProps, BpkBoxSpecificProps` — no `Omit` needed

### `BpkFlexSpecificProps` (`types.ts`) + `BpkFlex.tsx`
- Add `flexShrink` as a direct CSS prop alias alongside existing `shrink`; `shrink` takes precedence if both are provided

### Token processing (`tokenUtils.ts`)
- Add `convertBpkPositionValue` — uses `BPK_SPACING_TOKEN_SET.has()` as the sole discriminator; no duplicated raw-value regex
- All position-family props (`top/right/bottom/left`, `insetInlineStart/End`, `scrollMarginTop/Bottom`) go through `convertBpkPositionValue`
- Update `processSpacingProps` JSDoc to list all handled prop groups

### Documentation
- `README.md` updated: `scrollMarginTop/Bottom` moved to Position offsets section with correct type and sticky-header example; `XXXL` token added; `transform` constraint clarified (BpkBox only); `pointerEvents` added to interaction surface; `flexShrink` alias noted

## Acceptance Criteria

- [x] Add `scrollMarginTop` and `scrollMarginBottom` support to common layout props
- [x] Add Backpack spacing token support for logical inset props (`insetInlineStart`, `insetInlineEnd`)
- [x] Add `transform` support for `BpkBox`
- [x] Add `pointerEvents` support for `BpkBox` and `BpkFlex`
- [x] Update `BpkPositionValue` so both arbitrary values and BPK tokens are accepted
- [x] Add `bpk-spacing-xxxl` where appropriate across tokens, docs, and types
- [x] Add tests and Storybook/docs examples for all new supported props and token behaviour

## Testing

- `tokenUtils-test.ts`: `bpk-spacing-xxxl` conversion; spacing tokens and raw rem in position props; `insetInlineStart/End` (scalar + responsive + raw); `scrollMarginTop/Bottom` (token + raw rem `'3.5rem'`); negative percentages (`-50%`); `convertBpkPositionValue` passthrough
- `BpkBox-test.tsx`: `transform`, `pointerEvents`, `insetInlineStart/End`, `scrollMarginTop/Bottom` (token + rem)
- `BpkFlex-test.tsx`: `pointerEvents`, `flexShrink` (direct prop + precedence over `shrink`)
- Storybook stories added: `Transform`, `PointerEvents`, `InsetInline` on `BpkBox`; `FlexShrink`, `FlexPointerEvents` on `BpkFlex`; `BpkSpacing.XXXL` folded into existing `Spacing` story

## Checklist

- [x] PR title includes component name and JIRA ticket
- [x] Component `README.md` updated
- [x] Tests added
- [x] Storybook examples created/updated
- [ ] Accessibility tests (not applicable — structural token/prop changes only)