### PR TITLE
[STAR-352] [BpkBadge] Wrap BpkBadge in forwardRef

### DIFF
--- a/packages/backpack-web/src/bpk-component-badge/README.md
+++ b/packages/backpack-web/src/bpk-component-badge/README.md
@@ -89,7 +89,7 @@ export default () => (
 );
 ```
 
-`BpkBadge` forwards its `ref` to the underlying `<button>` (when `as="button"`) or `<a>` (when `as="a"`) element. For a plain `<span>` badge, no ref is forwarded.
+`BpkBadge` forwards its `ref` to the underlying `<button>` (when `as="button"`) or `<a>` (when `as="a"`) element. For non-interactive `<span>` badge, no ref is forwarded.
 
 ### Accessibility
 

--- a/packages/backpack-web/src/bpk-component-badge/README.md
+++ b/packages/backpack-web/src/bpk-component-badge/README.md
@@ -89,6 +89,8 @@ export default () => (
 );
 ```
 
+`BpkBadge` forwards its `ref` to the underlying `<button>` (when `as="button"`) or `<a>` (when `as="a"`) element. For a plain `<span>` badge, no ref is forwarded.
+
 ### Accessibility
 
 Non-interactive badges render as `<span>` element. Interactive badges render as native `<button>` or `<a>` elements, so keyboard navigation and screen reader announcement work without any extra configuration. The trailing info icon is marked `aria-hidden`.

--- a/packages/backpack-web/src/bpk-component-badge/src/BpkBadge.tsx
+++ b/packages/backpack-web/src/bpk-component-badge/src/BpkBadge.tsx
@@ -15,7 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ReactNode, AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes } from 'react';
+import type { ReactNode, AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, Ref} from 'react';
+import { forwardRef } from 'react';
 
 import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
 
@@ -98,7 +99,7 @@ const BadgeInfoCircleLogo = () => (
   </svg>
 );
 
-const BpkBadge = (
+const BpkBadgeInner = (
   {
     as = 'span',
     centered = false,
@@ -108,6 +109,7 @@ const BpkBadge = (
     type = BADGE_TYPES.normal,
     ...rest
   }: Props,
+  ref: Ref<HTMLButtonElement | HTMLAnchorElement >,
 ) => {
   const classNames = getClassName(
     'bpk-badge',
@@ -134,6 +136,7 @@ const BpkBadge = (
     const resolvedTarget = blank ? '_blank' : target;
 
     return (<a
+      ref={ref as Ref<HTMLAnchorElement>}
       rel={resolvedRel}
       {...anchorRest}
       className={classNames}
@@ -149,6 +152,7 @@ const BpkBadge = (
     const buttonRest = rest as Omit<ButtonProps, 'as' | 'children'>;
     return (
       <button
+        ref={ref as Ref<HTMLButtonElement>}
         {...buttonRest}
         type="button"
         className={classNames}
@@ -168,5 +172,7 @@ const BpkBadge = (
     >{children}</span>
   );
 };
+
+const BpkBadge = forwardRef(BpkBadgeInner);
 
 export default BpkBadge;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
## BpkBadge Interactive 
This PR is a follow up to https://github.com/Skyscanner/backpack/pull/4896.
It wraps BpkBadge in forwardRef to expose the underlying <button> or <a> DOM node to consumers, following the pattern in BpkPressable. 
The ref is forwarded only for interactive variants (`as="button"` or `as="a"`); the default <span> badge does not forward a ref. 
This change is needed for  programmatically focus the badge after an action such as closing a bottom sheet, returning focus to the trigger. 


Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
