### PR TITLE
[CLOV-1868] Part 1: Add opt-in Nx analysis foundation

### DIFF
--- a/packages/backpack-adoption-guard/README.md
+++ b/packages/backpack-adoption-guard/README.md
@@ -41,6 +41,33 @@ The action emits one of three guard statuses:
 | Pull request, main adoption ≥ configured threshold | Fails when adoption drops, or when files were skipped on either side (incomplete data). `dry-run: true` downgrades the failure to a warning. |
 | Pull request, base ref unavailable | Fails (`warn` under `dry-run`) so the workflow surfaces the misconfiguration. |
 
+### Per-project guard (NX workspaces)
+
+When the scanned repository is an NX workspace (an `nx.json` exists at the
+root), the action additionally attributes every scanned file to the NX
+project that owns it — using the same longest-root-prefix matching NX itself
+uses — and evaluates the guard rules above **per project**, not just for the
+repository as a whole.
+
+This means a large, high-adoption project's improvement can no longer mask a
+regression in a smaller project: if any individual project would fail the
+guard on its own (per the rules in the table above), the overall guard status
+becomes `fail`, even if the repository-wide percentage held steady or
+improved. The same logic applies to `warn`. The top-level `reason` names the
+project(s) responsible so it's clear at a glance who to talk to.
+
+Files that don't fall under any detected NX project root are grouped into a
+`(unassigned)` bucket rather than being dropped or folded into another
+project. This is intentional (it mirrors `Skyscanner/ds-analyser`) — a large
+`(unassigned)` bucket usually means root-level files, or a directory that
+should have its own `project.json`, and is worth investigating rather than
+hiding.
+
+Per-project results are included in the PR step summary as an additional
+table, and in the generated results JSON under `head.projects` /
+`guard.projects`. Non-NX repositories are unaffected: `projects` is simply
+absent everywhere.
+
 ## Inputs
 
 | Input | Description | Required | Default |
@@ -75,10 +102,33 @@ data stays in the GitHub step summary and action internals.
       "nonPureBackpack": { "count": 134, "percentage": 6.75 },
       "nonBackpack": { "count": 500, "percentage": 25.35 },
       "rawHtml": { "count": 240, "percentage": 12.15 }
+    },
+    "projects": {
+      "banana-webapp": {
+        "filesAnalyzed": 210,
+        "backpack": { "count": 900, "percentage": 70.31 },
+        "pureBackpack": { "count": 850, "percentage": 66.41 },
+        "nonPureBackpack": { "count": 50, "percentage": 3.9 },
+        "nonBackpack": { "count": 300, "percentage": 23.44 },
+        "rawHtml": { "count": 80, "percentage": 6.25 }
+      },
+      "(unassigned)": {
+        "filesAnalyzed": 12,
+        "backpack": { "count": 10, "percentage": 20 },
+        "pureBackpack": { "count": 10, "percentage": 20 },
+        "nonPureBackpack": { "count": 0, "percentage": 0 },
+        "nonBackpack": { "count": 5, "percentage": 10 },
+        "rawHtml": { "count": 35, "percentage": 70 }
+      }
     }
   }
 }
 ```
+
+`projects` is only present for NX workspaces, and (to keep the always-loaded
+Cortex payload small) each project entry omits `componentCounts` — the full
+per-project detail, including component counts, is available in the PR step
+summary and the generated `backpack-adoption-results.json`'s `head.projects`.
 
 ```yaml
 - uses: actions/checkout@v6
@@ -135,6 +185,15 @@ GitHub JavaScript action must still contain the generated bundle because
 source changes.
 
 ## Releasing
+
+> **Migration to v2**: Starting with `backpack-adoption-guard/v2.0.0`, the
+> guard evaluates NX projects individually (see
+> [Per-project guard (NX workspaces)](#per-project-guard-nx-workspaces)) —
+> a PR that regresses a single NX project now fails even if the
+> repository-wide adoption percentage is unchanged or improved. This is a
+> pass/fail behaviour change: consumers on NX workspaces should expect some
+> previously-passing PRs to start failing (or warn, under `dry-run`) once
+> they upgrade. Non-NX repositories are unaffected.
 
 Use the `Backpack Adoption Guard Release` workflow and choose the semver bump
 type:

--- a/packages/backpack-adoption-guard/README.md
+++ b/packages/backpack-adoption-guard/README.md
@@ -41,33 +41,6 @@ The action emits one of three guard statuses:
 | Pull request, main adoption ≥ configured threshold | Fails when adoption drops, or when files were skipped on either side (incomplete data). `dry-run: true` downgrades the failure to a warning. |
 | Pull request, base ref unavailable | Fails (`warn` under `dry-run`) so the workflow surfaces the misconfiguration. |
 
-### Per-project guard (NX workspaces)
-
-When the scanned repository is an NX workspace (an `nx.json` exists at the
-root), the action additionally attributes every scanned file to the NX
-project that owns it — using the same longest-root-prefix matching NX itself
-uses — and evaluates the guard rules above **per project**, not just for the
-repository as a whole.
-
-This means a large, high-adoption project's improvement can no longer mask a
-regression in a smaller project: if any individual project would fail the
-guard on its own (per the rules in the table above), the overall guard status
-becomes `fail`, even if the repository-wide percentage held steady or
-improved. The same logic applies to `warn`. The top-level `reason` names the
-project(s) responsible so it's clear at a glance who to talk to.
-
-Files that don't fall under any detected NX project root are grouped into a
-`(unassigned)` bucket rather than being dropped or folded into another
-project. This is intentional (it mirrors `Skyscanner/ds-analyser`) — a large
-`(unassigned)` bucket usually means root-level files, or a directory that
-should have its own `project.json`, and is worth investigating rather than
-hiding.
-
-Per-project results are included in the PR step summary as an additional
-table, and in the generated results JSON under `head.projects` /
-`guard.projects`. Non-NX repositories are unaffected: `projects` is simply
-absent everywhere.
-
 ## Inputs
 
 | Input | Description | Required | Default |
@@ -102,33 +75,10 @@ data stays in the GitHub step summary and action internals.
       "nonPureBackpack": { "count": 134, "percentage": 6.75 },
       "nonBackpack": { "count": 500, "percentage": 25.35 },
       "rawHtml": { "count": 240, "percentage": 12.15 }
-    },
-    "projects": {
-      "banana-webapp": {
-        "filesAnalyzed": 210,
-        "backpack": { "count": 900, "percentage": 70.31 },
-        "pureBackpack": { "count": 850, "percentage": 66.41 },
-        "nonPureBackpack": { "count": 50, "percentage": 3.9 },
-        "nonBackpack": { "count": 300, "percentage": 23.44 },
-        "rawHtml": { "count": 80, "percentage": 6.25 }
-      },
-      "(unassigned)": {
-        "filesAnalyzed": 12,
-        "backpack": { "count": 10, "percentage": 20 },
-        "pureBackpack": { "count": 10, "percentage": 20 },
-        "nonPureBackpack": { "count": 0, "percentage": 0 },
-        "nonBackpack": { "count": 5, "percentage": 10 },
-        "rawHtml": { "count": 35, "percentage": 70 }
-      }
     }
   }
 }
 ```
-
-`projects` is only present for NX workspaces, and (to keep the always-loaded
-Cortex payload small) each project entry omits `componentCounts` — the full
-per-project detail, including component counts, is available in the PR step
-summary and the generated `backpack-adoption-results.json`'s `head.projects`.
 
 ```yaml
 - uses: actions/checkout@v6
@@ -185,15 +135,6 @@ GitHub JavaScript action must still contain the generated bundle because
 source changes.
 
 ## Releasing
