### PR TITLE
[bpk-component-carousel] Hide page indicator when only one image is present

### DIFF
--- a/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel-test.tsx
+++ b/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel-test.tsx
@@ -91,7 +91,7 @@ describe('BpkCarousel', () => {
     expect(screen.queryByTestId('carousel-page-indicator-container')).toBeNull();
   });
 
-  it('should render costom bottom', async () => {
+  it('should render custom bottom', async () => {
     render(<BpkCarousel images={images} bottom={48} />);
 
     expect(screen.getByTestId('carousel-page-indicator-container')).toHaveStyle({bottom: '48px'});

--- a/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel-test.tsx
+++ b/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel-test.tsx
@@ -85,6 +85,12 @@ describe('BpkCarousel', () => {
     expect(screen.getByTestId('image-gallery-scroll-container').childElementCount).toBe(1);
   });
 
+  it('should not render page indicator when only one image is present', () => {
+    render(<BpkCarousel images={[images[0]]} />);
+
+    expect(screen.queryByTestId('carousel-page-indicator-container')).toBeNull();
+  });
+
   it('should render costom bottom', async () => {
     render(<BpkCarousel images={images} bottom={48} />);
 

--- a/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel.stories.js
+++ b/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel.stories.js
@@ -62,6 +62,18 @@ const WithCarouselPageIndicatorExample = () => (
   </div>
 );
 
+const SingleImageExample = () => (
+  <div
+    style={{
+      maxWidth: '800px',
+      width: '100%',
+      margin: 'auto',
+    }}
+  >
+    <BpkCarousel images={[imagesList[0]]} bottom={16} />
+  </div>
+);
+
 const MixedExample = () => (
   <div>
     <DefaultExample />
@@ -83,6 +95,10 @@ export const Default = {
 
 export const WithCarouselPageIndicator = {
   render: () => <WithCarouselPageIndicatorExample />,
+};
+
+export const SingleImage = {
+  render: () => <SingleImageExample />,
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel.tsx
+++ b/packages/backpack-web/src/bpk-component-carousel/src/BpkCarousel.tsx
@@ -70,24 +70,26 @@ const BpkCarousel = ({
         imagesRef={imagesRef}
         onImageChanged={onImageChanged}
       />
-      <div
-        className={getClassName('bpk-carousel__page-indicator-over-image')}
-        style={bottom ? {
-          bottom
-        } : undefined}
-        data-testid="carousel-page-indicator-container"
-      >
-        <BpkPageIndicator
-          currentIndex={shownImageIndex}
-          totalIndicators={images.length}
-          variant={pageIndicatorVariant}
-          indicatorLabel={accessibilityLabels.indicatorLabel ?? "Go to slide"}
-          prevNavLabel={accessibilityLabels.prevNavLabel ?? "Previous slide"}
-          nextNavLabel={accessibilityLabels.nextNavLabel ?? "Next slide"}
-          showNav={showNav}
-          onClick={showNav ? handleIndicatorClick : () => {}}
-        />
-      </div>
+      {images.length > 1 && (
+        <div
+          className={getClassName('bpk-carousel__page-indicator-over-image')}
+          style={bottom ? {
+            bottom
+          } : undefined}
+          data-testid="carousel-page-indicator-container"
+        >
+          <BpkPageIndicator
+            currentIndex={shownImageIndex}
+            totalIndicators={images.length}
+            variant={pageIndicatorVariant}
+            indicatorLabel={accessibilityLabels.indicatorLabel ?? "Go to slide"}
+            prevNavLabel={accessibilityLabels.prevNavLabel ?? "Previous slide"}
+            nextNavLabel={accessibilityLabels.nextNavLabel ?? "Next slide"}
+            showNav={showNav}
+            onClick={showNav ? handleIndicatorClick : () => {}}
+          />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Wraps the `BpkPageIndicator` block in `BpkCarousel` with an `images.length > 1` guard, so the indicator (dots and nav buttons) is not rendered when only a single image is present
- Adds a test asserting the page indicator container is absent for a single-image carousel
- Adds a `SingleImage` Storybook story to demonstrate the behaviour

<img width="1137" height="692" alt="Screenshot 2026-07-14 at 10 26 09" src="https://github.com/user-attachments/assets/89ca840d-dfda-4324-98f4-d530e6f91b5e" />


## Test plan

- [x] Existing carousel tests pass
- [x] New test `should not render page indicator when only one image is present` passes
- [x] `SingleImage` story renders a carousel with one image and no page indicator overlay
- [x] Multi-image stories are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)