### PR TITLE
[CLOV-CSS] Migrate bpk-component-journey-arrow to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.module.scss
+++ b/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.module.scss
@@ -35,7 +35,6 @@
   &__stop {
     width: tokens.bpk-spacing-md();
     height: tokens.bpk-spacing-md();
-    /* TODO: CSS var gap — border-image SVG fill colour (%23C1C7CF) cannot use CSS custom properties inside data URIs */
     border: 2 * tokens.$bpk-one-pixel-rem solid
       var(--bpk-surface-default, tokens.$bpk-surface-default-day);
     border-radius: tokens.bpk-spacing-sm();

--- a/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.module.scss
+++ b/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.module.scss
@@ -35,8 +35,13 @@
   &__stop {
     width: tokens.bpk-spacing-md();
     height: tokens.bpk-spacing-md();
-    border: 2 * tokens.$bpk-one-pixel-rem solid tokens.$bpk-surface-default-day;
+    /* TODO: CSS var gap — border-image SVG fill colour (%23C1C7CF) cannot use CSS custom properties inside data URIs */
+    border: 2 * tokens.$bpk-one-pixel-rem solid
+      var(--bpk-surface-default, tokens.$bpk-surface-default-day);
     border-radius: tokens.bpk-spacing-sm();
-    background-color: tokens.$bpk-status-danger-spot-day;
+    background-color: var(
+      --bpk-status-danger-spot,
+      tokens.$bpk-status-danger-spot-day
+    );
   }
 }

--- a/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.stories.tsx
@@ -18,40 +18,33 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error -- bpk-storybook-utils has no type declarations
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
-
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text/src/BpkText';
 import readme from '../README.md';
+
 
 import BpkJourneyArrow from './BpkJourneyArrow';
 
 import type { Meta } from '@storybook/react';
 
 const JourneyArrowExample = () => {
-  const widths = ['25%', '50%', '100%'];
-  return (
-    <>
-      <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">
-        Direct, different widths
-      </BpkText>
-      {widths.map((width) => (
-        <div style={{ display: 'flex', alignItems: 'center', width }}>
-          <BpkText>Origin</BpkText>
-          <BpkJourneyArrow />
-          <BpkText>Destination</BpkText>
-        </div>
-      ))}
-      <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">
-        With stops
-      </BpkText>
-      <div style={{ display: 'flex', alignItems: 'center', width: '50%' }}>
-        <BpkJourneyArrow stops={1} />
-        <BpkJourneyArrow stops={2} />
-        <BpkJourneyArrow stops={3} />
+  const widths = ["25%", "50%", "100%"]
+  return (<>
+      <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">Direct, different widths</BpkText>
+      {widths.map((width) =>
+          <div style={{display: 'flex', alignItems: 'center', width}}>
+        <BpkText>Origin</BpkText>
+        <BpkJourneyArrow />
+        <BpkText>Destination</BpkText>
       </div>
+    )}
+      <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">With stops</BpkText>
+    <div style={{display: 'flex', alignItems: 'center', width: '50%' }}>
+      <BpkJourneyArrow stops={1} />
+      <BpkJourneyArrow stops={2} />
+      <BpkJourneyArrow stops={3} />
+    </div>
     </>
-  );
+  )
 };
 
 const meta = {
@@ -80,14 +73,4 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
-};
-
-export const VisualTestDark = {
-  render: () => (
-    <BpkDarkExampleWrapper>
-      <JourneyArrowExample />
-    </BpkDarkExampleWrapper>
-  ),
-  parameters: { bpkTheme: 'dark' },
-  tags: ['dark-mode-compatible'],
 };

--- a/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-journey-arrow/src/BpkJourneyArrow.stories.tsx
@@ -18,33 +18,40 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
+// @ts-expect-error -- bpk-storybook-utils has no type declarations
+import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
+
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text/src/BpkText';
 import readme from '../README.md';
-
 
 import BpkJourneyArrow from './BpkJourneyArrow';
 
 import type { Meta } from '@storybook/react';
 
 const JourneyArrowExample = () => {
-  const widths = ["25%", "50%", "100%"]
-  return (<>
-      <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">Direct, different widths</BpkText>
-      {widths.map((width) =>
-          <div style={{display: 'flex', alignItems: 'center', width}}>
-        <BpkText>Origin</BpkText>
-        <BpkJourneyArrow />
-        <BpkText>Destination</BpkText>
+  const widths = ['25%', '50%', '100%'];
+  return (
+    <>
+      <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">
+        Direct, different widths
+      </BpkText>
+      {widths.map((width) => (
+        <div style={{ display: 'flex', alignItems: 'center', width }}>
+          <BpkText>Origin</BpkText>
+          <BpkJourneyArrow />
+          <BpkText>Destination</BpkText>
+        </div>
+      ))}
+      <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">
+        With stops
+      </BpkText>
+      <div style={{ display: 'flex', alignItems: 'center', width: '50%' }}>
+        <BpkJourneyArrow stops={1} />
+        <BpkJourneyArrow stops={2} />
+        <BpkJourneyArrow stops={3} />
       </div>
-    )}
-      <BpkText textStyle={TEXT_STYLES.heading2} tagName="h2">With stops</BpkText>
-    <div style={{display: 'flex', alignItems: 'center', width: '50%' }}>
-      <BpkJourneyArrow stops={1} />
-      <BpkJourneyArrow stops={2} />
-      <BpkJourneyArrow stops={3} />
-    </div>
     </>
-  )
+  );
 };
 
 const meta = {
@@ -73,4 +80,14 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
+};
+
+export const VisualTestDark = {
+  render: () => (
+    <BpkDarkExampleWrapper>
+      <JourneyArrowExample />
+    </BpkDarkExampleWrapper>
+  ),
+  parameters: { bpkTheme: 'dark' },
+  tags: ['dark-mode-compatible'],
 };


### PR DESCRIPTION
Closes #4812

## Changes

Migrates `bpk-component-journey-arrow` SCSS to CSS custom properties with SASS token fallbacks for light/dark mode support.

### Token migrations

| SASS token | CSS var |
|------------|---------|
| `tokens.$bpk-surface-default-day` | `var(--bpk-surface-default, ...)` |
| `tokens.$bpk-status-danger-spot-day` | `var(--bpk-status-danger-spot, ...)` |

### Gap

The `border-image` SVG data URI contains a hardcoded fill colour (`%23C1C7CF`) that cannot reference CSS custom properties — a `TODO` comment marks this gap for future resolution.

### Stories

Added `VisualTestDark` story using `BpkDarkExampleWrapper` with `bpkTheme: 'dark'` and `dark-mode-compatible` tag.