### PR TITLE
[CLOV-CSS] Migrate bpk-component-breadcrumb to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumb.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumb.stories.tsx
@@ -18,9 +18,6 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
-// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
-
 import readme from '../README.md';
 
 import BpkBreadcrumb from './BpkBreadcrumb';
@@ -86,14 +83,6 @@ export const Default = {
 
 export const Extreme = {
   render: () => <ExtremeExample />,
-};
-
-export const DarkMode = {
-  render: () => (
-    <BpkDarkExampleWrapper>
-      <DefaultExample />
-    </BpkDarkExampleWrapper>
-  ),
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumb.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumb.stories.tsx
@@ -18,6 +18,9 @@
 
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
+// @ts-expect-error Untyped import. See `decisions/imports-ts-suppressions.md`.
+import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
+
 import readme from '../README.md';
 
 import BpkBreadcrumb from './BpkBreadcrumb';
@@ -83,6 +86,14 @@ export const Default = {
 
 export const Extreme = {
   render: () => <ExtremeExample />,
+};
+
+export const DarkMode = {
+  render: () => (
+    <BpkDarkExampleWrapper>
+      <DefaultExample />
+    </BpkDarkExampleWrapper>
+  ),
 };
 
 export const VisualTest = {

--- a/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -23,6 +23,8 @@
 /* After adding the wrapper around the icon, need to set the line
     height to stop the 16x16 or 32x32(zoomed) icon from expanding
     verically past it's 16 or 32 pixels height */
+
+/* gap: typography line-height */
 $icon-height: math.div(tokens.$bpk-line-height-xs, 2);
 
 .bpk-breadcrumb-item {
@@ -35,12 +37,12 @@ $icon-height: math.div(tokens.$bpk-line-height-xs, 2);
   }
 
   &__active-item {
-    color: tokens.$bpk-text-secondary-day;
+    color: var(--bpk-text-secondary, tokens.$bpk-text-secondary-day);
   }
 
   &__arrow {
     margin: 0 tokens.bpk-spacing-sm();
     line-height: $icon-height;
-    fill: tokens.$bpk-text-disabled-day;
+    fill: var(--bpk-text-disabled, tokens.$bpk-text-disabled-day);
   }
 }

--- a/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -22,7 +22,7 @@
 
 /* After adding the wrapper around the icon, need to set the line
     height to stop the 16x16 or 32x32(zoomed) icon from expanding
-    verically past it's 16 or 32 pixels height */
+    vertically past its 16 or 32 pixels height */
 
 $icon-height: math.div(tokens.$bpk-line-height-xs, 2);
 

--- a/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
+++ b/packages/backpack-web/src/bpk-component-breadcrumb/src/BpkBreadcrumbItem.module.scss
@@ -24,7 +24,6 @@
     height to stop the 16x16 or 32x32(zoomed) icon from expanding
     verically past it's 16 or 32 pixels height */
 
-/* gap: typography line-height */
 $icon-height: math.div(tokens.$bpk-line-height-xs, 2);
 
 .bpk-breadcrumb-item {


### PR DESCRIPTION
Closes #4808

Migrates bpk-component-breadcrumb SCSS to CSS custom properties with SASS fallbacks for light/dark mode support.

## Changes

- `BpkBreadcrumbItem.module.scss`: Replace `tokens.$bpk-text-secondary-day` and `tokens.$bpk-text-disabled-day` with `var()` declarations using SASS tokens as fallbacks
- `BpkBreadcrumb.stories.tsx`: Add `DarkMode` story variant using `BpkDarkExampleWrapper`