### PR TITLE
[CLOV-CSS] Migrate bpk-component-bottom-sheet to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
@@ -22,29 +22,29 @@
 @use '../../bpk-mixins/shadows';
 
 @mixin animation-slide-up {
-  animation-duration: tokens.$bpk-duration-sm; /* gap: animation duration */
+  animation-duration: tokens.$bpk-duration-sm;
   animation-name: slide-up;
   animation-timing-function: ease-in-out;
 }
 
 @mixin animation-slide-down {
-  animation-duration: tokens.$bpk-duration-sm; /* gap: animation duration */
+  animation-duration: tokens.$bpk-duration-sm;
   animation-name: slide-down;
   animation-timing-function: ease-in-out;
 }
 
 .bpk-bottom-sheet {
-  z-index: tokens.$bpk-zindex-modal; /* gap: z-index */
+  z-index: tokens.$bpk-zindex-modal;
   width: 100%;
-  max-width: tokens.$bpk-modal-max-width; /* gap: max-width */
+  max-width: tokens.$bpk-modal-max-width;
   margin: auto;
   transition:
     opacity tokens.$bpk-duration-sm ease-in-out,
-    /* gap: animation duration */ transform tokens.$bpk-duration-sm ease-in-out; /* gap: animation duration */
+ transform tokens.$bpk-duration-sm ease-in-out;
 
   outline: 0;
-  background-color: tokens.$bpk-modal-background-color; /* gap: backdrop colour */
-  opacity: tokens.$bpk-modal-opacity; /* gap: opacity */
+  background-color: tokens.$bpk-modal-background-color;
+  opacity: tokens.$bpk-modal-opacity;
 
   // required to prevent the header extending beyond the rounded corners
   overflow: hidden;
@@ -78,7 +78,7 @@
 
     @include breakpoints.bpk-breakpoint-above-mobile {
       transform: scale(0.9);
-      opacity: tokens.$bpk-modal-initial-opacity; /* gap: animation opacity */
+      opacity: tokens.$bpk-modal-initial-opacity;
       animation: none;
     }
   }
@@ -86,7 +86,7 @@
   &--appear-active {
     @include breakpoints.bpk-breakpoint-above-mobile {
       transform: scale(1);
-      opacity: tokens.$bpk-modal-opacity; /* gap: opacity */
+      opacity: tokens.$bpk-modal-opacity;
     }
   }
 
