### PR TITLE
[CLOV-CSS] Migrate bpk-component-content-cards to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-content-cards/src/BpkContentCard.module.scss
+++ b/packages/backpack-web/src/bpk-component-content-cards/src/BpkContentCard.module.scss
@@ -25,7 +25,7 @@
   &--link {
     position: relative;
     display: block;
-    border-radius: tokens.$bpk-border-radius-md;
+    border-radius: var(--bpk-radius-md, tokens.$bpk-border-radius-md);
     color: inherit;
     /* stylelint-disable backpack/use-typography-styles */
     font: inherit;
@@ -40,6 +40,7 @@
     display: grid;
     column-gap: tokens.bpk-spacing-xxl();
     grid-template-columns:
+      /* tokens.$bpk-one-pixel-rem is used for pixel-precise sizing; no CSS var equivalent */
       minmax(min(10%, 50%), tokens.$bpk-one-pixel-rem * 620)
       40%;
     align-items: center;
@@ -85,7 +86,7 @@
   }
 
   &--description {
-    color: tokens.$bpk-text-secondary-day;
+    color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
 
     @include typography.bpk-body-default;
   }
@@ -93,7 +94,7 @@
   &--image {
     width: 100%;
     height: 100%;
-    border-radius: tokens.$bpk-border-radius-md;
+    border-radius: var(--bpk-radius-md, tokens.$bpk-border-radius-md);
     object-fit: cover;
   }
 }

--- a/packages/backpack-web/src/bpk-component-content-cards/src/BpkContentCards.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-content-cards/src/BpkContentCards.stories.tsx
@@ -20,9 +20,6 @@ import type { ComponentProps } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error -- bpk-storybook-utils has no type declarations
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
-
 import readme from '../README.md';
 
 import BpkContentCards from './BpkContentCards';
@@ -67,7 +64,7 @@ const contentCardProps: ComponentProps<typeof BpkContentCards> = {
       },
       headline: 'Try the food of the Gods',
       description:
-        "Greece gave us the Gyros. A vessel of bread lifting chips from plate to mouth. It doesn't get godlier than this.",
+        'Greece gave us the Gyros. A vessel of bread lifting chips from plate to mouth. It doesn\'t get godlier than this.',
       href: 'https://www.skyscanner.net',
     },
     {
@@ -77,7 +74,7 @@ const contentCardProps: ComponentProps<typeof BpkContentCards> = {
       },
       headline: 'Our top 10 Greek islands',
       description:
-        "There are islands for everything. You can party, relax, chill, eat and hike, and that's just Santorini.",
+        'There are islands for everything. You can party, relax, chill, eat and hike, and that\'s just Santorini.',
       href: 'https://www.skyscanner.net',
     },
   ],
@@ -114,12 +111,4 @@ export const DefaultThreeCards= {
 
 export const VisualTestThreeCards= {
   render: () => <WithThreeCardsExample />,
-};
-
-export const VisualTestThreeCardsDark = {
-  render: () => (
-    <BpkDarkExampleWrapper>
-      <WithThreeCardsExample />
-    </BpkDarkExampleWrapper>
-  ),
 };

--- a/packages/backpack-web/src/bpk-component-content-cards/src/BpkContentCards.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-content-cards/src/BpkContentCards.stories.tsx
@@ -20,6 +20,9 @@ import type { ComponentProps } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
+// @ts-expect-error -- bpk-storybook-utils has no type declarations
+import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
+
 import readme from '../README.md';
 
 import BpkContentCards from './BpkContentCards';
@@ -64,7 +67,7 @@ const contentCardProps: ComponentProps<typeof BpkContentCards> = {
       },
       headline: 'Try the food of the Gods',
       description:
-        'Greece gave us the Gyros. A vessel of bread lifting chips from plate to mouth. It doesn\'t get godlier than this.',
+        "Greece gave us the Gyros. A vessel of bread lifting chips from plate to mouth. It doesn't get godlier than this.",
       href: 'https://www.skyscanner.net',
     },
     {
@@ -74,7 +77,7 @@ const contentCardProps: ComponentProps<typeof BpkContentCards> = {
       },
       headline: 'Our top 10 Greek islands',
       description:
-        'There are islands for everything. You can party, relax, chill, eat and hike, and that\'s just Santorini.',
+        "There are islands for everything. You can party, relax, chill, eat and hike, and that's just Santorini.",
       href: 'https://www.skyscanner.net',
     },
   ],
@@ -111,4 +114,12 @@ export const DefaultThreeCards= {
 
 export const VisualTestThreeCards= {
   render: () => <WithThreeCardsExample />,
+};
+
+export const VisualTestThreeCardsDark = {
+  render: () => (
+    <BpkDarkExampleWrapper>
+      <WithThreeCardsExample />
+    </BpkDarkExampleWrapper>
+  ),
 };


### PR DESCRIPTION
Closes #4825

Migrates `bpk-component-content-cards` SCSS to CSS custom properties with SASS fallbacks for light/dark mode support.

## Changes

- `BpkContentCard.module.scss`: Migrated two `border-radius` declarations to `var(--bpk-radius-md, tokens.$bpk-border-radius-md)` and description text colour to `var(--bpk-text-secondary, tokens.$bpk-text-secondary-day)`. Added a comment explaining `tokens.$bpk-one-pixel-rem` pixel-precise sizing usage (no CSS var equivalent).
- `BpkContentCards.stories.tsx`: Added `VisualTestThreeCardsDark` story using `BpkDarkExampleWrapper` for dark mode visual testing.