### PR TITLE
[CLOV-CSS] Migrate bpk-component-price-range to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceMarker.module.scss
+++ b/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceMarker.module.scss
@@ -32,7 +32,7 @@ $arrow-size: tokens.bpk-spacing-base();
   border-radius: var(--bpk-radius-xs, tokens.$bpk-border-radius-xs);
   background: none;
   white-space: nowrap;
-  box-shadow: tokens.$bpk-box-shadow-sm; /* gap: box-shadow shorthand, no CSS var */
+  box-shadow: tokens.$bpk-box-shadow-sm;
   margin-block-end: tokens.bpk-spacing-sm() * 1.5;
 
   span {

--- a/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceMarker.module.scss
+++ b/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceMarker.module.scss
@@ -29,18 +29,18 @@ $arrow-size: tokens.bpk-spacing-base();
   align-items: center;
   flex: none;
   border: none;
-  border-radius: tokens.$bpk-border-radius-xs;
+  border-radius: var(--bpk-radius-xs, tokens.$bpk-border-radius-xs);
   background: none;
   white-space: nowrap;
-  box-shadow: tokens.$bpk-box-shadow-sm;
+  box-shadow: tokens.$bpk-box-shadow-sm; /* gap: box-shadow shorthand, no CSS var */
   margin-block-end: tokens.bpk-spacing-sm() * 1.5;
 
   span {
     display: inline-flex;
     z-index: 1;
     padding: math.div(tokens.bpk-spacing-sm(), 2) tokens.bpk-spacing-md();
-    border-radius: tokens.$bpk-border-radius-xs;
-    color: tokens.$bpk-text-primary-inverse-day;
+    border-radius: var(--bpk-radius-xs, tokens.$bpk-border-radius-xs);
+    color: var(--bpk-text-inverse, tokens.$bpk-text-primary-inverse-day);
   }
 
   &__arrow {
@@ -55,14 +55,20 @@ $arrow-size: tokens.bpk-spacing-base();
   }
 
   &--low {
-    background-color: tokens.$bpk-status-success-spot-day;
+    background-color: var(
+      --bpk-status-success-spot,
+      tokens.$bpk-status-success-spot-day
+    );
   }
 
   &--medium {
-    background-color: tokens.$bpk-core-primary-day;
+    background-color: var(--bpk-core-primary, tokens.$bpk-core-primary-day);
   }
 
   &--high {
-    background-color: tokens.$bpk-status-danger-spot-day;
+    background-color: var(
+      --bpk-status-danger-spot,
+      tokens.$bpk-status-danger-spot-day
+    );
   }
 }

--- a/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.module.scss
+++ b/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.module.scss
@@ -50,32 +50,59 @@ $large-lines-height: tokens.bpk-spacing-md();
     &--low {
       width: calc(100% * var(--low));
       height: 100%;
-      background-color: tokens.$bpk-status-success-spot-day;
-      border-end-start-radius: tokens.$bpk-border-radius-sm;
-      border-start-start-radius: tokens.$bpk-border-radius-sm;
+      background-color: var(
+        --bpk-status-success-spot,
+        tokens.$bpk-status-success-spot-day
+      );
+      border-end-start-radius: var(
+        --bpk-radius-sm,
+        tokens.$bpk-border-radius-sm
+      );
+      border-start-start-radius: var(
+        --bpk-radius-sm,
+        tokens.$bpk-border-radius-sm
+      );
 
       &Large {
-        border-end-start-radius: tokens.$bpk-border-radius-md;
-        border-start-start-radius: tokens.$bpk-border-radius-md;
+        border-end-start-radius: var(
+          --bpk-radius-md,
+          tokens.$bpk-border-radius-md
+        );
+        border-start-start-radius: var(
+          --bpk-radius-md,
+          tokens.$bpk-border-radius-md
+        );
       }
     }
 
     &--medium {
       width: calc(100% * (var(--high) - var(--low)));
       height: 100%;
-      background-color: tokens.$bpk-core-primary-day;
+      background-color: var(--bpk-core-primary, tokens.$bpk-core-primary-day);
     }
 
     &--high {
       width: calc(100% * (1 - var(--high)));
       height: 100%;
-      background-color: tokens.$bpk-status-danger-spot-day;
-      border-end-end-radius: tokens.$bpk-border-radius-sm;
-      border-start-end-radius: tokens.$bpk-border-radius-sm;
+      background-color: var(
+        --bpk-status-danger-spot,
+        tokens.$bpk-status-danger-spot-day
+      );
+      border-end-end-radius: var(--bpk-radius-sm, tokens.$bpk-border-radius-sm);
+      border-start-end-radius: var(
+        --bpk-radius-sm,
+        tokens.$bpk-border-radius-sm
+      );
 
       &Large {
-        border-end-end-radius: tokens.$bpk-border-radius-md;
-        border-start-end-radius: tokens.$bpk-border-radius-md;
+        border-end-end-radius: var(
+          --bpk-radius-md,
+          tokens.$bpk-border-radius-md
+        );
+        border-start-end-radius: var(
+          --bpk-radius-md,
+          tokens.$bpk-border-radius-md
+        );
       }
     }
 
