### PR TITLE
[CLOV-1868] Part 3: add public Backpack Adoption NX plugin

### DIFF
--- a/.github/actions/compute-next-semver/action.yml
+++ b/.github/actions/compute-next-semver/action.yml
@@ -1,0 +1,73 @@
+name: Compute next semver release tag
+description: Computes the next stable semver version and tag for a package release.
+
+inputs:
+  release_type:
+    description: Semver component to increment.
+    required: true
+  tag_prefix:
+    description: Prefix before /vX.Y.Z in release tags.
+    required: true
+
+outputs:
+  release_tag:
+    description: The next release tag.
+    value: ${{ steps.compute.outputs.release_tag }}
+  release_version:
+    description: The next release version.
+    value: ${{ steps.compute.outputs.release_version }}
+
+runs:
+  using: composite
+  steps:
+    - id: compute
+      shell: bash
+      env:
+        RELEASE_TYPE: ${{ inputs.release_type }}
+        TAG_PREFIX: ${{ inputs.tag_prefix }}
+      run: |
+        case "$RELEASE_TYPE" in
+          patch|minor|major) ;;
+          *)
+            echo "::error::release_type must be patch, minor, or major (got: $RELEASE_TYPE)"
+            exit 1
+            ;;
+        esac
+
+        latest_version="$(
+          while IFS= read -r tag; do
+            version="${tag#"$TAG_PREFIX"/v}"
+            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "$version"
+            fi
+          done < <(git tag --list "$TAG_PREFIX/v*" | sort -V)
+        )"
+        latest_version="$(printf '%s\n' "$latest_version" | tail -n 1)"
+
+        if [ -z "$latest_version" ]; then
+          case "$RELEASE_TYPE" in
+            major) next_version="1.0.0" ;;
+            minor) next_version="0.1.0" ;;
+            patch) next_version="0.0.1" ;;
+          esac
+        else
+          IFS=. read -r major minor patch <<< "$latest_version"
+          case "$RELEASE_TYPE" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          next_version="${major}.${minor}.${patch}"
+        fi
+
+        {
+          echo "release_version=${next_version}"
+          echo "release_tag=${TAG_PREFIX}/v${next_version}"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/backpack-adoption-guard-release.yml
+++ b/.github/workflows/backpack-adoption-guard-release.yml
@@ -51,59 +51,14 @@ jobs:
           echo "target_sha=${sha}" >> "$GITHUB_OUTPUT"
           echo "Resolved ${GITHUB_REF} -> ${sha}"
 
+      - run: git fetch --force --tags origin
+
       - name: Compute next release tag
         id: compute
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-        run: |
-          case "$RELEASE_TYPE" in
-            patch|minor|major) ;;
-            *)
-              echo "::error::release_type must be patch, minor, or major (got: $RELEASE_TYPE)"
-              exit 1
-              ;;
-          esac
-
-          git fetch --force --tags origin
-
-          latest_version="$(
-            git tag --list 'backpack-adoption-guard/v[0-9]*.[0-9]*.[0-9]*' \
-              | sed -nE 's#^backpack-adoption-guard/v([0-9]+)\.([0-9]+)\.([0-9]+)$#\1.\2.\3#p' \
-              | sort -V \
-              | tail -n 1
-          )"
-
-          if [ -z "$latest_version" ]; then
-            case "$RELEASE_TYPE" in
-              major) next_version="1.0.0" ;;
-              minor) next_version="0.1.0" ;;
-              patch) next_version="0.0.1" ;;
-            esac
-          else
-            IFS=. read -r major minor patch <<< "$latest_version"
-            case "$RELEASE_TYPE" in
-              major)
-                major=$((major + 1))
-                minor=0
-                patch=0
-                ;;
-              minor)
-                minor=$((minor + 1))
-                patch=0
-                ;;
-              patch)
-                patch=$((patch + 1))
-                ;;
-            esac
-            next_version="${major}.${minor}.${patch}"
-          fi
-
-          {
-            echo "release_version=${next_version}"
-            echo "release_tag=backpack-adoption-guard/v${next_version}"
-          } >> "$GITHUB_OUTPUT"
-          echo "Latest release: ${latest_version:-none}"
-          echo "Next ${RELEASE_TYPE} release: ${next_version}"
+        uses: ./.github/actions/compute-next-semver
+        with:
+          release_type: ${{ inputs.release_type }}
+          tag_prefix: backpack-adoption-guard
 
       - name: Ensure release tag does not already exist
         env:

--- a/.github/workflows/backpack-adoption-nx-plugin-release.yml
+++ b/.github/workflows/backpack-adoption-nx-plugin-release.yml
@@ -113,12 +113,11 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: .nvmrc
+          # Node 24 includes npm 11, required for npm trusted publishing OIDC.
+          node-version: 24.14.0
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
-      # npm trusted publishing requires npm 11.5.1 or newer for OIDC support.
-      - run: npm install --global npm@11.5.1
       - run: pnpm install --frozen-lockfile
       - run: npx nx run backpack-adoption-nx-plugin:build
       - name: Stamp release version

--- a/.github/workflows/backpack-adoption-nx-plugin-release.yml
+++ b/.github/workflows/backpack-adoption-nx-plugin-release.yml
@@ -59,6 +59,15 @@ jobs:
           release_type: ${{ inputs.release_type || 'minor' }}
           tag_prefix: backpack-adoption-nx-plugin
 
+      - name: Ensure release tag does not already exist
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+        run: |
+          if git rev-parse "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $RELEASE_TAG already exists"
+            exit 1
+          fi
+
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -107,6 +116,15 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: npx nx run backpack-adoption-nx-plugin:build
+      - name: Recheck release tag before publishing
+        env:
+          RELEASE_TAG: ${{ needs.Validate.outputs.release_tag }}
+        run: |
+          git fetch --force --tags origin
+          if git rev-parse "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $RELEASE_TAG already exists"
+            exit 1
+          fi
       - name: Stamp release version
         env:
           RELEASE_VERSION: ${{ needs.Validate.outputs.release_version }}

--- a/.github/workflows/backpack-adoption-nx-plugin-release.yml
+++ b/.github/workflows/backpack-adoption-nx-plugin-release.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/backpack-adoption-nx-plugin-release.yml'
-      - 'packages/backpack-adoption-analyzer/**'
+      - 'libs/backpack-adoption-analyzer/**'
       - 'packages/backpack-adoption-nx-plugin/**'
       - 'pnpm-lock.yaml'
       - 'tsconfig.json'
@@ -37,7 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     outputs:
       release_tag: ${{ steps.version.outputs.release_tag }}
       release_version: ${{ steps.version.outputs.release_version }}
@@ -96,6 +95,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run && github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
@@ -117,6 +117,8 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
+      # npm trusted publishing requires npm 11.5.1 or newer for OIDC support.
+      - run: npm install --global npm@11.5.1
       - run: pnpm install --frozen-lockfile
       - run: npx nx run backpack-adoption-nx-plugin:build
       - name: Stamp release version

--- a/.github/workflows/backpack-adoption-nx-plugin-release.yml
+++ b/.github/workflows/backpack-adoption-nx-plugin-release.yml
@@ -1,6 +1,13 @@
 name: Backpack Adoption NX Plugin Release
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/backpack-adoption-nx-plugin-release.yml'
+      - 'packages/backpack-adoption-analyzer/**'
+      - 'packages/backpack-adoption-nx-plugin/**'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.json'
   workflow_dispatch:
     inputs:
       release_type:
@@ -46,7 +53,7 @@ jobs:
 
       - id: version
         env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
