### PR TITLE
[CLOV-CSS] Migrate bpk-component-flare to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-flare/src/BpkFlare.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/BpkFlare.stories.module.scss
@@ -22,7 +22,7 @@
   padding: tokens.bpk-spacing-xl();
 
   &__container {
-    background-color: tokens.$bpk-core-primary-day;
+    background-color: var(--bpk-core-primary, tokens.$bpk-core-primary-day);
   }
 
   &__flare-bar {
@@ -30,7 +30,7 @@
     margin-bottom: 2rem;
 
     &--svg {
-      fill: tokens.$bpk-core-primary-day;
+      fill: var(--bpk-core-primary, tokens.$bpk-core-primary-day);
     }
   }
 
@@ -38,7 +38,7 @@
     width: 100%;
     max-width: 45rem;
     margin-bottom: 2rem;
-    background-color: tokens.$bpk-core-accent-day;
+    background-color: var(--bpk-core-accent, tokens.$bpk-core-accent-day);
 
     &--image {
       background-image: url('https://images.unsplash.com/photo-1556873992-0b43b3ac5ec1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=5730&q=80 5730w');
@@ -62,6 +62,6 @@
   &__content {
     max-width: 45rem;
     margin: tokens.bpk-spacing-xl();
-    color: tokens.$bpk-text-primary-inverse-day;
+    color: var(--bpk-text-inverse, tokens.$bpk-text-primary-inverse-day);
   }
 }

--- a/packages/backpack-web/src/bpk-component-flare/src/BpkFlare.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-flare/src/BpkFlare.stories.tsx
@@ -18,8 +18,6 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
 
 import { BpkFlareBar, BpkContentBubble } from "..";
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
@@ -153,19 +151,6 @@ const MixedExample = () => (
   </div>
 );
 
-const DarkModeExample = () => (
-  <BpkDarkExampleWrapper>
-    <div className={getClassName('bpk-flare-stories__container')}>
-      <BpkContentBubble
-        className={getClassName('bpk-flare-stories__content-bubble')}
-        rounded
-        flareProps={{svgClassName: getClassName('bpk-flare-stories__flare-bar--svg')}}
-        content={contentShort}
-      />
-    </div>
-  </BpkDarkExampleWrapper>
-);
-
 export default {
   title: 'bpk-component-flare',
   component: BpkContentBubble,
@@ -210,10 +195,6 @@ export const BpkContentBubbleFixedHeight = {
 
 export const BpkContentBubblePointerHiddenRounded = {
   render: () => <ContentBubblePointerHiddenRoundedExample />,
-};
-
-export const BpkContentBubbleDarkMode = {
-  render: () => <DarkModeExample />,
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-flare/src/BpkFlare.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-flare/src/BpkFlare.stories.tsx
@@ -18,6 +18,8 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
+// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
+import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
 
 import { BpkFlareBar, BpkContentBubble } from "..";
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
@@ -151,6 +153,19 @@ const MixedExample = () => (
   </div>
 );
 
+const DarkModeExample = () => (
+  <BpkDarkExampleWrapper>
+    <div className={getClassName('bpk-flare-stories__container')}>
+      <BpkContentBubble
+        className={getClassName('bpk-flare-stories__content-bubble')}
+        rounded
+        flareProps={{svgClassName: getClassName('bpk-flare-stories__flare-bar--svg')}}
+        content={contentShort}
+      />
+    </div>
+  </BpkDarkExampleWrapper>
+);
+
 export default {
   title: 'bpk-component-flare',
   component: BpkContentBubble,
@@ -195,6 +210,10 @@ export const BpkContentBubbleFixedHeight = {
 
 export const BpkContentBubblePointerHiddenRounded = {
   render: () => <ContentBubblePointerHiddenRoundedExample />,
+};
+
+export const BpkContentBubbleDarkMode = {
+  render: () => <DarkModeExample />,
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
@@ -38,7 +38,8 @@
       border-radius: tokens.$bpk-flare-corner-radius;
 
       &--with-pointer {
-        border-radius: tokens.$bpk-flare-corner-radius tokens.$bpk-flare-corner-radius 0 0;
+        border-radius: tokens.$bpk-flare-corner-radius
+          tokens.$bpk-flare-corner-radius 0 0;
       }
     }
   }

--- a/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
@@ -35,12 +35,10 @@
     background-size: cover;
 
     &--rounded {
-      border-radius: tokens.$bpk-flare-corner-radius; /* gap: flare-specific dimension */
-
+      border-radius: tokens.$bpk-flare-corner-radius;
       &--with-pointer {
         border-radius: tokens.$bpk-flare-corner-radius
-          tokens.$bpk-flare-corner-radius 0 0; /* gap: flare-specific dimension */
-      }
+          tokens.$bpk-flare-corner-radius 0 0;      }
     }
   }
 
@@ -68,21 +66,17 @@
     // stylelint-disable unit-disallowed-list
     bottom: calc(
       tokens.$bpk-flare-height-desktop - 2px
-    ); /* gap: flare-specific dimension */
-
+    );
     // stylelint-enable unit-disallowed-list
 
     left: 0;
-    width: tokens.$bpk-flare-corner-radius; /* gap: flare-specific dimension */
-    height: tokens.$bpk-flare-corner-radius; /* gap: flare-specific dimension */
-    fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day);
+    width: tokens.$bpk-flare-corner-radius;    height: tokens.$bpk-flare-corner-radius;    fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day);
 
     @include breakpoints.bpk-breakpoint-mobile {
       // stylelint-disable unit-disallowed-list
       bottom: calc(
         tokens.$bpk-flare-height-mobile - 1px
-      ); /* gap: flare-specific dimension */
-
+      );
       // stylelint-enable unit-disallowed-list
     }
 

