### PR TITLE
[CLOV-CSS] Migrate bpk-component-horizontal-nav to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.module.scss
+++ b/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.module.scss
@@ -23,11 +23,17 @@
   position: relative;
 
   &--show-default-underline {
-    @include borders.bpk-border-bottom-sm(tokens.$bpk-line-day, '');
+    @include borders.bpk-border-bottom-sm(
+      var(--bpk-other-line-default, tokens.$bpk-line-day),
+      ''
+    );
   }
 
   &--show-light-underline {
-    @include borders.bpk-border-bottom-sm(tokens.$bpk-line-day, '');
+    @include borders.bpk-border-bottom-sm(
+      var(--bpk-other-line-default, tokens.$bpk-line-day),
+      ''
+    );
   }
 
   &__list {

--- a/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.stories.js
+++ b/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.stories.js
@@ -20,6 +20,7 @@ import { Fragment, useState } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
+
 import {
   onePixelRem,
   colorSkyGrayTint06,
@@ -281,14 +282,4 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
-};
-
-export const VisualTestDark = {
-  render: () => (
-    <BpkDarkExampleWrapper>
-      <MixedExample />
-    </BpkDarkExampleWrapper>
-  ),
-  parameters: { bpkTheme: 'dark' },
-  tags: ['dark-mode-compatible'],
 };

--- a/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.stories.js
+++ b/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.stories.js
@@ -20,7 +20,6 @@ import { Fragment, useState } from 'react';
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-
 import {
   onePixelRem,
   colorSkyGrayTint06,
@@ -282,4 +281,14 @@ export const VisualTestWithZoom = {
   args: {
     zoomEnabled: true,
   },
+};
+
+export const VisualTestDark = {
+  render: () => (
+    <BpkDarkExampleWrapper>
+      <MixedExample />
+    </BpkDarkExampleWrapper>
+  ),
+  parameters: { bpkTheme: 'dark' },
+  tags: ['dark-mode-compatible'],
 };

--- a/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.stories.module.scss
+++ b/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNav.stories.module.scss
@@ -19,7 +19,10 @@
 @use '../../bpk-mixins/tokens';
 @use '../../bpk-mixins/scroll-indicators';
 
-$custom-color: tokens.$bpk-status-success-fill-day;
+$custom-color: var(
+  --bpk-surface-success-fill,
+  tokens.$bpk-status-success-fill-day
+);
 
 .bpk-horizontal-nav-custom-scrollers {
   background: $custom-color;

--- a/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.module.scss
+++ b/packages/backpack-web/src/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.module.scss
@@ -48,65 +48,48 @@
     }
 
     &--default {
-      @include utils.bpk-themeable-property(
-        color,
-        --bpk-horizontal-nav-link-color,
-        tokens.$bpk-text-secondary-day
-      );
+      color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
 
       @include utils.bpk-hover {
+        color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
+
         @include borders.bpk-border-bottom-xl(
-          tokens.$bpk-surface-highlight-day
-        );
-        @include utils.bpk-themeable-property(
-          color,
-          --bpk-horizontal-nav-link-hover-color,
-          tokens.$bpk-text-secondary-day
+          var(--bpk-surface-highlight, tokens.$bpk-surface-highlight-day)
         );
       }
 
       &:active {
-        @include borders.bpk-border-bottom-xl(tokens.$bpk-line-day);
-        @include utils.bpk-themeable-property(
-          color,
-          --bpk-horizontal-nav-link-active-color,
-          tokens.$bpk-text-secondary-day
+        color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
+
+        @include borders.bpk-border-bottom-xl(
+          var(--bpk-other-line-default, tokens.$bpk-line-day)
         );
       }
 
       &-disabled {
-        color: tokens.$bpk-text-disabled-day;
+        color: var(--bpk-text-disabled, tokens.$bpk-text-disabled-day);
         cursor: not-allowed;
 
         &:active {
-          color: tokens.$bpk-text-disabled-day;
+          color: var(--bpk-text-disabled, tokens.$bpk-text-disabled-day);
           box-shadow: unset;
         }
       }
 
       &-selected {
-        @include borders.bpk-border-bottom-xl(
-          tokens.$bpk-horizontal-nav-bar-selected-color
-        );
+        color: var(--bpk-text-deprecated-link, tokens.$bpk-text-link-day);
+
         @include borders.bpk-border-bottom-xl(
           var(
-            --bpk-horizontal-nav-bar-selected-color,
+            --bpk-text-deprecated-link,
             tokens.$bpk-horizontal-nav-bar-selected-color
           )
-        );
-        @include utils.bpk-themeable-property(
-          color,
-          --bpk-horizontal-nav-link-selected-color,
-          tokens.$bpk-text-link-day
         );
 
         @include utils.bpk-hover {
           @include borders.bpk-border-bottom-xl(
-            tokens.$bpk-horizontal-nav-bar-selected-color
-          );
-          @include borders.bpk-border-bottom-xl(
             var(
-              --bpk-horizontal-nav-bar-selected-color,
+              --bpk-text-deprecated-link,
               tokens.$bpk-horizontal-nav-bar-selected-color
             )
           );
@@ -114,11 +97,8 @@
 
         &:active {
           @include borders.bpk-border-bottom-xl(
-            tokens.$bpk-horizontal-nav-bar-selected-color
-          );
-          @include borders.bpk-border-bottom-xl(
             var(
-              --bpk-horizontal-nav-bar-selected-color,
+              --bpk-text-deprecated-link,
               tokens.$bpk-horizontal-nav-bar-selected-color
             )
           );
@@ -127,37 +107,47 @@
     }
 
     &--light {
-      color: tokens.$bpk-text-on-dark-day;
+      color: var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day);
 
       @include utils.bpk-hover {
-        @include borders.bpk-border-bottom-xl(tokens.$bpk-text-on-dark-day);
+        @include borders.bpk-border-bottom-xl(
+          var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day)
+        );
       }
 
       &:active {
-        @include borders.bpk-border-bottom-xl(tokens.$bpk-text-on-dark-day);
+        @include borders.bpk-border-bottom-xl(
+          var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day)
+        );
       }
 
       &-disabled {
-        color: tokens.$bpk-text-disabled-day;
+        color: var(--bpk-text-disabled, tokens.$bpk-text-disabled-day);
         cursor: not-allowed;
 
         &:active {
-          color: tokens.$bpk-text-disabled-day;
+          color: var(--bpk-text-disabled, tokens.$bpk-text-disabled-day);
           box-shadow: unset;
         }
       }
 
       &-selected {
-        color: tokens.$bpk-text-on-dark-day;
+        color: var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day);
 
-        @include borders.bpk-border-bottom-xl(tokens.$bpk-text-on-dark-day);
+        @include borders.bpk-border-bottom-xl(
+          var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day)
+        );
 
         @include utils.bpk-hover {
-          @include borders.bpk-border-bottom-xl(tokens.$bpk-text-on-dark-day);
+          @include borders.bpk-border-bottom-xl(
+            var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day)
+          );
         }
 
         &:active {
-          @include borders.bpk-border-bottom-xl(tokens.$bpk-text-on-dark-day);
+          @include borders.bpk-border-bottom-xl(
+            var(--bpk-text-on-dark, tokens.$bpk-text-on-dark-day)
+          );
         }
       }
     }


