### PR TITLE
[BpkPriceRange] Fix Percy VisualTestWithZoom flakiness

### DIFF
--- a/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.stories.tsx
@@ -18,6 +18,8 @@
 
 import type { ReactNode } from 'react';
 
+import { waitFor } from 'storybook/test';
+
 import BpkPriceRange, {
   type BpkPriceRangeProps,
 } from './BpkPriceRange';
@@ -219,5 +221,26 @@ export const VisualTestWithZoom = {
   render: () => <MixedExample />,
   args: {
     zoomEnabled: true,
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    // Wait for the ResizeObserver + useEffect measurement cycle to complete.
+    // --prefilled-width starts at 0px and is updated asynchronously after
+    // scrollWidth is measured. Percy must not snapshot before this settles,
+    // otherwise the bubble marker position is inconsistent between runs.
+    await waitFor(() => {
+      const markers = canvasElement.querySelectorAll<HTMLElement>(
+        '[data-backpack-ds-component="PriceMarker"]',
+      );
+      markers.forEach((marker) => {
+        const priceRange = marker.closest<HTMLElement>(
+          '[data-backpack-ds-component="PriceRange"]',
+        );
+        if (!priceRange) return;
+        const prefilledWidth = priceRange.style.getPropertyValue('--prefilled-width');
+        if (!prefilledWidth || prefilledWidth === '0px') {
+          throw new Error('--prefilled-width not yet settled');
+        }
+      });
+    });
   },
 };


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

The `VisualTestWithZoom` story for `BpkPriceRange` was producing inconsistent Percy snapshots because the component's `--prefilled-width` CSS variable (which positions the bubble marker) is set asynchronously via a `ResizeObserver` + `useEffect` measurement cycle. Percy was snapshotting before this settled, resulting in the marker appearing at different positions between runs.

The fix adds a `play` function that uses `waitFor` from `storybook/test` to poll the DOM until `--prefilled-width` has a non-zero value on all `PriceRange` elements containing a `PriceMarker`. Storybook's Percy integration waits for the `play` function to complete before capturing the snapshot, guaranteeing a stable layout every time.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here