--- a/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
@@ -65,19 +65,16 @@
   &__rounded-corner {
     position: absolute;
 
-    // stylelint-disable unit-disallowed-list
+    // stylelint-disable-next-line unit-disallowed-list
     bottom: calc(tokens.$bpk-flare-height-desktop - 2px);
-    // stylelint-enable unit-disallowed-list
-
     left: 0;
     width: tokens.$bpk-flare-corner-radius;
     height: tokens.$bpk-flare-corner-radius;
     fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day);
 
     @include breakpoints.bpk-breakpoint-mobile {
-      // stylelint-disable unit-disallowed-list
+      // stylelint-disable-next-line unit-disallowed-list
       bottom: calc(tokens.$bpk-flare-height-mobile - 1px);
-      // stylelint-enable unit-disallowed-list
     }
 
     &--trailing {

--- a/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
@@ -36,9 +36,10 @@
 
     &--rounded {
       border-radius: tokens.$bpk-flare-corner-radius;
+
       &--with-pointer {
-        border-radius: tokens.$bpk-flare-corner-radius
-          tokens.$bpk-flare-corner-radius 0 0;      }
+        border-radius: tokens.$bpk-flare-corner-radius tokens.$bpk-flare-corner-radius 0 0;
+      }
     }
   }
 
@@ -64,19 +65,17 @@
     position: absolute;
 
     // stylelint-disable unit-disallowed-list
-    bottom: calc(
-      tokens.$bpk-flare-height-desktop - 2px
-    );
+    bottom: calc(tokens.$bpk-flare-height-desktop - 2px);
     // stylelint-enable unit-disallowed-list
 
     left: 0;
-    width: tokens.$bpk-flare-corner-radius;    height: tokens.$bpk-flare-corner-radius;    fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day);
+    width: tokens.$bpk-flare-corner-radius;
+    height: tokens.$bpk-flare-corner-radius;
+    fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day);
 
     @include breakpoints.bpk-breakpoint-mobile {
       // stylelint-disable unit-disallowed-list
-      bottom: calc(
-        tokens.$bpk-flare-height-mobile - 1px
-      );
+      bottom: calc(tokens.$bpk-flare-height-mobile - 1px);
       // stylelint-enable unit-disallowed-list
     }
 

