### PR TITLE
[CLOV-CSS] Migrate bpk-component-floating-notification to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
+++ b/packages/backpack-web/src/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
@@ -30,14 +30,13 @@
   margin: auto;
   padding: tokens.bpk-spacing-lg();
   align-items: center;
-  /* gap: animation duration — $bpk-duration-base has no CSS var equivalent */
   transition:
     opacity tokens.$bpk-duration-base ease-in-out,
     transform tokens.$bpk-duration-base ease-in-out;
   border-radius: var(--bpk-radius-md, tokens.$bpk-border-radius-md);
   background: var(--bpk-core-primary, tokens.$bpk-core-primary-day);
   color: var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day);
-  box-shadow: tokens.$bpk-box-shadow-xl, tokens.$bpk-box-shadow-lg; /* gap: box-shadow shorthand */
+  box-shadow: tokens.$bpk-box-shadow-xl, tokens.$bpk-box-shadow-lg;
 
   @include breakpoints.bpk-breakpoint-mobile {
     max-width: 100%;

--- a/packages/backpack-web/src/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
+++ b/packages/backpack-web/src/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
@@ -44,7 +44,10 @@
   }
 
   &--critical {
-    background-color: var(--bpk-status-danger-spot, tokens.$bpk-status-danger-spot-day);
+    background-color: var(
+      --bpk-status-danger-spot,
+      tokens.$bpk-status-danger-spot-day
+    );
     color: var(--bpk-text-inverse, tokens.$bpk-text-primary-inverse-day);
   }
 

--- a/packages/backpack-web/src/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
+++ b/packages/backpack-web/src/bpk-component-floating-notification/src/BpkFloatingNotification.module.scss
@@ -30,13 +30,14 @@
   margin: auto;
   padding: tokens.bpk-spacing-lg();
   align-items: center;
+  /* gap: animation duration — $bpk-duration-base has no CSS var equivalent */
   transition:
     opacity tokens.$bpk-duration-base ease-in-out,
     transform tokens.$bpk-duration-base ease-in-out;
-  border-radius: tokens.$bpk-border-radius-md;
-  background: tokens.$bpk-core-primary-day;
-  color: tokens.$bpk-text-on-dark-day;
-  box-shadow: tokens.$bpk-box-shadow-xl, tokens.$bpk-box-shadow-lg;
+  border-radius: var(--bpk-radius-md, tokens.$bpk-border-radius-md);
+  background: var(--bpk-core-primary, tokens.$bpk-core-primary-day);
+  color: var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day);
+  box-shadow: tokens.$bpk-box-shadow-xl, tokens.$bpk-box-shadow-lg; /* gap: box-shadow shorthand */
 
   @include breakpoints.bpk-breakpoint-mobile {
     max-width: 100%;
@@ -44,8 +45,8 @@
   }
 
   &--critical {
-    background-color: tokens.$bpk-status-danger-spot-day;
-    color: tokens.$bpk-text-primary-inverse-day;
+    background-color: var(--bpk-status-danger-spot, tokens.$bpk-status-danger-spot-day);
+    color: var(--bpk-text-inverse, tokens.$bpk-text-primary-inverse-day);
   }
 
   &--leave {


### PR DESCRIPTION
Closes #4840

## Changes

Migrates `bpk-component-floating-notification` SCSS to CSS custom properties with SASS token fallbacks for light/dark mode support.

### Token migrations

| SASS token | CSS custom property |
|---|---|
| `tokens.$bpk-border-radius-md` | `var(--bpk-radius-md, ...)` |
| `tokens.$bpk-core-primary-day` | `var(--bpk-core-primary, ...)` |
| `tokens.$bpk-text-on-dark-day` | `var(--bpk-text-on-dark, ...)` |
| `tokens.$bpk-status-danger-spot-day` | `var(--bpk-status-danger-spot, ...)` |
| `tokens.$bpk-text-primary-inverse-day` | `var(--bpk-text-inverse, ...)` |

### Gap tokens (kept as bare SASS — no CSS var equivalent)

- `$bpk-box-shadow-xl` / `$bpk-box-shadow-lg` — box-shadow shorthand
- `$bpk-duration-base` — animation duration

No `themeAttributes.tsx` needed — component has no theme hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)