### PR TITLE
[CLOV-1864] Preserve .github from storybook-prs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -106,10 +106,11 @@ jobs:
       run: |
         trap 'rm -rf _prs_tmp' EXIT
         gh repo clone backpack/storybook-prs _prs_tmp -- \
-          --depth 1 --filter=blob:none --sparse
-        git -C _prs_tmp sparse-checkout set .github 2>/dev/null || true
+          --depth 1 --filter=blob:none --sparse --branch main
+        git -C _prs_tmp sparse-checkout set .github
         if [ -d _prs_tmp/.github ]; then
-          cp -r _prs_tmp/.github build/.github
+          mkdir -p build/.github
+          cp -r _prs_tmp/.github/. build/.github/
         fi
 
     - name: Deploy Storybook to backpack.github.io/storybook-prs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,6 +99,19 @@ jobs:
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
 
+    - name: Preserve .github from storybook-prs
+      if: github.ref != 'refs/heads/main' && github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]'
+      env:
+        GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+      run: |
+        trap 'rm -rf _prs_tmp' EXIT
+        gh repo clone backpack/storybook-prs _prs_tmp -- \
+          --depth 1 --filter=blob:none --sparse
+        git -C _prs_tmp sparse-checkout set .github 2>/dev/null || true
+        if [ -d _prs_tmp/.github ]; then
+          cp -r _prs_tmp/.github build/.github
+        fi
+
     - name: Deploy Storybook to backpack.github.io/storybook-prs
       uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
       if: github.ref != 'refs/heads/main' && github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]'


### PR DESCRIPTION
## What

Adds a CI step to preserve the \`.github/\` directory in the \`backpack/storybook-prs\` repository across Storybook deployments. Related [PR](https://github.com/backpack/storybook-prs/pull/3/changes)

\`peaceiris/actions-gh-pages\` force-pushes the \`build/\` directory to \`storybook-prs\` on every PR build. Any files that exist in that repo but are not in \`build/\` (e.g. \`.github/CNAME\`, GitHub Pages config) risk being wiped if \`keep_files\` doesn't behave as expected for external repos on a \`main\` branch.

The new step runs before the deploy and copies \`.github/\` from the current \`storybook-prs\` state into \`build/\`, so it's included in the push.

## How

- Sparse-clones \`backpack/storybook-prs\` (depth 1, blobs only for \`.github/\`) via \`gh repo clone\` — token stays in \`GH_TOKEN\` env var and never appears in the clone URL
- Uses \`trap 'rm -rf _prs_tmp' EXIT\` so the temp directory is cleaned up even if the step fails
- Copies \`.github/\` into \`build/\` only if it exists in the remote (no-op on first deploy)
- Same \`if:\` condition as the surrounding deploy steps (non-main, same-repo, non-dependabot)

## Checklist

- [x] No component changes — CI-only
- [x] No changelog entry needed (`skip-changelog`)