### PR TITLE
[CLOV-CSS] Migrate bpk-component-tooltip to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.module.scss
+++ b/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.module.scss
@@ -28,11 +28,11 @@ $dark-background-color: var(
 );
 
 .bpk-tooltip--container {
-  z-index: tokens.$bpk-zindex-tooltip; /* gap: z-index, not in token-sync */
+  z-index: tokens.$bpk-zindex-tooltip;
 }
 
 .bpk-tooltip {
-  transition: opacity tokens.$bpk-duration-sm ease-in-out; /* gap: animation duration */
+  transition: opacity tokens.$bpk-duration-sm ease-in-out;
   outline: 0;
   opacity: 1;
 

--- a/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.module.scss
+++ b/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.module.scss
@@ -22,14 +22,17 @@
 @use '../../bpk-mixins/shadows';
 
 $arrow-size: tokens.bpk-spacing-md();
-$dark-background-color: tokens.$bpk-surface-contrast-day;
+$dark-background-color: var(
+  --bpk-surface-contrast,
+  tokens.$bpk-surface-contrast-day
+);
 
 .bpk-tooltip--container {
-  z-index: tokens.$bpk-zindex-tooltip;
+  z-index: tokens.$bpk-zindex-tooltip; /* gap: z-index, not in token-sync */
 }
 
 .bpk-tooltip {
-  transition: opacity tokens.$bpk-duration-sm ease-in-out;
+  transition: opacity tokens.$bpk-duration-sm ease-in-out; /* gap: animation duration */
   outline: 0;
   opacity: 1;
 
@@ -46,7 +49,7 @@ $dark-background-color: tokens.$bpk-surface-contrast-day;
   &__arrow {
     width: $arrow-size;
     height: $arrow-size;
-    fill: tokens.$bpk-surface-default-day;
+    fill: var(--bpk-surface-default, tokens.$bpk-surface-default-day);
 
     &--dark {
       fill: $dark-background-color;
@@ -59,7 +62,7 @@ $dark-background-color: tokens.$bpk-surface-contrast-day;
     }
 
     &--dark {
-      color: tokens.$bpk-text-primary-inverse-day;
+      color: var(--bpk-text-inverse, tokens.$bpk-text-primary-inverse-day);
 
       @include layers.bpk-layer($dark-background-color, $dark-background-color);
     }

--- a/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.stories.tsx
@@ -18,9 +18,6 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
-
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { withDefaultProps } from '../../bpk-react-utils';
 import readme from '../README.md';
@@ -204,26 +201,6 @@ export const WithoutPadding = { render: () => <NoPaddingExample /> };
 export const OnALink = { render: () => <LinkExample /> };
 export const WithCustomZIndex = { render: () => <CustomZIndexExample /> };
 
-const VisualTestDarkExample = () => (
-  <BpkDarkExampleWrapper>
-    <div style={wrapperStyle}>
-      <BpkTooltip
-        ariaLabel="Montréal-Trudeau International Airport"
-        id="my-tooltip-dark"
-        type={TOOLTIP_TYPES.dark}
-        target={
-          <div>
-            <Heading>YUL</Heading>
-          </div>
-        }
-        isOpen
-      >
-        Montréal-Trudeau International Airport
-      </BpkTooltip>
-    </div>
-  </BpkDarkExampleWrapper>
-);
-
 export const VisualTest = {
   render: () => <VisualTestExample />,
   parameters: {
@@ -237,15 +214,6 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
-  parameters: {
-    percy: {
-      waitForTimeout: 10000
-    }
-  }
-};
-
-export const VisualTestDark = {
-  render: () => <VisualTestDarkExample />,
   parameters: {
     percy: {
       waitForTimeout: 10000

--- a/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-tooltip/src/BpkTooltip.stories.tsx
@@ -18,6 +18,9 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
+// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
+import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
+
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { withDefaultProps } from '../../bpk-react-utils';
 import readme from '../README.md';
@@ -201,6 +204,26 @@ export const WithoutPadding = { render: () => <NoPaddingExample /> };
 export const OnALink = { render: () => <LinkExample /> };
 export const WithCustomZIndex = { render: () => <CustomZIndexExample /> };
 
+const VisualTestDarkExample = () => (
+  <BpkDarkExampleWrapper>
+    <div style={wrapperStyle}>
+      <BpkTooltip
+        ariaLabel="Montréal-Trudeau International Airport"
+        id="my-tooltip-dark"
+        type={TOOLTIP_TYPES.dark}
+        target={
+          <div>
+            <Heading>YUL</Heading>
+          </div>
+        }
+        isOpen
+      >
+        Montréal-Trudeau International Airport
+      </BpkTooltip>
+    </div>
+  </BpkDarkExampleWrapper>
+);
+
 export const VisualTest = {
   render: () => <VisualTestExample />,
   parameters: {
@@ -214,6 +237,15 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
+  parameters: {
+    percy: {
+      waitForTimeout: 10000
+    }
+  }
+};
+
+export const VisualTestDark = {
+  render: () => <VisualTestDarkExample />,
   parameters: {
     percy: {
       waitForTimeout: 10000


### PR DESCRIPTION
Closes #4813

## Changes

Migrates `bpk-component-tooltip` SCSS to use CSS custom properties with SASS token fallbacks, enabling light/dark mode theming via the CSS var system.

### Token migrations

| SASS token | CSS custom property |
|---|---|
| `tokens.$bpk-surface-contrast-day` | `var(--bpk-surface-contrast, ...)` |
| `tokens.$bpk-surface-default-day` | `var(--bpk-surface-default, ...)` |
| `tokens.$bpk-text-primary-inverse-day` | `var(--bpk-text-inverse, ...)` |

### Gap tokens (annotated, no CSS var equivalent)

- `tokens.$bpk-zindex-tooltip` — `/* gap: z-index, not in token-sync */`
- `tokens.$bpk-duration-sm` — `/* gap: animation duration */`

### Story additions

- Added `VisualTestDark` story using `BpkDarkExampleWrapper` to verify dark mode rendering

No `themeAttributes.tsx` changes required.

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>