### PR TITLE
[BpkChipGroup] POC: renderChip render prop for custom subcomponents

### DIFF
--- a/packages/backpack-web/src/bpk-component-chip-group/index.ts
+++ b/packages/backpack-web/src/bpk-component-chip-group/index.ts
@@ -19,6 +19,7 @@
 import BpkMultiSelectChipGroup, {
   type MultiSelectProps,
   type ChipItem,
+  type ChipRenderProps,
   type SingleSelectChipItem,
   CHIP_COMPONENT,
   CHIP_GROUP_TYPES,
@@ -29,6 +30,7 @@ import BpkSingleSelectChipGroup, {
 
 export type {
   ChipItem,
+  ChipRenderProps,
   MultiSelectProps,
   SingleSelectProps,
   SingleSelectChipItem,

--- a/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroup.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroup.stories.tsx
@@ -20,7 +20,8 @@ import { useState } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-import { CHIP_TYPES } from '../../bpk-component-chip';
+import { CHIP_TYPES, BpkDropdownChip } from '../../bpk-component-chip';
+import BpkPopover from '../../bpk-component-popover';
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
 import readme from '../README.md';
@@ -31,7 +32,7 @@ import BpkMultiSelectChipGroup, {
 } from './BpkMultiSelectChipGroup';
 import BpkSingleSelectChipGroup from './BpkSingleSelectChipGroup';
 
-import type { MultiSelectProps, ChipItem } from './BpkMultiSelectChipGroup';
+import type { MultiSelectProps, ChipItem, ChipRenderProps } from './BpkMultiSelectChipGroup';
 import type { SingleSelectProps } from './BpkSingleSelectChipGroup';
 import type { Meta } from '@storybook/react';
 
@@ -445,6 +446,71 @@ export const AllChipTypes = {
 
 export const ExampleStateManagement = {
   render: () => <StateManagement />,
+};
+
+const WithPopoverExample = () => {
+  const [selectedChips, setSelectedChips] = useState([false, false, false]);
+
+  const chipsWithPopover: ChipItem[] = [
+    {
+      text: 'Flights',
+      selected: selectedChips[0],
+      onClick: (selected: boolean, index: number) => {
+        const next = [...selectedChips];
+        next[index] = selected;
+        setSelectedChips(next);
+      },
+    },
+    {
+      text: 'Hotels',
+      selected: selectedChips[1],
+      onClick: (selected: boolean, index: number) => {
+        const next = [...selectedChips];
+        next[index] = selected;
+        setSelectedChips(next);
+      },
+    },
+    {
+      text: 'Filter',
+      selected: selectedChips[2],
+      renderChip: ({ accessibilityLabel, chipStyle, index, onClick, selected }: ChipRenderProps) => (
+        <BpkPopover
+          key="filter-popover"
+          id="filter-popover"
+          label="Filter options"
+          labelAsTitle
+          onClose={onClick}
+          closeButtonLabel="Close filter"
+          target={
+            <BpkDropdownChip
+              accessibilityLabel={accessibilityLabel}
+              type={chipStyle}
+              selected={selected}
+              onClick={onClick}
+            >
+              Filter
+            </BpkDropdownChip>
+          }
+        >
+          <BpkText>Popover anchored to chip {index + 1}</BpkText>
+        </BpkPopover>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <BpkMultiSelectChipGroup
+        type={CHIP_GROUP_TYPES.wrap}
+        chips={chipsWithPopover}
+        ariaLabel="Select filters"
+      />
+    </div>
+  );
+};
+
+export const WithPopover = {
+  render: () => <WithPopoverExample />,
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroup.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroup.stories.tsx
@@ -448,55 +448,39 @@ export const ExampleStateManagement = {
   render: () => <StateManagement />,
 };
 
-const WithPopoverExample = () => {
-  const [selectedChips, setSelectedChips] = useState([false, false, false]);
+const POPOVER_CHIP_LABELS = ['Flights', 'Hotels', 'Car hire', 'Trains'];
 
-  const chipsWithPopover: ChipItem[] = [
-    {
-      text: 'Flights',
-      selected: selectedChips[0],
-      onClick: (selected: boolean, index: number) => {
-        const next = [...selectedChips];
-        next[index] = selected;
-        setSelectedChips(next);
-      },
-    },
-    {
-      text: 'Hotels',
-      selected: selectedChips[1],
-      onClick: (selected: boolean, index: number) => {
-        const next = [...selectedChips];
-        next[index] = selected;
-        setSelectedChips(next);
-      },
-    },
-    {
-      text: 'Filter',
-      selected: selectedChips[2],
-      renderChip: ({ accessibilityLabel, chipStyle, index, onClick, selected }: ChipRenderProps) => (
-        <BpkPopover
-          key="filter-popover"
-          id="filter-popover"
-          label="Filter options"
-          labelAsTitle
-          onClose={onClick}
-          closeButtonLabel="Close filter"
-          target={
-            <BpkDropdownChip
-              accessibilityLabel={accessibilityLabel}
-              type={chipStyle}
-              selected={selected}
-              onClick={onClick}
-            >
-              Filter
-            </BpkDropdownChip>
-          }
-        >
-          <BpkText>Popover anchored to chip {index + 1}</BpkText>
-        </BpkPopover>
-      ),
-    },
-  ];
+const WithPopoverExample = () => {
+  const chipsWithPopover: ChipItem[] = POPOVER_CHIP_LABELS.map((label) => ({
+    text: label,
+    renderChip: ({
+      accessibilityLabel,
+      chipStyle,
+      index,
+      selected,
+    }: ChipRenderProps) => (
+      <BpkPopover
+        id={`popover-chip-${index}`}
+        label={`${label} options`}
+        labelAsTitle
+        placement="bottom"
+        closeButtonLabel={`Close ${label} options`}
+        onClose={() => {}}
+        target={
+          <BpkDropdownChip
+            accessibilityLabel={accessibilityLabel}
+            type={chipStyle}
+            selected={selected}
+            onClick={() => {}}
+          >
+            {label}
+          </BpkDropdownChip>
+        }
+      >
+        <BpkText>Content for {label}</BpkText>
+      </BpkPopover>
+    ),
+  }));
 
   return (
     <div>

--- a/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroup.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-chip-group/src/BpkChipGroup.stories.tsx
@@ -464,6 +464,7 @@ const WithPopoverExample = () => {
         label={`${label} options`}
         labelAsTitle
         placement="bottom"
+        showArrow={false}
         closeButtonLabel={`Close ${label} options`}
         onClose={() => {}}
         target={

--- a/packages/backpack-web/src/bpk-component-chip-group/src/BpkMultiSelectChipGroup.tsx
+++ b/packages/backpack-web/src/bpk-component-chip-group/src/BpkMultiSelectChipGroup.tsx
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ReactNode } from 'react';
+import type { ReactNode, ReactElement } from 'react';
 import { useRef } from 'react';
 
 import BpkBreakpoint, { BREAKPOINTS } from '../../bpk-component-breakpoint';
@@ -69,8 +69,17 @@ export type SingleSelectChipItem = {
   [rest: string]: any; // Inexact rest. See decisions/inexact-rest.md
 };
 
+export type ChipRenderProps = {
+  selected: boolean;
+  chipStyle: ChipStyleType;
+  accessibilityLabel: string;
+  onClick: () => void;
+  index: number;
+};
+
 export type ChipItem = {
   component?: ChipComponentType;
+  renderChip?: (props: ChipRenderProps) => ReactElement | null;
   onClick?: (selected: boolean, index: number) => void;
   selected?: boolean;
   hidden?: boolean;
@@ -113,21 +122,37 @@ const Chip = ({
     hidden = false,
     leadingAccessoryView = null,
     onClick,
+    renderChip,
     selected,
     text,
     ...rest
   } = chipItem;
+
+  if (hidden) return null;
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick(!selected, chipIndex);
+    }
+  };
+
+  if (renderChip) {
+    return renderChip({
+      selected: selected ?? false,
+      chipStyle,
+      accessibilityLabel: accessibilityLabel || text,
+      onClick: handleClick,
+      index: chipIndex,
+    });
+  }
+
   const Component = CHIP_COMPONENT_MAP[component];
-  return hidden ? null : (
+  return (
     <Component
       selected={selected ?? false}
       type={chipStyle}
       accessibilityLabel={accessibilityLabel || text}
-      onClick={() => {
-        if (onClick) {
-          onClick(!selected, chipIndex);
-        }
-      }}
+      onClick={handleClick}
       role={ariaMultiselectable ? 'checkbox' : 'radio'}
       leadingAccessoryView={leadingAccessoryView}
       {...rest}

--- a/packages/backpack-web/src/bpk-component-chip/src/BpkDropdownChip.tsx
+++ b/packages/backpack-web/src/bpk-component-chip/src/BpkDropdownChip.tsx
@@ -21,6 +21,8 @@ The dropdown chip component is just a selectable chip component
 with a trailing accessory view of a chevron down icon.
 */
 
+import { forwardRef } from 'react';
+
 import ChevronDownIconSm from '../../bpk-component-icon/sm/chevron-down';
 import { getDataComponentAttribute } from '../../bpk-react-utils';
 
@@ -29,14 +31,15 @@ import { CHIP_TYPES } from './commonTypes';
 
 import type { CommonProps as Props } from './commonTypes';
 
-const BpkDropdownChip = ({
+const BpkDropdownChip = forwardRef<HTMLButtonElement, Props>(({
   disabled = false,
   leadingAccessoryView = null,
   selected = false,
   type = CHIP_TYPES.default,
   ...rest
-}: Props) => (
+}, ref) => (
   <BpkSelectableChip
+    ref={ref}
     disabled={disabled}
     leadingAccessoryView={leadingAccessoryView}
     selected={selected}
@@ -45,6 +48,6 @@ const BpkDropdownChip = ({
     {...rest}
     trailingAccessoryView={<ChevronDownIconSm />}
   />
-);
+));
 
 export default BpkDropdownChip;

--- a/packages/backpack-web/src/bpk-component-chip/src/BpkSelectableChip.tsx
+++ b/packages/backpack-web/src/bpk-component-chip/src/BpkSelectableChip.tsx
@@ -17,6 +17,7 @@
  */
 
 import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
 
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { cssModules, getDataComponentAttribute } from '../../bpk-react-utils';
@@ -35,7 +36,7 @@ export interface Props extends CommonProps {
   trailingAccessoryView?: ReactNode;
 }
 
-const BpkSelectableChip = ({
+const BpkSelectableChip = forwardRef<HTMLButtonElement, Props>(({
   accessibilityLabel,
   children,
   className,
@@ -47,7 +48,7 @@ const BpkSelectableChip = ({
   trailingAccessoryView = null,
   type = CHIP_TYPES.default,
   ...rest
-}: Props) => {
+}, ref) => {
   const classNames = getClassName(
     'bpk-chip',
     `bpk-chip--${type}`,
@@ -61,6 +62,7 @@ const BpkSelectableChip = ({
 
   return (
     <button
+      ref={ref}
       aria-checked={role === 'button' || role === 'tab' ? undefined : selected}
       className={classNames}
       {...getDataComponentAttribute('SelectableChip')}
@@ -88,6 +90,6 @@ const BpkSelectableChip = ({
       )}
     </button>
   );
-};
+});
 
 export default BpkSelectableChip;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

## Summary

Adds an optional `renderChip` prop to `ChipItem` that lets callers supply a custom render function for individual chip slots in `BpkMultiSelectChipGroup`. When `renderChip` is provided, the group delegates leaf rendering to the caller instead of picking from the internal `CHIP_COMPONENT_MAP`. This is a POC to support attaching a `BpkPopover` (or any other component) directly to a chip rather than the group root, which fixes incorrect popover positioning when used inside a chip group.

A `WithPopover` Storybook story demonstrates the pattern: two chips render normally via the data-driven API, and one chip uses `renderChip` to wrap a `BpkDropdownChip` inside a `BpkPopover` anchored to that chip. The new `ChipRenderProps` type is exported from the package barrel for consumer use.

Remember to include the following changes:

- [x] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [x] Storybook examples created/updated (`WithPopover` story added)
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here