### PR TITLE
[CLOV-CSS] Migrate bpk-component-modal to CSS custom properties

### DIFF
--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalInner.module.scss
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalInner.module.scss
@@ -85,13 +85,18 @@
 
   &__modal-style {
     &--surface-contrast {
-      background-color: tokens.$bpk-surface-contrast-day;
+      background-color: var(
+        --bpk-surface-contrast,
+        tokens.$bpk-surface-contrast-day
+      );
       color: tokens.$bpk-text-primary-dark-color;
     }
   }
 
   &__header {
-    @include borders.bpk-border-bottom-sm(tokens.$bpk-line-day);
+    @include borders.bpk-border-bottom-sm(
+      var(--bpk-other-line-default, tokens.$bpk-line-day)
+    );
   }
 
   &__navigation {
@@ -113,7 +118,10 @@
     }
 
     &-style--surface-contrast {
-      background-color: tokens.$bpk-surface-contrast-day;
+      background-color: var(
+        --bpk-surface-contrast,
+        tokens.$bpk-surface-contrast-day
+      );
       color: tokens.$bpk-text-primary-dark-color;
 
       @include utils.bpk-hover {

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV2/BpKModal.module.scss
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV2/BpKModal.module.scss
@@ -55,7 +55,7 @@
     position: fixed;
     z-index: 0;
     margin: 0 auto;
-    background-color: tokens.$bpk-scrim-day;
+    background-color: var(--bpk-other-scrim, tokens.$bpk-scrim-day);
     animation: bpk-modal-scrim tokens.$bpk-duration-sm ease-in-out;
     inset: 0;
     inset-block-end: 0;
@@ -98,7 +98,7 @@
     max-width: none;
     height: fit-content;
     max-height: 90%;
-    border-radius: tokens.$bpk-border-radius-md;
+    border-radius: var(--bpk-radius-md, tokens.$bpk-border-radius-md);
 
     &--full-screen-desktop {
       width: 100%;
@@ -131,7 +131,7 @@
 
   &::backdrop {
     position: fixed;
-    background-color: tokens.$bpk-scrim-day;
+    background-color: var(--bpk-other-scrim, tokens.$bpk-scrim-day);
     animation: bpk-modal-scrim tokens.$bpk-duration-sm ease-in-out;
     inset: 0;
     inset-block-end: 0;
@@ -149,7 +149,10 @@
     @include header;
 
     &-style--surface-contrast {
-      background-color: tokens.$bpk-surface-contrast-day;
+      background-color: var(
+        --bpk-surface-contrast,
+        tokens.$bpk-surface-contrast-day
+      );
       color: tokens.$bpk-text-primary-dark-color;
     }
   }
@@ -167,7 +170,10 @@
     @include header;
 
     &-style--surface-contrast {
-      background-color: tokens.$bpk-surface-contrast-day;
+      background-color: var(
+        --bpk-surface-contrast,
+        tokens.$bpk-surface-contrast-day
+      );
       color: tokens.$bpk-text-primary-dark-color;
     }
   }
@@ -185,7 +191,10 @@
     }
 
     &--surface-contrast {
-      background-color: tokens.$bpk-surface-contrast-day;
+      background-color: var(
+        --bpk-surface-contrast,
+        tokens.$bpk-surface-contrast-day
+      );
       color: tokens.$bpk-text-primary-dark-color;
     }
   }

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
@@ -22,8 +22,6 @@ import { useState } from 'react';
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
 import BpkButton from '../../../bpk-component-button';