+          RELEASE_TYPE: ${{ inputs.release_type || 'minor' }}
         run: |
           git fetch --force --tags origin
           latest="$(git tag --list 'backpack-adoption-nx-plugin/v[0-9]*.[0-9]*.[0-9]*' | sed -nE 's#^backpack-adoption-nx-plugin/v([0-9]+\.[0-9]+\.[0-9]+)$#\1#p' | sort -V | tail -n 1)"
@@ -86,7 +93,7 @@ jobs:
   Publish:
     runs-on: ubuntu-latest
     needs: Validate
-    if: ${{ !inputs.dry_run && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run && github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/backpack-adoption-nx-plugin-release.yml
+++ b/.github/workflows/backpack-adoption-nx-plugin-release.yml
@@ -43,7 +43,7 @@ jobs:
       release_version: ${{ steps.version.outputs.release_version }}
       target_sha: ${{ steps.source.outputs.target_sha }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -104,7 +104,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-contents: write
 
-      - uses: actions/checkout@9c091bb21b7c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.Validate.outputs.target_sha }}
           persist-credentials: false

--- a/.github/workflows/backpack-adoption-nx-plugin-release.yml
+++ b/.github/workflows/backpack-adoption-nx-plugin-release.yml
@@ -1,0 +1,132 @@
+name: Backpack Adoption NX Plugin Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Semver bump to release
+        required: true
+        type: choice
+        default: minor
+        options: [patch, minor, major]
+      dry_run:
+        description: Validate only; do not publish or tag
+        required: false
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+permissions: {}
+
+concurrency:
+  group: backpack-adoption-nx-plugin-release
+  cancel-in-progress: false
+
+jobs:
+  Validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      release_version: ${{ steps.version.outputs.release_version }}
+      target_sha: ${{ steps.source.outputs.target_sha }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: source
+        run: echo "target_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - id: version
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        run: |
+          git fetch --force --tags origin
+          latest="$(git tag --list 'backpack-adoption-nx-plugin/v[0-9]*.[0-9]*.[0-9]*' | sed -nE 's#^backpack-adoption-nx-plugin/v([0-9]+\.[0-9]+\.[0-9]+)$#\1#p' | sort -V | tail -n 1)"
+          if [ -z "$latest" ]; then
+            case "$RELEASE_TYPE" in
+              major) next="1.0.0" ;;
+              minor) next="0.1.0" ;;
+              patch) next="0.0.1" ;;
+            esac
+          else
+            IFS=. read -r major minor patch <<< "$latest"
+            case "$RELEASE_TYPE" in
+              major) next="$((major + 1)).0.0" ;;
+              minor) next="$major.$((minor + 1)).0" ;;
+              patch) next="$major.$minor.$((patch + 1))" ;;
+            esac
+          fi
+          echo "release_version=$next" >> "$GITHUB_OUTPUT"
+          echo "release_tag=backpack-adoption-nx-plugin/v$next" >> "$GITHUB_OUTPUT"
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: npx nx run backpack-adoption-nx-plugin:lint
+      - run: npx nx run backpack-adoption-nx-plugin:typecheck
+      - run: npx nx run backpack-adoption-nx-plugin:test
+      - run: npx nx run backpack-adoption-nx-plugin:build
+      - run: npm pack --dry-run --ignore-scripts
+        working-directory: packages/backpack-adoption-nx-plugin
+
+  Publish:
+    runs-on: ubuntu-latest
+    needs: Validate
+    if: ${{ !inputs.dry_run && github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - uses: actions/checkout@9c091bb21b7c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.Validate.outputs.target_sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: npx nx run backpack-adoption-nx-plugin:build
+      - name: Stamp release version
+        env:
+          RELEASE_VERSION: ${{ needs.Validate.outputs.release_version }}
+        run: npm version "$RELEASE_VERSION" --no-git-tag-version --ignore-scripts
+        working-directory: packages/backpack-adoption-nx-plugin
+      - name: Publish public npm package
+        run: npm publish --ignore-scripts --access public --provenance
+        working-directory: packages/backpack-adoption-nx-plugin
+      - name: Create and push release tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_TAG: ${{ needs.Validate.outputs.release_tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$RELEASE_TAG" -m "$RELEASE_TAG"
+          basic_auth="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${basic_auth}" push origin "refs/tags/$RELEASE_TAG"

--- a/.github/workflows/backpack-adoption-nx-plugin-release.yml
+++ b/.github/workflows/backpack-adoption-nx-plugin-release.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/backpack-adoption-nx-plugin-release.yml'
+      - '.github/actions/compute-next-semver/**'
       - 'libs/backpack-adoption-analyzer/**'
       - 'packages/backpack-adoption-nx-plugin/**'
       - 'pnpm-lock.yaml'
@@ -29,7 +30,7 @@ defaults:
 permissions: {}
 
 concurrency:
-  group: backpack-adoption-nx-plugin-release
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -50,28 +51,13 @@ jobs:
       - id: source
         run: echo "target_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - run: git fetch --force --tags origin
+
       - id: version
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type || 'minor' }}
-        run: |
-          git fetch --force --tags origin
-          latest="$(git tag --list 'backpack-adoption-nx-plugin/v[0-9]*.[0-9]*.[0-9]*' | sed -nE 's#^backpack-adoption-nx-plugin/v([0-9]+\.[0-9]+\.[0-9]+)$#\1#p' | sort -V | tail -n 1)"
-          if [ -z "$latest" ]; then
-            case "$RELEASE_TYPE" in
-              major) next="1.0.0" ;;
-              minor) next="0.1.0" ;;
-              patch) next="0.0.1" ;;
-            esac
-          else
-            IFS=. read -r major minor patch <<< "$latest"
-            case "$RELEASE_TYPE" in
-              major) next="$((major + 1)).0.0" ;;
-              minor) next="$major.$((minor + 1)).0" ;;
-              patch) next="$major.$minor.$((patch + 1))" ;;
-            esac
-          fi
-          echo "release_version=$next" >> "$GITHUB_OUTPUT"
-          echo "release_tag=backpack-adoption-nx-plugin/v$next" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/compute-next-semver
+        with:
+          release_type: ${{ inputs.release_type || 'minor' }}
+          tag_prefix: backpack-adoption-nx-plugin
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -113,7 +99,8 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          # Node 24 includes npm 11, required for npm trusted publishing OIDC.
+          # Validation uses .nvmrc; Node 24 is only used here because its npm
+          # 11 supports npm trusted publishing through OIDC.
           node-version: 24.14.0
           registry-url: https://registry.npmjs.org
           cache: pnpm

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /dist
 /packages/backpack-web/dist
 /packages/backpack-adoption-guard/dist
+/packages/backpack-adoption-nx-plugin/dist
 /dist-sassdoc
 /libs/backpack-storybook-host/dist-storybook
 /coverage

