### PR TITLE
[IRN-6860][BpkCollapsible] Add useBpkCollapsibleContext hook and asChild on RootProvider

### DIFF
--- a/packages/backpack-web/src/bpk-component-collapsible/README.md
+++ b/packages/backpack-web/src/bpk-component-collapsible/README.md
@@ -159,6 +159,8 @@ By default `RootProvider` renders a `<div>` to host its ARIA attributes and clas
 
 The `<li>` becomes the collapsible root — no wrapper `<div>` is inserted between it and the `<ul>`.
 
+> **Note:** `asChild` requires exactly one React element child. Passing a fragment, a string, or multiple siblings will throw a runtime error from Ark's slot merging.
+
 ## Lazy mounting
 
 Use `lazyMount` to defer rendering the content until the first time the section is opened. Pair with `unmountOnExit` to remove the content from the DOM whenever it closes.

--- a/packages/backpack-web/src/bpk-component-collapsible/README.md
+++ b/packages/backpack-web/src/bpk-component-collapsible/README.md
@@ -21,6 +21,7 @@ Check the main [Readme](https://github.com/skyscanner/backpack#usage) for a comp
 The package also exports:
 
 - `useBpkCollapsible` — the underlying Ark state machine hook.
+- `useBpkCollapsibleContext` — reader hook for consuming the shared machine from inside a `Root` or `RootProvider` subtree without prop-drilling.
 - `COLLAPSIBLE_VARIANTS` — variant constants (`default`, `onContrast`).
 
 ## Usage
@@ -113,6 +114,50 @@ const Example = () => {
 ```
 
 `useBpkCollapsible` accepts the same machine props as Ark's `useCollapsible` and returns the live state plus imperative `setOpen`. `RootProvider` accepts the same `variant` prop as `Root`.
+
+### Reading state from deep children with `useBpkCollapsibleContext`
+
+Any component inside a `Root` or `RootProvider` subtree can call `useBpkCollapsibleContext()` to read the current machine state without having it prop-drilled from above:
+
+```tsx
+import BpkCollapsible, {
+  useBpkCollapsible,
+  useBpkCollapsibleContext,
+} from '@skyscanner/backpack-web/bpk-component-collapsible';
+
+const StatusBadge = () => {
+  const { disabled, open } = useBpkCollapsibleContext();
+  return <span>{open ? 'Open' : 'Closed'}{disabled ? ' (disabled)' : ''}</span>;
+};
+
+const Example = () => {
+  const collapsible = useBpkCollapsible();
+  return (
+    <BpkCollapsible.RootProvider value={collapsible}>
+      <BpkCollapsible.Trigger>…</BpkCollapsible.Trigger>
+      <StatusBadge />
+      <BpkCollapsible.Content>…</BpkCollapsible.Content>
+    </BpkCollapsible.RootProvider>
+  );
+};
+```
+
+### Preventing a wrapper element with `asChild`
+
+By default `RootProvider` renders a `<div>` to host its ARIA attributes and class names. Pass `asChild` to merge those props onto your single child element instead — useful when the provider wraps an existing item element and an extra DOM node would break layout or produce invalid HTML:
+
+```tsx
+<ul>
+  <BpkCollapsible.RootProvider value={collapsible} asChild>
+    <li>
+      <BpkCollapsible.Trigger>…</BpkCollapsible.Trigger>
+      <BpkCollapsible.Content>…</BpkCollapsible.Content>
+    </li>
+  </BpkCollapsible.RootProvider>
+</ul>
+```
+
+The `<li>` becomes the collapsible root — no wrapper `<div>` is inserted between it and the `<ul>`.
 
 ## Lazy mounting
 

--- a/packages/backpack-web/src/bpk-component-collapsible/index.ts
+++ b/packages/backpack-web/src/bpk-component-collapsible/index.ts
@@ -19,6 +19,7 @@
 import BpkCollapsible from './src/BpkCollapsible';
 
 export { default as useBpkCollapsible } from './src/useBpkCollapsible';
+export { default as useBpkCollapsibleContext } from './src/useBpkCollapsibleContext';
 export { COLLAPSIBLE_VARIANTS } from './src/common-types';
 
 export default BpkCollapsible;

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
@@ -23,6 +23,7 @@ import userEvent from '@testing-library/user-event';
 
 import BpkCollapsible from './BpkCollapsible';
 import useBpkCollapsible from './useBpkCollapsible';
+import useBpkCollapsibleContext from './useBpkCollapsibleContext';
 
 import type { BpkCollapsibleRootProps } from './BpkCollapsibleRoot';
 
@@ -275,6 +276,94 @@ describe('BpkCollapsible', () => {
 
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
       expect(onOpen).toHaveBeenCalled();
+    });
+  });
+
+  describe('useBpkCollapsibleContext', () => {
+    const ReadState = () => {
+      const { disabled, open, visible } = useBpkCollapsibleContext();
+      return (
+        <div>
+          <span data-testid="open">{String(open)}</span>
+          <span data-testid="visible">{String(visible)}</span>
+          <span data-testid="disabled">{String(disabled)}</span>
+        </div>
+      );
+    };
+
+    it('reads open/visible/disabled from a Root', () => {
+      render(
+        <BpkCollapsible.Root defaultOpen>
+          <BpkCollapsible.Trigger>Toggle</BpkCollapsible.Trigger>
+          <BpkCollapsible.Content>
+            <ReadState />
+          </BpkCollapsible.Content>
+        </BpkCollapsible.Root>,
+      );
+
+      expect(screen.getByTestId('open').textContent).toBe('true');
+      expect(screen.getByTestId('disabled').textContent).toBe('false');
+    });
+
+    it('reads open/visible/disabled from a RootProvider', () => {
+      const Harness = () => {
+        const collapsible = useBpkCollapsible({ defaultOpen: true });
+        return (
+          <BpkCollapsible.RootProvider value={collapsible}>
+            <BpkCollapsible.Trigger>Toggle</BpkCollapsible.Trigger>
+            <BpkCollapsible.Content>
+              <ReadState />
+            </BpkCollapsible.Content>
+          </BpkCollapsible.RootProvider>
+        );
+      };
+      render(<Harness />);
+
+      expect(screen.getByTestId('open').textContent).toBe('true');
+      expect(screen.getByTestId('disabled').textContent).toBe('false');
+    });
+
+  });
+
+  describe('RootProvider asChild', () => {
+    it('renders no wrapper element when asChild is true', () => {
+      const Harness = () => {
+        const collapsible = useBpkCollapsible();
+        return (
+          <ul>
+            <BpkCollapsible.RootProvider value={collapsible} asChild>
+              <li>
+                <BpkCollapsible.Trigger>Toggle</BpkCollapsible.Trigger>
+                <BpkCollapsible.Content>Body</BpkCollapsible.Content>
+              </li>
+            </BpkCollapsible.RootProvider>
+          </ul>
+        );
+      };
+      const { container } = render(<Harness />);
+      const list = container.querySelector('ul') as HTMLElement;
+      // With asChild the <li> is the direct child of <ul>; without asChild
+      // Ark injects a <div> between them.
+      expect(list.firstElementChild?.tagName).toBe('LI');
+    });
+
+    it('renders a wrapper element when asChild is omitted', () => {
+      const Harness = () => {
+        const collapsible = useBpkCollapsible();
+        return (
+          <ul>
+            <BpkCollapsible.RootProvider value={collapsible}>
+              <li>
+                <BpkCollapsible.Trigger>Toggle</BpkCollapsible.Trigger>
+                <BpkCollapsible.Content>Body</BpkCollapsible.Content>
+              </li>
+            </BpkCollapsible.RootProvider>
+          </ul>
+        );
+      };
+      const { container } = render(<Harness />);
+      const list = container.querySelector('ul') as HTMLElement;
+      expect(list.firstElementChild?.tagName).not.toBe('LI');
     });
   });
 

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
@@ -302,6 +302,7 @@ describe('BpkCollapsible', () => {
       );
 
       expect(screen.getByTestId('open').textContent).toBe('true');
+      expect(screen.getByTestId('visible').textContent).toBe('true');
       expect(screen.getByTestId('disabled').textContent).toBe('false');
     });
 
@@ -351,9 +352,28 @@ describe('BpkCollapsible', () => {
       const Harness = () => {
         const collapsible = useBpkCollapsible();
         return (
-          <ul>
+          <div data-testid="wrapper">
             <BpkCollapsible.RootProvider value={collapsible}>
-              <li>
+              <span>
+                <BpkCollapsible.Trigger>Toggle</BpkCollapsible.Trigger>
+                <BpkCollapsible.Content>Body</BpkCollapsible.Content>
+              </span>
+            </BpkCollapsible.RootProvider>
+          </div>
+        );
+      };
+      const { container } = render(<Harness />);
+      const wrapper = container.querySelector('[data-testid="wrapper"]') as HTMLElement;
+      expect(wrapper.firstElementChild?.tagName).toBe('DIV');
+    });
+
+    it('merges collapsible attributes onto the child element when asChild is true', () => {
+      const Harness = () => {
+        const collapsible = useBpkCollapsible({ defaultOpen: true });
+        return (
+          <ul>
+            <BpkCollapsible.RootProvider value={collapsible} asChild>
+              <li data-testid="item">
                 <BpkCollapsible.Trigger>Toggle</BpkCollapsible.Trigger>
                 <BpkCollapsible.Content>Body</BpkCollapsible.Content>
               </li>
@@ -361,9 +381,12 @@ describe('BpkCollapsible', () => {
           </ul>
         );
       };
-      const { container } = render(<Harness />);
-      const list = container.querySelector('ul') as HTMLElement;
-      expect(list.firstElementChild?.tagName).not.toBe('LI');
+      render(<Harness />);
+
+      const item = screen.getByTestId('item');
+      expect(item.tagName).toBe('LI');
+      expect(item).toHaveAttribute('data-state', 'open');
+      expect(item).toHaveAttribute('data-backpack-ds-component');
     });
   });
 

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible.stories.tsx
@@ -473,11 +473,11 @@ const AsChildRootProvider = () => {
     <BpkVStack gap={BpkSpacing.Base} alignItems="flex-start">
       <BpkText textStyle={TEXT_STYLES.bodyDefault}>
         Without <code>asChild</code>: RootProvider renders a wrapper{' '}
-        <code>&lt;div&gt;</code> around the list item.
+        <code>&lt;div&gt;</code> around its child.
       </BpkText>
-      <ul>
+      <div>
         <BpkCollapsible.RootProvider value={withoutAsChild}>
-          <li>
+          <div>
             <BpkCollapsible.Trigger>
               <BpkText textStyle={TEXT_STYLES.heading5}>Without asChild</BpkText>
               <BpkCollapsible.Indicator>
@@ -489,9 +489,9 @@ const AsChildRootProvider = () => {
                 <BpkText textStyle={TEXT_STYLES.bodyDefault}>Content</BpkText>
               </BpkBox>
             </BpkCollapsible.Content>
-          </li>
+          </div>
         </BpkCollapsible.RootProvider>
-      </ul>
+      </div>
 
       <BpkText textStyle={TEXT_STYLES.bodyDefault}>
         With <code>asChild</code>: the <code>&lt;li&gt;</code> becomes the root

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible.stories.tsx
@@ -37,6 +37,7 @@ import { cssModules } from '../../bpk-react-utils';
 import BpkCollapsible from './BpkCollapsible';
 import { COLLAPSIBLE_VARIANTS } from './common-types';
 import useBpkCollapsible from './useBpkCollapsible';
+import useBpkCollapsibleContext from './useBpkCollapsibleContext';
 
 import type { Meta } from '@storybook/react';
 
@@ -421,6 +422,102 @@ const RootProviderWithStateMachine = () => {
   );
 };
 
+// Reads state via useBpkCollapsibleContext() — no props passed in from above.
+// Rendered adjacent to the trigger so the values are always visible regardless
+// of open state, making it clear the hook works outside Content too.
+const StateReadout = () => {
+  const { disabled, open, visible } = useBpkCollapsibleContext();
+  return (
+    <BpkText textStyle={TEXT_STYLES.bodyDefault}>
+      open: {String(open)} · visible: {String(visible)} · disabled:{' '}
+      {String(disabled)}
+    </BpkText>
+  );
+};
+
+const ContextReader = () => {
+  const collapsible = useBpkCollapsible();
+  return (
+    <BpkVStack gap={BpkSpacing.Base} alignItems="flex-start">
+      <BpkText textStyle={TEXT_STYLES.bodyDefault}>
+        <code>StateReadout</code> calls <code>useBpkCollapsibleContext()</code>{' '}
+        directly — no props passed to it from above.
+      </BpkText>
+      <BpkCollapsible.RootProvider value={collapsible}>
+        <BpkCollapsible.Trigger>
+          <BpkText textStyle={TEXT_STYLES.heading5}>Toggle</BpkText>
+          <BpkCollapsible.Indicator>
+            <ChevronIcon />
+          </BpkCollapsible.Indicator>
+        </BpkCollapsible.Trigger>
+        <StateReadout />
+        <BpkCollapsible.Content>
+          <BpkBox paddingTop={BpkSpacing.SM}>
+            <BpkText textStyle={TEXT_STYLES.bodyDefault}>
+              Hidden content
+            </BpkText>
+          </BpkBox>
+        </BpkCollapsible.Content>
+      </BpkCollapsible.RootProvider>
+    </BpkVStack>
+  );
+};
+
+// Demonstrates asChild: the RootProvider merges its props onto the child
+// <li> element instead of injecting a wrapper <div>. Inspect the DOM to
+// confirm the output is <li data-backpack-ds-component …> with no extra node.
+const AsChildRootProvider = () => {
+  const withoutAsChild = useBpkCollapsible({ defaultOpen: true });
+  const withAsChild = useBpkCollapsible({ defaultOpen: true });
+  return (
+    <BpkVStack gap={BpkSpacing.Base} alignItems="flex-start">
+      <BpkText textStyle={TEXT_STYLES.bodyDefault}>
+        Without <code>asChild</code>: RootProvider renders a wrapper{' '}
+        <code>&lt;div&gt;</code> around the list item.
+      </BpkText>
+      <ul>
+        <BpkCollapsible.RootProvider value={withoutAsChild}>
+          <li>
+            <BpkCollapsible.Trigger>
+              <BpkText textStyle={TEXT_STYLES.heading5}>Without asChild</BpkText>
+              <BpkCollapsible.Indicator>
+                <ChevronIcon />
+              </BpkCollapsible.Indicator>
+            </BpkCollapsible.Trigger>
+            <BpkCollapsible.Content>
+              <BpkBox paddingTop={BpkSpacing.SM}>
+                <BpkText textStyle={TEXT_STYLES.bodyDefault}>Content</BpkText>
+              </BpkBox>
+            </BpkCollapsible.Content>
+          </li>
+        </BpkCollapsible.RootProvider>
+      </ul>
+
+      <BpkText textStyle={TEXT_STYLES.bodyDefault}>
+        With <code>asChild</code>: the <code>&lt;li&gt;</code> becomes the root
+        — no wrapper inserted.
+      </BpkText>
+      <ul>
+        <BpkCollapsible.RootProvider value={withAsChild} asChild>
+          <li>
+            <BpkCollapsible.Trigger>
+              <BpkText textStyle={TEXT_STYLES.heading5}>With asChild</BpkText>
+              <BpkCollapsible.Indicator>
+                <ChevronIcon />
+              </BpkCollapsible.Indicator>
+            </BpkCollapsible.Trigger>
+            <BpkCollapsible.Content>
+              <BpkBox paddingTop={BpkSpacing.SM}>
+                <BpkText textStyle={TEXT_STYLES.bodyDefault}>Content</BpkText>
+              </BpkBox>
+            </BpkCollapsible.Content>
+          </li>
+        </BpkCollapsible.RootProvider>
+      </ul>
+    </BpkVStack>
+  );
+};
+
 const VisualTest = () => (
   <BpkVStack gap={BpkSpacing.Base}>
     <Basic />
@@ -466,3 +563,5 @@ export const DisabledState = { render: () => <Disabled /> };
 export const CollapsedHeightShowMore = { render: () => <ShowMore /> };
 export const LongContentExample = { render: () => <LongContent /> };
 export const VisualTestComposite = { render: () => <VisualTest /> };
+export const ContextReaderHook = { render: () => <ContextReader /> };
+export const AsChildOnRootProvider = { render: () => <AsChildRootProvider /> };

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsibleRootProvider.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsibleRootProvider.tsx
@@ -31,14 +31,20 @@ export type BpkCollapsibleRootProviderProps = {
   children: ReactNode;
   value: BpkUseCollapsibleReturn;
   variant?: BpkCollapsibleVariant;
+  // When true, merges all provider props onto the single child element instead
+  // of injecting a wrapper div — load-bearing for pixel parity in layouts that
+  // hoist the provider over an existing item element.
+  asChild?: boolean;
 };
 
 const BpkCollapsibleRootProvider = ({
+  asChild,
   children,
   value,
   variant = COLLAPSIBLE_VARIANTS.default,
 }: BpkCollapsibleRootProviderProps) => (
   <Collapsible.RootProvider
+    asChild={asChild}
     className={getRootClassName(variant)}
     value={value}
     {...getDataComponentAttribute('Collapsible')}

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsibleRootProvider.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsibleRootProvider.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { Collapsible } from '@ark-ui/react';
 
@@ -27,15 +27,15 @@ import { COLLAPSIBLE_VARIANTS, getRootClassName } from './common-types';
 import type { BpkCollapsibleVariant } from './common-types';
 import type { BpkUseCollapsibleReturn } from './useBpkCollapsible';
 
+// Discriminated union so `asChild: true` enforces a single ReactElement child
+// (required by Ark's slot merging) while the default case keeps ReactNode.
 export type BpkCollapsibleRootProviderProps = {
-  children: ReactNode;
   value: BpkUseCollapsibleReturn;
   variant?: BpkCollapsibleVariant;
-  // When true, merges all provider props onto the single child element instead
-  // of injecting a wrapper div — load-bearing for pixel parity in layouts that
-  // hoist the provider over an existing item element.
-  asChild?: boolean;
-};
+} & (
+  | { asChild: true; children: ReactElement }
+  | { asChild?: false; children: ReactNode }
+);
 
 const BpkCollapsibleRootProvider = ({
   asChild,

--- a/packages/backpack-web/src/bpk-component-collapsible/src/useBpkCollapsibleContext.ts
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/useBpkCollapsibleContext.ts
@@ -1,0 +1,29 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCollapsibleContext } from '@ark-ui/react';
+
+import type { BpkUseCollapsibleReturn } from './useBpkCollapsible';
+
+// Reader hook for the shared collapsible machine. Call from any component
+// inside BpkCollapsible.Root or BpkCollapsible.RootProvider to access the
+// current open/disabled/visible state and setOpen without prop-drilling.
+const useBpkCollapsibleContext = (): BpkUseCollapsibleReturn =>
+  useCollapsibleContext();
+
+export default useBpkCollapsibleContext;


### PR DESCRIPTION
JIRA Link: https://skyscanner.atlassian.net/browse/IRN-6860

## What has changed, and why?

**Component:** `bpk-component-collapsible`

**Class of change:** new API surface, no behaviour change to existing usage

Adds two capabilities to `BpkCollapsible` that are required groundwork for the FLEXP-661 Expandables MVP fare-card integration.

**`useBpkCollapsibleContext()`** — a consumer-side reader hook. Any component nested inside `BpkCollapsible.Root` or `BpkCollapsible.RootProvider` can now call this hook to read the current machine state (`open`, `visible`, `disabled`, `setOpen`) without prop-drilling. Follows the same pattern as `useCollapsibleContext` from Ark internally, but exposed under a stable BPK name. Precedent: `useCheckboxCardContext` in `bpk-component-checkbox-card`.

**`asChild` on `RootProvider`** — when `true`, the provider merges its props onto the single child element instead of injecting a wrapper `<div>`. This is load-bearing for pixel parity in the fare-card layout, where the provider needs to wrap an existing item element without adding a DOM node between it and its parent. Precedent: `BpkModalV3Trigger` already ships `asChild`.

Both are demonstrated in new Storybook stories (`ContextReaderHook`, `AsChildOnRootProvider`).

---

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [x] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR.