### PR TITLE
TEST-[NOJIRA][bpk-stylesheets] Add locale-aware line-break rules (v42 dev release)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Determine dev version
         id: version
         run: |
-          BASE_VERSION=$(git describe --tags --abbrev=0 --exclude='*-*' HEAD)
+          BASE_VERSION="42.28.0"
           DEV_VERSION="${BASE_VERSION}-dev-v${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"
           echo "dev_version=${DEV_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Dev version: ${DEV_VERSION}"

--- a/packages/backpack-web/src/bpk-stylesheets/README.md
+++ b/packages/backpack-web/src/bpk-stylesheets/README.md
@@ -161,13 +161,13 @@ By default, Japanese text (`:lang(ja)`) wraps safely in every browser:
 - **Chromium** (Chrome/Edge) uses `word-break: auto-phrase` to break at natural phrase (文節) boundaries automatically.
 - **Firefox / Safari** have no equivalent, so they fall back to standard per-character wrapping under kinsoku (`line-break: strict`). This is the conventional way Japanese wraps in print and never overflows the container.
 
-For key marketing/UI copy where you want phrase-aware breaks in **all** browsers (not just Chromium), insert `<wbr>` at the phrase boundaries. Backpack detects the presence of `<wbr>` via `:lang(ja):has(wbr)` and automatically switches that text to `word-break: keep-all`, making the `<wbr>` marks the only break points — so Firefox and Safari honour the same boundaries as Chromium.
+For key marketing/UI copy where you want phrase-aware breaks in **all modern browsers** (Chrome 105+, Safari 15.4+, Firefox 121+), insert `<wbr>` at the phrase boundaries. Backpack detects the presence of `<wbr>` via `:lang(ja):has(wbr)` and automatically switches that text to `word-break: keep-all`, making the `<wbr>` marks the only break points — so Firefox and Safari honour the same boundaries as Chromium.
 
 ```jsx
 // Without <wbr>: safe everywhere, phrase-aware only in Chromium.
 <BpkText>プライスアラートを設定して東京行きのお得な航空券を見つけましょう</BpkText>
 
-// With <wbr>: phrase-aware in every browser. No className needed —
+// With <wbr>: phrase-aware in all modern browsers (Chrome 105+, Safari 15.4+, Firefox 121+). No className needed —
 // the presence of <wbr> is itself the opt-in signal.
 <BpkText>
   プライスアラートを<wbr />設定して<wbr />東京行きの<wbr />

--- a/packages/backpack-web/src/bpk-stylesheets/README.md
+++ b/packages/backpack-web/src/bpk-stylesheets/README.md
@@ -150,6 +150,39 @@ Defined in `font.scss`, `larken.scss`
 - If you introduce a new weight, add the corresponding `@font-face` entries.
 - In verification, check each used weight renders from the expected family in DevTools.
 
+## Locale-aware line breaking
+
+`font.scss` and `larken.scss` ship locale-aware line-break rules (`_locale-line-breaks.scss`) that are applied globally via the `:lang()` selector — they hook off the `<html lang="…">` (or any element `lang`) attribute you already set, so **no per-component or per-consumer changes are required**. The rules implement the kinsoku/line-break conventions for CJK, Korean, Thai, Arabic, Hebrew, and other non-Latin scripts.
+
+### Japanese phrase-level breaking (optional `<wbr>` hints)
+
+By default, Japanese text (`:lang(ja)`) wraps safely in every browser:
+
+- **Chromium** (Chrome/Edge) uses `word-break: auto-phrase` to break at natural phrase (文節) boundaries automatically.
+- **Firefox / Safari** have no equivalent, so they fall back to standard per-character wrapping under kinsoku (`line-break: strict`). This is the conventional way Japanese wraps in print and never overflows the container.
+
+For key marketing/UI copy where you want phrase-aware breaks in **all** browsers (not just Chromium), insert `<wbr>` at the phrase boundaries. Backpack detects the presence of `<wbr>` via `:lang(ja):has(wbr)` and automatically switches that text to `word-break: keep-all`, making the `<wbr>` marks the only break points — so Firefox and Safari honour the same boundaries as Chromium.
+
+```jsx
+// Without <wbr>: safe everywhere, phrase-aware only in Chromium.
+<BpkText>プライスアラートを設定して東京行きのお得な航空券を見つけましょう</BpkText>
+
+// With <wbr>: phrase-aware in every browser. No className needed —
+// the presence of <wbr> is itself the opt-in signal.
+<BpkText>
+  プライスアラートを<wbr />設定して<wbr />東京行きの<wbr />
+  お得な航空券を<wbr />見つけましょう
+</BpkText>
+```
+
+Guidance:
+
+- `<wbr>` is content, not a style API — pass it as part of the text children. Consumers never add a className.
+- Mark **every** phrase boundary. Under `keep-all`, per-character wrapping is suppressed, so a long stretch of Japanese with no `<wbr>` between it can overflow. (`overflow-wrap: break-word` remains as a last-resort safety net for embedded URLs / Latin runs, but not for pure Japanese.)
+- Only the author knows the semantic 文節 boundaries, which is why this is opt-in rather than automatic.
+
+See the [`bpk-stylesheets-fonts`](https://backpack.github.io/storybook/?path=/story/bpk-stylesheets-fonts--larken-font) Larken story ("Japanese line-break validation") for live examples — compare the default sample against the `<wbr>`-hinted sample in Firefox to see the difference.
+
 ## Contributing
 
 Don't forget to rebuild and commit `base.css` after you make changes to this package.

--- a/packages/backpack-web/src/bpk-stylesheets/_locale-line-breaks.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/_locale-line-breaks.scss
@@ -23,18 +23,36 @@
   // Must be after font-stack rules so source order wins over browser defaults.
   // :lang() matches subtags - :lang(ja) covers ja, ja-JP, etc.
 
-  // Japanese: preserve phrase boundaries. Browsers with auto-phrase can infer
-  // better phrase breaks; others should use explicit <wbr> hints for key copy.
+  // Japanese: preserve phrase boundaries where the browser can.
+  // Base rule keeps the default `word-break: normal`, which gives standard
+  // per-character CJK wrapping under kinsoku (line-break: strict). This is the
+  // correct, universal fallback: Japanese has no word spaces, so `keep-all`
+  // would forbid every break and overflow the container in browsers without
+  // auto-phrase (Safari, Firefox). auto-phrase, where supported (Chromium),
+  // upgrades this to phrase-level breaks; overflow-wrap: break-word is a
+  // last-resort safety net for long unbreakable runs (e.g. embedded URLs).
   :lang(ja) {
     line-break: strict;
-    overflow-wrap: normal;
-    word-break: keep-all;
+    overflow-wrap: break-word;
   }
 
   @supports (word-break: auto-phrase) {
     :lang(ja) {
       word-break: auto-phrase;
     }
+  }
+
+  // Author-hinted phrase breaks: when the copy contains explicit <wbr> break
+  // opportunities, switch to `word-break: keep-all` so per-character wrapping
+  // is suppressed and the <wbr> marks become the *only* break points. This
+  // makes Firefox and Safari (which lack auto-phrase) honour the author's
+  // phrase boundaries too, matching Chromium. No consumer className required —
+  // the presence of <wbr> in the content is itself the opt-in signal.
+  // Higher specificity than the @supports rule above, so keep-all wins over
+  // auto-phrase and behaviour is identical across all browsers when hinted.
+  // stylelint-disable-next-line order/order, selector-max-type
+  :lang(ja):has(wbr) {
+    word-break: keep-all;
   }
 
   // Chinese: strict kinsoku controls punctuation and prohibited line-start

--- a/packages/backpack-web/src/bpk-stylesheets/_locale-line-breaks.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/_locale-line-breaks.scss
@@ -1,0 +1,92 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../bpk-mixins/tokens';
+
+@mixin bpk-locale-line-breaks {
+  // Locale-aware line-break rules.
+  // Must be after font-stack rules so source order wins over browser defaults.
+  // :lang() matches subtags - :lang(ja) covers ja, ja-JP, etc.
+
+  // Japanese: preserve phrase boundaries. Browsers with auto-phrase can infer
+  // better phrase breaks; others should use explicit <wbr> hints for key copy.
+  :lang(ja) {
+    line-break: strict;
+    overflow-wrap: normal;
+    word-break: keep-all;
+  }
+
+  @supports (word-break: auto-phrase) {
+    :lang(ja) {
+      word-break: auto-phrase;
+    }
+  }
+
+  // Chinese: strict kinsoku controls punctuation and prohibited line-start
+  // characters. `break-word` is a conservative fallback that avoids overflow.
+  :lang(zh) {
+    line-break: strict;
+    overflow-wrap: break-word;
+  }
+
+  // Korean: word-level breaks (KS X 1026 kinsoku), not character-level.
+  // word-break: keep-all preserves syllable blocks (Korean typographic convention).
+  // overflow-wrap: break-word fallback required for long compounds with no spaces.
+  :lang(ko) {
+    line-break: strict;
+    overflow-wrap: break-word;
+    word-break: keep-all;
+  }
+
+  // Mobile: strict can leave uneven rag or orphaned characters on narrow viewports.
+  // stylelint-disable-next-line order/order
+  @media #{tokens.$bpk-breakpoint-query-small-tablet} {
+    :lang(zh),
+    :lang(ko) {
+      line-break: loose;
+    }
+  }
+
+  // Arabic, Hebrew - overflow only; direction handled by existing html[dir] RTL system.
+  :lang(ar),
+  :lang(he) {
+    overflow-wrap: break-word;
+  }
+
+  // Thai - no word spaces; ICU dictionary failure = no natural break points.
+  // overflow-wrap: anywhere (not just break-word) because Thai strings have no
+  // space characters to serve as natural break opportunities.
+  :lang(th) {
+    line-break: loose;
+    overflow-wrap: anywhere;
+    word-break: break-all;
+  }
+
+  // Hindi (Devanagari) - space-delimited, wraps like Latin.
+  :lang(hi) {
+    overflow-wrap: break-word;
+  }
+
+  // Russian, Ukrainian - Cyrillic wraps like Latin.
+  // hyphens: auto works in Safari and Firefox; Chrome degrades silently to no hyphens.
+  :lang(ru),
+  :lang(uk) {
+    hyphens: auto;
+    overflow-wrap: break-word;
+  }
+}

--- a/packages/backpack-web/src/bpk-stylesheets/_locale-line-breaks.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/_locale-line-breaks.scss
@@ -86,13 +86,11 @@
     overflow-wrap: break-word;
   }
 
-  // Thai - no word spaces; ICU dictionary failure = no natural break points.
-  // overflow-wrap: anywhere (not just break-word) because Thai strings have no
-  // space characters to serve as natural break opportunities.
+  // Thai - no word spaces; ICU dictionary handles word boundaries where available.
+  // overflow-wrap: anywhere (not break-word) because Thai strings have no space
+  // characters to serve as natural break opportunities — needed as last resort.
   :lang(th) {
-    line-break: loose;
     overflow-wrap: anywhere;
-    word-break: break-all;
   }
 
   // Hindi (Devanagari) - space-delimited, wraps like Latin.

--- a/packages/backpack-web/src/bpk-stylesheets/font.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/font.scss
@@ -21,6 +21,7 @@ $font-formats: (woff2, woff, ttf);
 
 @use 'sass:list';
 @use 'sass:map';
+@use '../bpk-mixins/tokens';
 
 // Table-driven font registry: add families/weights in $bpk-fonts, and the mixin
 // will emit matching @font-face rules. Filenames are the hashed names without
@@ -558,8 +559,7 @@ $bpk-fonts: (
 }
 
 // Mobile: strict can leave uneven rag or orphaned characters on narrow viewports.
-// 48rem = bpk-breakpoint-query-small-tablet
-@media (max-width: 48rem) {
+@media #{tokens.$bpk-breakpoint-query-small-tablet} {
   :lang(zh),
   :lang(ja),
   :lang(ko) {

--- a/packages/backpack-web/src/bpk-stylesheets/font.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/font.scss
@@ -558,7 +558,8 @@ $bpk-fonts: (
 }
 
 // Mobile: strict can leave uneven rag or orphaned characters on narrow viewports.
-@media #{tokens.$bpk-breakpoint-query-small-tablet} {
+// 48rem = bpk-breakpoint-query-small-tablet
+@media (max-width: 48rem) {
   :lang(zh),
   :lang(ja),
   :lang(ko) {

--- a/packages/backpack-web/src/bpk-stylesheets/font.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/font.scss
@@ -532,3 +532,64 @@ $bpk-fonts: (
 :where([lang]) {
   font-family: var(--bpk-base-font-stack);
 }
+
+// Locale-aware line-break rules.
+// Must be after font-stack rules so source order wins over browser defaults.
+// :lang() matches subtags — :lang(ja) covers ja, ja-JP, etc.
+
+// CJK: strict kinsoku (JIS X 4051 / GB/T 15834) — punctuation/particles cannot
+// appear at line-start. Fixes headlines breaking before を、に、の etc.
+// overflow-wrap: anywhere is last-resort only — preserves Latin brand names/URLs
+// on mixed-script pages by only breaking at non-standard points as a final fallback.
+:lang(zh),
+:lang(ja) {
+  line-break: strict;
+  overflow-wrap: anywhere;
+}
+
+// Korean: word-level breaks (KS X 1026 kinsoku), not character-level.
+// word-break: keep-all preserves syllable blocks (Korean typographic convention).
+// overflow-wrap: break-word fallback required — on 360–390px viewports a long
+// compound word with no spaces still overflows with keep-all alone.
+:lang(ko) {
+  line-break: strict;
+  overflow-wrap: break-word;
+  word-break: keep-all;
+}
+
+// Mobile: strict can leave uneven rag or orphaned characters on narrow viewports.
+@media #{tokens.$bpk-breakpoint-query-small-tablet} {
+  :lang(zh),
+  :lang(ja),
+  :lang(ko) {
+    line-break: loose;
+  }
+}
+
+// Arabic, Hebrew — overflow only; direction handled by existing html[dir] RTL system.
+:lang(ar),
+:lang(he) {
+  overflow-wrap: break-word;
+}
+
+// Thai — no word spaces; ICU dictionary failure = no natural break points.
+// overflow-wrap: anywhere (not just break-word) because Thai strings have no
+// space characters to serve as natural break opportunities.
+:lang(th) {
+  line-break: loose;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
+// Hindi (Devanagari) — space-delimited, wraps like Latin.
+:lang(hi) {
+  overflow-wrap: break-word;
+}
+
+// Russian, Ukrainian — Cyrillic wraps like Latin.
+// hyphens: auto works in Safari and Firefox; Chrome degrades silently to no hyphens.
+:lang(ru),
+:lang(uk) {
+  hyphens: auto;
+  overflow-wrap: break-word;
+}

--- a/packages/backpack-web/src/bpk-stylesheets/font.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/font.scss
@@ -18,7 +18,7 @@
 
 @use 'sass:list';
 @use 'sass:map';
-@use '../bpk-mixins/tokens';
+@use './locale-line-breaks';
 
 $base-url: 'https://js.skyscnr.com/sttc/bpk-fonts';
 $font-formats: (woff2, woff, ttf);
@@ -534,63 +534,4 @@ $bpk-fonts: (
   font-family: var(--bpk-base-font-stack);
 }
 
-// Locale-aware line-break rules.
-// Must be after font-stack rules so source order wins over browser defaults.
-// :lang() matches subtags — :lang(ja) covers ja, ja-JP, etc.
-
-// CJK: strict kinsoku (JIS X 4051 / GB/T 15834) — punctuation/particles cannot
-// appear at line-start. Fixes headlines breaking before を、に、の etc.
-// overflow-wrap: anywhere is last-resort only — preserves Latin brand names/URLs
-// on mixed-script pages by only breaking at non-standard points as a final fallback.
-:lang(zh),
-:lang(ja) {
-  line-break: strict;
-  overflow-wrap: anywhere;
-}
-
-// Korean: word-level breaks (KS X 1026 kinsoku), not character-level.
-// word-break: keep-all preserves syllable blocks (Korean typographic convention).
-// overflow-wrap: break-word fallback required — on 360–390px viewports a long
-// compound word with no spaces still overflows with keep-all alone.
-:lang(ko) {
-  line-break: strict;
-  overflow-wrap: break-word;
-  word-break: keep-all;
-}
-
-// Mobile: strict can leave uneven rag or orphaned characters on narrow viewports.
-@media #{tokens.$bpk-breakpoint-query-small-tablet} {
-  :lang(zh),
-  :lang(ja),
-  :lang(ko) {
-    line-break: loose;
-  }
-}
-
-// Arabic, Hebrew — overflow only; direction handled by existing html[dir] RTL system.
-:lang(ar),
-:lang(he) {
-  overflow-wrap: break-word;
-}
-
-// Thai — no word spaces; ICU dictionary failure = no natural break points.
-// overflow-wrap: anywhere (not just break-word) because Thai strings have no
-// space characters to serve as natural break opportunities.
-:lang(th) {
-  line-break: loose;
-  overflow-wrap: anywhere;
-  word-break: break-all;
-}
-
-// Hindi (Devanagari) — space-delimited, wraps like Latin.
-:lang(hi) {
-  overflow-wrap: break-word;
-}
-
-// Russian, Ukrainian — Cyrillic wraps like Latin.
-// hyphens: auto works in Safari and Firefox; Chrome degrades silently to no hyphens.
-:lang(ru),
-:lang(uk) {
-  hyphens: auto;
-  overflow-wrap: break-word;
-}
+@include locale-line-breaks.bpk-locale-line-breaks;

--- a/packages/backpack-web/src/bpk-stylesheets/font.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/font.scss
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
-$base-url: 'https://js.skyscnr.com/sttc/bpk-fonts';
-$font-formats: (woff2, woff, ttf);
-
 @use 'sass:list';
 @use 'sass:map';
 @use '../bpk-mixins/tokens';
+
+$base-url: 'https://js.skyscnr.com/sttc/bpk-fonts';
+$font-formats: (woff2, woff, ttf);
 
 // Table-driven font registry: add families/weights in $bpk-fonts, and the mixin
 // will emit matching @font-face rules. Filenames are the hashed names without

--- a/packages/backpack-web/src/bpk-stylesheets/larken.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/larken.scss
@@ -244,7 +244,6 @@ $bpk-fonts: (
 
 @use 'sass:list';
 @use 'sass:map';
-@use './locale-line-breaks';
 
 @mixin bpk-font-face($family, $style, $weight, $files) {
   $srcs: ();
@@ -361,5 +360,3 @@ $bpk-fonts: (
     larken, 'Noto Serif', 'Noto Sans Arabic', 'Noto Serif Hebrew',
     'Noto Serif Devanagari', 'Noto Serif Thai', sans-serif;
 }
-
-@include locale-line-breaks.bpk-locale-line-breaks;

--- a/packages/backpack-web/src/bpk-stylesheets/larken.scss
+++ b/packages/backpack-web/src/bpk-stylesheets/larken.scss
@@ -244,6 +244,7 @@ $bpk-fonts: (
 
 @use 'sass:list';
 @use 'sass:map';
+@use './locale-line-breaks';
 
 @mixin bpk-font-face($family, $style, $weight, $files) {
   $srcs: ();
@@ -360,3 +361,5 @@ $bpk-fonts: (
     larken, 'Noto Serif', 'Noto Sans Arabic', 'Noto Serif Hebrew',
     'Noto Serif Devanagari', 'Noto Serif Thai', sans-serif;
 }
+
+@include locale-line-breaks.bpk-locale-line-breaks;

--- a/packages/backpack-web/src/bpk-stylesheets/src/BpkStylesheetsFonts.stories.tsx
+++ b/packages/backpack-web/src/bpk-stylesheets/src/BpkStylesheetsFonts.stories.tsx
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import type { ReactNode } from 'react';
+
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 
 import type { Meta, StoryObj } from '@storybook/react';
@@ -31,6 +33,7 @@ type LanguageSample = { text: string; lang?: string };
 const LANGUAGE_SAMPLES: Record<string, LanguageSample> = {
   english: {
     text: 'The quick brown fox jumps over the lazy dog',
+    lang: 'en-GB',
   },
   vietnamese: {
     text: 'Tiếng Việt là ngôn ngữ chính thức của Việt Nam. Xin chào và chúc mừng năm mới!',
@@ -97,6 +100,59 @@ const LARKEN_WEIGHTS = [
   { weight: 300, style: FONT_STYLES.NORMAL, label: '300' },
   { weight: 400, style: FONT_STYLES.NORMAL, label: '400' },
 ];
+
+const JAPANESE_LINE_BREAK_SAMPLE = [
+  'プライスアラートを',
+  <wbr key="price-alert" />,
+  '設定して',
+  <wbr key="set-up" />,
+  '東京行きの',
+  <wbr key="tokyo-bound" />,
+  'お得な航空券を',
+  <wbr key="flight-ticket" />,
+  '見つけましょう',
+];
+
+const LineBreakSample = ({
+  children,
+  label,
+  lang,
+}: {
+  children: ReactNode;
+  label: string;
+  lang: string;
+}) => (
+  <div style={{ marginBottom: '1rem' }}>
+    <BpkText textStyle={TEXT_STYLES.caption}>{label}</BpkText>
+    <div lang={lang}>
+      <BpkText
+        textStyle={TEXT_STYLES.editorial2}
+        style={{
+          fontWeight: 300,
+        }}
+      >
+        {children}
+      </BpkText>
+    </div>
+  </div>
+);
+
+const LarkenLineBreakExample = () => (
+  <div>
+    <BpkText textStyle={TEXT_STYLES.heading3} tagName="h3">
+      Japanese line-break validation
+    </BpkText>
+    <LineBreakSample lang="ja-JP" label="Japanese default line breaks">
+      プライスアラートを設定して東京行きのお得な航空券を見つけましょう
+    </LineBreakSample>
+    <LineBreakSample lang="ja-JP" label="Japanese phrase break hints">
+      {JAPANESE_LINE_BREAK_SAMPLE}
+    </LineBreakSample>
+    <LineBreakSample lang="ko-KR" label="Korean comparison">
+      가격 알림을 설정하고 도쿄행 저렴한 항공권을 찾아보세요
+    </LineBreakSample>
+  </div>
+);
 
 interface FontTestRowProps {
   text: string;
@@ -171,6 +227,7 @@ const LarkenExample = () => (
         ))}
       </div>
     ))}
+    <LarkenLineBreakExample />
   </>
 );
 


### PR DESCRIPTION
This PR exists solely to trigger a dev release with a v42.x.x version number for testing PR #4732 changes against v42 consumers.

Based on latest main with PR #4732 changes cherry-picked on top. A `42.28.0` tag is on the base commit so the dev release version is `42.28.0-dev-v...` instead of `43.x.x-dev-v...`.

Related: #4732