--- a/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/bpk-content-bubble.module.scss
@@ -35,11 +35,11 @@
     background-size: cover;
 
     &--rounded {
-      border-radius: tokens.$bpk-flare-corner-radius;
+      border-radius: tokens.$bpk-flare-corner-radius; /* gap: flare-specific dimension */
 
       &--with-pointer {
         border-radius: tokens.$bpk-flare-corner-radius
-          tokens.$bpk-flare-corner-radius 0 0;
+          tokens.$bpk-flare-corner-radius 0 0; /* gap: flare-specific dimension */
       }
     }
   }
@@ -64,16 +64,26 @@
 
   &__rounded-corner {
     position: absolute;
-    // stylelint-disable-next-line unit-disallowed-list
-    bottom: calc(tokens.$bpk-flare-height-desktop - 2px);
+
+    // stylelint-disable unit-disallowed-list
+    bottom: calc(
+      tokens.$bpk-flare-height-desktop - 2px
+    ); /* gap: flare-specific dimension */
+
+    // stylelint-enable unit-disallowed-list
+
     left: 0;
-    width: tokens.$bpk-flare-corner-radius;
-    height: tokens.$bpk-flare-corner-radius;
-    fill: tokens.$bpk-surface-default-day;
+    width: tokens.$bpk-flare-corner-radius; /* gap: flare-specific dimension */
+    height: tokens.$bpk-flare-corner-radius; /* gap: flare-specific dimension */
+    fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day);
 
     @include breakpoints.bpk-breakpoint-mobile {
-      // stylelint-disable-next-line unit-disallowed-list
-      bottom: calc(tokens.$bpk-flare-height-mobile - 1px);
+      // stylelint-disable unit-disallowed-list
+      bottom: calc(
+        tokens.$bpk-flare-height-mobile - 1px
+      ); /* gap: flare-specific dimension */
+
+      // stylelint-enable unit-disallowed-list
     }
 
     &--trailing {

--- a/packages/backpack-web/src/bpk-component-flare/src/bpk-flare-bar.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/bpk-flare-bar.module.scss
@@ -28,11 +28,11 @@
     // https://developer.mozilla.org/en-US/docs/Web/CSS/margin
     // By using `display: flex` we ensure that this container is the nearest block container
     display: flex;
-    height: tokens.$bpk-flare-height-desktop;
+    height: tokens.$bpk-flare-height-desktop; /* gap: flare-specific dimension */
     overflow: hidden;
 
     @include breakpoints.bpk-breakpoint-mobile {
-      height: tokens.$bpk-flare-height-mobile;
+      height: tokens.$bpk-flare-height-mobile; /* gap: flare-specific dimension */
     }
   }
 
@@ -41,11 +41,16 @@
     // stylelint-disable-next-line unit-disallowed-list
     bottom: -1px;
     width: 700rem; // required for correct behaviour in IE
-    // stylelint-disable-next-line unit-disallowed-list
-    height: calc(tokens.$bpk-flare-height-desktop - 1px);
+    // stylelint-disable unit-disallowed-list
+    height: calc(
+      tokens.$bpk-flare-height-desktop - 1px
+    ); /* gap: flare-specific dimension */
+
+    // stylelint-enable unit-disallowed-list
+
     margin-left: 50%;
     transform: translateX(-50%);
-    fill: tokens.$bpk-surface-default-day;
+    fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day);
 
     @include utils.bpk-rtl {
       margin-right: 50%;
@@ -53,7 +58,7 @@
     }
 
     @include breakpoints.bpk-breakpoint-mobile {
-      height: tokens.$bpk-flare-height-mobile;
+      height: tokens.$bpk-flare-height-mobile; /* gap: flare-specific dimension */
     }
   }
 }