-
-> **Migration to v2**: Starting with `backpack-adoption-guard/v2.0.0`, the
-> guard evaluates NX projects individually (see
-> [Per-project guard (NX workspaces)](#per-project-guard-nx-workspaces)) —
-> a PR that regresses a single NX project now fails even if the
-> repository-wide adoption percentage is unchanged or improved. This is a
-> pass/fail behaviour change: consumers on NX workspaces should expect some
-> previously-passing PRs to start failing (or warn, under `dry-run`) once
-> they upgrade. Non-NX repositories are unaffected.
 
 Use the `Backpack Adoption Guard Release` workflow and choose the semver bump
 type:

--- a/packages/backpack-adoption-guard/src/action/run-test.ts
+++ b/packages/backpack-adoption-guard/src/action/run-test.ts
@@ -112,6 +112,8 @@ export const App = () => (
     expect(metrics).not.toHaveProperty("guard");
     expect(metrics).not.toHaveProperty("componentCounts");
     expect(metrics).not.toHaveProperty("parseErrors");
+    expect(metrics).not.toHaveProperty("projects");
+    expect(result.guard).not.toHaveProperty("projects");
   });
 
   it("writes per-project metrics for NX workspaces", async () => {

--- a/packages/backpack-adoption-guard/src/action/run-test.ts
+++ b/packages/backpack-adoption-guard/src/action/run-test.ts
@@ -116,7 +116,7 @@ export const App = () => (
     expect(result.guard).not.toHaveProperty("projects");
   });
 
-  it("writes per-project metrics for NX workspaces", async () => {
+  it("reports NX workspaces as a single repository", async () => {
     await writeRepoFile(repoPath, "nx.json", JSON.stringify({ version: 2 }));
     await writeRepoFile(
       repoPath,
@@ -150,17 +150,10 @@ export const RootThing = () => <div>root</div>;
     );
     const metrics = resultsFile["backpack-adoption"];
 
-    expect(result.head.isNx).toBe(true);
-    expect(result.head.projects).toBeDefined();
-    expect(result.guard.projects).toBeDefined();
-
-    expect(metrics.projects).toBeDefined();
-    expect(metrics.projects.flights).toEqual({
-      filesAnalyzed: result.head.projects!.flights.filesAnalyzed,
-      ...result.head.projects!.flights.usage,
-    });
-    expect(metrics.projects.flights).not.toHaveProperty("componentCounts");
-    expect(metrics.projects["(unassigned)"]).toBeDefined();
+    expect(result.head.isNx).toBeUndefined();
+    expect(result.head.projects).toBeUndefined();
+    expect(result.guard.projects).toBeUndefined();
+    expect(metrics.projects).toBeUndefined();
   });
 
   it("uses the default guard threshold when the input is omitted", async () => {

--- a/packages/backpack-adoption-guard/src/action/run-test.ts
+++ b/packages/backpack-adoption-guard/src/action/run-test.ts
@@ -114,6 +114,53 @@ export const App = () => (
     expect(metrics).not.toHaveProperty("parseErrors");
   });
 
+  it("writes per-project metrics for NX workspaces", async () => {
+    await writeRepoFile(repoPath, "nx.json", JSON.stringify({ version: 2 }));
+    await writeRepoFile(
+      repoPath,
+      "apps/flights/project.json",
+      JSON.stringify({
+        name: "flights",
+        root: "apps/flights",
+        projectType: "application",
+      }),
+    );
+    await writeRepoFile(
+      repoPath,
+      "apps/flights/src/App.tsx",
+      `
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
+
+export const App = () => <BpkButton>Book</BpkButton>;
+`,
+    );
+    await writeRepoFile(
+      repoPath,
+      "RootThing.tsx",
+      `
+export const RootThing = () => <div>root</div>;
+`,
+    );
+
+    const result = await run({ cwd: repoPath, io: createTestIO() });
+    const resultsFile = JSON.parse(
+      await readFile(join(repoPath, "backpack-adoption-results.json"), "utf8"),
+    );
+    const metrics = resultsFile["backpack-adoption"];
+
+    expect(result.head.isNx).toBe(true);
+    expect(result.head.projects).toBeDefined();
+    expect(result.guard.projects).toBeDefined();
+
+    expect(metrics.projects).toBeDefined();
+    expect(metrics.projects.flights).toEqual({
+      filesAnalyzed: result.head.projects!.flights.filesAnalyzed,
+      ...result.head.projects!.flights.usage,
+    });
+    expect(metrics.projects.flights).not.toHaveProperty("componentCounts");
+    expect(metrics.projects["(unassigned)"]).toBeDefined();
+  });
+
   it("uses the default guard threshold when the input is omitted", async () => {
     const result = await run({ cwd: repoPath, io: createTestIO() });
 

--- a/packages/backpack-adoption-guard/src/action/run.ts
+++ b/packages/backpack-adoption-guard/src/action/run.ts
@@ -243,11 +243,12 @@ export const run = async ({
   });
   const combinedStatus = combineGuardStatuses(guard, projectGuards);
   const combinedReason = buildCombinedReason(guard, projectGuards, combinedStatus);
-  const combinedGuard = {
+  const hasProjectGuards = Object.keys(projectGuards).length > 0;
+  const combinedGuard: GuardResult = {
     ...guard,
     status: combinedStatus,
     reason: combinedReason,
-    projects: projectGuards,
+    ...(hasProjectGuards ? { projects: projectGuards } : {}),
   };
   const result = createActionResult({
     baseReport,

--- a/packages/backpack-adoption-guard/src/action/run.ts
+++ b/packages/backpack-adoption-guard/src/action/run.ts
@@ -29,9 +29,14 @@ import type {
   ActionResult,
   AdoptionReport,
   BackpackAdoptionMetrics,
+  GuardResult,
   ResultsFile,
 } from "../shared/types";
-import { evaluateGuard } from "../guard/evaluate-guard";
+import {
+  combineGuardStatuses,
+  evaluateGuard,
+  evaluateProjectGuards,
+} from "../guard/evaluate-guard";
 import {
   getPullRequestBaseRef,
   isMainBranch,
@@ -63,6 +68,16 @@ const writeResults = async (
     skippedFiles: result.head.parseErrors.length,
     usage: result.head.usage,
   };
+
+  if (result.head.projects) {
+    metrics.projects = {};
+    for (const [name, project] of Object.entries(result.head.projects)) {
+      metrics.projects[name] = {
+        filesAnalyzed: project.filesAnalyzed,
+        ...project.usage,
+      };
+    }
+  }
 
   const resultsFile: ResultsFile = {
     [BACKPACK_ADOPTION_OUTPUT_KEY]: metrics,
@@ -164,6 +179,32 @@ const parseThresholdInput = (input: string) => {
   return threshold;
 };
 
+const projectNamesWithStatus = (
+  projectGuards: Record<string, GuardResult>,
+  status: GuardResult["status"],
+) =>
+  Object.entries(projectGuards)
+    .filter(([, projectGuard]) => projectGuard.status === status)
+    .map(([name]) => name);
+
+const buildCombinedReason = (
+  guard: GuardResult,
+  projectGuards: Record<string, GuardResult>,
+  combinedStatus: GuardResult["status"],
+): string => {
+  if (combinedStatus === guard.status) {
+    return guard.reason;
+  }
+
+  if (combinedStatus === "fail") {
+    const names = projectNamesWithStatus(projectGuards, "fail").join(", ");
+    return `${guard.reason} Also failing due to per-project regression in: ${names}.`;
+  }
+
+  const names = projectNamesWithStatus(projectGuards, "warn").join(", ");
+  return `${guard.reason} Also warning due to per-project regression in: ${names}.`;
+};
+
 export const run = async ({
   cwd = process.cwd(),
   io = createGitHubActionsIO(),
@@ -193,10 +234,25 @@ export const run = async ({
     isMain: main,
     threshold,
   });
+  const projectGuards = evaluateProjectGuards({
+    baseReport,
+    dryRun,
+    headReport,
+    isMain: main,
+    threshold,
+  });
+  const combinedStatus = combineGuardStatuses(guard, projectGuards);
+  const combinedReason = buildCombinedReason(guard, projectGuards, combinedStatus);
+  const combinedGuard = {
+    ...guard,
+    status: combinedStatus,
+    reason: combinedReason,
+    projects: projectGuards,
+  };
   const result = createActionResult({
     baseReport,
     eventName: process.env.GITHUB_EVENT_NAME || null,
-    guard,
+    guard: combinedGuard,
     headReport,
     isMain: main,
     isPullRequest: pullRequest,
@@ -227,12 +283,12 @@ export const run = async ({
     );
   }
 
-  if (guard.status === "warn") {
-    io.warning(guard.reason);
+  if (result.guard.status === "warn") {
+    io.warning(result.guard.reason);
   }
 
-  if (guard.status === "fail") {
-    io.setFailed(guard.reason);
+  if (result.guard.status === "fail") {
+    io.setFailed(result.guard.reason);
   }
 
   return result;

--- a/packages/backpack-adoption-guard/src/action/run.ts
+++ b/packages/backpack-adoption-guard/src/action/run.ts
@@ -29,14 +29,9 @@ import type {
   ActionResult,
   AdoptionReport,
   BackpackAdoptionMetrics,
-  GuardResult,
   ResultsFile,
 } from "../shared/types";
-import {
-  combineGuardStatuses,
-  evaluateGuard,
-  evaluateProjectGuards,
-} from "../guard/evaluate-guard";
+import { evaluateGuard } from "../guard/evaluate-guard";
 import {
   getPullRequestBaseRef,
   isMainBranch,
@@ -68,16 +63,6 @@ const writeResults = async (
     skippedFiles: result.head.parseErrors.length,
     usage: result.head.usage,
   };
-
-  if (result.head.projects) {
-    metrics.projects = {};
-    for (const [name, project] of Object.entries(result.head.projects)) {
-      metrics.projects[name] = {
-        filesAnalyzed: project.filesAnalyzed,
-        ...project.usage,
-      };
-    }
-  }
 
   const resultsFile: ResultsFile = {
     [BACKPACK_ADOPTION_OUTPUT_KEY]: metrics,
@@ -179,32 +164,6 @@ const parseThresholdInput = (input: string) => {
   return threshold;
 };
 
-const projectNamesWithStatus = (
-  projectGuards: Record<string, GuardResult>,
-  status: GuardResult["status"],
-) =>
-  Object.entries(projectGuards)
-    .filter(([, projectGuard]) => projectGuard.status === status)
-    .map(([name]) => name);
-
-const buildCombinedReason = (
-  guard: GuardResult,
-  projectGuards: Record<string, GuardResult>,
-  combinedStatus: GuardResult["status"],
-): string => {
-  if (combinedStatus === guard.status) {
-    return guard.reason;
-  }
-
-  if (combinedStatus === "fail") {
-    const names = projectNamesWithStatus(projectGuards, "fail").join(", ");
-    return `${guard.reason} Also failing due to per-project regression in: ${names}.`;
-  }
-
-  const names = projectNamesWithStatus(projectGuards, "warn").join(", ");
-  return `${guard.reason} Also warning due to per-project regression in: ${names}.`;
-};
-
 export const run = async ({
   cwd = process.cwd(),
   io = createGitHubActionsIO(),
@@ -234,26 +193,10 @@ export const run = async ({
     isMain: main,
     threshold,
   });
-  const projectGuards = evaluateProjectGuards({
-    baseReport,
-    dryRun,
-    headReport,
-    isMain: main,
-    threshold,
-  });
-  const combinedStatus = combineGuardStatuses(guard, projectGuards);
-  const combinedReason = buildCombinedReason(guard, projectGuards, combinedStatus);
-  const hasProjectGuards = Object.keys(projectGuards).length > 0;
-  const combinedGuard: GuardResult = {
-    ...guard,
-    status: combinedStatus,
-    reason: combinedReason,
-    ...(hasProjectGuards ? { projects: projectGuards } : {}),
-  };
   const result = createActionResult({
     baseReport,
     eventName: process.env.GITHUB_EVENT_NAME || null,
-    guard: combinedGuard,
+    guard,
     headReport,
     isMain: main,
     isPullRequest: pullRequest,

--- a/packages/backpack-adoption-guard/src/action/summary.ts
+++ b/packages/backpack-adoption-guard/src/action/summary.ts
@@ -23,6 +23,12 @@ const STATUS_HEADER: Record<GuardResult["status"], string> = {
   warn: "⚠️ Backpack Adoption Guard — Warning",
 };
 
+const STATUS_ICON: Record<GuardResult["status"], string> = {
+  pass: "✅",
+  fail: "❌",
+  warn: "⚠️",
+};
+
 const formatPercentage = (value: number | null) =>
   value === null ? "n/a" : `${value.toFixed(2)}%`;
 
@@ -86,6 +92,69 @@ ${items}
 `;
 };
 
+const buildMainProjectsTable = (head: AdoptionReport) => {
+  if (!head.projects) {
+    return "";
+  }
+
+  const rows = Object.entries(head.projects)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(
+      ([name, project]) =>
+        `| ${name} | ${formatPercentage(project.usage.backpack.percentage)} | ${formatCount(project.filesAnalyzed)} |`,
+    )
+    .join("\n");
+
+  return `
+### Per-project adoption
+
+| Project | Adoption | Files |
+| --- | ---: | ---: |
+${rows}
+`;
+};
+
+const buildComparisonProjectsTable = (result: ActionResult) => {
+  const { base, head, guard } = result;
+  if (!head.projects || !base) {
+    return "";
+  }
+
+  const projectGuards = guard.projects || {};
+  const baseProjects = base.projects || {};
+
+  const rows = Object.entries(head.projects)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, project]) => {
+      const baseProject = baseProjects[name];
+      const projectGuard = projectGuards[name];
+      const mainCell = baseProject
+        ? formatPercentage(baseProject.usage.backpack.percentage)
+        : "n/a";
+      const changeCell = baseProject
+        ? formatDelta(
+            Number(
+              (
+                project.usage.backpack.percentage -
+                baseProject.usage.backpack.percentage
+              ).toFixed(2),
+            ),
+          )
+        : "n/a";
+      const statusCell = projectGuard ? STATUS_ICON[projectGuard.status] : "—";
+      return `| ${name} | ${formatPercentage(project.usage.backpack.percentage)} | ${mainCell} | ${changeCell} | ${statusCell} |`;
+    })
+    .join("\n");
+
+  return `
+### Per-project adoption
+
+| Project | This PR | Main | Change | Status |
+| --- | ---: | ---: | ---: | :---: |
+${rows}
+`;
+};
+
 const buildMainView = (result: ActionResult) => {
   const { head, guard } = result;
   const skipped = head.parseErrors.length;
@@ -106,7 +175,7 @@ ${buildPlainEnglishMain(head)}
 | └ With className override | ${formatCount(head.usage.nonPureBackpack.count)} | ${head.usage.nonPureBackpack.percentage.toFixed(2)}% |
 | Non-Backpack | ${formatCount(head.usage.nonBackpack.count)} | ${head.usage.nonBackpack.percentage.toFixed(2)}% |
 | Raw HTML | ${formatCount(head.usage.rawHtml.count)} | ${head.usage.rawHtml.percentage.toFixed(2)}% |
-
+${buildMainProjectsTable(head)}
 ### Run details
 
 | Detail | Value |
@@ -138,7 +207,7 @@ ${buildPlainEnglishMain(head)}
 | └ With className override | ${formatCount(head.usage.nonPureBackpack.count)} | ${head.usage.nonPureBackpack.percentage.toFixed(2)}% |
 | Non-Backpack | ${formatCount(head.usage.nonBackpack.count)} | ${head.usage.nonBackpack.percentage.toFixed(2)}% |
 | Raw HTML | ${formatCount(head.usage.rawHtml.count)} | ${head.usage.rawHtml.percentage.toFixed(2)}% |
-
+${buildMainProjectsTable(head)}
 ### Run details
 
 | Detail | Value |
@@ -176,7 +245,7 @@ ${buildPlainEnglishComparison(head, base)}
 | └ With className override | ${formatPercentageAndCount(head.usage.nonPureBackpack.percentage, head.usage.nonPureBackpack.count)} | ${formatPercentageAndCount(base.usage.nonPureBackpack.percentage, base.usage.nonPureBackpack.count)} | ${formatDelta(Number((head.usage.nonPureBackpack.percentage - base.usage.nonPureBackpack.percentage).toFixed(2)))} |
 | Non-Backpack | ${formatPercentageAndCount(head.usage.nonBackpack.percentage, head.usage.nonBackpack.count)} | ${formatPercentageAndCount(base.usage.nonBackpack.percentage, base.usage.nonBackpack.count)} | ${formatDelta(Number((head.usage.nonBackpack.percentage - base.usage.nonBackpack.percentage).toFixed(2)))} |
 | Raw HTML | ${formatPercentageAndCount(head.usage.rawHtml.percentage, head.usage.rawHtml.count)} | ${formatPercentageAndCount(base.usage.rawHtml.percentage, base.usage.rawHtml.count)} | ${formatDelta(Number((head.usage.rawHtml.percentage - base.usage.rawHtml.percentage).toFixed(2)))} |
-
+${buildComparisonProjectsTable(result)}
 ### Run details
 
 | Detail | Value |

--- a/packages/backpack-adoption-guard/src/action/summary.ts
+++ b/packages/backpack-adoption-guard/src/action/summary.ts
@@ -23,12 +23,6 @@ const STATUS_HEADER: Record<GuardResult["status"], string> = {
   warn: "⚠️ Backpack Adoption Guard — Warning",
 };
 
-const STATUS_ICON: Record<GuardResult["status"], string> = {
-  pass: "✅",
-  fail: "❌",
-  warn: "⚠️",
-};
-
 const formatPercentage = (value: number | null) =>
   value === null ? "n/a" : `${value.toFixed(2)}%`;
 
@@ -92,69 +86,6 @@ ${items}
 `;
 };
 
-const buildMainProjectsTable = (head: AdoptionReport) => {
-  if (!head.projects) {
-    return "";
-  }
-
-  const rows = Object.entries(head.projects)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(
-      ([name, project]) =>
-        `| ${name} | ${formatPercentage(project.usage.backpack.percentage)} | ${formatCount(project.filesAnalyzed)} |`,
-    )
-    .join("\n");
-
-  return `
-### Per-project adoption
-
-| Project | Adoption | Files |
-| --- | ---: | ---: |
-${rows}
-`;
-};
-
-const buildComparisonProjectsTable = (result: ActionResult) => {
-  const { base, head, guard } = result;
-  if (!head.projects || !base) {
-    return "";
-  }
-
-  const projectGuards = guard.projects || {};
-  const baseProjects = base.projects || {};
-
-  const rows = Object.entries(head.projects)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([name, project]) => {
-      const baseProject = baseProjects[name];
-      const projectGuard = projectGuards[name];
-      const mainCell = baseProject
-        ? formatPercentage(baseProject.usage.backpack.percentage)
-        : "n/a";
-      const changeCell = baseProject
-        ? formatDelta(
-            Number(
-              (
-                project.usage.backpack.percentage -
-                baseProject.usage.backpack.percentage
-              ).toFixed(2),
-            ),
-          )
-        : "n/a";
-      const statusCell = projectGuard ? STATUS_ICON[projectGuard.status] : "—";
-      return `| ${name} | ${formatPercentage(project.usage.backpack.percentage)} | ${mainCell} | ${changeCell} | ${statusCell} |`;
-    })
-    .join("\n");
-
-  return `
-### Per-project adoption
-
-| Project | This PR | Main | Change | Status |
-| --- | ---: | ---: | ---: | :---: |
-${rows}
-`;
-};
-
 const buildMainView = (result: ActionResult) => {
   const { head, guard } = result;
   const skipped = head.parseErrors.length;
@@ -175,7 +106,6 @@ ${buildPlainEnglishMain(head)}
 | └ With className override | ${formatCount(head.usage.nonPureBackpack.count)} | ${head.usage.nonPureBackpack.percentage.toFixed(2)}% |
 | Non-Backpack | ${formatCount(head.usage.nonBackpack.count)} | ${head.usage.nonBackpack.percentage.toFixed(2)}% |
 | Raw HTML | ${formatCount(head.usage.rawHtml.count)} | ${head.usage.rawHtml.percentage.toFixed(2)}% |
-${buildMainProjectsTable(head)}
 ### Run details
 
 | Detail | Value |
@@ -207,7 +137,6 @@ ${buildPlainEnglishMain(head)}
 | └ With className override | ${formatCount(head.usage.nonPureBackpack.count)} | ${head.usage.nonPureBackpack.percentage.toFixed(2)}% |
 | Non-Backpack | ${formatCount(head.usage.nonBackpack.count)} | ${head.usage.nonBackpack.percentage.toFixed(2)}% |
 | Raw HTML | ${formatCount(head.usage.rawHtml.count)} | ${head.usage.rawHtml.percentage.toFixed(2)}% |
-${buildMainProjectsTable(head)}
 ### Run details
 
 | Detail | Value |
@@ -245,7 +174,6 @@ ${buildPlainEnglishComparison(head, base)}
 | └ With className override | ${formatPercentageAndCount(head.usage.nonPureBackpack.percentage, head.usage.nonPureBackpack.count)} | ${formatPercentageAndCount(base.usage.nonPureBackpack.percentage, base.usage.nonPureBackpack.count)} | ${formatDelta(Number((head.usage.nonPureBackpack.percentage - base.usage.nonPureBackpack.percentage).toFixed(2)))} |
 | Non-Backpack | ${formatPercentageAndCount(head.usage.nonBackpack.percentage, head.usage.nonBackpack.count)} | ${formatPercentageAndCount(base.usage.nonBackpack.percentage, base.usage.nonBackpack.count)} | ${formatDelta(Number((head.usage.nonBackpack.percentage - base.usage.nonBackpack.percentage).toFixed(2)))} |
 | Raw HTML | ${formatPercentageAndCount(head.usage.rawHtml.percentage, head.usage.rawHtml.count)} | ${formatPercentageAndCount(base.usage.rawHtml.percentage, base.usage.rawHtml.count)} | ${formatDelta(Number((head.usage.rawHtml.percentage - base.usage.rawHtml.percentage).toFixed(2)))} |
-${buildComparisonProjectsTable(result)}
 ### Run details
 
 | Detail | Value |

--- a/packages/backpack-adoption-guard/src/analysis/analyze-repository-test.ts
+++ b/packages/backpack-adoption-guard/src/analysis/analyze-repository-test.ts
@@ -164,6 +164,93 @@ export const App = () => (
     expect(report.usage.nonPureBackpack.count).toBe(3);
   });
 
+  it("attributes usages to NX projects, keeping an (unassigned) bucket", async () => {
+    await writeRepoFile(repoPath, "nx.json", JSON.stringify({ version: 2 }));
+    await writeRepoFile(
+      repoPath,
+      "apps/flights/project.json",
+      JSON.stringify({
+        name: "flights",
+        root: "apps/flights",
+        projectType: "application",
+      }),
+    );
+    await writeRepoFile(
+      repoPath,
+      "libs/shared-ui/project.json",
+      JSON.stringify({
+        name: "shared-ui",
+        root: "libs/shared-ui",
+        projectType: "library",
+      }),
+    );
+    await writeRepoFile(
+      repoPath,
+      "apps/flights/src/App.tsx",
+      `
+import { BpkButton } from '@skyscanner/backpack-web';
+
+export const App = () => <BpkButton>Go</BpkButton>;
+`,
+    );
+    await writeRepoFile(
+      repoPath,
+      "libs/shared-ui/src/Card.tsx",
+      `
+import { BpkCard, BpkText } from '@skyscanner/backpack-web';
+
+export const Card = () => <BpkCard><BpkText>t</BpkText></BpkCard>;
+`,
+    );
+    await writeRepoFile(
+      repoPath,
+      "RootThing.tsx",
+      `
+export const RootThing = () => <div>root</div>;
+`,
+    );
+
+    const report = await analyzeRepository(repoPath);
+
+    expect(report.isNx).toBe(true);
+    expect(report.projects).toBeDefined();
+
+    const projects = report.projects!;
+    expect(projects.flights.usage.backpack.count).toBe(1);
+    expect(projects["shared-ui"].usage.backpack.count).toBe(2);
+    expect(projects["(unassigned)"].usage.rawHtml.count).toBe(1);
+
+    // Repo-wide usage totals are unaffected by per-project attribution.
+    const projectBackpackTotal = Object.values(projects).reduce(
+      (sum, project) => sum + project.usage.backpack.count,
+      0,
+    );
+    expect(projectBackpackTotal).toBe(report.usage.backpack.count);
+
+    const projectFilesTotal = Object.values(projects).reduce(
+      (sum, project) => sum + project.filesAnalyzed,
+      0,
+    );
+    expect(projectFilesTotal).toBe(report.filesAnalyzed);
+  });
+
+  it("omits projects/isNx for non-NX repositories", async () => {
+    await writeRepoFile(
+      repoPath,
+      "src/App.tsx",
+      `
+import BpkText from '@skyscanner/backpack-web/bpk-component-text';
+
+export const App = () => <BpkText>Prod</BpkText>;
+`,
+    );
+
+    const report = await analyzeRepository(repoPath);
+
+    expect(report.isNx).toBeUndefined();
+    expect(report.projects).toBeUndefined();
+  });
+
   it("ignores spec, story, and mock files (alignment with ds-analyser)", async () => {
     await writeRepoFile(
       repoPath,

--- a/packages/backpack-adoption-guard/src/analysis/analyze-repository-test.ts
+++ b/packages/backpack-adoption-guard/src/analysis/analyze-repository-test.ts
@@ -132,7 +132,7 @@ export const App = () => (
 `,
     );
 
-    const report = await analyzeRepository(repoPath);
+    const report = await analyzeRepository(repoPath, { includeNxProjects: true });
 
     expect(report.usage.backpack.count).toBe(1);
     // classNames(variable) cannot be statically resolved → ds-analyser does
@@ -155,7 +155,7 @@ export const App = () => (
 `,
     );
 
-    const report = await analyzeRepository(repoPath);
+    const report = await analyzeRepository(repoPath, { includeNxProjects: true });
 
     // 1 Backpack usage, but classNames(...) has 3 string args → overrideCount 3.
     // ds-analyser pure = backpackUsages - classNameOverrides = 1 - 3 = -2.
@@ -210,7 +210,7 @@ export const RootThing = () => <div>root</div>;
 `,
     );
 
-    const report = await analyzeRepository(repoPath);
+    const report = await analyzeRepository(repoPath, { includeNxProjects: true });
 
     expect(report.isNx).toBe(true);
     expect(report.projects).toBeDefined();
@@ -251,7 +251,7 @@ export const RootThing = () => <div>root</div>;
       "export const Broken = () => <div>{",
     );
 
-    const report = await analyzeRepository(repoPath);
+    const report = await analyzeRepository(repoPath, { includeNxProjects: true });
 
     // The file failed to parse (no usages recorded), but it still matched
     // the glob and its project should still count it as analyzed — matching

--- a/packages/backpack-adoption-guard/src/analysis/analyze-repository-test.ts
+++ b/packages/backpack-adoption-guard/src/analysis/analyze-repository-test.ts
@@ -234,6 +234,39 @@ export const RootThing = () => <div>root</div>;
     expect(projectFilesTotal).toBe(report.filesAnalyzed);
   });
 
+  it("counts a file with a parse error toward its project's filesAnalyzed", async () => {
+    await writeRepoFile(repoPath, "nx.json", JSON.stringify({ version: 2 }));
+    await writeRepoFile(
+      repoPath,
+      "apps/flights/project.json",
+      JSON.stringify({
+        name: "flights",
+        root: "apps/flights",
+        projectType: "application",
+      }),
+    );
+    await writeRepoFile(
+      repoPath,
+      "apps/flights/src/Broken.tsx",
+      "export const Broken = () => <div>{",
+    );
+
+    const report = await analyzeRepository(repoPath);
+
+    // The file failed to parse (no usages recorded), but it still matched
+    // the glob and its project should still count it as analyzed — matching
+    // the repo-wide filesAnalyzed, which counts every matched file.
+    expect(report.filesAnalyzed).toBe(1);
+    expect(report.parseErrors).toHaveLength(1);
+    expect(report.projects!.flights.filesAnalyzed).toBe(1);
+
+    const projectFilesTotal = Object.values(report.projects!).reduce(
+      (sum, project) => sum + project.filesAnalyzed,
+      0,
+    );
+    expect(projectFilesTotal).toBe(report.filesAnalyzed);
+  });
+
   it("omits projects/isNx for non-NX repositories", async () => {
     await writeRepoFile(
       repoPath,

--- a/packages/backpack-adoption-guard/src/analysis/analyze-repository.ts
+++ b/packages/backpack-adoption-guard/src/analysis/analyze-repository.ts
@@ -48,9 +48,15 @@ import {
   isNonVisualComponentName,
   isRawHTMLElement,
 } from "./jsx-helpers";
+import {
+  type NxProjectIndexEntry,
+  buildProjectIndex,
+  detectNxProjects,
+  resolveProject,
+} from "./nx-projects";
 import { buildVisualComponentRegistry } from "./visual-components";
 import { DEFAULT_IGNORE_PATTERNS, DEFAULT_PATTERN } from "../shared/config";
-import type { AdoptionReport } from "../shared/types";
+import type { AdoptionReport, UsageSummary } from "../shared/types";
 
 const traverse = (
   (_traverse as unknown as { default?: typeof _traverse }).default ?? _traverse
@@ -132,6 +138,145 @@ type AnalyzerOptions = {
   ignore?: string[];
   components?: string[] | null;
 };
+
+type FileAnalysisResult = ReturnType<typeof analyzeFile>;
+
+/**
+ * Creates an empty result-accumulator bucket. Used for both the repo-wide
+ * totals and per-NX-project sub-totals so they share an identical shape.
+ */
+function createResultBucket(repository: string): AnalyzerResults {
+  return {
+    repository,
+    filesAnalyzed: 0,
+    components: {},
+    totalUsages: 0,
+    classNameOverrides: 0,
+    backpackUsages: 0,
+    nonBackpackUsages: 0,
+    nonBackpackComponents: { visual: {}, nonVisual: {} },
+    rawHtmlUsages: 0,
+    rawHtmlComponents: {},
+    excludedUsages: 0,
+    excludedComponents: {},
+    backpackPercentage: 0,
+    rawHtmlPercentage: 0,
+  };
+}
+
+/**
+ * Merges a single file's analysis output into an accumulator bucket.
+ * Mutates `target` in place. Sets remain Sets at this stage.
+ * Verbatim port of ds-analyser's mergeFileResults from analyzer.js.
+ */
+function mergeFileResults(
+  target: AnalyzerResults,
+  fileResults: FileAnalysisResult,
+): void {
+  for (const [componentName, usage] of Object.entries(fileResults.components)) {
+    if (!target.components[componentName]) {
+      target.components[componentName] = {
+        name: componentName,
+        totalUsages: 0,
+        files: new Set(),
+        variants: {},
+        classNameOverrides: 0,
+        locations: [],
+      };
+    }
+    const comp = target.components[componentName];
+    comp.totalUsages += usage.totalUsages;
+    comp.classNameOverrides += usage.classNameOverrides;
+    usage.files.forEach((f: string) => comp.files.add(f));
+    comp.locations.push(...usage.locations);
+
+    for (const [variant, count] of Object.entries(usage.variants)) {
+      comp.variants[variant] = (comp.variants[variant] || 0) + (count as number);
+    }
+  }
+
+  target.totalUsages += fileResults.totalUsages;
+  target.classNameOverrides += fileResults.classNameOverrides;
+  target.backpackUsages += fileResults.backpackUsages || 0;
+  target.nonBackpackUsages += fileResults.nonBackpackUsages || 0;
+  target.rawHtmlUsages += fileResults.rawHtmlUsages || 0;
+  target.excludedUsages += fileResults.excludedUsages || 0;
+
+  if (fileResults.rawHtmlComponents) {
+    for (const [tagName, usage] of Object.entries(fileResults.rawHtmlComponents)) {
+      if (!target.rawHtmlComponents[tagName]) {
+        target.rawHtmlComponents[tagName] = {
+          name: tagName,
+          totalUsages: 0,
+          styledUsages: 0,
+          files: new Set(),
+          locations: [],
+        };
+      }
+      const comp = target.rawHtmlComponents[tagName];
+      comp.totalUsages += usage.totalUsages;
+      comp.styledUsages += usage.styledUsages || 0;
+      usage.files.forEach((f: string) => comp.files.add(f));
+      comp.locations.push(...usage.locations);
+    }
+  }
+
+  if (fileResults.nonBackpackComponents) {
+    for (const [componentName, usage] of Object.entries(
+      fileResults.nonBackpackComponents.visual || {},
+    )) {
+      if (!target.nonBackpackComponents.visual[componentName]) {
+        target.nonBackpackComponents.visual[componentName] = {
+          name: componentName,
+          totalUsages: 0,
+          files: new Set(),
+          locations: [],
+        };
+      }
+      const comp = target.nonBackpackComponents.visual[componentName];
+      comp.totalUsages += usage.totalUsages;
+      usage.files.forEach((f: string) => comp.files.add(f));
+      comp.locations.push(...(usage.locations || []));
+    }
+
+    for (const [componentName, usage] of Object.entries(
+      fileResults.nonBackpackComponents.nonVisual || {},
+    )) {
+      if (!target.nonBackpackComponents.nonVisual[componentName]) {
+        target.nonBackpackComponents.nonVisual[componentName] = {
+          name: componentName,
+          totalUsages: 0,
+          files: new Set(),
+          locations: [],
+        };
+      }
+      const comp = target.nonBackpackComponents.nonVisual[componentName];
+      comp.totalUsages += usage.totalUsages;
+      usage.files.forEach((f: string) => comp.files.add(f));
+      comp.locations.push(...(usage.locations || []));
+    }
+  }
+
+  if (fileResults.excludedComponents) {
+    for (const [componentName, count] of Object.entries(fileResults.excludedComponents)) {
+      target.excludedComponents[componentName] =
+        (target.excludedComponents[componentName] || 0) + (count as number);
+    }
+  }
+}
+
+/**
+ * Converts the Set-valued `files` fields of a bucket to arrays and computes
+ * the backpack/rawHtml percentages. Idempotent enough for one-shot use.
+ */
+function finalizeBucket(bucket: AnalyzerResults): void {
+  const totalElementUsages =
+    bucket.backpackUsages + bucket.nonBackpackUsages + bucket.rawHtmlUsages;
+  if (totalElementUsages > 0) {
+    bucket.backpackPercentage = (bucket.backpackUsages / totalElementUsages) * 100;
+    bucket.rawHtmlPercentage = (bucket.rawHtmlUsages / totalElementUsages) * 100;
+  }
+}
 
 function buildLocation(
   node: any,
@@ -514,7 +659,13 @@ function analyzeFile(
 async function runAnalyzer(
   repoPath: string,
   options: AnalyzerOptions,
-): Promise<AnalyzerResults & { parseErrors: Array<{ file: string; message: string }> }> {
+): Promise<
+  AnalyzerResults & {
+    parseErrors: Array<{ file: string; message: string }>;
+    isNx: boolean;
+    projectBuckets: Record<string, AnalyzerResults> | null;
+  }
+> {
   const {
     pattern = DEFAULT_PATTERN,
     ignore = DEFAULT_IGNORE_PATTERNS,
@@ -529,27 +680,24 @@ async function runAnalyzer(
 
   const visualComponentRegistry = buildVisualComponentRegistry(files);
 
-  const results: AnalyzerResults = {
-    repository: basename(repoPath),
-    filesAnalyzed: files.length,
-    components: {},
-    totalUsages: 0,
-    classNameOverrides: 0,
-    backpackUsages: 0,
-    nonBackpackUsages: 0,
-    nonBackpackComponents: { visual: {}, nonVisual: {} },
-    rawHtmlUsages: 0,
-    rawHtmlComponents: {},
-    excludedUsages: 0,
-    excludedComponents: {},
-    backpackPercentage: 0,
-    rawHtmlPercentage: 0,
-  };
+  const results = createResultBucket(basename(repoPath));
+  results.filesAnalyzed = files.length;
+
+  // Detect NX projects so file-level results can be attributed per project.
+  // Static read only — no NX runtime. Disabled for non-NX repos (no nx.json).
+  const nxInfo = detectNxProjects(repoPath);
+  const projectIndex: NxProjectIndexEntry[] | null = nxInfo.isNx
+    ? buildProjectIndex(nxInfo.projects)
+    : null;
+  const projectBuckets: Record<string, AnalyzerResults> | null = nxInfo.isNx
+    ? {}
+    : null;
 
   const parseErrors: Array<{ file: string; message: string }> = [];
 
   for (let i = 0; i < files.length; i += 1) {
     const filePath = files[i];
+    const relativePath = relative(repoPath, filePath);
 
     try {
       const content = readFileSync(filePath, "utf-8");
@@ -561,114 +709,35 @@ async function runAnalyzer(
         visualComponentRegistry,
       );
 
-      for (const [componentName, usage] of Object.entries(fileResults.components)) {
-        if (!results.components[componentName]) {
-          results.components[componentName] = {
-            name: componentName,
-            totalUsages: 0,
-            files: new Set(),
-            variants: {},
-            classNameOverrides: 0,
-            locations: [],
-          };
-        }
-        const comp = results.components[componentName];
-        comp.totalUsages += usage.totalUsages;
-        comp.classNameOverrides += usage.classNameOverrides;
-        usage.files.forEach((f: string) => comp.files.add(f));
-        comp.locations.push(...usage.locations);
+      // Merge into the repo-wide totals
+      mergeFileResults(results, fileResults);
 
-        for (const [variant, count] of Object.entries(usage.variants)) {
-          comp.variants[variant] = (comp.variants[variant] || 0) + (count as number);
+      // Attribute the same file's results to its NX project bucket
+      if (projectBuckets) {
+        const projectName = resolveProject(relativePath, projectIndex);
+        if (!projectBuckets[projectName]) {
+          projectBuckets[projectName] = createResultBucket(projectName);
         }
-      }
-
-      results.totalUsages += fileResults.totalUsages;
-      results.classNameOverrides += fileResults.classNameOverrides;
-      results.backpackUsages += fileResults.backpackUsages || 0;
-      results.nonBackpackUsages += fileResults.nonBackpackUsages || 0;
-      results.rawHtmlUsages += fileResults.rawHtmlUsages || 0;
-      results.excludedUsages += fileResults.excludedUsages || 0;
-
-      if (fileResults.rawHtmlComponents) {
-        for (const [tagName, usage] of Object.entries(fileResults.rawHtmlComponents)) {
-          if (!results.rawHtmlComponents[tagName]) {
-            results.rawHtmlComponents[tagName] = {
-              name: tagName,
-              totalUsages: 0,
-              styledUsages: 0,
-              files: new Set(),
-              locations: [],
-            };
-          }
-          const comp = results.rawHtmlComponents[tagName];
-          comp.totalUsages += usage.totalUsages;
-          comp.styledUsages += usage.styledUsages || 0;
-          usage.files.forEach((f: string) => comp.files.add(f));
-          comp.locations.push(...usage.locations);
-        }
-      }
-
-      if (fileResults.nonBackpackComponents) {
-        for (const [componentName, usage] of Object.entries(
-          fileResults.nonBackpackComponents.visual || {},
-        )) {
-          if (!results.nonBackpackComponents.visual[componentName]) {
-            results.nonBackpackComponents.visual[componentName] = {
-              name: componentName,
-              totalUsages: 0,
-              files: new Set(),
-              locations: [],
-            };
-          }
-          const comp = results.nonBackpackComponents.visual[componentName];
-          comp.totalUsages += usage.totalUsages;
-          usage.files.forEach((f: string) => comp.files.add(f));
-          comp.locations.push(...(usage.locations || []));
-        }
-
-        for (const [componentName, usage] of Object.entries(
-          fileResults.nonBackpackComponents.nonVisual || {},
-        )) {
-          if (!results.nonBackpackComponents.nonVisual[componentName]) {
-            results.nonBackpackComponents.nonVisual[componentName] = {
-              name: componentName,
-              totalUsages: 0,
-              files: new Set(),
-              locations: [],
-            };
-          }
-          const comp = results.nonBackpackComponents.nonVisual[componentName];
-          comp.totalUsages += usage.totalUsages;
-          usage.files.forEach((f: string) => comp.files.add(f));
-          comp.locations.push(...(usage.locations || []));
-        }
-      }
-
-      if (fileResults.excludedComponents) {
-        for (const [componentName, count] of Object.entries(fileResults.excludedComponents)) {
-          results.excludedComponents[componentName] =
-            (results.excludedComponents[componentName] || 0) + (count as number);
-        }
+        projectBuckets[projectName].filesAnalyzed += 1;
+        mergeFileResults(projectBuckets[projectName], fileResults);
       }
     } catch (error) {
       parseErrors.push({
-        file: relative(repoPath, filePath),
+        file: relativePath,
         message: error instanceof Error ? error.message : String(error),
       });
     }
   }
 
-  const totalElementUsages =
-    results.backpackUsages + results.nonBackpackUsages + results.rawHtmlUsages;
-  if (totalElementUsages > 0) {
-    results.backpackPercentage =
-      (results.backpackUsages / totalElementUsages) * 100;
-    results.rawHtmlPercentage =
-      (results.rawHtmlUsages / totalElementUsages) * 100;
+  finalizeBucket(results);
+
+  if (projectBuckets) {
+    for (const bucket of Object.values(projectBuckets)) {
+      finalizeBucket(bucket);
+    }
   }
 
-  return { ...results, parseErrors };
+  return { ...results, parseErrors, isNx: nxInfo.isNx, projectBuckets };
 }
 
 /**
@@ -719,16 +788,13 @@ async function findBackpackWebVersion(repoPath: string): Promise<string | null> 
 const roundPercentage = (value: number) => Number(value.toFixed(2));
 
 /**
- * Public entry point used by the action's run.ts. Wraps the ds-analyser-style
- * analyzer in our AdoptionReport shape so the guard logic and writer stay
- * stable.
+ * Derives the usage/componentCounts portion of an AdoptionReport from an
+ * analyzer result bucket. Shared between the repo-wide bucket and each
+ * per-NX-project bucket so both produce structurally identical reports.
  */
-export const analyzeRepository = async (
-  repoPath: string,
-  options: AnalyzerOptions = {},
-): Promise<AdoptionReport> => {
-  const analyzer = await runAnalyzer(repoPath, options);
-
+function buildUsageSummary(
+  analyzer: AnalyzerResults,
+): { usage: UsageSummary; componentCounts: Record<string, number> } {
   const totalElementUsages =
     analyzer.backpackUsages + analyzer.nonBackpackUsages + analyzer.rawHtmlUsages;
 
@@ -752,11 +818,6 @@ export const analyzeRepository = async (
   }
 
   return {
-    repository: basename(repoPath),
-    generatedAt: new Date().toISOString(),
-    filesAnalyzed: analyzer.filesAnalyzed,
-    parseErrors: analyzer.parseErrors,
-    backpackWebVersion: await findBackpackWebVersion(repoPath),
     usage: {
       backpack: {
         count: analyzer.backpackUsages,
@@ -781,4 +842,50 @@ export const analyzeRepository = async (
     },
     componentCounts,
   };
+}
+
+/**
+ * Public entry point used by the action's run.ts. Wraps the ds-analyser-style
+ * analyzer in our AdoptionReport shape so the guard logic and writer stay
+ * stable.
+ */
+export const analyzeRepository = async (
+  repoPath: string,
+  options: AnalyzerOptions = {},
+): Promise<AdoptionReport> => {
+  const analyzer = await runAnalyzer(repoPath, options);
+  const generatedAt = new Date().toISOString();
+  const backpackWebVersion = await findBackpackWebVersion(repoPath);
+  const { usage, componentCounts } = buildUsageSummary(analyzer);
+
+  const report: AdoptionReport = {
+    repository: basename(repoPath),
+    generatedAt,
+    filesAnalyzed: analyzer.filesAnalyzed,
+    parseErrors: analyzer.parseErrors,
+    backpackWebVersion,
+    usage,
+    componentCounts,
+  };
+
+  // (unassigned) bucket is kept as-is (not stripped) so consumers can see how
+  // much usage isn't attributed to any NX project, matching ds-analyser.
+  if (analyzer.isNx && analyzer.projectBuckets) {
+    report.isNx = true;
+    report.projects = {};
+    for (const [name, bucket] of Object.entries(analyzer.projectBuckets)) {
+      const projectUsage = buildUsageSummary(bucket);
+      report.projects[name] = {
+        repository: bucket.repository,
+        generatedAt,
+        filesAnalyzed: bucket.filesAnalyzed,
+        parseErrors: [],
+        backpackWebVersion,
+        usage: projectUsage.usage,
+        componentCounts: projectUsage.componentCounts,
+      };
+    }
+  }
+
+  return report;
 };

--- a/packages/backpack-adoption-guard/src/analysis/analyze-repository.ts
+++ b/packages/backpack-adoption-guard/src/analysis/analyze-repository.ts
@@ -266,8 +266,11 @@ function mergeFileResults(
 }
 
 /**
- * Converts the Set-valued `files` fields of a bucket to arrays and computes
- * the backpack/rawHtml percentages. Idempotent enough for one-shot use.
+ * Computes the backpack/rawHtml percentages for a bucket once all files have
+ * been merged into it. Idempotent enough for one-shot use. Unlike
+ * ds-analyser's finalizeBucket, this does not convert Set-valued `files`
+ * fields to arrays — nothing downstream serializes them, since
+ * buildUsageSummary only reads the numeric counts off each bucket.
  */
 function finalizeBucket(bucket: AnalyzerResults): void {
   const totalElementUsages =
@@ -699,6 +702,19 @@ async function runAnalyzer(
     const filePath = files[i];
     const relativePath = relative(repoPath, filePath);
 
+    // Every matched file counts toward its project's filesAnalyzed, even if
+    // analysis below fails, so per-project totals stay in lockstep with the
+    // repo-wide filesAnalyzed (= files.length).
+    let projectBucket: AnalyzerResults | null = null;
+    if (projectBuckets) {
+      const projectName = resolveProject(relativePath, projectIndex);
+      if (!projectBuckets[projectName]) {
+        projectBuckets[projectName] = createResultBucket(projectName);
+      }
+      projectBucket = projectBuckets[projectName];
+      projectBucket.filesAnalyzed += 1;
+    }
+
     try {
       const content = readFileSync(filePath, "utf-8");
       const fileResults = analyzeFile(
@@ -713,13 +729,8 @@ async function runAnalyzer(
       mergeFileResults(results, fileResults);
 
       // Attribute the same file's results to its NX project bucket
-      if (projectBuckets) {
-        const projectName = resolveProject(relativePath, projectIndex);
-        if (!projectBuckets[projectName]) {
-          projectBuckets[projectName] = createResultBucket(projectName);
-        }
-        projectBuckets[projectName].filesAnalyzed += 1;
-        mergeFileResults(projectBuckets[projectName], fileResults);
+      if (projectBucket) {
+        mergeFileResults(projectBucket, fileResults);
       }
     } catch (error) {
       parseErrors.push({

--- a/packages/backpack-adoption-guard/src/analysis/analyze-repository.ts
+++ b/packages/backpack-adoption-guard/src/analysis/analyze-repository.ts
@@ -137,6 +137,7 @@ type AnalyzerOptions = {
   pattern?: string;
   ignore?: string[];
   components?: string[] | null;
+  includeNxProjects?: boolean;
 };
 
 type FileAnalysisResult = ReturnType<typeof analyzeFile>;
@@ -673,6 +674,7 @@ async function runAnalyzer(
     pattern = DEFAULT_PATTERN,
     ignore = DEFAULT_IGNORE_PATTERNS,
     components = null,
+    includeNxProjects = false,
   } = options;
 
   const files = await glob(pattern, {
@@ -686,9 +688,11 @@ async function runAnalyzer(
   const results = createResultBucket(basename(repoPath));
   results.filesAnalyzed = files.length;
 
-  // Detect NX projects so file-level results can be attributed per project.
-  // Static read only — no NX runtime. Disabled for non-NX repos (no nx.json).
-  const nxInfo = detectNxProjects(repoPath);
+  // Project attribution is opt-in. The GitHub Action only needs repository-wide
+  // metrics; Nx-specific consumers enable it explicitly.
+  const nxInfo = includeNxProjects
+    ? detectNxProjects(repoPath)
+    : { isNx: false, projects: [] };
   const projectIndex: NxProjectIndexEntry[] | null = nxInfo.isNx
     ? buildProjectIndex(nxInfo.projects)
     : null;

--- a/packages/backpack-adoption-guard/src/analysis/nx-projects-test.ts
+++ b/packages/backpack-adoption-guard/src/analysis/nx-projects-test.ts
@@ -17,7 +17,7 @@
  */
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import {
   UNASSIGNED,
@@ -34,7 +34,7 @@ const writeRepoFile = async (
   content: string,
 ) => {
   const absolutePath = join(repoPath, filePath);
-  await mkdir(join(absolutePath, ".."), { recursive: true });
+  await mkdir(dirname(absolutePath), { recursive: true });
   await writeFile(absolutePath, content, "utf8");
 };
 

--- a/packages/backpack-adoption-guard/src/analysis/nx-projects-test.ts
+++ b/packages/backpack-adoption-guard/src/analysis/nx-projects-test.ts
@@ -1,0 +1,135 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  UNASSIGNED,
+  buildProjectIndex,
+  detectNxProjects,
+  resolveProject,
+} from "./nx-projects";
+
+const createRepo = async () => mkdtemp(join(tmpdir(), "bpk-nx-test-"));
+
+const writeRepoFile = async (
+  repoPath: string,
+  filePath: string,
+  content: string,
+) => {
+  const absolutePath = join(repoPath, filePath);
+  await mkdir(join(absolutePath, ".."), { recursive: true });
+  await writeFile(absolutePath, content, "utf8");
+};
+
+describe("nx-projects", () => {
+  let repoPath: string;
+
+  beforeEach(async () => {
+    repoPath = await createRepo();
+  });
+
+  afterEach(async () => {
+    await rm(repoPath, { force: true, recursive: true });
+  });
+
+  describe("detectNxProjects", () => {
+    it("returns isNx false when no nx.json exists", async () => {
+      await writeRepoFile(repoPath, "App.tsx", "export const A = () => null;");
+
+      const { isNx, projects } = detectNxProjects(repoPath);
+
+      expect(isNx).toBe(false);
+      expect(projects).toEqual([]);
+    });
+
+    it("discovers project.json projects", async () => {
+      await writeRepoFile(repoPath, "nx.json", '{ "version": 2 }');
+      await writeRepoFile(
+        repoPath,
+        "apps/flights/project.json",
+        '{ "name": "flights", "root": "apps/flights", "projectType": "application" }',
+      );
+      await writeRepoFile(
+        repoPath,
+        "libs/shared-ui/project.json",
+        '{ "name": "shared-ui", "root": "libs/shared-ui", "projectType": "library" }',
+      );
+
+      const { isNx, projects } = detectNxProjects(repoPath);
+
+      expect(isNx).toBe(true);
+      const names = projects.map((p) => p.name).sort();
+      expect(names).toEqual(["flights", "shared-ui"]);
+
+      const flights = projects.find((p) => p.name === "flights");
+      expect(flights?.root).toBe("apps/flights");
+      expect(flights?.type).toBe("application");
+    });
+
+    it("discovers package.json projects that carry an nx field", async () => {
+      await writeRepoFile(repoPath, "nx.json", '{ "version": 2 }');
+      await writeRepoFile(
+        repoPath,
+        "libs/checkout/package.json",
+        JSON.stringify({
+          name: "checkout-pkg",
+          nx: { name: "checkout", projectType: "library" },
+        }),
+      );
+
+      const { isNx, projects } = detectNxProjects(repoPath);
+
+      expect(isNx).toBe(true);
+      const checkout = projects.find((p) => p.name === "checkout");
+      expect(checkout?.root).toBe("libs/checkout");
+      expect(checkout?.type).toBe("library");
+    });
+  });
+
+  describe("resolveProject", () => {
+    it("uses longest-prefix match and falls back to the unassigned bucket", () => {
+      const index = buildProjectIndex([
+        { name: "flights", root: "apps/flights", type: null },
+        { name: "shared-ui", root: "libs/shared-ui", type: null },
+      ]);
+
+      expect(resolveProject("apps/flights/src/App.tsx", index)).toBe(
+        "flights",
+      );
+      expect(resolveProject("libs/shared-ui/src/Card.tsx", index)).toBe(
+        "shared-ui",
+      );
+      expect(resolveProject("RootThing.tsx", index)).toBe(UNASSIGNED);
+      expect(resolveProject("apps/other/x.tsx", index)).toBe(UNASSIGNED);
+    });
+
+    it("prefers the longer of two nested roots", () => {
+      const index = buildProjectIndex([
+        { name: "web", root: "apps/web", type: null },
+        { name: "web-feature", root: "apps/web/features/checkout", type: null },
+      ]);
+
+      expect(
+        resolveProject("apps/web/features/checkout/Page.tsx", index),
+      ).toBe("web-feature");
+      expect(resolveProject("apps/web/Home.tsx", index)).toBe("web");
+    });
+  });
+});

--- a/packages/backpack-adoption-guard/src/analysis/nx-projects-test.ts
+++ b/packages/backpack-adoption-guard/src/analysis/nx-projects-test.ts
@@ -75,12 +75,13 @@ describe("nx-projects", () => {
       const { isNx, projects } = detectNxProjects(repoPath);
 
       expect(isNx).toBe(true);
-      const names = projects.map((p) => p.name).sort();
-      expect(names).toEqual(["flights", "shared-ui"]);
-
-      const flights = projects.find((p) => p.name === "flights");
-      expect(flights?.root).toBe("apps/flights");
-      expect(flights?.type).toBe("application");
+      expect(projects.map((project) => project.name).sort()).toEqual([
+        "flights",
+        "shared-ui",
+      ]);
+      expect(projects.find((project) => project.name === "flights")?.root).toBe(
+        "apps/flights",
+      );
     });
 
     it("discovers package.json projects that carry an nx field", async () => {
@@ -94,10 +95,8 @@ describe("nx-projects", () => {
         }),
       );
 
-      const { isNx, projects } = detectNxProjects(repoPath);
-
-      expect(isNx).toBe(true);
-      const checkout = projects.find((p) => p.name === "checkout");
+      const { projects } = detectNxProjects(repoPath);
+      const checkout = projects.find((project) => project.name === "checkout");
       expect(checkout?.root).toBe("libs/checkout");
       expect(checkout?.type).toBe("library");
     });
@@ -110,14 +109,9 @@ describe("nx-projects", () => {
         { name: "shared-ui", root: "libs/shared-ui", type: null },
       ]);
 
-      expect(resolveProject("apps/flights/src/App.tsx", index)).toBe(
-        "flights",
-      );
-      expect(resolveProject("libs/shared-ui/src/Card.tsx", index)).toBe(
-        "shared-ui",
-      );
+      expect(resolveProject("apps/flights/src/App.tsx", index)).toBe("flights");
+      expect(resolveProject("libs/shared-ui/src/Card.tsx", index)).toBe("shared-ui");
       expect(resolveProject("RootThing.tsx", index)).toBe(UNASSIGNED);
-      expect(resolveProject("apps/other/x.tsx", index)).toBe(UNASSIGNED);
     });
 
     it("prefers the longer of two nested roots", () => {
@@ -126,9 +120,9 @@ describe("nx-projects", () => {
         { name: "web-feature", root: "apps/web/features/checkout", type: null },
       ]);
 
-      expect(
-        resolveProject("apps/web/features/checkout/Page.tsx", index),
-      ).toBe("web-feature");
+      expect(resolveProject("apps/web/features/checkout/Page.tsx", index)).toBe(
+        "web-feature",
+      );
       expect(resolveProject("apps/web/Home.tsx", index)).toBe("web");
     });
   });

--- a/packages/backpack-adoption-guard/src/analysis/nx-projects.ts
+++ b/packages/backpack-adoption-guard/src/analysis/nx-projects.ts
@@ -1,0 +1,164 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Verbatim port of Skyscanner/ds-analyser src/nx-projects.js to TypeScript.
+// Behaviour matches the JS source one-for-one; see analyze-repository.ts for
+// the verbatim-port convention used across this package.
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, sep } from "node:path";
+
+import { globSync } from "glob";
+
+export const UNASSIGNED = "(unassigned)";
+
+export type NxProject = {
+  name: string;
+  root: string;
+  type: string | null;
+};
+
+export type NxProjectIndexEntry = {
+  name: string;
+  root: string;
+  prefix: string;
+};
+
+function toPosix(p: string): string {
+  return sep === "/" ? p : p.split(sep).join("/");
+}
+
+function readProjectFile(absPath: string, root: string): NxProject | null {
+  try {
+    const json = JSON.parse(readFileSync(absPath, "utf-8"));
+    return {
+      name: json.name || root,
+      root: json.root ? toPosix(json.root) : root,
+      type: json.projectType || null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect NX projects in a repository using static file reads only.
+ * No NX runtime, daemon, or `npm install` is required — safe to run in the
+ * weekly clone-and-scan worker.
+ *
+ * Detection:
+ *   - isNx: an `nx.json` exists at the repo root
+ *   - projects: discovered by globbing `project.json` files and `package.json`
+ *     files that carry an `nx` field. Each project's `root` is its directory
+ *     relative to the repo (POSIX-style, matching analyzer relative paths).
+ *
+ * @param repoPath - Absolute path to the repository root
+ */
+export function detectNxProjects(
+  repoPath: string,
+): { isNx: boolean; projects: NxProject[] } {
+  const isNx = existsSync(join(repoPath, "nx.json"));
+
+  if (!isNx) {
+    return { isNx: false, projects: [] };
+  }
+
+  const projects: NxProject[] = [];
+  const seenRoots = new Set<string>();
+
+  // project.json is the canonical NX project marker
+  const projectFiles = globSync("**/project.json", {
+    cwd: repoPath,
+    ignore: ["**/node_modules/**", "**/dist/**", "**/build/**"],
+    absolute: false,
+  }) as string[];
+
+  for (const file of projectFiles) {
+    const root = toPosix(dirname(file));
+    if (seenRoots.has(root)) continue;
+    const project = readProjectFile(join(repoPath, file), root);
+    if (project) {
+      projects.push(project);
+      seenRoots.add(root);
+    }
+  }
+
+  // package.json files with an `nx` field are also valid NX projects
+  const packageFiles = globSync("**/package.json", {
+    cwd: repoPath,
+    ignore: ["**/node_modules/**", "**/dist/**", "**/build/**"],
+    absolute: false,
+  }) as string[];
+
+  for (const file of packageFiles) {
+    const root = toPosix(dirname(file));
+    if (seenRoots.has(root)) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(join(repoPath, file), "utf-8"));
+      // Only treat as a project if it opts into NX or declares a workspace name
+      if (pkg.nx || (pkg.name && root !== ".")) {
+        projects.push({
+          name: pkg.nx?.name || pkg.name || root,
+          root,
+          type: pkg.nx?.projectType || null,
+        });
+        seenRoots.add(root);
+      }
+    } catch {
+      // Skip unparseable package.json files
+    }
+  }
+
+  return { isNx: true, projects };
+}
+
+/**
+ * Build an index for fast longest-prefix project resolution.
+ * Roots are sorted longest-first so the first match wins.
+ */
+export function buildProjectIndex(
+  projects: NxProject[],
+): NxProjectIndexEntry[] {
+  return projects
+    .map((p) => ({
+      name: p.name,
+      root: p.root,
+      // Normalise root to a path prefix ending in '/', except for the repo root '.'
+      prefix: p.root === "." ? "" : `${p.root.replace(/\/+$/, "")}/`,
+    }))
+    .sort((a, b) => b.prefix.length - a.prefix.length);
+}
+
+/**
+ * Resolve which NX project a file belongs to via longest-matching root prefix.
+ * Files matching no project root fall into the `(unassigned)` bucket.
+ *
+ * @param relativePath - Repo-relative file path (POSIX or native sep)
+ * @param projectIndex - From buildProjectIndex
+ */
+export function resolveProject(
+  relativePath: string,
+  projectIndex: NxProjectIndexEntry[] | null,
+): string {
+  if (!projectIndex || projectIndex.length === 0) return UNASSIGNED;
+  const path = toPosix(relativePath);
+  for (const project of projectIndex) {
+    if (project.prefix === "" || path.startsWith(project.prefix)) {
+      return project.name;
+    }
+  }
+  return UNASSIGNED;
+}

--- a/packages/backpack-adoption-guard/src/analysis/nx-projects.ts
+++ b/packages/backpack-adoption-guard/src/analysis/nx-projects.ts
@@ -15,9 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Verbatim port of Skyscanner/ds-analyser src/nx-projects.js to TypeScript.
-// Behaviour matches the JS source one-for-one; see analyze-repository.ts for
-// the verbatim-port convention used across this package.
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, sep } from "node:path";
 
@@ -25,17 +22,9 @@ import { globSync } from "glob";
 
 export const UNASSIGNED = "(unassigned)";
 
-export type NxProject = {
-  name: string;
-  root: string;
-  type: string | null;
-};
+export type NxProject = { name: string; root: string; type: string | null };
 
-export type NxProjectIndexEntry = {
-  name: string;
-  root: string;
-  prefix: string;
-};
+export type NxProjectIndexEntry = { name: string; root: string; prefix: string };
 
 function toPosix(p: string): string {
   return sep === "/" ? p : p.split(sep).join("/");
@@ -54,39 +43,21 @@ function readProjectFile(absPath: string, root: string): NxProject | null {
   }
 }
 
-/**
- * Detect NX projects in a repository using static file reads only.
- * No NX runtime, daemon, or `npm install` is required — safe to run in the
- * weekly clone-and-scan worker.
- *
- * Detection:
- *   - isNx: an `nx.json` exists at the repo root
- *   - projects: discovered by globbing `project.json` files and `package.json`
- *     files that carry an `nx` field. Each project's `root` is its directory
- *     relative to the repo (POSIX-style, matching analyzer relative paths).
- *
- * @param repoPath - Absolute path to the repository root
- */
 export function detectNxProjects(
   repoPath: string,
 ): { isNx: boolean; projects: NxProject[] } {
   const isNx = existsSync(join(repoPath, "nx.json"));
-
-  if (!isNx) {
-    return { isNx: false, projects: [] };
-  }
+  if (!isNx) return { isNx: false, projects: [] };
 
   const projects: NxProject[] = [];
   const seenRoots = new Set<string>();
-
-  // project.json is the canonical NX project marker
-  const projectFiles = globSync("**/project.json", {
+  const options = {
     cwd: repoPath,
     ignore: ["**/node_modules/**", "**/dist/**", "**/build/**"],
     absolute: false,
-  }) as string[];
+  };
 
-  for (const file of projectFiles) {
+  for (const file of globSync("**/project.json", options) as string[]) {
     const root = toPosix(dirname(file));
     if (seenRoots.has(root)) continue;
     const project = readProjectFile(join(repoPath, file), root);
@@ -96,19 +67,11 @@ export function detectNxProjects(
     }
   }
 
-  // package.json files with an `nx` field are also valid NX projects
-  const packageFiles = globSync("**/package.json", {
-    cwd: repoPath,
-    ignore: ["**/node_modules/**", "**/dist/**", "**/build/**"],
-    absolute: false,
-  }) as string[];
-
-  for (const file of packageFiles) {
+  for (const file of globSync("**/package.json", options) as string[]) {
     const root = toPosix(dirname(file));
     if (seenRoots.has(root)) continue;
     try {
       const pkg = JSON.parse(readFileSync(join(repoPath, file), "utf-8"));
-      // Only treat as a project if it opts into NX or declares a workspace name
       if (pkg.nx || (pkg.name && root !== ".")) {
         projects.push({
           name: pkg.nx?.name || pkg.name || root,
@@ -118,37 +81,23 @@ export function detectNxProjects(
         seenRoots.add(root);
       }
     } catch {
-      // Skip unparseable package.json files
+      // Skip unparseable package.json files.
     }
   }
 
   return { isNx: true, projects };
 }
 
-/**
- * Build an index for fast longest-prefix project resolution.
- * Roots are sorted longest-first so the first match wins.
- */
-export function buildProjectIndex(
-  projects: NxProject[],
-): NxProjectIndexEntry[] {
+export function buildProjectIndex(projects: NxProject[]): NxProjectIndexEntry[] {
   return projects
-    .map((p) => ({
-      name: p.name,
-      root: p.root,
-      // Normalise root to a path prefix ending in '/', except for the repo root '.'
-      prefix: p.root === "." ? "" : `${p.root.replace(/\/+$/, "")}/`,
+    .map((project) => ({
+      name: project.name,
+      root: project.root,
+      prefix: project.root === "." ? "" : `${project.root.replace(/\/+$/, "")}/`,
     }))
     .sort((a, b) => b.prefix.length - a.prefix.length);
 }
 
-/**
- * Resolve which NX project a file belongs to via longest-matching root prefix.
- * Files matching no project root fall into the `(unassigned)` bucket.
- *
- * @param relativePath - Repo-relative file path (POSIX or native sep)
- * @param projectIndex - From buildProjectIndex
- */
 export function resolveProject(
   relativePath: string,
   projectIndex: NxProjectIndexEntry[] | null,

--- a/packages/backpack-adoption-guard/src/guard/evaluate-guard-test.ts
+++ b/packages/backpack-adoption-guard/src/guard/evaluate-guard-test.ts
@@ -16,11 +16,9 @@
  * limitations under the License.
  */
 import {
-  combineGuardStatuses,
   evaluateGuard,
-  evaluateProjectGuards,
 } from "./evaluate-guard";
-import type { AdoptionReport, GuardResult } from "../shared/types";
+import type { AdoptionReport } from "../shared/types";
 
 const reportWithBackpackPercentage = (percentage: number): AdoptionReport => ({
   repository: "repo",
@@ -234,135 +232,5 @@ describe("evaluateGuard", () => {
     expect(result.status).toBe("pass");
     expect(result.threshold).toBe(70);
     expect(result.reason).toContain("70% threshold");
-  });
-});
-
-const reportWithProjects = (
-  overallPercentage: number,
-  projects: Record<string, number>,
-): AdoptionReport => {
-  const report = reportWithBackpackPercentage(overallPercentage);
-  report.projects = {};
-  for (const [name, percentage] of Object.entries(projects)) {
-    report.projects[name] = reportWithBackpackPercentage(percentage);
-  }
-  return report;
-};
-
-describe("evaluateProjectGuards", () => {
-  it("evaluates each project independently using the same rules as evaluateGuard", () => {
-    const baseReport = reportWithProjects(65, { flights: 70, hotels: 50 });
-    const headReport = reportWithProjects(66, { flights: 65, hotels: 55 });
-
-    const results = evaluateProjectGuards({
-      baseReport,
-      dryRun: false,
-      headReport,
-      isMain: false,
-      threshold: DEFAULT_THRESHOLD,
-    });
-
-    // flights: base (70) >= threshold, head decreased (65) -> fail
-    expect(results.flights.status).toBe("fail");
-    // hotels: base (50) < threshold -> pass regardless of head movement
-    expect(results.hotels.status).toBe("pass");
-  });
-
-  it("treats a project missing from base as unable to compare", () => {
-    const baseReport = reportWithProjects(65, { flights: 70 });
-    const headReport = reportWithProjects(66, { flights: 70, hotels: 55 });
-
-    const results = evaluateProjectGuards({
-      baseReport,
-      dryRun: false,
-      headReport,
-      isMain: false,
-      threshold: DEFAULT_THRESHOLD,
-    });
-
-    expect(results.hotels.status).toBe("fail");
-    expect(results.hotels.reason).toContain("Could not load `main`");
-  });
-
-  it("skips projects that exist only in base (removed in this PR)", () => {
-    const baseReport = reportWithProjects(65, { flights: 70, hotels: 50 });
-    const headReport = reportWithProjects(66, { flights: 70 });
-
-    const results = evaluateProjectGuards({
-      baseReport,
-      dryRun: false,
-      headReport,
-      isMain: false,
-      threshold: DEFAULT_THRESHOLD,
-    });
-
-    expect(Object.keys(results)).toEqual(["flights"]);
-  });
-
-  it("returns an empty map when neither side has NX projects", () => {
-    const results = evaluateProjectGuards({
-      baseReport: reportWithBackpackPercentage(65),
-      dryRun: false,
-      headReport: reportWithBackpackPercentage(66),
-      isMain: false,
-      threshold: DEFAULT_THRESHOLD,
-    });
-
-    expect(results).toEqual({});
-  });
-});
-
-describe("combineGuardStatuses", () => {
-  const passResult: GuardResult = {
-    status: "pass",
-    reason: "ok",
-    dryRun: false,
-    threshold: 60,
-    baseBackpackPercentage: 65,
-    headBackpackPercentage: 66,
-    delta: 1,
-  };
-
-  it("returns fail when the overall status passes but a project fails", () => {
-    const failingProject: GuardResult = { ...passResult, status: "fail" };
-
-    const combined = combineGuardStatuses(passResult, {
-      flights: failingProject,
-      hotels: passResult,
-    });
-
-    expect(combined).toBe("fail");
-  });
-
-  it("returns warn when no project fails but one warns", () => {
-    const warningProject: GuardResult = { ...passResult, status: "warn" };
-
-    const combined = combineGuardStatuses(passResult, {
-      flights: warningProject,
-      hotels: passResult,
-    });
-
-    expect(combined).toBe("warn");
-  });
-
-  it("keeps the overall status when no project fails or warns", () => {
-    const combined = combineGuardStatuses(passResult, {
-      flights: passResult,
-      hotels: passResult,
-    });
-
-    expect(combined).toBe("pass");
-  });
-
-  it("prefers fail over warn when both are present", () => {
-    const failingProject: GuardResult = { ...passResult, status: "fail" };
-    const warningProject: GuardResult = { ...passResult, status: "warn" };
-
-    const combined = combineGuardStatuses(passResult, {
-      flights: failingProject,
-      hotels: warningProject,
-    });
-
-    expect(combined).toBe("fail");
   });
 });

--- a/packages/backpack-adoption-guard/src/guard/evaluate-guard-test.ts
+++ b/packages/backpack-adoption-guard/src/guard/evaluate-guard-test.ts
@@ -15,8 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { evaluateGuard } from "./evaluate-guard";
-import type { AdoptionReport } from "../shared/types";
+import {
+  combineGuardStatuses,
+  evaluateGuard,
+  evaluateProjectGuards,
+} from "./evaluate-guard";
+import type { AdoptionReport, GuardResult } from "../shared/types";
 
 const reportWithBackpackPercentage = (percentage: number): AdoptionReport => ({
   repository: "repo",
@@ -230,5 +234,135 @@ describe("evaluateGuard", () => {
     expect(result.status).toBe("pass");
     expect(result.threshold).toBe(70);
     expect(result.reason).toContain("70% threshold");
+  });
+});
+
+const reportWithProjects = (
+  overallPercentage: number,
+  projects: Record<string, number>,
+): AdoptionReport => {
+  const report = reportWithBackpackPercentage(overallPercentage);
+  report.projects = {};
+  for (const [name, percentage] of Object.entries(projects)) {
+    report.projects[name] = reportWithBackpackPercentage(percentage);
+  }
+  return report;
+};
+
+describe("evaluateProjectGuards", () => {
+  it("evaluates each project independently using the same rules as evaluateGuard", () => {
+    const baseReport = reportWithProjects(65, { flights: 70, hotels: 50 });
+    const headReport = reportWithProjects(66, { flights: 65, hotels: 55 });
+
+    const results = evaluateProjectGuards({
+      baseReport,
+      dryRun: false,
+      headReport,
+      isMain: false,
+      threshold: DEFAULT_THRESHOLD,
+    });
+
+    // flights: base (70) >= threshold, head decreased (65) -> fail
+    expect(results.flights.status).toBe("fail");
+    // hotels: base (50) < threshold -> pass regardless of head movement
+    expect(results.hotels.status).toBe("pass");
+  });
+
+  it("treats a project missing from base as unable to compare", () => {
+    const baseReport = reportWithProjects(65, { flights: 70 });
+    const headReport = reportWithProjects(66, { flights: 70, hotels: 55 });
+
+    const results = evaluateProjectGuards({
+      baseReport,
+      dryRun: false,
+      headReport,
+      isMain: false,
+      threshold: DEFAULT_THRESHOLD,
+    });
+
+    expect(results.hotels.status).toBe("fail");
+    expect(results.hotels.reason).toContain("Could not load `main`");
+  });
+
+  it("skips projects that exist only in base (removed in this PR)", () => {
+    const baseReport = reportWithProjects(65, { flights: 70, hotels: 50 });
+    const headReport = reportWithProjects(66, { flights: 70 });
+
+    const results = evaluateProjectGuards({
+      baseReport,
+      dryRun: false,
+      headReport,
+      isMain: false,
+      threshold: DEFAULT_THRESHOLD,
+    });
+
+    expect(Object.keys(results)).toEqual(["flights"]);
+  });
+
+  it("returns an empty map when neither side has NX projects", () => {
+    const results = evaluateProjectGuards({
+      baseReport: reportWithBackpackPercentage(65),
+      dryRun: false,
+      headReport: reportWithBackpackPercentage(66),
+      isMain: false,
+      threshold: DEFAULT_THRESHOLD,
+    });
+
+    expect(results).toEqual({});
+  });
+});
+
+describe("combineGuardStatuses", () => {
+  const passResult: GuardResult = {
+    status: "pass",
+    reason: "ok",
+    dryRun: false,
+    threshold: 60,
+    baseBackpackPercentage: 65,
+    headBackpackPercentage: 66,
+    delta: 1,
+  };
+
+  it("returns fail when the overall status passes but a project fails", () => {
+    const failingProject: GuardResult = { ...passResult, status: "fail" };
+
+    const combined = combineGuardStatuses(passResult, {
+      flights: failingProject,
+      hotels: passResult,
+    });
+
+    expect(combined).toBe("fail");
+  });
+
+  it("returns warn when no project fails but one warns", () => {
+    const warningProject: GuardResult = { ...passResult, status: "warn" };
+
+    const combined = combineGuardStatuses(passResult, {
+      flights: warningProject,
+      hotels: passResult,
+    });
+
+    expect(combined).toBe("warn");
+  });
+
+  it("keeps the overall status when no project fails or warns", () => {
+    const combined = combineGuardStatuses(passResult, {
+      flights: passResult,
+      hotels: passResult,
+    });
+
+    expect(combined).toBe("pass");
+  });
+
+  it("prefers fail over warn when both are present", () => {
+    const failingProject: GuardResult = { ...passResult, status: "fail" };
+    const warningProject: GuardResult = { ...passResult, status: "warn" };
+
+    const combined = combineGuardStatuses(passResult, {
+      flights: failingProject,
+      hotels: warningProject,
+    });
+
+    expect(combined).toBe("fail");
   });
 });

--- a/packages/backpack-adoption-guard/src/guard/evaluate-guard.ts
+++ b/packages/backpack-adoption-guard/src/guard/evaluate-guard.ts
@@ -18,7 +18,6 @@
 import type {
   AdoptionReport,
   GuardResult,
-  GuardStatus,
 } from "../shared/types";
 
 export const evaluateGuard = ({
@@ -142,73 +141,4 @@ export const evaluateGuard = ({
     headBackpackPercentage,
     delta,
   };
-};
-
-/**
- * Runs evaluateGuard's per-project bucket (including the `(unassigned)`
- * bucket, kept as its own entry rather than special-cased away) so a
- * regression in one NX project fails the guard even if the repo-wide
- * percentage looks fine.
- */
-export const evaluateProjectGuards = ({
-  baseReport,
-  dryRun,
-  headReport,
-  isMain,
-  threshold,
-}: {
-  baseReport: AdoptionReport | null;
-  dryRun: boolean;
-  headReport: AdoptionReport;
-  isMain: boolean;
-  threshold: number;
-}): Record<string, GuardResult> => {
-  const headProjects = headReport.projects || {};
-  const baseProjects = baseReport?.projects || {};
-  const projectNames = Array.from(
-    new Set([...Object.keys(headProjects), ...Object.keys(baseProjects)]),
-  );
-
-  const projectResults: Record<string, GuardResult> = {};
-
-  for (const projectName of projectNames) {
-    const headProjectReport = headProjects[projectName];
-    if (!headProjectReport) {
-      // Project existed on the other side only (e.g. removed in this PR);
-      // nothing to evaluate for the head side.
-      continue;
-    }
-
-    projectResults[projectName] = evaluateGuard({
-      baseReport: baseProjects[projectName] ?? null,
-      dryRun,
-      headReport: headProjectReport,
-      isMain,
-      threshold,
-    });
-  }
-
-  return projectResults;
-};
-
-/**
- * Combines the repo-wide guard result with the per-project results: any
- * project fail forces an overall fail, any project warn forces an overall
- * warn (unless already failing), otherwise the repo-wide status is kept.
- */
-export const combineGuardStatuses = (
-  overall: GuardResult,
-  projectResults: Record<string, GuardResult>,
-): GuardStatus => {
-  const statuses = Object.values(projectResults).map((result) => result.status);
-
-  if (statuses.some((status) => status === "fail")) {
-    return "fail";
-  }
-
-  if (statuses.some((status) => status === "warn")) {
-    return "warn";
-  }
-
-  return overall.status;
 };

--- a/packages/backpack-adoption-guard/src/guard/evaluate-guard.ts
+++ b/packages/backpack-adoption-guard/src/guard/evaluate-guard.ts
@@ -15,7 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { AdoptionReport, GuardResult } from "../shared/types";
+import type {
+  AdoptionReport,
+  GuardResult,
+  GuardStatus,
+} from "../shared/types";
 
 export const evaluateGuard = ({
   baseReport,
@@ -138,4 +142,74 @@ export const evaluateGuard = ({
     headBackpackPercentage,
     delta,
   };
+};
+
+/**
+ * Runs evaluateGuard's per-project bucket (including the `(unassigned)`
+ * bucket, kept as its own entry rather than special-cased away) so a
+ * regression in one NX project fails the guard even if the repo-wide
+ * percentage looks fine.
+ */
+export const evaluateProjectGuards = ({
+  baseReport,
+  dryRun,
+  headReport,
+  isMain,
+  threshold,
+}: {
+  baseReport: AdoptionReport | null;
+  dryRun: boolean;
+  headReport: AdoptionReport;
+  isMain: boolean;
+  threshold: number;
+}): Record<string, GuardResult> => {
+  const headProjects = headReport.projects || {};
+  const baseProjects = baseReport?.projects || {};
+  const projectNames = new Set([
+    ...Object.keys(headProjects),
+    ...Object.keys(baseProjects),
+  ]);
+
+  const projectResults: Record<string, GuardResult> = {};
+
+  for (const projectName of projectNames) {
+    const headProjectReport = headProjects[projectName];
+    if (!headProjectReport) {
+      // Project existed on the other side only (e.g. removed in this PR);
+      // nothing to evaluate for the head side.
+      continue;
+    }
+
+    projectResults[projectName] = evaluateGuard({
+      baseReport: baseProjects[projectName] ?? null,
+      dryRun,
+      headReport: headProjectReport,
+      isMain,
+      threshold,
+    });
+  }
+
+  return projectResults;
+};
+
+/**
+ * Combines the repo-wide guard result with the per-project results: any
+ * project fail forces an overall fail, any project warn forces an overall
+ * warn (unless already failing), otherwise the repo-wide status is kept.
+ */
+export const combineGuardStatuses = (
+  overall: GuardResult,
+  projectResults: Record<string, GuardResult>,
+): GuardStatus => {
+  const statuses = Object.values(projectResults).map((result) => result.status);
+
+  if (statuses.some((status) => status === "fail")) {
+    return "fail";
+  }
+
+  if (statuses.some((status) => status === "warn")) {
+    return "warn";
+  }
+
+  return overall.status;
 };

--- a/packages/backpack-adoption-guard/src/guard/evaluate-guard.ts
+++ b/packages/backpack-adoption-guard/src/guard/evaluate-guard.ts
@@ -165,10 +165,9 @@ export const evaluateProjectGuards = ({
 }): Record<string, GuardResult> => {
   const headProjects = headReport.projects || {};
   const baseProjects = baseReport?.projects || {};
-  const projectNames = new Set([
-    ...Object.keys(headProjects),
-    ...Object.keys(baseProjects),
-  ]);
+  const projectNames = Array.from(
+    new Set([...Object.keys(headProjects), ...Object.keys(baseProjects)]),
+  );
 
   const projectResults: Record<string, GuardResult> = {};
 

--- a/packages/backpack-adoption-guard/src/shared/types.ts
+++ b/packages/backpack-adoption-guard/src/shared/types.ts
@@ -39,6 +39,12 @@ export type AdoptionReport = {
   backpackWebVersion: string | null;
   usage: UsageSummary;
   componentCounts: Record<string, number>;
+  // Present when the repository is an NX workspace (an `nx.json` exists at
+  // the root). `projects` maps NX project name -> that project's own
+  // AdoptionReport slice, including the `(unassigned)` bucket for files that
+  // don't fall under any detected project root.
+  isNx?: boolean;
+  projects?: Record<string, Omit<AdoptionReport, "projects" | "isNx">>;
 };
 
 export type GuardStatus = "pass" | "fail" | "warn";
@@ -51,6 +57,9 @@ export type GuardResult = {
   baseBackpackPercentage: number | null;
   headBackpackPercentage: number;
   delta: number | null;
+  // Present on the top-level guard result once per-project evaluation runs;
+  // keyed by NX project name (including the `(unassigned)` bucket).
+  projects?: Record<string, GuardResult>;
 };
 
 export type ActionResult = {
@@ -80,6 +89,10 @@ export type BackpackAdoptionMetrics = {
   filesAnalyzed: number;
   skippedFiles: number;
   usage: UsageSummary;
+  // Lightweight per-project metrics for NX workspaces. Deliberately omits
+  // componentCounts to keep the Cortex payload small (mirrors ds-analyser's
+  // toProjectTimeSeriesBlock).
+  projects?: Record<string, UsageSummary & { filesAnalyzed: number }>;
 };
 
 export type ResultsFile = {


### PR DESCRIPTION
## Summary

- Adds optional Nx project attribution to the adoption analysis engine:
  project discovery, file-to-project mapping, per-project metric buckets, and
  an `(unassigned)` bucket.
- Keeps `backpack-adoption-guard` repository-wide: the GitHub Action does not
  enable Nx analysis and does not produce per-project summaries, thresholds, or
  blocking decisions.
- Establishes the analysis foundation that PR #4915 moves into
  `backpack-adoption-analyzer`; the public Nx plugin will enable and consume
  the per-project capability separately.

## Review order

PR 1 of 3. This introduces the opt-in Nx analysis foundation in the current
Guard codebase. PR #4915 extracts it into `backpack-adoption-analyzer`; the
public Nx plugin follows in PR 3.

## Validation

- Guard lint, test, typecheck, and bundle build
- Nx project-attribution unit tests
- Carhire whole-repository preview verification