### PR TITLE
[CLOV-1864] Fix .github being wiped by exclude_assets default on Storybook deploy

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,6 +120,7 @@ jobs:
         personal_token: ${{ secrets.DEPLOY_TOKEN }}
         publish_dir: build/
         keep_files: true
+        exclude_assets: ''
         external_repository: backpack/storybook-prs
         publish_branch: main
 


### PR DESCRIPTION
## What

Fixes `.github/` being wiped from `backpack/storybook-prs` on every Storybook deploy.

`peaceiris/actions-gh-pages` has a default `exclude_assets: .github` that strips `.github/` from the working directory **before** pushing — even when `keep_files: true` is set and even if the preserve step ([#4887](https://github.com/Skyscanner/backpack/pull/4887)) has already copied `.github/` into `build/`. The result: every deploy silently deletes whatever lives in `storybook-prs/.github/`.

## How

- Overrides `exclude_assets` to `''` so the `.github/` copied by the preserve step actually reaches `storybook-prs`.
- Together with the preserve step from #4887 (clone → sparse-checkout → copy into `build/`), this makes each deploy a round-trip: read current `.github/` → include it in the push → storybook-prs retains it.

## Checklist

- [x] No component changes — CI-only
- [x] No changelog entry needed (`skip-changelog`)