### PR DESCRIPTION
Closes #4823

Migrates `bpk-component-horizontal-nav` SCSS modules to CSS custom properties with SASS fallbacks for light/dark mode support.

## Changes

**`BpkHorizontalNav.module.scss`**
- Underline borders: `tokens.$bpk-line-day` → `var(--bpk-other-line-default, ...)`

**`BpkHorizontalNavItem.module.scss`**
- Default link text: `tokens.$bpk-text-secondary-day` → `var(--bpk-text-secondary, ...)`
- Hover border: `tokens.$bpk-surface-highlight-day` → `var(--bpk-surface-highlight, ...)`
- Active border: `tokens.$bpk-line-day` → `var(--bpk-other-line-default, ...)`
- Disabled text: `tokens.$bpk-text-disabled-day` → `var(--bpk-text-disabled, ...)`
- Selected border + text: old `--bpk-horizontal-nav-bar-selected-color` hook → `var(--bpk-text-deprecated-link, ...)`
- Light variant text + border: `tokens.$bpk-text-on-dark-day` → `var(--bpk-text-on-dark, ...)`
- Removes all `bpk-themeable-property` mixin usage in favour of plain `var()`

**`BpkHorizontalNav.stories.module.scss`**
- Custom scroll color: `tokens.$bpk-status-success-fill-day` → `var(--bpk-surface-success-fill, ...)`

**`BpkHorizontalNav.stories.js`**
- Adds `VisualTestDark` story using `BpkDarkExampleWrapper` tagged `dark-mode-compatible`