--- a/packages/backpack-adoption-nx-plugin/.eslintrc
+++ b/packages/backpack-adoption-nx-plugin/.eslintrc
@@ -1,0 +1,43 @@
+{
+  "extends": "../../.eslintrc",
+  "env": {
+    "browser": false,
+    "node": true,
+    "jest": true
+  },
+  "rules": {
+    "@nx/enforce-module-boundaries": [
+      "error",
+      {
+        "enforceBuildableLibDependency": false,
+        "allow": [],
+        "depConstraints": [
+          {
+            "sourceTag": "scope:publishable",
+            "onlyDependOnLibsWithTags": ["scope:publishable"]
+          },
+          {
+            "sourceTag": "scope:internal",
+            "onlyDependOnLibsWithTags": ["scope:publishable", "scope:internal"]
+          }
+        ]
+      }
+    ],
+    "backpack/use-tokens": "off",
+    "compat/compat": "off",
+    "dot-notation": "off",
+    "import/order": "off",
+    "import/extensions": "off",
+    "import/prefer-default-export": "off",
+    "no-console": "off",
+    "no-continue": "off",
+    "no-else-return": "off",
+    "no-param-reassign": "off",
+    "no-restricted-syntax": "off",
+    "prefer-destructuring": "off",
+    "sort-destructure-keys/sort-destructure-keys": "off",
+    "valid-jsdoc": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/packages/backpack-adoption-nx-plugin/README.md
+++ b/packages/backpack-adoption-nx-plugin/README.md
@@ -41,8 +41,10 @@ writes `adoption-guard-results.json` in that root and always succeeds so all
 projects can report their results before the final verdict is calculated.
 
 For pull-request comparisons, provide `baseWorktreePath` as an absolute path
-to a checkout of the base ref. `dryRun: true` changes otherwise failing
-regressions into warnings.
+to a checkout of the base ref. The base checkout must be **outside** the Nx
+workspace root, otherwise Nx discovers its `project.json` files a second time
+and fails while constructing the project graph. `dryRun: true` changes
+otherwise failing regressions into warnings.
 
 ## Aggregate the result
 

--- a/packages/backpack-adoption-nx-plugin/README.md
+++ b/packages/backpack-adoption-nx-plugin/README.md
@@ -1,0 +1,104 @@
+# Backpack Adoption Guard NX Plugin
+
+This public npm package provides per-project Backpack adoption guard thresholds. Each
+project runs the `analyze` executor and writes its own result file; a workspace
+target runs the `report` executor after those tasks and produces the overall
+pass/fail verdict.
+
+It is separate from the GitHub Action package. Use the Action for a single
+whole-repository scan; use this plugin when an NX workspace needs a different
+threshold in each project's `project.json`.
+
+Install it in the consuming workspace:
+
+```bash
+pnpm add -D @skyscanner/backpack-adoption-nx-plugin
+```
+
+The plugin bundle includes Backpack's private analyzer implementation. Consumers
+do not install or configure a separate analyzer package.
+
+## Configure projects
+
+Add an `adoption-guard` target to every project to analyse. `threshold` is
+configured locally, so each project can choose its own adoption starting point.
+
+```json
+{
+  "targets": {
+    "adoption-guard": {
+      "executor": "@skyscanner/backpack-adoption-nx-plugin:analyze",
+      "options": {
+        "threshold": 75
+      }
+    }
+  }
+}
+```
+
+The executor scans `**/*.{jsx,tsx}` below the project root by default. It
+writes `adoption-guard-results.json` in that root and always succeeds so all
+projects can report their results before the final verdict is calculated.
+
+For pull-request comparisons, provide `baseWorktreePath` as an absolute path
+to a checkout of the base ref. `dryRun: true` changes otherwise failing
+regressions into warnings.
+
+## Aggregate the result
+
+Add a workspace-level target that depends on the project targets and invokes
+the `report` executor. The `report` target is the task that fails when any
+project's adoption guard fails.
+
+```json
+{
+  "targets": {
+    "adoption-guard-report": {
+      "executor": "@skyscanner/backpack-adoption-nx-plugin:report",
+      "dependsOn": [
+        { "target": "adoption-guard", "projects": "all" }
+      ],
+      "options": {
+        "projects": ["banana-webapp", "flights-webapp"]
+      }
+    }
+  }
+}
+```
+
+Run the report target to execute the dependency graph and obtain one CI verdict:
+
+```bash
+nx run workspace:adoption-guard-report
+```
+
+`projects` is optional. When omitted, the report executor considers all NX
+projects that have a result file at the configured location. Use
+`resultsFileName` on the report target if the analyse targets use a different
+result filename.
+
+## Publishing
+
+`@skyscanner/backpack-adoption-nx-plugin` is released to the public npm
+registry by the **Backpack Adoption NX Plugin Release** workflow. The published
+bundle contains the private `backpack-adoption-analyzer` implementation, so
+there is no analyzer package for consumers to install or version separately.
+
+## Options
+
+`analyze` options:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `pattern` | `**/*.{jsx,tsx}` | Glob relative to the project root. |
+| `threshold` | `60` | Adoption percentage at which regressions start failing. |
+| `dryRun` | `false` | Downgrade failures to warnings. |
+| `outputPath` | `adoption-guard-results.json` | Result path relative to the project root. |
+| `baseWorktreePath` | — | Absolute workspace-root path for the PR base checkout. |
+
+`report` options:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `projects` | all projects with result files | Project names to aggregate. |
+| `resultsFileName` | `adoption-guard-results.json` | Result filename relative to each project root. |

--- a/packages/backpack-adoption-nx-plugin/README.md
+++ b/packages/backpack-adoption-nx-plugin/README.md
@@ -84,6 +84,10 @@ registry by the **Backpack Adoption NX Plugin Release** workflow. The published
 bundle contains the private `backpack-adoption-analyzer` implementation, so
 there is no analyzer package for consumers to install or version separately.
 
+Pull requests that change the plugin or analyzer run the workflow's validation
+job automatically. The publish job only runs from a manual, non-dry-run
+dispatch on `main`.
+
 ## Options
 
 `analyze` options:

--- a/packages/backpack-adoption-nx-plugin/README.md
+++ b/packages/backpack-adoption-nx-plugin/README.md
@@ -86,7 +86,11 @@ there is no analyzer package for consumers to install or version separately.
 
 Pull requests that change the plugin or analyzer run the workflow's validation
 job automatically. The publish job only runs from a manual, non-dry-run
-dispatch on `main`.
+dispatch on `main`. Before automated publishing, configure npm trusted
+publishing for `@skyscanner/backpack-adoption-nx-plugin` with GitHub Actions:
+organization `Skyscanner`, repository `backpack`, and workflow filename
+`backpack-adoption-nx-plugin-release.yml`. The workflow uses its OIDC identity
+and does not require an npm publish token.
 
 ## Options
 

--- a/packages/backpack-adoption-nx-plugin/README.md
+++ b/packages/backpack-adoption-nx-plugin/README.md
@@ -40,6 +40,10 @@ The executor scans `**/*.{jsx,tsx}` below the project root by default. It
 writes `adoption-guard-results.json` in that root and always succeeds so all
 projects can report their results before the final verdict is calculated.
 
+Without `baseWorktreePath`, this is a metrics-only run: it reports the current
+adoption percentage but does not block. To enforce regression protection in a
+pull-request workflow, provide a checkout of the base ref as described below.
+
 For pull-request comparisons, provide `baseWorktreePath` as an absolute path
 to a checkout of the base ref. The base checkout must be **outside** the Nx
 workspace root, otherwise Nx discovers its `project.json` files a second time
@@ -75,7 +79,9 @@ nx run workspace:adoption-guard-report
 ```
 
 `projects` is optional. When omitted, the report executor considers all NX
-projects that have a result file at the configured location. Use
+projects that have a result file at the configured location. When it is set,
+every listed project must resolve and must have produced a result file; this
+prevents a typo or missing dependency from yielding a false passing verdict. Use
 `resultsFileName` on the report target if the analyse targets use a different
 result filename.
 

--- a/packages/backpack-adoption-nx-plugin/executors.json
+++ b/packages/backpack-adoption-nx-plugin/executors.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "executors": {
+    "analyze": {
+      "implementation": "./dist/executors/analyze/executor.js",
+      "schema": "./dist/executors/analyze/schema.json",
+      "description": "Analyze this NX project's JSX/TSX files for Backpack adoption and write a per-project result file."
+    },
+    "report": {
+      "implementation": "./dist/executors/report/executor.js",
+      "schema": "./dist/executors/report/schema.json",
+      "description": "Aggregate per-project Backpack adoption results (written by the analyze executor) into one pass/fail verdict."
+    }
+  }
+}

--- a/packages/backpack-adoption-nx-plugin/jest.config.js
+++ b/packages/backpack-adoption-nx-plugin/jest.config.js
@@ -1,0 +1,26 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports = {
+  rootDir: __dirname,
+  transform: {
+    '^.+\\.[jt]s$': ['babel-jest', { rootMode: 'upward' }],
+  },
+  testEnvironment: 'node',
+  testRegex: 'src/.*-test\\.ts$',
+  verbose: true,
+};

--- a/packages/backpack-adoption-nx-plugin/package.json
+++ b/packages/backpack-adoption-nx-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyscanner/backpack-adoption-nx-plugin",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -26,10 +26,8 @@
     "test": "jest --config jest.config.js",
     "typecheck": "tsc --project tsconfig.json"
   },
-  "dependencies": {
-    "@nx/devkit": "22.7.1"
-  },
   "peerDependencies": {
+    "@nx/devkit": ">=20",
     "nx": ">=20"
   },
   "devDependencies": {

--- a/packages/backpack-adoption-nx-plugin/package.json
+++ b/packages/backpack-adoption-nx-plugin/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@skyscanner/backpack-adoption-nx-plugin",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Skyscanner/backpack.git",
+    "directory": "packages/backpack-adoption-nx-plugin"
+  },
+  "main": "dist/index.js",
+  "executors": "./executors.json",
+  "exports": {
+    ".": {
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": ["dist", "executors.json", "README.md"],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "build": "node scripts/build.js",
+    "lint": "eslint src jest.config.js --ext .js,.ts",
+    "test": "jest --config jest.config.js",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "dependencies": {
+    "@nx/devkit": "22.7.1"
+  },
+  "peerDependencies": {
+    "nx": ">=20"
+  },
+  "devDependencies": {
+    "@skyscanner/backpack-adoption-analyzer": "workspace:*",
+    "@types/node": "25.9.1",
+    "esbuild": "0.27.7",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/backpack-adoption-nx-plugin/project.json
+++ b/packages/backpack-adoption-nx-plugin/project.json
@@ -1,0 +1,52 @@
+{
+  "name": "backpack-adoption-nx-plugin",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/backpack-adoption-nx-plugin/src",
+  "projectType": "library",
+  "tags": ["scope:internal", "type:tooling"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @skyscanner/backpack-adoption-nx-plugin run build"
+      },
+      "outputs": ["{projectRoot}/dist"],
+      "cache": true,
+      "inputs": ["production", "^production"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @skyscanner/backpack-adoption-nx-plugin run lint"
+      },
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/**/*.{js,ts}",
+        "{workspaceRoot}/.eslintrc*",
+        "{workspaceRoot}/.eslintignore"
+      ]
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @skyscanner/backpack-adoption-nx-plugin run test"
+      },
+      "cache": true,
+      "inputs": ["default", "^production"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @skyscanner/backpack-adoption-nx-plugin run typecheck"
+      },
+      "outputs": [],
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/**/*.ts",
+        "{projectRoot}/tsconfig*.json",
+        "{workspaceRoot}/tsconfig.base.json",
+        "{workspaceRoot}/tsconfig.json"
+      ]
+    }
+  }
+}

--- a/packages/backpack-adoption-nx-plugin/scripts/build.js
+++ b/packages/backpack-adoption-nx-plugin/scripts/build.js
@@ -1,0 +1,53 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const { cpSync, mkdirSync, rmSync } = require("node:fs");
+const { join } = require("node:path");
+
+const { buildSync } = require("esbuild");
+
+const packageRoot = join(__dirname, "..");
+const distRoot = join(packageRoot, "dist");
+
+rmSync(distRoot, { force: true, recursive: true });
+mkdirSync(distRoot, { recursive: true });
+
+const bundle = (entryPoint, outputPath) => {
+  buildSync({
+    bundle: true,
+    entryPoints: [join(packageRoot, entryPoint)],
+    external: ["@nx/devkit"],
+    format: "cjs",
+    outfile: join(distRoot, outputPath),
+    platform: "node",
+    sourcemap: true,
+    target: "node20",
+  });
+};
+
+bundle("src/index.ts", "index.js");
+bundle("src/executors/analyze/executor.ts", "executors/analyze/executor.js");
+bundle("src/executors/report/executor.ts", "executors/report/executor.js");
+
+for (const executor of ["analyze", "report"]) {
+  const destination = join(distRoot, "executors", executor);
+  mkdirSync(destination, { recursive: true });
+  cpSync(
+    join(packageRoot, "src", "executors", executor, "schema.json"),
+    join(destination, "schema.json"),
+  );
+}

--- a/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor-test.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor-test.ts
@@ -120,6 +120,8 @@ export const App = () => <div>Raw HTML only</div>;
     expect(written.headReport.filesAnalyzed).toBe(1);
     expect(written.headReport.usage.backpack.count).toBe(1);
     expect(written.guard.threshold).toBe(75);
+    expect(written.guard.status).toBe("pass");
+    expect(written.guard.reason).toContain("never blocks");
   });
 
   it("compares against a base worktree when baseWorktreePath is provided", async () => {

--- a/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor-test.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor-test.ts
@@ -1,0 +1,167 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import runExecutor from "./executor";
+
+import type { ExecutorContext } from "@nx/devkit";
+import type { AnalyzeExecutorSchema } from "./schema";
+
+const createWorkspace = async () => mkdtemp(join(tmpdir(), "bpk-nx-analyze-test-"));
+
+const writeWorkspaceFile = async (
+  workspaceRoot: string,
+  filePath: string,
+  content: string,
+) => {
+  const absolutePath = join(workspaceRoot, filePath);
+  await mkdir(join(absolutePath, ".."), { recursive: true });
+  await writeFile(absolutePath, content, "utf8");
+};
+
+const buildContext = (
+  workspaceRoot: string,
+  projectName: string,
+  projectRoot: string,
+): ExecutorContext => ({
+  root: workspaceRoot,
+  cwd: workspaceRoot,
+  isVerbose: false,
+  projectName,
+  projectGraph: { nodes: {}, dependencies: {} },
+  projectsConfigurations: {
+    projects: {
+      [projectName]: { root: projectRoot },
+    },
+    version: 2,
+  },
+  nxJsonConfiguration: {},
+});
+
+describe("analyze executor", () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await createWorkspace();
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { force: true, recursive: true });
+  });
+
+  it("fails when the executor context has no project name", async () => {
+    const context = buildContext(workspaceRoot, "flights", "apps/flights");
+    const result = await runExecutor({}, { ...context, projectName: undefined });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when the project root cannot be resolved", async () => {
+    const context: ExecutorContext = {
+      ...buildContext(workspaceRoot, "flights", "apps/flights"),
+      projectsConfigurations: { projects: {}, version: 2 },
+    };
+
+    const result = await runExecutor({}, context);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("analyzes only the target project's files and writes a result file using the configured threshold", async () => {
+    await writeWorkspaceFile(
+      workspaceRoot,
+      "apps/flights/src/App.tsx",
+      `
+import { BpkButton } from '@skyscanner/backpack-web';
+export const App = () => <BpkButton>Go</BpkButton>;
+`,
+    );
+    await writeWorkspaceFile(
+      workspaceRoot,
+      "apps/hotels/src/App.tsx",
+      `
+export const App = () => <div>Raw HTML only</div>;
+`,
+    );
+
+    const context = buildContext(workspaceRoot, "flights", "apps/flights");
+    const options: AnalyzeExecutorSchema = {
+      threshold: 75,
+      outputPath: "results.json",
+    };
+
+    const result = await runExecutor(options, context);
+
+    expect(result.success).toBe(true);
+
+    const written = JSON.parse(
+      await readFile(join(workspaceRoot, "apps/flights/results.json"), "utf8"),
+    );
+
+    expect(written.projectName).toBe("flights");
+    expect(written.threshold).toBe(75);
+    expect(written.headReport.filesAnalyzed).toBe(1);
+    expect(written.headReport.usage.backpack.count).toBe(1);
+    expect(written.guard.threshold).toBe(75);
+  });
+
+  it("compares against a base worktree when baseWorktreePath is provided", async () => {
+    const baseWorktreePath = await createWorkspace();
+    try {
+      await writeWorkspaceFile(
+        baseWorktreePath,
+        "apps/flights/src/App.tsx",
+        `
+import { BpkButton } from '@skyscanner/backpack-web';
+export const App = () => <BpkButton>Go</BpkButton>;
+`,
+      );
+      await writeWorkspaceFile(
+        workspaceRoot,
+        "apps/flights/src/App.tsx",
+        `
+export const App = () => <div>Regressed to raw HTML</div>;
+`,
+      );
+
+      const context = buildContext(workspaceRoot, "flights", "apps/flights");
+      const options: AnalyzeExecutorSchema = {
+        threshold: 50,
+        baseWorktreePath,
+        outputPath: "results.json",
+      };
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+
+      const written = JSON.parse(
+        await readFile(join(workspaceRoot, "apps/flights/results.json"), "utf8"),
+      );
+
+      expect(written.baseReport).not.toBeNull();
+      expect(written.baseReport.usage.backpack.percentage).toBe(100);
+      expect(written.headReport.usage.backpack.percentage).toBe(0);
+      expect(written.guard.status).toBe("fail");
+    } finally {
+      await rm(baseWorktreePath, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor.ts
@@ -1,0 +1,87 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { joinPathFragments, logger } from "@nx/devkit";
+import {
+  DEFAULT_ADOPTION_GUARD_THRESHOLD,
+  DEFAULT_PATTERN,
+  analyzeRepository,
+  evaluateGuard,
+} from "@skyscanner/backpack-adoption-analyzer";
+
+import { DEFAULT_RESULTS_FILE_NAME, writeProjectResult } from "../results-store.ts";
+
+import type { ExecutorContext, PromiseExecutor } from "@nx/devkit";
+import type { AnalyzeExecutorSchema } from "./schema.ts";
+
+/**
+ * Analyzes a single NX project's Backpack adoption and writes a per-project
+ * result file. Always returns success — the `report` executor (which depends
+ * on every project's `analyze` run) reads these result files and decides the
+ * real pass/fail verdict, mirroring devex-web's a11y `emitPrResult` +
+ * aggregator pattern.
+ */
+const runExecutor: PromiseExecutor<AnalyzeExecutorSchema> = async (
+  options,
+  context: ExecutorContext,
+) => {
+  const { projectName } = context;
+  if (!projectName) {
+    logger.error("adoption-guard analyze executor requires a project context.");
+    return { success: false };
+  }
+
+  const projectRoot = context.projectsConfigurations.projects[projectName]?.root;
+  if (!projectRoot) {
+    logger.error(`Could not resolve project root for ${projectName}.`);
+    return { success: false };
+  }
+
+  const pattern = joinPathFragments(projectRoot, options.pattern ?? DEFAULT_PATTERN);
+  const threshold = options.threshold ?? DEFAULT_ADOPTION_GUARD_THRESHOLD;
+
+  // Scan from the workspace root (not projectRoot) so findBackpackWebVersion
+  // and any other root-relative lookups inside analyzeRepository still work;
+  // `pattern` alone scopes the actual file matching to this project.
+  const headReport = await analyzeRepository(context.root, { pattern });
+  const baseReport = options.baseWorktreePath
+    ? await analyzeRepository(options.baseWorktreePath, { pattern })
+    : null;
+
+  const guard = evaluateGuard({
+    baseReport,
+    dryRun: options.dryRun ?? false,
+    headReport,
+    isMain: false,
+    threshold,
+  });
+
+  const outputPath = joinPathFragments(
+    context.root,
+    projectRoot,
+    options.outputPath ?? DEFAULT_RESULTS_FILE_NAME,
+  );
+  writeProjectResult(outputPath, { projectName, threshold, headReport, baseReport, guard });
+
+  logger.info(
+    `[${projectName}] Backpack adoption: ${headReport.usage.backpack.percentage}% (threshold ${threshold}%)`,
+  );
+
+  return { success: true };
+};
+
+export default runExecutor;

--- a/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor.ts
@@ -66,7 +66,10 @@ const runExecutor: PromiseExecutor<AnalyzeExecutorSchema> = async (
     baseReport,
     dryRun: options.dryRun ?? false,
     headReport,
-    isMain: false,
+    // A threshold guards regressions, which requires a base report. Without a
+    // base worktree this is a metrics-only invocation, equivalent to main:
+    // report adoption without blocking the target.
+    isMain: !options.baseWorktreePath,
     threshold,
   });
 

--- a/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/analyze/executor.ts
@@ -23,10 +23,10 @@ import {
   evaluateGuard,
 } from "@skyscanner/backpack-adoption-analyzer";
 
-import { DEFAULT_RESULTS_FILE_NAME, writeProjectResult } from "../results-store.ts";
+import { DEFAULT_RESULTS_FILE_NAME, writeProjectResult } from "../results-store";
 
 import type { ExecutorContext, PromiseExecutor } from "@nx/devkit";
-import type { AnalyzeExecutorSchema } from "./schema.ts";
+import type { AnalyzeExecutorSchema } from "./schema";
 
 /**
  * Analyzes a single NX project's Backpack adoption and writes a per-project

--- a/packages/backpack-adoption-nx-plugin/src/executors/analyze/schema.d.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/analyze/schema.d.ts
@@ -1,0 +1,24 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface AnalyzeExecutorSchema {
+  pattern?: string;
+  threshold?: number;
+  dryRun?: boolean;
+  outputPath?: string;
+  baseWorktreePath?: string;
+}

--- a/packages/backpack-adoption-nx-plugin/src/executors/analyze/schema.json
+++ b/packages/backpack-adoption-nx-plugin/src/executors/analyze/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "Backpack Adoption Analyze executor",
+  "description": "Analyzes this NX project's JSX/TSX files for Backpack adoption and writes a per-project result file.",
+  "type": "object",
+  "properties": {
+    "pattern": {
+      "type": "string",
+      "description": "Glob (relative to the project root) for files to scan.",
+      "default": "**/*.{jsx,tsx}"
+    },
+    "threshold": {
+      "type": "number",
+      "description": "Backpack adoption percentage threshold for this project.",
+      "default": 60
+    },
+    "dryRun": {
+      "type": "boolean",
+      "description": "Report regressions as warnings instead of failures.",
+      "default": false
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "Where to write this project's adoption result JSON, relative to the project root.",
+      "default": "adoption-guard-results.json"
+    },
+    "baseWorktreePath": {
+      "type": "string",
+      "description": "Absolute path to a checkout of the PR base ref (workspace root), if PR comparison is desired. When omitted, only head is reported."
+    }
+  }
+}

--- a/packages/backpack-adoption-nx-plugin/src/executors/report/executor-test.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/report/executor-test.ts
@@ -209,4 +209,32 @@ describe("report executor", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("fails when an explicitly listed project cannot be resolved", async () => {
+    const context = buildContext(workspaceRoot, { flights: "apps/flights" });
+
+    const result = await runExecutor({ projects: ["flgihts"] }, context);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when an explicitly listed project did not produce a result", async () => {
+    const context = buildContext(workspaceRoot, { flights: "apps/flights" });
+
+    const result = await runExecutor({ projects: ["flights"] }, context);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("fails cleanly when a result path cannot be read", async () => {
+    await mkdir(join(workspaceRoot, "apps/flights/results"), { recursive: true });
+    const context = buildContext(workspaceRoot, { flights: "apps/flights" });
+
+    const result = await runExecutor(
+      { projects: ["flights"], resultsFileName: "results" },
+      context,
+    );
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/backpack-adoption-nx-plugin/src/executors/report/executor-test.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/report/executor-test.ts
@@ -1,0 +1,212 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import runExecutor from "./executor";
+
+import type { ExecutorContext } from "@nx/devkit";
+import type { GuardResult } from "@skyscanner/backpack-adoption-analyzer";
+import type { ProjectAdoptionResult } from "../results-store";
+
+const createWorkspace = async () => mkdtemp(join(tmpdir(), "bpk-nx-report-test-"));
+
+const buildContext = (
+  workspaceRoot: string,
+  projects: Record<string, string>,
+): ExecutorContext => ({
+  root: workspaceRoot,
+  cwd: workspaceRoot,
+  isVerbose: false,
+  projectGraph: { nodes: {}, dependencies: {} },
+  projectsConfigurations: {
+    projects: Object.fromEntries(
+      Object.entries(projects).map(([name, root]) => [name, { root }]),
+    ),
+    version: 2,
+  },
+  nxJsonConfiguration: {},
+});
+
+const guardWithStatus = (status: GuardResult["status"]): GuardResult => ({
+  status,
+  reason: `stubbed ${status}`,
+  dryRun: false,
+  threshold: 60,
+  baseBackpackPercentage: 60,
+  headBackpackPercentage: status === "pass" ? 61 : 59,
+  delta: status === "pass" ? 1 : -1,
+});
+
+const writeProjectResultFile = async (
+  workspaceRoot: string,
+  projectRoot: string,
+  fileName: string,
+  result: ProjectAdoptionResult,
+) => {
+  const absolutePath = join(workspaceRoot, projectRoot, fileName);
+  await mkdir(join(absolutePath, ".."), { recursive: true });
+  await writeFile(absolutePath, JSON.stringify(result), "utf8");
+};
+
+const stubResult = (
+  projectName: string,
+  status: GuardResult["status"],
+): ProjectAdoptionResult => ({
+  projectName,
+  threshold: 60,
+  headReport: {
+    repository: "workspace",
+    generatedAt: "2026-07-20T00:00:00.000Z",
+    filesAnalyzed: 1,
+    parseErrors: [],
+    backpackWebVersion: null,
+    usage: {
+      backpack: { count: 1, percentage: 60 },
+      pureBackpack: { count: 1, percentage: 60 },
+      nonPureBackpack: { count: 0, percentage: 0 },
+      nonBackpack: { count: 0, percentage: 0 },
+      rawHtml: { count: 0, percentage: 40 },
+    },
+    componentCounts: {},
+  },
+  baseReport: null,
+  guard: guardWithStatus(status),
+});
+
+describe("report executor", () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await createWorkspace();
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { force: true, recursive: true });
+  });
+
+  it("succeeds when every project's guard passed", async () => {
+    await writeProjectResultFile(
+      workspaceRoot,
+      "apps/flights",
+      "results.json",
+      stubResult("flights", "pass"),
+    );
+    await writeProjectResultFile(
+      workspaceRoot,
+      "apps/hotels",
+      "results.json",
+      stubResult("hotels", "pass"),
+    );
+
+    const context = buildContext(workspaceRoot, {
+      flights: "apps/flights",
+      hotels: "apps/hotels",
+    });
+
+    const result = await runExecutor({ resultsFileName: "results.json" }, context);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("fails when any project's guard failed, even if others passed", async () => {
+    await writeProjectResultFile(
+      workspaceRoot,
+      "apps/flights",
+      "results.json",
+      stubResult("flights", "pass"),
+    );
+    await writeProjectResultFile(
+      workspaceRoot,
+      "apps/hotels",
+      "results.json",
+      stubResult("hotels", "fail"),
+    );
+
+    const context = buildContext(workspaceRoot, {
+      flights: "apps/flights",
+      hotels: "apps/hotels",
+    });
+
+    const result = await runExecutor({ resultsFileName: "results.json" }, context);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("succeeds (with a warning) when a project warns but none fail", async () => {
+    await writeProjectResultFile(
+      workspaceRoot,
+      "apps/flights",
+      "results.json",
+      stubResult("flights", "warn"),
+    );
+
+    const context = buildContext(workspaceRoot, { flights: "apps/flights" });
+
+    const result = await runExecutor({ resultsFileName: "results.json" }, context);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("ignores projects with no results file on disk", async () => {
+    await writeProjectResultFile(
+      workspaceRoot,
+      "apps/flights",
+      "results.json",
+      stubResult("flights", "pass"),
+    );
+    // apps/hotels has no results file written.
+
+    const context = buildContext(workspaceRoot, {
+      flights: "apps/flights",
+      hotels: "apps/hotels",
+    });
+
+    const result = await runExecutor({ resultsFileName: "results.json" }, context);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("restricts aggregation to the explicitly listed projects", async () => {
+    await writeProjectResultFile(
+      workspaceRoot,
+      "apps/flights",
+      "results.json",
+      stubResult("flights", "pass"),
+    );
+    await writeProjectResultFile(
+      workspaceRoot,
+      "apps/hotels",
+      "results.json",
+      stubResult("hotels", "fail"),
+    );
+
+    const context = buildContext(workspaceRoot, {
+      flights: "apps/flights",
+      hotels: "apps/hotels",
+    });
+
+    const result = await runExecutor(
+      { resultsFileName: "results.json", projects: ["flights"] },
+      context,
+    );
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/backpack-adoption-nx-plugin/src/executors/report/executor.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/report/executor.ts
@@ -1,0 +1,97 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { joinPathFragments, logger } from "@nx/devkit";
+import { combineGuardStatuses } from "@skyscanner/backpack-adoption-analyzer";
+
+import { DEFAULT_RESULTS_FILE_NAME, readProjectResult } from "../results-store.ts";
+
+import type { GuardResult } from "@skyscanner/backpack-adoption-analyzer";
+import type { ExecutorContext, PromiseExecutor } from "@nx/devkit";
+import type { ReportExecutorSchema } from "./schema.ts";
+
+// No repo-wide analysis run backs this aggregation (each project already ran
+// its own `analyze` executor) — this trivial "pass" baseline lets
+// combineGuardStatuses reduce purely to "fail if any project fails, warn if
+// any warns, else pass".
+const BASELINE_PASS_GUARD: GuardResult = {
+  status: "pass",
+  reason: "No repo-wide guard; verdict is derived entirely from per-project results.",
+  dryRun: false,
+  threshold: 0,
+  baseBackpackPercentage: null,
+  headBackpackPercentage: 0,
+  delta: null,
+};
+
+/**
+ * Aggregates every NX project's `adoption-guard-results.json` (written by
+ * the `analyze` executor) into one pass/fail verdict. Intended to run as a
+ * target with `dependsOn: [{ "target": "adoption-guard", "projects": "all" }]`
+ * so it executes after every project's `analyze` run has completed.
+ */
+const runExecutor: PromiseExecutor<ReportExecutorSchema> = async (
+  options,
+  context: ExecutorContext,
+) => {
+  const resultsFileName = options.resultsFileName ?? DEFAULT_RESULTS_FILE_NAME;
+  const projectNames =
+    options.projects ?? Object.keys(context.projectsConfigurations.projects);
+
+  const projectGuards: Record<string, GuardResult> = {};
+
+  for (const projectName of projectNames) {
+    const projectRoot = context.projectsConfigurations.projects[projectName]?.root;
+    if (!projectRoot) {
+      continue;
+    }
+
+    const resultsPath = joinPathFragments(context.root, projectRoot, resultsFileName);
+    const result = readProjectResult(resultsPath);
+    if (!result) {
+      continue;
+    }
+
+    projectGuards[projectName] = result.guard;
+    logger.info(`[${projectName}] guard status: ${result.guard.status}`);
+  }
+
+  const combinedStatus = combineGuardStatuses(BASELINE_PASS_GUARD, projectGuards);
+
+  if (combinedStatus === "fail") {
+    const failingProjects = Object.entries(projectGuards)
+      .filter(([, guard]) => guard.status === "fail")
+      .map(([name]) => name);
+    logger.error(
+      `Backpack adoption guard failed for: ${failingProjects.join(", ")}.`,
+    );
+    return { success: false };
+  }
+
+  if (combinedStatus === "warn") {
+    const warningProjects = Object.entries(projectGuards)
+      .filter(([, guard]) => guard.status === "warn")
+      .map(([name]) => name);
+    logger.warn(
+      `Backpack adoption guard warned for: ${warningProjects.join(", ")}.`,
+    );
+  }
+
+  return { success: true };
+};
+
+export default runExecutor;

--- a/packages/backpack-adoption-nx-plugin/src/executors/report/executor.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/report/executor.ts
@@ -18,11 +18,11 @@
 import { joinPathFragments, logger } from "@nx/devkit";
 import { combineGuardStatuses } from "@skyscanner/backpack-adoption-analyzer";
 
-import { DEFAULT_RESULTS_FILE_NAME, readProjectResult } from "../results-store.ts";
+import { DEFAULT_RESULTS_FILE_NAME, readProjectResult } from "../results-store";
 
 import type { GuardResult } from "@skyscanner/backpack-adoption-analyzer";
 import type { ExecutorContext, PromiseExecutor } from "@nx/devkit";
-import type { ReportExecutorSchema } from "./schema.ts";
+import type { ReportExecutorSchema } from "./schema";
 
 // No repo-wide analysis run backs this aggregation (each project already ran
 // its own `analyze` executor) — this trivial "pass" baseline lets

--- a/packages/backpack-adoption-nx-plugin/src/executors/report/executor.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/report/executor.ts
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 import { joinPathFragments, logger } from "@nx/devkit";
-import { combineGuardStatuses } from "@skyscanner/backpack-adoption-analyzer";
 
 import { DEFAULT_RESULTS_FILE_NAME, readProjectResult } from "../results-store";
 
@@ -24,19 +23,8 @@ import type { GuardResult } from "@skyscanner/backpack-adoption-analyzer";
 import type { ExecutorContext, PromiseExecutor } from "@nx/devkit";
 import type { ReportExecutorSchema } from "./schema";
 
-// No repo-wide analysis run backs this aggregation (each project already ran
-// its own `analyze` executor) — this trivial "pass" baseline lets
-// combineGuardStatuses reduce purely to "fail if any project fails, warn if
-// any warns, else pass".
-const BASELINE_PASS_GUARD: GuardResult = {
-  status: "pass",
-  reason: "No repo-wide guard; verdict is derived entirely from per-project results.",
-  dryRun: false,
-  threshold: 0,
-  baseBackpackPercentage: null,
-  headBackpackPercentage: 0,
-  delta: null,
-};
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
 
 /**
  * Aggregates every NX project's `adoption-guard-results.json` (written by
@@ -53,16 +41,37 @@ const runExecutor: PromiseExecutor<ReportExecutorSchema> = async (
     options.projects ?? Object.keys(context.projectsConfigurations.projects);
 
   const projectGuards: Record<string, GuardResult> = {};
+  let hasConfigurationError = false;
 
   for (const projectName of projectNames) {
     const projectRoot = context.projectsConfigurations.projects[projectName]?.root;
     if (!projectRoot) {
+      if (options.projects) {
+        logger.error(`Could not resolve project root for ${projectName}.`);
+        hasConfigurationError = true;
+      }
       continue;
     }
 
     const resultsPath = joinPathFragments(context.root, projectRoot, resultsFileName);
-    const result = readProjectResult(resultsPath);
+    let result;
+    try {
+      result = readProjectResult(resultsPath);
+    } catch (error) {
+      logger.error(
+        `[${projectName}] Could not read adoption result at ${resultsPath}: ${getErrorMessage(error)}`,
+      );
+      hasConfigurationError = true;
+      continue;
+    }
+
     if (!result) {
+      if (options.projects) {
+        logger.error(
+          `[${projectName}] No adoption result found at ${resultsPath}. Ensure its analyze target runs before this report.`,
+        );
+        hasConfigurationError = true;
+      }
       continue;
     }
 
@@ -70,7 +79,17 @@ const runExecutor: PromiseExecutor<ReportExecutorSchema> = async (
     logger.info(`[${projectName}] guard status: ${result.guard.status}`);
   }
 
-  const combinedStatus = combineGuardStatuses(BASELINE_PASS_GUARD, projectGuards);
+  if (hasConfigurationError) {
+    logger.error("Backpack adoption report has configuration errors.");
+    return { success: false };
+  }
+
+  const statuses = Object.values(projectGuards).map((guard) => guard.status);
+  const combinedStatus = statuses.includes("fail")
+    ? "fail"
+    : statuses.includes("warn")
+      ? "warn"
+      : "pass";
 
   if (combinedStatus === "fail") {
     const failingProjects = Object.entries(projectGuards)

--- a/packages/backpack-adoption-nx-plugin/src/executors/report/executor.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/report/executor.ts
@@ -85,11 +85,12 @@ const runExecutor: PromiseExecutor<ReportExecutorSchema> = async (
   }
 
   const statuses = Object.values(projectGuards).map((guard) => guard.status);
-  const combinedStatus = statuses.includes("fail")
-    ? "fail"
-    : statuses.includes("warn")
-      ? "warn"
-      : "pass";
+  let combinedStatus: GuardResult["status"] = "pass";
+  if (statuses.includes("fail")) {
+    combinedStatus = "fail";
+  } else if (statuses.includes("warn")) {
+    combinedStatus = "warn";
+  }
 
   if (combinedStatus === "fail") {
     const failingProjects = Object.entries(projectGuards)

--- a/packages/backpack-adoption-nx-plugin/src/executors/report/schema.d.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/report/schema.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface ReportExecutorSchema {
+  projects?: string[];
+  resultsFileName?: string;
+}

--- a/packages/backpack-adoption-nx-plugin/src/executors/report/schema.json
+++ b/packages/backpack-adoption-nx-plugin/src/executors/report/schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "Backpack Adoption Report executor",
+  "description": "Aggregates per-project Backpack adoption results (written by the analyze executor) into one pass/fail verdict.",
+  "type": "object",
+  "properties": {
+    "projects": {
+      "type": "array",
+      "description": "NX project names whose adoption-guard results should be aggregated. Defaults to every project with a results file on disk.",
+      "items": { "type": "string" }
+    },
+    "resultsFileName": {
+      "type": "string",
+      "description": "Filename (relative to each project's root) that the analyze executor wrote its results to.",
+      "default": "adoption-guard-results.json"
+    }
+  }
+}

--- a/packages/backpack-adoption-nx-plugin/src/executors/results-store-test.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/results-store-test.ts
@@ -1,0 +1,85 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readProjectResult, writeProjectResult } from "./results-store";
+
+import type { ProjectAdoptionResult } from "./results-store";
+
+const projectResult: ProjectAdoptionResult = {
+  projectName: "flights",
+  threshold: 60,
+  headReport: {
+    repository: "workspace",
+    generatedAt: "2026-07-20T00:00:00.000Z",
+    filesAnalyzed: 1,
+    parseErrors: [],
+    backpackWebVersion: null,
+    usage: {
+      backpack: { count: 1, percentage: 100 },
+      pureBackpack: { count: 1, percentage: 100 },
+      nonPureBackpack: { count: 0, percentage: 0 },
+      nonBackpack: { count: 0, percentage: 0 },
+      rawHtml: { count: 0, percentage: 0 },
+    },
+    componentCounts: {},
+  },
+  baseReport: null,
+  guard: {
+    status: "pass",
+    reason: "stubbed pass",
+    dryRun: false,
+    threshold: 60,
+    baseBackpackPercentage: null,
+    headBackpackPercentage: 100,
+    delta: null,
+  },
+};
+
+describe("project results store", () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), "bpk-nx-results-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { force: true, recursive: true });
+  });
+
+  it("writes and reads a project result, creating parent directories", () => {
+    const resultsPath = join(workspaceRoot, "apps/flights/.reports/result.json");
+
+    writeProjectResult(resultsPath, projectResult);
+
+    expect(readProjectResult(resultsPath)).toEqual(projectResult);
+  });
+
+  it("returns null when no result file exists", () => {
+    expect(readProjectResult(join(workspaceRoot, "missing.json"))).toBeNull();
+  });
+
+  it("returns null when a result file contains invalid JSON", async () => {
+    const resultsPath = join(workspaceRoot, "invalid.json");
+    await writeFile(resultsPath, "not JSON", "utf8");
+
+    expect(readProjectResult(resultsPath)).toBeNull();
+  });
+});

--- a/packages/backpack-adoption-nx-plugin/src/executors/results-store.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/results-store.ts
@@ -43,7 +43,14 @@ export const readProjectResult = (
 ): ProjectAdoptionResult | null => {
   try {
     return JSON.parse(readFileSync(resultsPath, "utf8")) as ProjectAdoptionResult;
-  } catch {
-    return null;
+  } catch (error) {
+    if (
+      error instanceof SyntaxError ||
+      (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT")
+    ) {
+      return null;
+    }
+
+    throw error;
   }
 };

--- a/packages/backpack-adoption-nx-plugin/src/executors/results-store.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/results-store.ts
@@ -46,7 +46,10 @@ export const readProjectResult = (
   } catch (error) {
     if (
       error instanceof SyntaxError ||
-      (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT")
+      (typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT")
     ) {
       return null;
     }

--- a/packages/backpack-adoption-nx-plugin/src/executors/results-store.ts
+++ b/packages/backpack-adoption-nx-plugin/src/executors/results-store.ts
@@ -1,0 +1,49 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import type { AdoptionReport, GuardResult } from "@skyscanner/backpack-adoption-analyzer";
+
+export const DEFAULT_RESULTS_FILE_NAME = "adoption-guard-results.json";
+
+export type ProjectAdoptionResult = {
+  projectName: string;
+  threshold: number;
+  headReport: AdoptionReport;
+  baseReport: AdoptionReport | null;
+  guard: GuardResult;
+};
+
+export const writeProjectResult = (
+  outputPath: string,
+  result: ProjectAdoptionResult,
+): void => {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+};
+
+export const readProjectResult = (
+  resultsPath: string,
+): ProjectAdoptionResult | null => {
+  try {
+    return JSON.parse(readFileSync(resultsPath, "utf8")) as ProjectAdoptionResult;
+  } catch {
+    return null;
+  }
+};

--- a/packages/backpack-adoption-nx-plugin/src/index.ts
+++ b/packages/backpack-adoption-nx-plugin/src/index.ts
@@ -18,5 +18,5 @@
 // This package is consumed via its NX executors (see executors.json),
 // referenced by name in consumers' project.json — not via JS imports. This
 // barrel only exists to satisfy package.json's `main`/`exports` fields.
-export type { AnalyzeExecutorSchema } from "./executors/analyze/schema.ts";
-export type { ReportExecutorSchema } from "./executors/report/schema.ts";
+export type { AnalyzeExecutorSchema } from "./executors/analyze/schema";
+export type { ReportExecutorSchema } from "./executors/report/schema";

--- a/packages/backpack-adoption-nx-plugin/src/index.ts
+++ b/packages/backpack-adoption-nx-plugin/src/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// This package is consumed via its NX executors (see executors.json),
+// referenced by name in consumers' project.json — not via JS imports. This
+// barrel only exists to satisfy package.json's `main`/`exports` fields.
+export type { AnalyzeExecutorSchema } from "./executors/analyze/schema.ts";
+export type { ReportExecutorSchema } from "./executors/report/schema.ts";

--- a/packages/backpack-adoption-nx-plugin/tsconfig.json
+++ b/packages/backpack-adoption-nx-plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node", "jest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/backpack-adoption-nx-plugin/tsconfig.json
+++ b/packages/backpack-adoption-nx-plugin/tsconfig.json
@@ -9,7 +9,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,28 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  packages/backpack-adoption-nx-plugin:
+    dependencies:
+      '@nx/devkit':
+        specifier: 22.7.1
+        version: 22.7.1(nx@22.7.1)
+      nx:
+        specifier: '>=20'
+        version: 22.7.1
+    devDependencies:
+      '@skyscanner/backpack-adoption-analyzer':
+        specifier: workspace:*
+        version: link:../../libs/backpack-adoption-analyzer
+      '@types/node':
+        specifier: 25.9.1
+        version: 25.9.1
+      esbuild:
+        specifier: 0.27.7
+        version: 0.27.7
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   packages/backpack-web:
     dependencies:
       '@ark-ui/react':
@@ -14108,7 +14130,7 @@ snapshots:
       enquirer: 2.3.6
       minimatch: 10.2.4
       nx: 22.7.1
-      semver: 7.8.1
+      semver: 7.8.5
       tslib: 2.8.1
       yargs-parser: 21.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,7 +353,7 @@ importers:
   packages/backpack-adoption-nx-plugin:
     dependencies:
       '@nx/devkit':
-        specifier: 22.7.1
+        specifier: '>=20'
         version: 22.7.1(nx@22.7.1)
       nx:
         specifier: '>=20'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
-    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

- Adds the public `@skyscanner/backpack-adoption-nx-plugin` npm package with per-project `analyze` and aggregate `report` Nx executors.
- Bundles the private analyzer from `libs/backpack-adoption-analyzer` into compiled executor artifacts; consumers install no analyzer package.
- Adds validation and manual release automation for the public npm package.

## Release model

- The plugin is published with `--access public` from a manual, non-dry-run dispatch on `main`.
- The release job uses npm trusted publishing (GitHub Actions OIDC), not a long-lived npm publish token. npm must be configured for `Skyscanner/backpack` and `backpack-adoption-nx-plugin-release.yml` before the first automated release.
- The `minor` label represents the initial `0.1.0` release.

## Review scope

This PR is rebased on `main` after Parts 1 and 2 merged. Its diff contains only the Nx plugin, its release workflow, and the minimal workspace configuration needed to bundle the existing analyzer.

## Validation

- The workflow validates lint, typecheck, tests, build, and `npm pack --dry-run` on PRs.
- The prior release-workflow validation passed; the rebased workflow run is the final CI verification.