### PR TITLE
[IRN-6874][BpkDrawer] Fix close button position regression when hideTitle is set

### DIFF
--- a/packages/backpack-web/src/bpk-component-drawer/index.ts
+++ b/packages/backpack-web/src/bpk-component-drawer/index.ts
@@ -22,8 +22,10 @@ import BpkDrawer from './src/BpkDrawer';
 import themeAttributes from './src/themeAttributes';
 
 import type { Props } from './src/BpkDrawer';
+import type { SecondaryPanelProps } from './src/types';
 
 export type BpkDrawerProps = Props;
+export type { SecondaryPanelProps };
 
 export default BpkDrawer;
 export { themeAttributes };

--- a/packages/backpack-web/src/bpk-component-drawer/src/BpkDrawerContent.module.scss
+++ b/packages/backpack-web/src/bpk-component-drawer/src/BpkDrawerContent.module.scss
@@ -94,6 +94,7 @@
 
   &__close-button {
     float: right;
+    margin-inline-start: auto;
 
     @include utils.bpk-rtl {
       float: left;

--- a/packages/backpack-web/src/bpk-component-drawer/src/BpkDrawerContent.module.scss
+++ b/packages/backpack-web/src/bpk-component-drawer/src/BpkDrawerContent.module.scss
@@ -81,6 +81,13 @@
     justify-content: space-between;
     align-items: center;
     flex: 0 0;
+
+    // Keep the close control at the trailing edge even when the title is
+    // visually hidden (out of flex flow) and only one flex item remains.
+    // Covers both the close-button and closeText (BpkLink) variants.
+    > :last-child {
+      margin-inline-start: auto;
+    }
   }
 
   &__heading {
@@ -94,7 +101,6 @@
 
   &__close-button {
     float: right;
-    margin-inline-start: auto;
 
     @include utils.bpk-rtl {
       float: left;


### PR DESCRIPTION
## Problem

Since **43.7.0**, the drawer close control jumps to the **top-left** (LTR) instead of top-right whenever the title is visually hidden (`hideTitle`). This blocks consumers bumping to ≥43.14.0 (IRN-6874).

## Root cause

PR #4848 (secondary panel, 43.7.0) removed an `&nbsp;` from the drawer header. The header is `display: flex; justify-content: space-between`, so it relied on **two** flex items (title + close) to push the close control to the trailing edge.

When `hideTitle` is set, the `<h2>` becomes `position: absolute` (out of flex flow), leaving the close control as the only flex item — which `space-between` renders at `flex-start` (left in LTR). The `&nbsp;` had silently been the second flex item holding the line. Its removal surfaced the regression.

## Before / After

| | Close control position |
|---|---|
| **Before** (43.7.0–43.15.0, `hideTitle`) | ❌ top-left |
| **After** | ✅ top-right (LTR) / top-left = trailing (RTL) |

<!-- Steve: drag the "before" screenshot from the ticket + the after screenshots here -->

## Fix

**`BpkDrawerContent.module.scss`** — pin the header's last child to the trailing edge:

```scss
&__header {
  ...
  > :last-child {
    margin-inline-start: auto;
  }
}
```

- Covers **both** close variants — the `__close-button` div *and* the `closeText` `<BpkLink>` — so `hideTitle` + `closeText` together also stays pinned.
- `margin-inline-start` is a logical property → RTL-safe with no direction-specific override (resolves to right in LTR, left in RTL).

**`index.ts`** — also exports `SecondaryPanelProps` (added to `Props` in 43.7.0 but never surfaced publicly), fixing TS2742 in consumers that emit declaration files.

## Test plan

Verified in Storybook (`localhost:9001`), drawer opened in each case:

- [x] **Default** (visible title + ✕) — title left, ✕ right ✓
- [x] **With Visually Hidden Title** (✕ only) — ✕ right ✓
- [x] **Close Button Text** (title + "Done" link) — title left, link right ✓
- [x] **RTL + hidden title** — drawer mirrors left, ✕ at trailing edge ✓
- [x] `pnpm run typecheck` — clean
- [x] `pnpm jest bpk-component-drawer` — 12/12 pass, 6 snapshots unchanged (HTML unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)