### PR TITLE
[CLOV-CSS] Migrate bpk-component-datatable to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.module.scss
+++ b/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.module.scss
@@ -21,7 +21,6 @@
 @use '../../bpk-mixins/typography';
 @use '../../bpk-mixins/utils';
 
-// gap: hairline border utility — $bpk-one-pixel-rem has no CSS var equivalent
 $bpk-outline-offset: -1 * (4 * tokens.$bpk-one-pixel-rem);
 
 @mixin bpk-datatable-border-left() {

--- a/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.module.scss
+++ b/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.module.scss
@@ -21,22 +21,19 @@
 @use '../../bpk-mixins/typography';
 @use '../../bpk-mixins/utils';
 
-$bpk-border-size-datatable: tokens.$bpk-border-size-xl * 2;
+// gap: hairline border utility — $bpk-one-pixel-rem has no CSS var equivalent
+$bpk-outline-offset: -1 * (4 * tokens.$bpk-one-pixel-rem);
 
 @mixin bpk-datatable-border-left() {
-  @include borders.bpk-border-left(
-    $bpk-border-size-datatable,
-    tokens.$bpk-core-accent-day,
-    inset
-  );
+  // Datatable accent border = $bpk-border-size-xl * 2 = 6px
+  box-shadow: calc(var(--bpk-border-3, tokens.$bpk-border-size-xl) * 2) 0 0 0
+    var(--bpk-core-accent, tokens.$bpk-core-accent-day) inset;
 }
 
 @mixin bpk-datatable-border-right() {
-  @include borders.bpk-border-right(
-    $bpk-border-size-datatable,
-    tokens.$bpk-core-accent-day,
-    inset
-  );
+  // Datatable accent border = $bpk-border-size-xl * 2 = 6px
+  box-shadow: calc(var(--bpk-border-3, tokens.$bpk-border-size-xl) * -2) 0 0 0
+    var(--bpk-core-accent, tokens.$bpk-core-accent-day) inset;
 }
 
 .bpk-data-table {
@@ -50,19 +47,24 @@ $bpk-border-size-datatable: tokens.$bpk-border-size-xl * 2;
     display: flex;
     flex-direction: row;
     align-items: center;
-    border: tokens.$bpk-border-size-sm solid tokens.$bpk-line-day;
+    border: var(--bpk-border-1, tokens.$bpk-border-size-sm) solid
+      var(--bpk-other-line-default, tokens.$bpk-line-day);
     border-bottom: none;
-    outline-offset: -1 * (4 * tokens.$bpk-one-pixel-rem);
-    color: tokens.$bpk-text-primary-day;
+    outline-offset: $bpk-outline-offset;
+    color: var(--bpk-text-primary, tokens.$bpk-text-primary-day);
 
     @include typography.bpk-footnote;
 
     &:last-child:not(.bpk-data-table__header-row) {
-      border-bottom: tokens.$bpk-border-size-sm solid tokens.$bpk-line-day;
+      border-bottom: var(--bpk-border-1, tokens.$bpk-border-size-sm) solid
+        var(--bpk-other-line-default, tokens.$bpk-line-day);
     }
 
     &--clickable:not(.bpk-data-table__header-row):hover {
-      background-color: tokens.$bpk-canvas-contrast-day;
+      background-color: var(
+        --bpk-canvas-contrast,
+        tokens.$bpk-canvas-contrast-day
+      );
       cursor: pointer;
 
       @include bpk-datatable-border-left;
@@ -73,7 +75,10 @@ $bpk-border-size-datatable: tokens.$bpk-border-size-xl * 2;
     }
 
     &--selected {
-      background-color: tokens.$bpk-status-warning-fill-day;
+      background-color: var(
+        --bpk-surface-warning-fill,
+        tokens.$bpk-status-warning-fill-day
+      );
 
       @include bpk-datatable-border-left;
 

--- a/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.stories.tsx
@@ -18,6 +18,9 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
+// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
+import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
+
 import readme from '../README.md';
 
 import BpkDataTable from './BpkDataTable';
@@ -318,6 +321,12 @@ const WithColumnArrayExample = () => (
   />
 );
 
+const VisualTestDarkExample = () => (
+  <BpkDarkExampleWrapper>
+    <AutowidthExample />
+  </BpkDarkExampleWrapper>
+);
+
 export default {
   title: 'bpk-component-datatable',
   component: BpkDataTable,
@@ -353,4 +362,8 @@ export const VisualTest: Story = { render: () => <AutowidthExample /> };
 export const VisualTestWithZoom: Story = {
   render: () => <AutowidthExample />,
   args: {zoomEnabled: true}
+};
+
+export const VisualTestDark: Story = {
+  render: () => <VisualTestDarkExample />,
 };

--- a/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTable.stories.tsx
@@ -18,9 +18,6 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
-
 import readme from '../README.md';
 
 import BpkDataTable from './BpkDataTable';
@@ -321,12 +318,6 @@ const WithColumnArrayExample = () => (
   />
 );
 
-const VisualTestDarkExample = () => (
-  <BpkDarkExampleWrapper>
-    <AutowidthExample />
-  </BpkDarkExampleWrapper>
-);
-
 export default {
   title: 'bpk-component-datatable',
   component: BpkDataTable,
@@ -362,8 +353,4 @@ export const VisualTest: Story = { render: () => <AutowidthExample /> };
 export const VisualTestWithZoom: Story = {
   render: () => <AutowidthExample />,
   args: {zoomEnabled: true}
-};
-
-export const VisualTestDark: Story = {
-  render: () => <VisualTestDarkExample />,
 };

--- a/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTableHeader.module.scss
+++ b/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTableHeader.module.scss
@@ -22,7 +22,6 @@
 @use '../../bpk-mixins/utils';
 
 $bpk-margin-size-sort-icons: tokens.bpk-spacing-sm() + tokens.bpk-spacing-md();
-
 $icon-height: math.div(tokens.$bpk-line-height-xs, 2);
 
 .bpk-data-table-column__header {

--- a/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTableHeader.module.scss
+++ b/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTableHeader.module.scss
@@ -22,6 +22,8 @@
 @use '../../bpk-mixins/utils';
 
 $bpk-margin-size-sort-icons: tokens.bpk-spacing-sm() + tokens.bpk-spacing-md();
+
+// gap: typography line-height — $bpk-line-height-xs has no CSS var equivalent
 $icon-height: math.div(tokens.$bpk-line-height-xs, 2);
 
 .bpk-data-table-column__header {
@@ -50,16 +52,16 @@ $icon-height: math.div(tokens.$bpk-line-height-xs, 2);
 .bpk-data-table-column__sort-icon {
   display: block;
   line-height: $icon-height;
-  fill: tokens.$bpk-line-day;
+  fill: var(--bpk-other-line-default, tokens.$bpk-line-day);
 
   &:hover {
-    fill: tokens.$bpk-line-day;
+    fill: var(--bpk-other-line-default, tokens.$bpk-line-day);
   }
 
   &--selected {
     &,
     &:hover {
-      fill: tokens.$bpk-core-accent-day;
+      fill: var(--bpk-core-accent, tokens.$bpk-core-accent-day);
     }
   }
 }

--- a/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTableHeader.module.scss
+++ b/packages/backpack-web/src/bpk-component-datatable/src/BpkDataTableHeader.module.scss
@@ -23,7 +23,6 @@
 
 $bpk-margin-size-sort-icons: tokens.bpk-spacing-sm() + tokens.bpk-spacing-md();
 
-// gap: typography line-height — $bpk-line-height-xs has no CSS var equivalent
 $icon-height: math.div(tokens.$bpk-line-height-xs, 2);
 
 .bpk-data-table-column__header {


### PR DESCRIPTION
## Summary

- Migrates `bpk-component-datatable` SCSS files to use CSS custom properties (`var()`) with SASS token fallbacks, enabling light/dark mode support
- All 7 applicable token mappings applied per issue spec
- 2 gap tokens (`$bpk-line-height-xs`, `$bpk-one-pixel-rem`) documented with comments as having no CSS var equivalent
- Adds `VisualTestDark` story using `BpkDarkExampleWrapper` for Percy dark mode snapshots

**Token migrations:**
| SASS token | CSS var |
|---|---|
| `$bpk-border-size-sm` | `var(--bpk-border-1)` |
| `$bpk-border-size-xl` | `var(--bpk-border-3)` via `calc()` (doubled for accent border) |
| `$bpk-canvas-contrast-day` | `var(--bpk-canvas-contrast)` |
| `$bpk-core-accent-day` | `var(--bpk-core-accent)` |
| `$bpk-line-day` | `var(--bpk-other-line-default)` |
| `$bpk-status-warning-fill-day` | `var(--bpk-surface-warning-fill)` |
| `$bpk-text-primary-day` | `var(--bpk-text-primary)` |

Closes #4822

## Test plan

- [x] All existing tests pass (22/22, 3 suites)
- [x] SCSS lints cleanly via stylelint
- [x] CSS compiled output contains `var()` declarations with SASS fallbacks
- [x] Dark mode story added for Percy visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)