### PR TITLE
[WOODPECKER-4447] Upgrade pnpm from 9 to 10

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,7 @@ engine-strict=true
 # Dependabot is not compatible with pnpm strict peer dependency installs.
 # Keep installs unblocked and enforce peer dependency health via a separate CI check.
 strict-peer-dependencies=false
+
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=*stylelint*
+public-hoist-pattern[]=*prettier*

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -400,7 +400,7 @@ Components MUST be built with performance in mind:
 ### Supported Platforms & Browsers
 
 - **Node.js**: >=18.20.4
-- **pnpm**: >=9.15.9
+- **pnpm**: >=10.33.0
 - **React**: 18.3.1
 - **TypeScript**: 5.9.2
 - **Browsers** (from [browserslist-config-skyscanner](https://github.skyscannertools.net/web-engineering/browserslist-config-skyscanner)):

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -64,7 +64,7 @@ VALIDATION:
 **Build Tools**: Webpack 5, Babel 7
 **Linting**: ESLint (@skyscanner/eslint-config-skyscanner), Stylelint
 **Component Library**: Backpack Design System (Monorepo)
-**Package Manager**: pnpm >=9.15.9
+**Package Manager**: pnpm >=10.33.0
 **Node Version**: >=18.20.4
 **Target Browsers**: Chrome 109+, Edge 129+, Firefox 131+, Safari 15+, Samsung 26+
 **Performance Goals**: Meet test coverage thresholds (70% branches, 75% functions/lines/statements)

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.1",
   "license": "Apache-2.0",
   "private": true,
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=22.9.0",
-    "pnpm": ">=9.15.9"
+    "pnpm": ">=10.33.0"
   },
   "repository": {
     "type": "git",
@@ -206,6 +206,6 @@
     "overrides": {
       "braces": "3.0.3"
     },
-    "neverBuiltDependencies": ["node-sass"]
+    "ignoredBuiltDependencies": ["node-sass"]
   }
 }


### PR DESCRIPTION
## Summary

Bump `packageManager` and `engines.pnpm` from `9.15.9` → `10.33.0`


Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