-// @ts-expect-error -- bpk-storybook-utils has no type declarations
-import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
 import {
   BpkBox,
   BpkBreakpoint,
@@ -820,12 +818,4 @@ export const VisualTestChatbotWithZoom = {
   args: {
     zoomEnabled: true,
   },
-};
-
-export const VisualTestDark = {
-  render: () => (
-    <BpkDarkExampleWrapper>
-      <DefaultExample />
-    </BpkDarkExampleWrapper>
-  ),
 };

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3.stories.tsx
@@ -22,6 +22,8 @@ import { useState } from 'react';
 import { ArgTypes, Markdown } from '@storybook/addon-docs/blocks';
 
 import BpkButton from '../../../bpk-component-button';
+// @ts-expect-error -- bpk-storybook-utils has no type declarations
+import { BpkDarkExampleWrapper } from 'bpk-storybook-utils';
 import {
   BpkBox,
   BpkBreakpoint,
@@ -818,4 +820,12 @@ export const VisualTestChatbotWithZoom = {
   args: {
     zoomEnabled: true,
   },
+};
+
+export const VisualTestDark = {
+  render: () => (
+    <BpkDarkExampleWrapper>
+      <DefaultExample />
+    </BpkDarkExampleWrapper>
+  ),
 };

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3CloseTrigger/BpkModalV3CloseTrigger.module.scss
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3CloseTrigger/BpkModalV3CloseTrigger.module.scss
@@ -31,10 +31,13 @@
   align-items: center;
   flex-shrink: 0;
   border: none;
-  border-radius: tokens.$bpk-border-radius-lg;
+  border-radius: var(--bpk-radius-lg, tokens.$bpk-border-radius-lg);
   outline: none;
-  background-color: tokens.$bpk-line-on-dark-day;
-  color: tokens.$bpk-text-primary-day;
+  background-color: var(
+    --bpk-other-line-on-contrast,
+    tokens.$bpk-line-on-dark-day
+  );
+  color: var(--bpk-text-primary, tokens.$bpk-text-primary-day);
   cursor: pointer;
   inset-inline-end: tokens.bpk-spacing-lg();
 

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Content/BpkModalV3Content.module.scss
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Content/BpkModalV3Content.module.scss
@@ -54,7 +54,10 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  background-color: tokens.$bpk-surface-elevated-day;
+  background-color: var(
+    --bpk-surface-elevated,
+    tokens.$bpk-surface-elevated-day
+  );
   overflow: clip;
   pointer-events: none;
 
@@ -71,7 +74,7 @@
     transition:
       transform tokens.$bpk-duration-sm ease-in-out,
       opacity tokens.$bpk-duration-sm ease-in-out;
-    border-radius: tokens.$bpk-border-radius-lg;
+    border-radius: var(--bpk-radius-lg, tokens.$bpk-border-radius-lg);
     opacity: 0;
 
     @include shadows.bpk-box-shadow-lg;
@@ -114,7 +117,8 @@
     transition:
       opacity tokens.$bpk-duration-base cubic-bezier(0.5, 0, 0, 1),
       transform tokens.$bpk-duration-base cubic-bezier(0.5, 0, 0, 1);
-    border-radius: tokens.$bpk-border-radius-lg tokens.$bpk-border-radius-lg 0 0;
+    border-radius: var(--bpk-radius-lg, tokens.$bpk-border-radius-lg)
+      var(--bpk-radius-lg, tokens.$bpk-border-radius-lg) 0 0;
     opacity: 0;
 
     @include shadows.bpk-box-shadow-lg;
@@ -159,7 +163,10 @@
     transform: translateX(100%);
     transition: transform tokens.$bpk-duration-base cubic-bezier(0.5, 0, 0, 1);
     border-radius: 0;
-    background-color: tokens.$bpk-canvas-contrast-day;
+    background-color: var(
+      --bpk-canvas-contrast,
+      tokens.$bpk-canvas-contrast-day
+    );
 
     @include utils.bpk-rtl {
       transform: translateX(-100%);

--- a/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Scrim/BpkModalV3Scrim.module.scss
+++ b/packages/backpack-web/src/bpk-component-modal/src/BpkModalV3/BpkModalV3Scrim/BpkModalV3Scrim.module.scss
@@ -22,7 +22,7 @@
   position: fixed;
   z-index: tokens.$bpk-zindex-modal;
   transition: opacity tokens.$bpk-duration-sm ease-in-out;
-  background-color: tokens.$bpk-scrim-day;
+  background-color: var(--bpk-other-scrim, tokens.$bpk-scrim-day);
   opacity: 0;
   inset: 0;
   pointer-events: none;


### PR DESCRIPTION
Closes #4838

Migrates bpk-component-modal SCSS to CSS custom properties with SASS fallbacks for light/dark mode support.

## Changes
- Replace static SASS tokens with `var(--css-var, sass-fallback)` pattern in 5 SCSS files
- Tokens with no CSS var equivalent kept as bare SASS tokens (duration, z-index, component-specific tokens)
- Add dark mode story (`VisualTestDark`) to BpkModalV3 stories