### PR TITLE
fix(adoption-analyzer): remove polynomial ReDoS in nx-projects path regex

### DIFF
--- a/libs/backpack-adoption-analyzer/src/analysis/nx-projects-test.ts
+++ b/libs/backpack-adoption-analyzer/src/analysis/nx-projects-test.ts
@@ -111,6 +111,15 @@ describe("nx-projects", () => {
       expect(entry.prefix).toBe("apps/web/");
       expect(resolveProject("apps/web/Home.tsx", [entry])).toBe("web");
     });
+
+    it("maps a root of \".\" to an empty prefix that matches every path", () => {
+      const [entry] = buildProjectIndex([
+        { name: "root", root: ".", type: null },
+      ]);
+
+      expect(entry.prefix).toBe("");
+      expect(resolveProject("App.tsx", [entry])).toBe("root");
+    });
   });
 
   describe("resolveProject", () => {

--- a/libs/backpack-adoption-analyzer/src/analysis/nx-projects-test.ts
+++ b/libs/backpack-adoption-analyzer/src/analysis/nx-projects-test.ts
@@ -102,6 +102,17 @@ describe("nx-projects", () => {
     });
   });
 
+  describe("buildProjectIndex", () => {
+    it("strips trailing slashes from the project root when building the prefix", () => {
+      const [entry] = buildProjectIndex([
+        { name: "web", root: "apps/web///", type: null },
+      ]);
+
+      expect(entry.prefix).toBe("apps/web/");
+      expect(resolveProject("apps/web/Home.tsx", [entry])).toBe("web");
+    });
+  });
+
   describe("resolveProject", () => {
     it("uses longest-prefix match and falls back to the unassigned bucket", () => {
       const index = buildProjectIndex([

--- a/libs/backpack-adoption-analyzer/src/analysis/nx-projects.ts
+++ b/libs/backpack-adoption-analyzer/src/analysis/nx-projects.ts
@@ -88,12 +88,18 @@ export function detectNxProjects(
   return { isNx: true, projects };
 }
 
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end -= 1;
+  return value.slice(0, end);
+}
+
 export function buildProjectIndex(projects: NxProject[]): NxProjectIndexEntry[] {
   return projects
     .map((project) => ({
       name: project.name,
       root: project.root,
-      prefix: project.root === "." ? "" : `${project.root.replace(/\/+$/, "")}/`,
+      prefix: project.root === "." ? "" : `${stripTrailingSlashes(project.root)}/`,
     }))
     .sort((a, b) => b.prefix.length - a.prefix.length);
 }


### PR DESCRIPTION
## What this solves

CodeQL code scanning alert [#120](https://github.com/Skyscanner/backpack/security/code-scanning/120): `js/polynomial-redos` (security severity: **high**).

Location: `libs/backpack-adoption-analyzer/src/analysis/nx-projects.ts:96`

```ts
prefix: project.root === "." ? "" : `${project.root.replace(/\/+$/, "")}/`,
```

`project.root` is parsed by `readProjectFile` from the `root` field of `project.json` / `package.json`, which CodeQL treats as **untrusted library input**. In the regex `/\/+$/`, the `\/+` can start matching anywhere within a run of consecutive slashes, and combined with the trailing `$` anchor this causes catastrophic backtracking: for inputs shaped like "many slashes followed by a non-slash char" (e.g. `"////…x"`), the engine re-scans the remaining slashes from every possible starting slash, giving **O(n²)** polynomial time complexity — a potential ReDoS (denial of service).

## What changed

- **`nx-projects.ts`**: Replaced the regex with a linear-time (O(n), no backtracking) `stripTrailingSlashes` helper. Behaviour is unchanged — it still strips all trailing slashes from `root`.
- **`nx-projects-test.ts`**: Added a targeted test verifying `root: "apps/web///"` → `prefix: "apps/web/"` and that the project still resolves correctly.

## Verification

- ✅ `jest`: 6 passed
- ✅ `tsc` typecheck: clean
- ✅ `eslint`: clean