### PR TITLE
[IRN-6872][BpkCollapsible] Add asChild support to BpkCollapsibleRoot

### DIFF
--- a/packages/backpack-web/src/bpk-component-collapsible/README.md
+++ b/packages/backpack-web/src/bpk-component-collapsible/README.md
@@ -144,7 +144,22 @@ const Example = () => {
 
 ### Preventing a wrapper element with `asChild`
 
-By default `RootProvider` renders a `<div>` to host its ARIA attributes and class names. Pass `asChild` to merge those props onto your single child element instead — useful when the provider wraps an existing item element and an extra DOM node would break layout or produce invalid HTML:
+Both `Root` and `RootProvider` accept an `asChild` prop. By default they render a `<div>` to host ARIA attributes and class names. Pass `asChild` to merge those props onto your single child element instead — useful when an extra DOM node would break layout or produce invalid HTML.
+
+**With `Root`:**
+
+```tsx
+<ul>
+  <BpkCollapsible.Root asChild>
+    <li>
+      <BpkCollapsible.Trigger>…</BpkCollapsible.Trigger>
+      <BpkCollapsible.Content>…</BpkCollapsible.Content>
+    </li>
+  </BpkCollapsible.Root>
+</ul>
+```
+
+**With `RootProvider`:**
 
 ```tsx
 <ul>
@@ -157,7 +172,7 @@ By default `RootProvider` renders a `<div>` to host its ARIA attributes and clas
 </ul>
 ```
 
-The `<li>` becomes the collapsible root — no wrapper `<div>` is inserted between it and the `<ul>`.
+In both cases the `<li>` becomes the collapsible root — no wrapper `<div>` is inserted between it and the `<ul>`.
 
 > **Note:** `asChild` requires exactly one React element child. Passing a fragment, a string, or multiple siblings will throw a runtime error from Ark's slot merging.
 

--- a/packages/backpack-web/src/bpk-component-collapsible/README.md
+++ b/packages/backpack-web/src/bpk-component-collapsible/README.md
@@ -174,7 +174,7 @@ Both `Root` and `RootProvider` accept an `asChild` prop. By default they render 
 
 In both cases the `<li>` becomes the collapsible root — no wrapper `<div>` is inserted between it and the `<ul>`.
 
-> **Note:** `asChild` requires exactly one React element child. Passing a fragment, a string, or multiple siblings will throw a runtime error from Ark's slot merging.
+> **Note:** `asChild` requires exactly one React element child. Passing a fragment, a string, or multiple siblings will throw a runtime error from Ark's slot merging. If the child is a custom React component (rather than a DOM element), it must forward the merged props and `ref` to an underlying DOM node — e.g. via `forwardRef` — otherwise the class names, ARIA attributes, and data attributes will not be applied.
 
 ## Lazy mounting
 

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
@@ -27,7 +27,7 @@ import useBpkCollapsibleContext from './useBpkCollapsibleContext';
 
 import type { BpkCollapsibleRootProps } from './BpkCollapsibleRoot';
 
-const SimpleCollapsible = (props: Partial<BpkCollapsibleRootProps> = {}) => (
+const SimpleCollapsible = (props: Omit<BpkCollapsibleRootProps, 'children' | 'asChild'> = {}) => (
   <BpkCollapsible.Root {...props}>
     <BpkCollapsible.Trigger>
       Toggle

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
@@ -326,6 +326,58 @@ describe('BpkCollapsible', () => {
 
   });
 
+  describe('Root asChild', () => {
+    it('renders no wrapper element when asChild is true', () => {
+      const { container } = render(
+        <ul>
+          <BpkCollapsible.Root asChild>
+            <li>
+              <BpkCollapsible.Trigger>Toggle</BpkCollapsible.Trigger>
+              <BpkCollapsible.Content>Body</BpkCollapsible.Content>
+            </li>
+          </BpkCollapsible.Root>
+        </ul>,
+      );
+      const list = container.querySelector('ul') as HTMLElement;
+      // With asChild the <li> is the direct child of <ul>; without asChild
+      // Ark injects a <div> between them.
+      expect(list.firstElementChild?.tagName).toBe('LI');
+    });
+
+    it('renders a wrapper element when asChild is omitted', () => {
+      const { container } = render(
+        <div data-testid="wrapper">
+          <BpkCollapsible.Root>
+            <span>
+              <BpkCollapsible.Trigger>Toggle</BpkCollapsible.Trigger>
+              <BpkCollapsible.Content>Body</BpkCollapsible.Content>
+            </span>
+          </BpkCollapsible.Root>
+        </div>,
+      );
+      const wrapper = container.querySelector('[data-testid="wrapper"]') as HTMLElement;
+      expect(wrapper.firstElementChild?.tagName).toBe('DIV');
+    });
+
+    it('merges collapsible attributes onto the child element when asChild is true', () => {
+      render(
+        <ul>
+          <BpkCollapsible.Root asChild defaultOpen>
+            <li data-testid="item">
+              <BpkCollapsible.Trigger>Toggle</BpkCollapsible.Trigger>
+              <BpkCollapsible.Content>Body</BpkCollapsible.Content>
+            </li>
+          </BpkCollapsible.Root>
+        </ul>,
+      );
+
+      const item = screen.getByTestId('item');
+      expect(item.tagName).toBe('LI');
+      expect(item).toHaveAttribute('data-state', 'open');
+      expect(item).toHaveAttribute('data-backpack-ds-component');
+    });
+  });
+
   describe('RootProvider asChild', () => {
     it('renders no wrapper element when asChild is true', () => {
       const Harness = () => {

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible-test.tsx
@@ -328,7 +328,7 @@ describe('BpkCollapsible', () => {
 
   describe('Root asChild', () => {
     it('renders no wrapper element when asChild is true', () => {
-      const { container } = render(
+      render(
         <ul>
           <BpkCollapsible.Root asChild>
             <li>
@@ -338,14 +338,14 @@ describe('BpkCollapsible', () => {
           </BpkCollapsible.Root>
         </ul>,
       );
-      const list = container.querySelector('ul') as HTMLElement;
+      const list = screen.getByRole('list');
       // With asChild the <li> is the direct child of <ul>; without asChild
       // Ark injects a <div> between them.
       expect(list.firstElementChild?.tagName).toBe('LI');
     });
 
     it('renders a wrapper element when asChild is omitted', () => {
-      const { container } = render(
+      render(
         <div data-testid="wrapper">
           <BpkCollapsible.Root>
             <span>
@@ -355,7 +355,7 @@ describe('BpkCollapsible', () => {
           </BpkCollapsible.Root>
         </div>,
       );
-      const wrapper = container.querySelector('[data-testid="wrapper"]') as HTMLElement;
+      const wrapper = screen.getByTestId('wrapper');
       expect(wrapper.firstElementChild?.tagName).toBe('DIV');
     });
 
@@ -393,8 +393,8 @@ describe('BpkCollapsible', () => {
           </ul>
         );
       };
-      const { container } = render(<Harness />);
-      const list = container.querySelector('ul') as HTMLElement;
+      render(<Harness />);
+      const list = screen.getByRole('list');
       // With asChild the <li> is the direct child of <ul>; without asChild
       // Ark injects a <div> between them.
       expect(list.firstElementChild?.tagName).toBe('LI');
@@ -414,8 +414,8 @@ describe('BpkCollapsible', () => {
           </div>
         );
       };
-      const { container } = render(<Harness />);
-      const wrapper = container.querySelector('[data-testid="wrapper"]') as HTMLElement;
+      render(<Harness />);
+      const wrapper = screen.getByTestId('wrapper');
       expect(wrapper.firstElementChild?.tagName).toBe('DIV');
     });
 

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsible.stories.tsx
@@ -466,6 +466,56 @@ const ContextReader = () => {
   );
 };
 
+// Demonstrates asChild on Root: the Root merges its props onto the child
+// element instead of injecting a wrapper <div>. No hook required.
+const AsChildRoot = () => (
+  <BpkVStack gap={BpkSpacing.Base} alignItems="flex-start">
+    <BpkText textStyle={TEXT_STYLES.bodyDefault}>
+      Without <code>asChild</code>: Root renders a wrapper{' '}
+      <code>&lt;div&gt;</code> around its child.
+    </BpkText>
+    <div>
+      <BpkCollapsible.Root defaultOpen>
+        <div>
+          <BpkCollapsible.Trigger>
+            <BpkText textStyle={TEXT_STYLES.heading5}>Without asChild</BpkText>
+            <BpkCollapsible.Indicator>
+              <ChevronIcon />
+            </BpkCollapsible.Indicator>
+          </BpkCollapsible.Trigger>
+          <BpkCollapsible.Content>
+            <BpkBox paddingTop={BpkSpacing.SM}>
+              <BpkText textStyle={TEXT_STYLES.bodyDefault}>Content</BpkText>
+            </BpkBox>
+          </BpkCollapsible.Content>
+        </div>
+      </BpkCollapsible.Root>
+    </div>
+
+    <BpkText textStyle={TEXT_STYLES.bodyDefault}>
+      With <code>asChild</code>: the <code>&lt;li&gt;</code> becomes the root
+      — no wrapper inserted.
+    </BpkText>
+    <ul>
+      <BpkCollapsible.Root asChild defaultOpen>
+        <li>
+          <BpkCollapsible.Trigger>
+            <BpkText textStyle={TEXT_STYLES.heading5}>With asChild</BpkText>
+            <BpkCollapsible.Indicator>
+              <ChevronIcon />
+            </BpkCollapsible.Indicator>
+          </BpkCollapsible.Trigger>
+          <BpkCollapsible.Content>
+            <BpkBox paddingTop={BpkSpacing.SM}>
+              <BpkText textStyle={TEXT_STYLES.bodyDefault}>Content</BpkText>
+            </BpkBox>
+          </BpkCollapsible.Content>
+        </li>
+      </BpkCollapsible.Root>
+    </ul>
+  </BpkVStack>
+);
+
 // Demonstrates asChild: the RootProvider merges its props onto the child
 // <li> element instead of injecting a wrapper <div>. Inspect the DOM to
 // confirm the output is <li data-backpack-ds-component …> with no extra node.
@@ -577,4 +627,5 @@ export const CollapsedHeightShowMore = { render: () => <ShowMore /> };
 export const LongContentExample = { render: () => <LongContent /> };
 export const VisualTestComposite = { render: () => <VisualTest /> };
 export const ContextReaderHook = { render: () => <ContextReader /> };
+export const AsChildOnRoot = { render: () => <AsChildRoot /> };
 export const AsChildOnRootProvider = { render: () => <AsChildRootProvider /> };

--- a/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsibleRoot.tsx
+++ b/packages/backpack-web/src/bpk-component-collapsible/src/BpkCollapsibleRoot.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { Collapsible } from '@ark-ui/react';
 
@@ -31,8 +31,9 @@ import type {
 
 type ElementIds = Partial<{ root: string; trigger: string; content: string }>;
 
+// Discriminated union so `asChild: true` enforces a single ReactElement child
+// (required by Ark's slot merging) while the default case keeps ReactNode.
 export type BpkCollapsibleRootProps = {
-  children: ReactNode;
   collapsedHeight?: string | number;
   defaultOpen?: boolean;
   disabled?: boolean;
@@ -43,9 +44,13 @@ export type BpkCollapsibleRootProps = {
   open?: boolean;
   unmountOnExit?: boolean;
   variant?: BpkCollapsibleVariant;
-};
+} & (
+  | { asChild: true; children: ReactElement }
+  | { asChild?: false; children: ReactNode }
+);
 
 const BpkCollapsibleRoot = ({
+  asChild,
   children,
   collapsedHeight,
   defaultOpen,
@@ -59,6 +64,7 @@ const BpkCollapsibleRoot = ({
   variant = COLLAPSIBLE_VARIANTS.default,
 }: BpkCollapsibleRootProps) => (
   <Collapsible.Root
+    asChild={asChild}
     className={getRootClassName(variant)}
     collapsedHeight={collapsedHeight}
     defaultOpen={defaultOpen}


### PR DESCRIPTION
Adds `asChild` support to `BpkCollapsibleRoot`, letting consumers project their own element as the collapsible root node without an injected wrapper `div`. This completes parity with `BpkCollapsibleRootProvider`, which already supports `asChild` (shipped in #4897). The implementation follows the exact same discriminated-union pattern — `asChild: true` enforces a single `ReactElement` child (required by Ark's slot merging) while the default keeps `ReactNode` — and simply passes `asChild` through to the underlying `Collapsible.Root`, which already extends `PolymorphicProps` natively.

**Changes:**
- `BpkCollapsibleRoot.tsx`: add the `asChild` discriminated union to `BpkCollapsibleRootProps`, import `ReactElement`, destructure and pass through `asChild`.
- `BpkCollapsible-test.tsx`: add `describe('Root asChild', ...)` block mirroring the existing `describe('RootProvider asChild', ...)` tests.