### PR TITLE
[CLOV-CSS] Migrate bpk-component-select to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-select/src/BpkSelect.module.scss
+++ b/packages/backpack-web/src/bpk-component-select/src/BpkSelect.module.scss
@@ -102,7 +102,6 @@ $select-image-large-height: 24 * tokens.$bpk-one-pixel-rem;
   &__image {
     position: absolute;
 
-    /* gap: $bpk-input-height — form input dimension, no CSS var exists yet */
     top: (tokens.$bpk-input-height - $select-image-height) * 0.5;
     left: tokens.bpk-spacing-md();
     width: $select-image-width;
@@ -115,7 +114,6 @@ $select-image-large-height: 24 * tokens.$bpk-one-pixel-rem;
     }
 
     &--large {
-      /* gap: $bpk-input-large-height — form input dimension, no CSS var exists yet */
       top: (tokens.$bpk-input-large-height - $select-image-large-height) * 0.5;
       left: tokens.bpk-spacing-base();
       width: $select-image-large-width;

--- a/packages/backpack-web/src/bpk-component-select/src/BpkSelect.module.scss
+++ b/packages/backpack-web/src/bpk-component-select/src/BpkSelect.module.scss
@@ -101,6 +101,8 @@ $select-image-large-height: 24 * tokens.$bpk-one-pixel-rem;
 
   &__image {
     position: absolute;
+
+    /* gap: $bpk-input-height — form input dimension, no CSS var exists yet */
     top: (tokens.$bpk-input-height - $select-image-height) * 0.5;
     left: tokens.bpk-spacing-md();
     width: $select-image-width;
@@ -113,6 +115,7 @@ $select-image-large-height: 24 * tokens.$bpk-one-pixel-rem;
     }
 
     &--large {
+      /* gap: $bpk-input-large-height — form input dimension, no CSS var exists yet */
       top: (tokens.$bpk-input-large-height - $select-image-large-height) * 0.5;
       left: tokens.bpk-spacing-base();
       width: $select-image-large-width;

--- a/packages/backpack-web/src/bpk-component-select/src/BpkSelect.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-select/src/BpkSelect.stories.tsx
@@ -21,8 +21,8 @@ import type { ChangeEvent } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import { action, BpkDarkExampleWrapper } from 'bpk-storybook-utils';
+// @ts-expect-error Untyped import
+import { action } from 'bpk-storybook-utils';
 
 import readme from '../README.md';
 
@@ -283,12 +283,6 @@ const MixedExample = () => (
   </div>
 );
 
-const DarkExample = () => (
-  <BpkDarkExampleWrapper>
-    <MixedExample />
-  </BpkDarkExampleWrapper>
-);
-
 const meta = {
   title: 'bpk-component-select',
   component: BpkSelect,
@@ -359,10 +353,4 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
-};
-
-export const VisualTestWithDarkMode = {
-  render: () => <DarkExample />,
-  parameters: { bpkTheme: 'dark' },
-  tags: ['dark-mode-compatible'],
 };

--- a/packages/backpack-web/src/bpk-component-select/src/BpkSelect.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-select/src/BpkSelect.stories.tsx
@@ -21,8 +21,8 @@ import type { ChangeEvent } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error Untyped import
-import { action } from 'bpk-storybook-utils';
+// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
+import { action, BpkDarkExampleWrapper } from 'bpk-storybook-utils';
 
 import readme from '../README.md';
 
@@ -283,6 +283,12 @@ const MixedExample = () => (
   </div>
 );
 
+const DarkExample = () => (
+  <BpkDarkExampleWrapper>
+    <MixedExample />
+  </BpkDarkExampleWrapper>
+);
+
 const meta = {
   title: 'bpk-component-select',
   component: BpkSelect,
@@ -353,4 +359,10 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
+};
+
+export const VisualTestWithDarkMode = {
+  render: () => <DarkExample />,
+  parameters: { bpkTheme: 'dark' },
+  tags: ['dark-mode-compatible'],
 };


### PR DESCRIPTION
Closes #4820

## Summary

- Documents gap tokens in `BpkSelect.module.scss` — no CSS vars exist yet for form input dimensions (`$bpk-input-height`, `$bpk-input-large-height`) or the hairline border utility (`$bpk-one-pixel-rem`)
- Adds `VisualTestWithDarkMode` story using `BpkDarkExampleWrapper`

## Gap tokens documented

| Token | Reason |
|-------|--------|
| `$bpk-input-height` | form input dimension, no CSS var exists yet |
| `$bpk-input-large-height` | form input dimension, no CSS var exists yet |
| `$bpk-one-pixel-rem` | hairline border utility, no CSS var equivalent |

No `themeAttributes.tsx` changes needed (existing `selectInvalidBorderColor` key has no CSS var equivalent yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)