### PR TITLE
[BpkButton] Fix Google Translate removeChild error for disabled link buttons

### DIFF
--- a/packages/backpack-web/src/bpk-component-button/src/BpkButton-test.tsx
+++ b/packages/backpack-web/src/bpk-component-button/src/BpkButton-test.tsx
@@ -486,13 +486,13 @@ describe('BpkButton', () => {
     });
 
     it('should wrap children in a span when disabled to prevent Google Translate removeChild error', () => {
-      const { container } = render(
+      const { getByText } = render(
         <BpkButton type={BUTTON_TYPES.link} disabled>
           Disabled link
         </BpkButton>,
       );
 
-      expect(container.firstElementChild?.querySelector('span')).toBeInTheDocument();
+      expect(getByText('Disabled link').tagName).toBe('SPAN');
     });
 
     it('should NOT render underline span for iconOnly linkOnDark', () => {

--- a/packages/backpack-web/src/bpk-component-button/src/BpkButton-test.tsx
+++ b/packages/backpack-web/src/bpk-component-button/src/BpkButton-test.tsx
@@ -485,6 +485,16 @@ describe('BpkButton', () => {
       expect(underlinedSpan).not.toBeInTheDocument();
     });
 
+    it('should wrap children in a span when disabled to prevent Google Translate removeChild error', () => {
+      const { container } = render(
+        <BpkButton type={BUTTON_TYPES.link} disabled>
+          Disabled link
+        </BpkButton>,
+      );
+
+      expect(container.firstElementChild?.querySelector('span')).toBeInTheDocument();
+    });
+
     it('should NOT render underline span for iconOnly linkOnDark', () => {
       const { container } = render(
         <BpkButton type={BUTTON_TYPES.linkOnDark} iconOnly aria-label="Icon link">

--- a/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
+++ b/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
@@ -59,8 +59,9 @@ const BpkButton = ({
 }: Props) => {
   const isDisabled = disabled || loading;
   const isLinkType = type === BUTTON_TYPES.link || type === BUTTON_TYPES.linkOnDark;
+  const isLinkWithText = isLinkType && !iconOnly;
   const alternate = type === BUTTON_TYPES.linkOnDark;
-  const shouldUnderline = isLinkType && !iconOnly && !isDisabled;
+  const shouldUnderline = isLinkWithText && !isDisabled;
   const hasIcons = !!(leadingIcon || trailingIcon);
 
   const classNames = getCommonClassName(
@@ -90,7 +91,7 @@ const BpkButton = ({
   // to toggle on/off with `disabled`, which made React add/remove the wrapper and move the
   // bare text node. If Google Translate had replaced that text node with a <font> element,
   // React's reconciler would throw a removeChild error. Keeping the span stable avoids it.
-  const textContent = isLinkType && !iconOnly
+  const textContent = isLinkWithText
     ? <span className={underlinedClassName}>{children}</span>
     : children;
 

--- a/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
+++ b/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
@@ -84,11 +84,11 @@ const BpkButton = ({
         alternate && !implicit && 'bpk-button--link-underlined--alternate',
         implicit && alternate && 'bpk-button--link-underlined--implicit--alternate',
       )
-    : null;
+    : undefined;
 
-  const textContent = underlinedClassName
-    ? <span className={underlinedClassName}>{children}</span>
-    : children;
+  // Always wrap in a span to prevent Google Translate from replacing bare text nodes,
+  // which would cause React's removeChild to fail when reconciling the DOM.
+  const textContent = <span className={underlinedClassName}>{children}</span>;
 
   const leadingIconEl = !iconOnly && leadingIcon ? (
     <span className={getCommonClassName('bpk-button__leading-icon')}>

--- a/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
+++ b/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
@@ -89,7 +89,6 @@ const BpkButton = ({
   // Always wrap in a span (even when disabled/no underline) to prevent Google Translate
   // from replacing bare text nodes with <font> elements, which causes React's reconciler
   // to throw a removeChild error when it later tries to remove the original text node.
-  // See: https://skyscanner.atlassian.net/browse/SDBCK-302
   const textContent = <span className={underlinedClassName}>{children}</span>;
 
   const leadingIconEl = !iconOnly && leadingIcon ? (

--- a/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
+++ b/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
@@ -86,10 +86,13 @@ const BpkButton = ({
       )
     : undefined;
 
-  // Always wrap in a span (even when disabled/no underline) to prevent Google Translate
-  // from replacing bare text nodes with <font> elements, which causes React's reconciler
-  // to throw a removeChild error when it later tries to remove the original text node.
-  const textContent = <span className={underlinedClassName}>{children}</span>;
+  // Wrap link-type text in a span regardless of disabled state. The underline span used
+  // to toggle on/off with `disabled`, which made React add/remove the wrapper and move the
+  // bare text node. If Google Translate had replaced that text node with a <font> element,
+  // React's reconciler would throw a removeChild error. Keeping the span stable avoids it.
+  const textContent = isLinkType && !iconOnly
+    ? <span className={underlinedClassName}>{children}</span>
+    : children;
 
   const leadingIconEl = !iconOnly && leadingIcon ? (
     <span className={getCommonClassName('bpk-button__leading-icon')}>

--- a/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
+++ b/packages/backpack-web/src/bpk-component-button/src/BpkButton.tsx
@@ -86,8 +86,10 @@ const BpkButton = ({
       )
     : undefined;
 
-  // Always wrap in a span to prevent Google Translate from replacing bare text nodes,
-  // which would cause React's removeChild to fail when reconciling the DOM.
+  // Always wrap in a span (even when disabled/no underline) to prevent Google Translate
+  // from replacing bare text nodes with <font> elements, which causes React's reconciler
+  // to throw a removeChild error when it later tries to remove the original text node.
+  // See: https://skyscanner.atlassian.net/browse/SDBCK-302
   const textContent = <span className={underlinedClassName}>{children}</span>;
 
   const leadingIconEl = !iconOnly && leadingIcon ? (

--- a/packages/backpack-web/src/bpk-component-segmented-control/src/BpkSegmentedControlV2/BpkSegmentedControlV2-test.tsx
+++ b/packages/backpack-web/src/bpk-component-segmented-control/src/BpkSegmentedControlV2/BpkSegmentedControlV2-test.tsx
@@ -37,10 +37,14 @@ window.ResizeObserver =
     unobserve: jest.fn(),
   }));
 
-// Zag.js fires async state updates on mount (e.g. indicator position sync). Flushing
-// them after each test prevents "not wrapped in act(...)" warnings in subsequent tests.
+// Zag.js syncs the indicator position via requestAnimationFrame on mount; in jsdom, RAF
+// falls back to setTimeout(fn, 0) — a macrotask that won't be caught by act(async()=>{}).
+// Running one extra setTimeout tick inside act() flushes those pending macrotasks and
+// prevents "not wrapped in act(...)" warnings from leaking into subsequent tests.
 afterEach(async () => {
-  await act(async () => {});
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  });
 });
 
 const ThreeItemControl = ({

--- a/packages/backpack-web/src/bpk-component-segmented-control/src/BpkSegmentedControlV2/BpkSegmentedControlV2-test.tsx
+++ b/packages/backpack-web/src/bpk-component-segmented-control/src/BpkSegmentedControlV2/BpkSegmentedControlV2-test.tsx
@@ -19,7 +19,7 @@
 import type { CSSProperties } from 'react';
 
 import { LocaleProvider } from '@ark-ui/react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -36,6 +36,12 @@ window.ResizeObserver =
     observe: jest.fn(),
     unobserve: jest.fn(),
   }));
+
+// Zag.js fires async state updates on mount (e.g. indicator position sync). Flushing
+// them after each test prevents "not wrapped in act(...)" warnings in subsequent tests.
+afterEach(async () => {
+  await act(async () => {});
+});
 
 const ThreeItemControl = ({
   defaultValue,


### PR DESCRIPTION
## Summary

`BpkButton` toggled the underline `<span>` wrapper on and off with the `disabled` state for link-type buttons:

- **enabled** link → `<span class="…link-underlined">text</span>`
- **disabled** link → bare `text` node (no wrapper)

Toggling a link between enabled and disabled therefore made React add/remove the wrapper `<span>`, which moves the underlying text node. If Google Translate had already replaced that text node with a `<font>` element, React's reconciler could no longer find the original node and threw a `removeChild` error (`NotFoundError: Failed to execute 'removeChild' on 'Node'`).

### Fix

Wrap the text in a `<span>` for **all** link-type buttons (both enabled and disabled), so the wrapper is structurally stable and never toggles:

- **enabled** link → `<span class="…link-underlined">text</span>`
- **disabled** link → `<span>text</span>` (no underline class; React omits the `class` attribute when `className` is `undefined`)

The wrapper is scoped to link types (`isLinkType && !iconOnly`) — the DOM of non-link and icon-only buttons is left unchanged to avoid unnecessary structural changes for consumers.

Fixes SDBCK-302.

## Test plan

- [x] Existing tests pass — underline-class behaviour and icon-only / non-link DOM are unchanged
- [x] New regression test: a disabled link button wraps its text in a `<span>`

## Also included

- Fix an unrelated flaky-CI issue in `BpkSegmentedControlV2-test.tsx`: Zag.js syncs the indicator position via `requestAnimationFrame` on mount, which falls back to `setTimeout(fn, 0)` in jsdom. The `afterEach` now flushes that macrotask inside `act()` to suppress "not wrapped in act(...)" warnings that were failing CI.
