### PR TITLE
Document registry-blocked install workaround, switch install examples to pnpm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,19 @@ Backpack is developed using Node. The required Node version is specified in `.nv
 
 If you use [nvm](https://github.com/creationix/nvm) or [nave](https://github.com/isaacs/nave) to manage your Node environment, Backpack has built-in support for these. Just run `nvm use` or `nave auto` to install the correct Node version.
 
-To install npm, use `npm install --global npm@^<version>`. For example, `npm install --global npm@^9.5.1`.
+Backpack uses pnpm as its package manager, pinned via the `packageManager` field in `package.json`. Run `corepack enable` to have the correct pnpm version resolved automatically.
+
+### Package registry access
+
+If your work device blocks direct access to public package registries (e.g. via a corporate network policy), do not edit this repository's `.npmrc` — it must keep pointing at the public npm registry so that external contributors without access to an internal registry mirror can still install dependencies.
+
+Instead, point your own environment at your organisation's allow-listed registry mirror with an environment variable, which takes precedence over the project-level `.npmrc`:
+
+```sh
+export npm_config_registry=<your-internal-registry-url>
+```
+
+Add this to your shell profile (e.g. `~/.zshrc`) so it persists across sessions, then run `pnpm install` as usual.
 
 ### Code style
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@
 ### Installation
 
 ```sh
-npm install --save @skyscanner/backpack-web
+pnpm add @skyscanner/backpack-web
 ```
+
+> If your device blocks direct access to public package registries, see [Package registry access](CONTRIBUTING.md#package-registry-access) in the contributing guide.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Some contributors' machines block direct access to public package registries via corporate network policy, which breaks a plain `pnpm install`. Added a "Package registry access" section to CONTRIBUTING.md documenting the env-var override (`npm_config_registry`), which takes precedence over the project-level `.npmrc` — this repo's `.npmrc` must stay pointed at the public npm registry so external contributors without an internal registry mirror can still install.
- Updated the stale `npm install --save`/`npm install --global npm@...` examples in README.md/CONTRIBUTING.md to `pnpm add`/`corepack enable`, matching the `packageManager` pin already in `package.json`.

## Test plan
- [ ] Docs-only change — no functional code affected
- [ ] Confirm rendered Markdown (headings, anchors, code blocks) look correct on GitHub