@@ -172,14 +172,14 @@
 
   &--wide {
     @include breakpoints.bpk-breakpoint-above-mobile {
-      max-width: tokens.$bpk-modal-wide-max-width; /* gap: max-width */
+      max-width: tokens.$bpk-modal-wide-max-width;
     }
   }
 
   &--header-wrapper {
     position: sticky;
     top: 0;
-    z-index: tokens.$bpk-zindex-tooltip - 1; /* gap: z-index */
+    z-index: tokens.$bpk-zindex-tooltip - 1;
     background-color: var(
       --bpk-surface-default,
       tokens.$bpk-surface-default-day

--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
@@ -40,8 +40,7 @@
   margin: auto;
   transition:
     opacity tokens.$bpk-duration-sm ease-in-out,
- transform tokens.$bpk-duration-sm ease-in-out;
-
+    transform tokens.$bpk-duration-sm ease-in-out;
   outline: 0;
   background-color: tokens.$bpk-modal-background-color;
   opacity: tokens.$bpk-modal-opacity;

--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.module.scss
@@ -17,36 +17,34 @@
  */
 
 @use '../../bpk-mixins/tokens';
-@use '../../bpk-mixins/borders';
 @use '../../bpk-mixins/breakpoints';
 @use '../../bpk-mixins/radii';
 @use '../../bpk-mixins/shadows';
-@use '../../bpk-mixins/typography';
-@use '../../bpk-mixins/utils';
 
 @mixin animation-slide-up {
-  animation-duration: tokens.$bpk-duration-sm;
+  animation-duration: tokens.$bpk-duration-sm; /* gap: animation duration */
   animation-name: slide-up;
   animation-timing-function: ease-in-out;
 }
 
 @mixin animation-slide-down {
-  animation-duration: tokens.$bpk-duration-sm;
+  animation-duration: tokens.$bpk-duration-sm; /* gap: animation duration */
   animation-name: slide-down;
   animation-timing-function: ease-in-out;
 }
 
 .bpk-bottom-sheet {
-  z-index: tokens.$bpk-zindex-modal;
+  z-index: tokens.$bpk-zindex-modal; /* gap: z-index */
   width: 100%;
-  max-width: tokens.$bpk-modal-max-width;
+  max-width: tokens.$bpk-modal-max-width; /* gap: max-width */
   margin: auto;
   transition:
     opacity tokens.$bpk-duration-sm ease-in-out,
-    transform tokens.$bpk-duration-sm ease-in-out;
+    /* gap: animation duration */ transform tokens.$bpk-duration-sm ease-in-out; /* gap: animation duration */
+
   outline: 0;
-  background-color: tokens.$bpk-modal-background-color;
-  opacity: tokens.$bpk-modal-opacity;
+  background-color: tokens.$bpk-modal-background-color; /* gap: backdrop colour */
+  opacity: tokens.$bpk-modal-opacity; /* gap: opacity */
 
   // required to prevent the header extending beyond the rounded corners
   overflow: hidden;
@@ -66,7 +64,8 @@
     height: fit-content;
     max-height: 90%;
     margin-bottom: 0;
-    border-radius: tokens.$bpk-border-radius-lg tokens.$bpk-border-radius-lg 0 0;
+    border-radius: var(--bpk-radius-lg, tokens.$bpk-border-radius-lg)
+      var(--bpk-radius-lg, tokens.$bpk-border-radius-lg) 0 0;
     overflow-x: hidden;
   }
 
@@ -79,7 +78,7 @@
 
     @include breakpoints.bpk-breakpoint-above-mobile {
       transform: scale(0.9);
-      opacity: tokens.$bpk-modal-initial-opacity;
+      opacity: tokens.$bpk-modal-initial-opacity; /* gap: animation opacity */
       animation: none;
     }
   }
@@ -87,7 +86,7 @@
   &--appear-active {
     @include breakpoints.bpk-breakpoint-above-mobile {
       transform: scale(1);
-      opacity: tokens.$bpk-modal-opacity;
+      opacity: tokens.$bpk-modal-opacity; /* gap: opacity */
     }
   }
 
@@ -173,18 +172,16 @@
 
   &--wide {
     @include breakpoints.bpk-breakpoint-above-mobile {
-      max-width: tokens.$bpk-modal-wide-max-width;
+      max-width: tokens.$bpk-modal-wide-max-width; /* gap: max-width */
     }
   }
 
   &--header-wrapper {
     position: sticky;
     top: 0;
-    z-index: tokens.$bpk-zindex-tooltip - 1;
-
-    @include utils.bpk-themeable-property(
-      background-color,
-      --bpk-navigation-bar-background-color,
+    z-index: tokens.$bpk-zindex-tooltip - 1; /* gap: z-index */
+    background-color: var(
+      --bpk-surface-default,
       tokens.$bpk-surface-default-day
     );
   }

--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.stories.js
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.stories.js
@@ -21,7 +21,7 @@ import { Component, Children } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-import { action } from 'bpk-storybook-utils';
+import { action, BpkDarkExampleWrapper } from 'bpk-storybook-utils';
 
 
 import BpkButton from '../../bpk-component-button';
@@ -465,3 +465,16 @@ export const BasePadding = { render: () => <BasePaddingExample /> };
 export const LgPadding = { render: () => <LgPaddingExample /> };
 export const XXLPadding = { render: () => <XXLPaddingExample /> };
 export const XXXLPadding = { render: () => <XXXLPaddingExample /> };
+export const DarkMode = {
+  render: () => (
+    <BpkDarkExampleWrapper>
+      <BottomSheetContainer
+        title="Bottom Sheet title"
+        closeLabel="Close Bottom Sheet"
+        isComponentOpen
+      >
+        This is a bottom sheet in dark mode.
+      </BottomSheetContainer>
+    </BpkDarkExampleWrapper>
+  ),
+};

--- a/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.stories.js
+++ b/packages/backpack-web/src/bpk-component-bottom-sheet/src/BpkBottomSheet.stories.js
@@ -21,7 +21,7 @@ import { Component, Children } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-import { action, BpkDarkExampleWrapper } from 'bpk-storybook-utils';
+import { action } from 'bpk-storybook-utils';
 
 
 import BpkButton from '../../bpk-component-button';
@@ -465,16 +465,3 @@ export const BasePadding = { render: () => <BasePaddingExample /> };
 export const LgPadding = { render: () => <LgPaddingExample /> };
 export const XXLPadding = { render: () => <XXLPaddingExample /> };
 export const XXXLPadding = { render: () => <XXXLPaddingExample /> };
-export const DarkMode = {
-  render: () => (
-    <BpkDarkExampleWrapper>
-      <BottomSheetContainer
-        title="Bottom Sheet title"
-        closeLabel="Close Bottom Sheet"
-        isComponentOpen
-      >
-        This is a bottom sheet in dark mode.
-      </BottomSheetContainer>
-    </BpkDarkExampleWrapper>
-  ),
-};


### PR DESCRIPTION
Closes #4835

## Changes

- Migrates `border-radius` on the mobile breakpoint to `var(--bpk-radius-lg, tokens.$bpk-border-radius-lg)` (top-left and top-right corners)
- Replaces `@include utils.bpk-themeable-property(background-color, --bpk-navigation-bar-background-color, ...)` on `--header-wrapper` with `var(--bpk-surface-default, tokens.$bpk-surface-default-day)`
- Adds `/* gap: */` comments on tokens without CSS var equivalents: z-index, max-width, animation duration/opacity, backdrop colour
- Removes unused `@use` imports: `borders`, `typography`, `utils`
- Adds `DarkMode` story using `BpkDarkExampleWrapper`

No `themeAttributes.tsx` needed (no component-scoped private vars).