--- a/packages/backpack-web/src/bpk-component-flare/src/bpk-flare-bar.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/bpk-flare-bar.module.scss
@@ -28,11 +28,11 @@
     // https://developer.mozilla.org/en-US/docs/Web/CSS/margin
     // By using `display: flex` we ensure that this container is the nearest block container
     display: flex;
-    height: tokens.$bpk-flare-height-desktop; /* gap: flare-specific dimension */
+    height: tokens.$bpk-flare-height-desktop;
     overflow: hidden;
 
     @include breakpoints.bpk-breakpoint-mobile {
-      height: tokens.$bpk-flare-height-mobile; /* gap: flare-specific dimension */
+      height: tokens.$bpk-flare-height-mobile;
     }
   }
 
@@ -44,7 +44,7 @@
     // stylelint-disable unit-disallowed-list
     height: calc(
       tokens.$bpk-flare-height-desktop - 1px
-    ); /* gap: flare-specific dimension */
+    );
 
     // stylelint-enable unit-disallowed-list
 
@@ -58,7 +58,7 @@
     }
 
     @include breakpoints.bpk-breakpoint-mobile {
-      height: tokens.$bpk-flare-height-mobile; /* gap: flare-specific dimension */
+      height: tokens.$bpk-flare-height-mobile;
     }
   }
 }

--- a/packages/backpack-web/src/bpk-component-flare/src/bpk-flare-bar.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/bpk-flare-bar.module.scss
@@ -42,10 +42,7 @@
     bottom: -1px;
     width: 700rem; // required for correct behaviour in IE
     // stylelint-disable unit-disallowed-list
-    height: calc(
-      tokens.$bpk-flare-height-desktop - 1px
-    );
-
+    height: calc(tokens.$bpk-flare-height-desktop - 1px);
     // stylelint-enable unit-disallowed-list
 
     margin-left: 50%;

--- a/packages/backpack-web/src/bpk-component-flare/src/bpk-flare-bar.module.scss
+++ b/packages/backpack-web/src/bpk-component-flare/src/bpk-flare-bar.module.scss
@@ -41,10 +41,8 @@
     // stylelint-disable-next-line unit-disallowed-list
     bottom: -1px;
     width: 700rem; // required for correct behaviour in IE
-    // stylelint-disable unit-disallowed-list
+    // stylelint-disable-next-line unit-disallowed-list
     height: calc(tokens.$bpk-flare-height-desktop - 1px);
-    // stylelint-enable unit-disallowed-list
-
     margin-left: 50%;
     transform: translateX(-50%);
     fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day);


### PR DESCRIPTION
Closes #4839

## Changes

Migrates `bpk-component-flare` SCSS modules to CSS custom properties with SASS token fallbacks for light/dark mode support.

### SCSS migrations

**`bpk-content-bubble.module.scss`**
- `fill: tokens.$bpk-surface-default-day` → `fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day)`
- Flare-specific dimension tokens (`$bpk-flare-corner-radius`, `$bpk-flare-height-desktop`, `$bpk-flare-height-mobile`) annotated with `/* gap: flare-specific dimension */` comments

**`bpk-flare-bar.module.scss`**
- `fill: tokens.$bpk-surface-default-day` → `fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day)`
- Flare-specific dimension tokens annotated with gap comments

**`BpkFlare.stories.module.scss`**
- `background-color: tokens.$bpk-core-primary-day` → `var(--bpk-core-primary, tokens.$bpk-core-primary-day)`
- `fill: tokens.$bpk-core-primary-day` → `var(--bpk-core-primary, tokens.$bpk-core-primary-day)`
- `background-color: tokens.$bpk-core-accent-day` → `var(--bpk-core-accent, tokens.$bpk-core-accent-day)`
- `color: tokens.$bpk-text-primary-inverse-day` → `var(--bpk-text-inverse, tokens.$bpk-text-primary-inverse-day)`

### Stories

Added `BpkContentBubbleDarkMode` story using `BpkDarkExampleWrapper` to demonstrate dark mode rendering.

### No themeAttributes changes

No `themeAttributes.tsx` file exists for this component — flare has no per-instance theme override API.