### PR TITLE
[CLOV-1864][CI] Fix storybook PR preview: cleanup old builds + token security

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -109,7 +109,7 @@ jobs:
         external_repository: backpack/storybook-prs
         publish_branch: main
 
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: app-token
       with:
         client-id: ${{ vars.GH_APP_ID }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -117,6 +117,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
         permission-issues: write
+        permission-pull-requests: write
 
     - name: Link to the pull request build
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,6 +114,8 @@ jobs:
       with:
         client-id: ${{ vars.GH_APP_ID }}
         private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
 
     - name: Link to the pull request build
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -109,10 +109,10 @@ jobs:
         external_repository: backpack/storybook-prs
         publish_branch: main
 
-    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
-        app-id: ${{ vars.GH_APP_ID }}
+        client-id: ${{ vars.GH_APP_ID }}
         private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
     - name: Link to the pull request build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -116,6 +116,7 @@ jobs:
         private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
+        permission-issues: write
 
     - name: Link to the pull request build
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -109,7 +109,7 @@ jobs:
         external_repository: backpack/storybook-prs
         publish_branch: main
 
-    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
         client-id: ${{ vars.GH_APP_ID }}

--- a/.github/workflows/storybook-cleanup-once.yml
+++ b/.github/workflows/storybook-cleanup-once.yml
@@ -17,6 +17,9 @@ permissions: {}
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
     steps:
       - name: Get open PR numbers
         id: open-prs
@@ -35,10 +38,12 @@ jobs:
         env:
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
+          git config --global credential.helper store
+          echo "https://x-access-token:${DEPLOY_TOKEN}@github.com" > ~/.git-credentials
           git clone \
             --depth 1 \
             --filter=blob:none \
-            https://x-access-token:${DEPLOY_TOKEN}@github.com/backpack/storybook-prs.git \
+            https://github.com/backpack/storybook-prs.git \
             /tmp/storybook-prs
 
       - name: Identify and remove closed PR directories
@@ -49,6 +54,7 @@ jobs:
           OPEN_PRS=$(cat /tmp/open_prs.json)
           REMOVED=0
 
+          shopt -s nullglob
           for dir in [0-9]*/; do
             PR_NUM="${dir%/}"
             IS_OPEN=$(echo "$OPEN_PRS" | jq -r --arg n "$PR_NUM" 'contains([$n])')

--- a/.github/workflows/storybook-cleanup-once.yml
+++ b/.github/workflows/storybook-cleanup-once.yml
@@ -1,0 +1,88 @@
+name: Cleanup Storybook PR Previews
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — list directories to delete without actually deleting'
+        type: boolean
+        default: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+permissions: {}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get open PR numbers
+        id: open-prs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr list \
+            --repo Skyscanner/backpack \
+            --state open \
+            --json number \
+            --limit 500 \
+            --jq '[.[].number | tostring]' > /tmp/open_prs.json
+          echo "Open PRs: $(cat /tmp/open_prs.json)"
+
+      - name: Clone storybook-prs (blobless — no file content downloaded)
+        env:
+          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+        run: |
+          git clone \
+            --depth 1 \
+            --filter=blob:none \
+            https://x-access-token:${DEPLOY_TOKEN}@github.com/backpack/storybook-prs.git \
+            /tmp/storybook-prs
+
+      - name: Identify and remove closed PR directories
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          cd /tmp/storybook-prs
+          OPEN_PRS=$(cat /tmp/open_prs.json)
+          REMOVED=0
+
+          for dir in [0-9]*/; do
+            PR_NUM="${dir%/}"
+            IS_OPEN=$(echo "$OPEN_PRS" | jq -r --arg n "$PR_NUM" 'contains([$n])')
+            if [ "$IS_OPEN" = "true" ]; then
+              echo "  KEEP  PR #$PR_NUM (open)"
+            else
+              echo "  REMOVE PR #$PR_NUM (closed)"
+              if [ "$DRY_RUN" != "true" ]; then
+                git rm -rf "$PR_NUM" --quiet
+              fi
+              REMOVED=$((REMOVED + 1))
+            fi
+          done
+
+          echo ""
+          echo "Total to remove: $REMOVED PR directories"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo ""
+            echo "DRY RUN — no changes made. Re-run with dry_run=false to apply."
+          fi
+
+      - name: Commit and push
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          cd /tmp/storybook-prs
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          CHANGED=$(git status --short | wc -l | tr -d ' ')
+          if [ "$CHANGED" -gt "0" ]; then
+            git commit -m "chore: remove storybook previews for closed PRs"
+            git push
+            echo "Done — pushed cleanup commit removing $CHANGED files."
+          else
+            echo "Nothing to remove."
+          fi

--- a/.github/workflows/storybook-cleanup-once.yml
+++ b/.github/workflows/storybook-cleanup-once.yml
@@ -63,7 +63,7 @@ jobs:
           shopt -s nullglob
           for dir in [0-9]*/; do
             PR_NUM="${dir%/}"
-            IS_OPEN=$(echo "$OPEN_PRS" | jq -r --arg n "$PR_NUM" 'contains([$n])')
+            IS_OPEN=$(echo "$OPEN_PRS" | jq -r --arg n "$PR_NUM" 'any(. == $n)')
             if [ "$IS_OPEN" = "true" ]; then
               echo "  KEEP  PR #$PR_NUM (open)"
             else
@@ -109,6 +109,7 @@ jobs:
 
               echo "Push failed; rebasing onto latest storybook-prs main and retrying."
               git fetch origin main
+              git rebase --abort 2>/dev/null || true
               git rebase origin/main
             done
           else

--- a/.github/workflows/storybook-cleanup-once.yml
+++ b/.github/workflows/storybook-cleanup-once.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           gh pr list \
             --repo Skyscanner/backpack \
             --state open \
@@ -38,6 +40,8 @@ jobs:
         env:
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
+          set -euo pipefail
+
           git config --global credential.helper store
           echo "https://x-access-token:${DEPLOY_TOKEN}@github.com" > ~/.git-credentials
           git clone \
@@ -50,6 +54,8 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
+          set -euo pipefail
+
           cd /tmp/storybook-prs
           OPEN_PRS=$(cat /tmp/open_prs.json)
           REMOVED=0
@@ -80,6 +86,8 @@ jobs:
       - name: Commit and push
         if: ${{ inputs.dry_run == false }}
         run: |
+          set -euo pipefail
+
           cd /tmp/storybook-prs
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
@@ -87,8 +95,22 @@ jobs:
           CHANGED=$(git status --short | wc -l | tr -d ' ')
           if [ "$CHANGED" -gt "0" ]; then
             git commit -m "chore: remove storybook previews for closed PRs"
-            git push
-            echo "Done — pushed cleanup commit removing $CHANGED files."
+
+            for attempt in 1 2 3; do
+              if git push origin HEAD:main; then
+                echo "Done — pushed cleanup commit removing $CHANGED files."
+                exit 0
+              fi
+
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::Failed to push cleanup after $attempt attempts."
+                exit 1
+              fi
+
+              echo "Push failed; rebasing onto latest storybook-prs main and retrying."
+              git fetch origin main
+              git rebase origin/main
+            done
           else
             echo "Nothing to remove."
           fi

--- a/.github/workflows/storybook-cleanup.yml
+++ b/.github/workflows/storybook-cleanup.yml
@@ -1,0 +1,45 @@
+name: Cleanup Storybook PR Preview on Close
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+permissions: {}
+
+jobs:
+  cleanup:
+    # Only run for PRs from the same repo (not forks) and not dependabot
+    if: >
+      github.repository == github.event.pull_request.head.repo.full_name &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone storybook-prs (blobless — no file content downloaded)
+        env:
+          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git clone \
+            --depth 1 \
+            --filter=blob:none \
+            https://x-access-token:${DEPLOY_TOKEN}@github.com/backpack/storybook-prs.git \
+            /tmp/storybook-prs
+
+          cd /tmp/storybook-prs
+
+          if [ ! -d "$PR_NUMBER" ]; then
+            echo "No storybook directory found for PR #$PR_NUMBER — nothing to clean up."
+            exit 0
+          fi
+
+          git rm -rf "$PR_NUMBER" --quiet
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git commit -m "chore: remove storybook preview for closed PR #$PR_NUMBER"
+          git push
+          echo "Removed storybook preview for PR #$PR_NUMBER."

--- a/.github/workflows/storybook-cleanup.yml
+++ b/.github/workflows/storybook-cleanup.yml
@@ -19,15 +19,18 @@ jobs:
       github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Clone storybook-prs (blobless — no file content downloaded)
+      - name: Clone storybook-prs and remove PR directory
         env:
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          git config --global credential.helper store
+          echo "https://x-access-token:${DEPLOY_TOKEN}@github.com" > ~/.git-credentials
+
           git clone \
             --depth 1 \
             --filter=blob:none \
-            https://x-access-token:${DEPLOY_TOKEN}@github.com/backpack/storybook-prs.git \
+            https://github.com/backpack/storybook-prs.git \
             /tmp/storybook-prs
 
           cd /tmp/storybook-prs

--- a/.github/workflows/storybook-cleanup.yml
+++ b/.github/workflows/storybook-cleanup.yml
@@ -60,5 +60,6 @@ jobs:
 
             echo "Push failed; rebasing onto latest storybook-prs main and retrying."
             git fetch origin main
+            git rebase --abort 2>/dev/null || true
             git rebase origin/main
           done

--- a/.github/workflows/storybook-cleanup.yml
+++ b/.github/workflows/storybook-cleanup.yml
@@ -13,10 +13,10 @@ permissions: {}
 
 jobs:
   cleanup:
-    # Only run for PRs from the same repo (not forks) and not dependabot
+    # Only run for PRs from the same repo (not forks) and not Dependabot-authored PRs.
     if: >
       github.repository == github.event.pull_request.head.repo.full_name &&
-      github.actor != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Clone storybook-prs and remove PR directory
@@ -24,6 +24,8 @@ jobs:
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
+
           git config --global credential.helper store
           echo "https://x-access-token:${DEPLOY_TOKEN}@github.com" > ~/.git-credentials
 
@@ -44,5 +46,19 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git commit -m "chore: remove storybook preview for closed PR #$PR_NUMBER"
-          git push
-          echo "Removed storybook preview for PR #$PR_NUMBER."
+
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              echo "Removed storybook preview for PR #$PR_NUMBER."
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to push cleanup after $attempt attempts."
+              exit 1
+            fi
+
+            echo "Push failed; rebasing onto latest storybook-prs main and retrying."
+            git fetch origin main
+            git rebase origin/main
+          done


### PR DESCRIPTION
## What

Storybook task built and deployed successfully but the pr storybook page displays 404. This might be an issue at the Backpack maintenance level. The repository is too large + legacy build type. The old version of the build pipeline of GitHub Pages has to handle the entire repo (a storybook containing hundreds of PRS), and has caused the pipeline to continuously time out or fail.

Adds cleanup workflows and a GitHub App token hardening fix to restore reliable Storybook PR previews.

<img width="402" height="132" alt="image" src="https://github.com/user-attachments/assets/afea2d8c-8bca-4f4c-ace1-8ba4a084c3db" />


### Changes

**`.github/workflows/storybook-cleanup-once.yml`** (new) — manual one-time cleanup  
Deletes Storybook preview directories for closed PRs from `backpack/storybook-prs`. The workflow defaults to `dry_run=true` so the removal list can be reviewed before applying. The apply path uses fail-fast shell settings and retries pushes after rebasing onto the latest `storybook-prs` `main`, so overlapping cleanup runs are less likely to leave stale previews behind.

**`.github/workflows/storybook-cleanup.yml`** (new) — automatic cleanup on PR close  
Removes a PR's Storybook preview directory when the PR is closed or merged. It skips forks and Dependabot-authored PRs, and push/rebase retry handling keeps the cleanup resilient when multiple PRs close around the same time.

**`.github/workflows/pr.yml`** — token security fix  
Scopes `actions/create-github-app-token` to the current repository with `owner` and `repositories`, requests explicit `permission-issues: write` and `permission-pull-requests: write` for the PR comment, and updates the input from deprecated `app-id` to `client-id`.

## Why

`backpack/storybook-prs` has accumulated hundreds of old PR preview directories. GitHub Pages is deploying the whole repo and recent Pages deployments have failed because the generated artifact is too large, which means the PR Storybook job can build and push successfully while `https://backpack.github.io/storybook-prs/<PR_NUMBER>/` still returns 404.

Cleaning closed PR preview directories reduces the Pages artifact size so the Pages deployment can succeed again, and the automatic cleanup prevents the preview repo from growing back into the same failure mode.

## How to use the one-time cleanup

After merging, go to **Actions → Cleanup Storybook PR Previews → Run workflow**:

1. Run with `dry_run=true` and review the directories that would be deleted.
2. Re-run with `dry_run=false` to apply the cleanup.
3. Confirm the `backpack/storybook-prs` Pages deployment succeeds, then re-run or update any active PR preview that still needs a fresh deployment.

---

- [x] PR title updated
- [x] No component changes — CI/workflow only, no README or tests needed
- [x] No breaking changes