@@ -97,7 +124,10 @@ $large-lines-height: tokens.bpk-spacing-md();
         width: $small-lines-height;
         height: $small-lines-height;
         border-radius: 50%;
-        background-color: tokens.$bpk-text-primary-inverse-day;
+        background-color: var(
+          --bpk-text-inverse,
+          tokens.$bpk-text-primary-inverse-day
+        );
       }
     }
   }

--- a/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.stories.tsx
@@ -20,9 +20,6 @@ import type { ReactNode } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error -- bpk-storybook-utils has no type declarations
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
-
 import readme from '../README.md';
 
 import BpkPriceRange, {
@@ -244,21 +241,6 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
-  parameters: {
-    percy: {
-      waitForTimeout: 10000,
-    },
-  },
-};
-
-const DarkExample = () => (
-  <BpkDarkExampleWrapper>
-    <MixedExample />
-  </BpkDarkExampleWrapper>
-);
-
-export const VisualTestDark = {
-  render: () => <DarkExample />,
   parameters: {
     percy: {
       waitForTimeout: 10000,

--- a/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-price-range/src/BpkPriceRange.stories.tsx
@@ -20,6 +20,9 @@ import type { ReactNode } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
+// @ts-expect-error -- bpk-storybook-utils has no type declarations
+import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
+
 import readme from '../README.md';
 
 import BpkPriceRange, {
@@ -241,6 +244,21 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
+  parameters: {
+    percy: {
+      waitForTimeout: 10000,
+    },
+  },
+};
+
+const DarkExample = () => (
+  <BpkDarkExampleWrapper>
+    <MixedExample />
+  </BpkDarkExampleWrapper>
+);
+
+export const VisualTestDark = {
+  render: () => <DarkExample />,
   parameters: {
     percy: {
       waitForTimeout: 10000,


### PR DESCRIPTION
Closes #4818

## Summary

Migrates `bpk-component-price-range` SCSS to CSS custom properties with SASS fallbacks for light/dark mode support.

### Changes

**`BpkPriceRange.module.scss`** — 12 CSS var replacements:
- `$bpk-status-success-spot-day` → `var(--bpk-status-success-spot, ...)`
- `$bpk-core-primary-day` → `var(--bpk-core-primary, ...)`
- `$bpk-status-danger-spot-day` → `var(--bpk-status-danger-spot, ...)`
- `$bpk-text-primary-inverse-day` → `var(--bpk-text-inverse, ...)`
- `$bpk-border-radius-sm/md` → `var(--bpk-radius-sm/md, ...)`

**`BpkPriceMarker.module.scss`** — 6 CSS var replacements:
- `$bpk-border-radius-xs` → `var(--bpk-radius-xs, ...)`
- `$bpk-text-primary-inverse-day` → `var(--bpk-text-inverse, ...)`
- `$bpk-status-success-spot-day` → `var(--bpk-status-success-spot, ...)`
- `$bpk-core-primary-day` → `var(--bpk-core-primary, ...)`
- `$bpk-status-danger-spot-day` → `var(--bpk-status-danger-spot, ...)`
- `$bpk-box-shadow-sm` kept as bare SASS token (no CSS var equivalent)

**`BpkPriceRange.stories.tsx`** — Adds `VisualTestDark` story using `BpkDarkExampleWrapper`.

No `themeAttributes.tsx` needed — the component has none.

## Test plan

- [ ] 19 existing tests pass
- [ ] Dark mode story renders correct colours under dark theme