### PR TITLE
[CLOV-CSS] Migrate bpk-component-rating to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-rating/src/BpkRating.module.scss
+++ b/packages/backpack-web/src/bpk-component-rating/src/BpkRating.module.scss
@@ -17,7 +17,6 @@
  */
 
 @use '../../bpk-mixins/tokens';
-@use '../../bpk-mixins/utils';
 
 .bpk-rating {
   display: flex;
@@ -40,24 +39,19 @@
     white-space: nowrap;
 
     &--large {
-      padding-top: tokens.$bpk-one-pixel-rem;
+      padding-top: var(--bpk-spacing-xxs, tokens.$bpk-one-pixel-rem);
       flex-direction: column;
       align-items: flex-start;
     }
   }
 
   &__scale {
-    color: tokens.$bpk-text-secondary-day;
+    color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
   }
 
   &__title {
     &--with-subtitle {
-      padding-right: tokens.bpk-spacing-md();
-
-      @include utils.bpk-rtl {
-        padding-right: 0;
-        padding-left: tokens.bpk-spacing-md();
-      }
+      padding-inline-end: tokens.bpk-spacing-md();
     }
   }
 
@@ -65,7 +59,7 @@
     min-width: 0;
     max-width: 100%;
     flex: 1 1 auto;
-    color: tokens.$bpk-text-secondary-day;
+    color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;

--- a/packages/backpack-web/src/bpk-component-rating/src/BpkRating.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-rating/src/BpkRating.stories.tsx
@@ -16,10 +16,9 @@
  * limitations under the License.
  */
 
+
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error Untyped import
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
 
 import BpkStarRating from '../../bpk-component-star-rating';
 import { cssModules } from '../../bpk-react-utils';
@@ -366,21 +365,9 @@ const MixedExample = () => (
   </div>
 );
 
-const DarkExample = () => (
-  <BpkDarkExampleWrapper>
-    <BpkRating
-      ariaLabel="4.8 Excellent 2,420 reviews"
-      value={4.8}
-      title="Excellent"
-      subtitle="2,420 reviews"
-    />
-  </BpkDarkExampleWrapper>
-);
-
 const meta = {
   title: 'bpk-component-rating',
   component: BpkRating,
-  tags: ['dark-mode-compatible'],
   parameters: {
     docs: {
       page: () => (
@@ -428,10 +415,4 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
-};
-
-export const VisualTestDark = {
-  render: () => <DarkExample />,
-  parameters: { bpkTheme: 'dark' },
-  tags: ['dark-mode-compatible'],
 };

--- a/packages/backpack-web/src/bpk-component-rating/src/BpkRating.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-rating/src/BpkRating.stories.tsx
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
+// @ts-expect-error Untyped import
+import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
 
 import BpkStarRating from '../../bpk-component-star-rating';
 import { cssModules } from '../../bpk-react-utils';
@@ -365,9 +366,21 @@ const MixedExample = () => (
   </div>
 );
 
+const DarkExample = () => (
+  <BpkDarkExampleWrapper>
+    <BpkRating
+      ariaLabel="4.8 Excellent 2,420 reviews"
+      value={4.8}
+      title="Excellent"
+      subtitle="2,420 reviews"
+    />
+  </BpkDarkExampleWrapper>
+);
+
 const meta = {
   title: 'bpk-component-rating',
   component: BpkRating,
+  tags: ['dark-mode-compatible'],
   parameters: {
     docs: {
       page: () => (
@@ -415,4 +428,10 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
+};
+
+export const VisualTestDark = {
+  render: () => <DarkExample />,
+  parameters: { bpkTheme: 'dark' },
+  tags: ['dark-mode-compatible'],
 };


### PR DESCRIPTION
Closes #4810

## Summary

Migrates `bpk-component-rating` SCSS to CSS custom properties with SASS fallbacks, enabling dark mode support.

### Changes

**`BpkRating.module.scss`**
- `$bpk-text-secondary-day` → `var(--bpk-text-secondary, tokens.$bpk-text-secondary-day)` on `__scale` and `__subtitle`
- `$bpk-one-pixel-rem` → `var(--bpk-spacing-xxs, ...)` on `__text-wrapper--large` padding-top
- Replaced `padding-right` + `bpk-rtl` mixin with `padding-inline-end` (CSS logical property, handles RTL natively)
- Removed now-unused `@use '../../bpk-mixins/utils'` import

**`BpkRating.stories.tsx`**
- Added `DarkExample` component using `BpkDarkExampleWrapper`
- Added `VisualTestDark` export with `bpkTheme: 'dark'` parameter
- Added `tags: ['dark-mode-compatible']` to meta