### PR TITLE
[NOJIRA] Expose adoption comparison action outputs

### DIFF
--- a/packages/backpack-adoption-guard/README.md
+++ b/packages/backpack-adoption-guard/README.md
@@ -54,9 +54,9 @@ The action emits one of three guard statuses:
 
 | Output | Description |
 | --- | --- |
-| `head-backpack-adoption` | Backpack adoption percentage for the checked-out ref. |
-| `base-backpack-adoption` | Backpack adoption percentage for the PR base ref; empty when unavailable. |
-| `backpack-adoption-delta` | Head minus base Backpack adoption percentage; empty when unavailable. |
+| `head-backpack-adoption` | Numeric percentage string from `0` to `100`, rounded to at most two decimal places with no `%` suffix, for the checked-out ref. |
+| `base-backpack-adoption` | Numeric percentage string from `0` to `100`, rounded to at most two decimal places with no `%` suffix, for the PR base ref; empty when unavailable. |
+| `backpack-adoption-delta` | Signed numeric percentage-point string, rounded to at most two decimal places with no `%` suffix; empty when unavailable. |
 
 ## Uploading metrics to Cortex
 

--- a/packages/backpack-adoption-guard/README.md
+++ b/packages/backpack-adoption-guard/README.md
@@ -54,9 +54,9 @@ The action emits one of three guard statuses:
 
 | Output | Description |
 | --- | --- |
-| `head-backpack-adoption` | Numeric percentage string from `0` to `100`, rounded to at most two decimal places with no `%` suffix, for the checked-out ref. |
-| `base-backpack-adoption` | Numeric percentage string from `0` to `100`, rounded to at most two decimal places with no `%` suffix, for the PR base ref; empty when unavailable. |
-| `backpack-adoption-delta` | Signed numeric percentage-point string, rounded to at most two decimal places with no `%` suffix; empty when unavailable. |
+| `head-backpack-adoption` | Numeric percentage string from `0` to `100` with exactly two decimal places and no `%` suffix, for the checked-out ref. |
+| `base-backpack-adoption` | Numeric percentage string from `0` to `100` with exactly two decimal places and no `%` suffix, for the PR base ref; empty when unavailable. |
+| `backpack-adoption-delta` | Signed numeric percentage-point string with exactly two decimal places and no `%` suffix; empty when unavailable. |
 
 ## Uploading metrics to Cortex
 

--- a/packages/backpack-adoption-guard/README.md
+++ b/packages/backpack-adoption-guard/README.md
@@ -50,6 +50,14 @@ The action emits one of three guard statuses:
 | `output-path` | Path for the generated adoption result JSON. | No | `backpack-adoption-results.json` |
 | `threshold` | Backpack adoption percentage threshold before the guard starts blocking decreases. | No | `60` |
 
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `head-backpack-adoption` | Backpack adoption percentage for the checked-out ref. |
+| `base-backpack-adoption` | Backpack adoption percentage for the PR base ref; empty when unavailable. |
+| `backpack-adoption-delta` | Head minus base Backpack adoption percentage; empty when unavailable. |
+
 ## Uploading metrics to Cortex
 
 This action only writes a JSON results file. To ship the results to Cortex on

--- a/packages/backpack-adoption-guard/action.yml
+++ b/packages/backpack-adoption-guard/action.yml
@@ -21,11 +21,11 @@ inputs:
 
 outputs:
   head-backpack-adoption:
-    description: Numeric percentage string (0-100, up to two decimal places, no percent sign) for the checked-out ref.
+    description: Numeric percentage string from 0 to 100 with exactly two decimal places and no percent sign for the checked-out ref.
   base-backpack-adoption:
-    description: Numeric percentage string (0-100, up to two decimal places, no percent sign) for the PR base ref, or an empty string when unavailable.
+    description: Numeric percentage string from 0 to 100 with exactly two decimal places and no percent sign for the PR base ref, or an empty string when unavailable.
   backpack-adoption-delta:
-    description: Signed numeric percentage-point string (up to two decimal places, no percent sign), or an empty string when unavailable.
+    description: Signed numeric percentage-point string with exactly two decimal places and no percent sign, or an empty string when unavailable.
 
 runs:
   using: node24

--- a/packages/backpack-adoption-guard/action.yml
+++ b/packages/backpack-adoption-guard/action.yml
@@ -21,11 +21,11 @@ inputs:
 
 outputs:
   head-backpack-adoption:
-    description: Backpack adoption percentage for the checked-out ref.
+    description: Numeric percentage string (0-100, up to two decimal places, no percent sign) for the checked-out ref.
   base-backpack-adoption:
-    description: Backpack adoption percentage for the PR base ref, or an empty string when unavailable.
+    description: Numeric percentage string (0-100, up to two decimal places, no percent sign) for the PR base ref, or an empty string when unavailable.
   backpack-adoption-delta:
-    description: Head minus base Backpack adoption percentage, or an empty string when unavailable.
+    description: Signed numeric percentage-point string (up to two decimal places, no percent sign), or an empty string when unavailable.
 
 runs:
   using: node24

--- a/packages/backpack-adoption-guard/action.yml
+++ b/packages/backpack-adoption-guard/action.yml
@@ -19,6 +19,14 @@ inputs:
     required: false
     default: "60"
 
+outputs:
+  head-backpack-adoption:
+    description: Backpack adoption percentage for the checked-out ref.
+  base-backpack-adoption:
+    description: Backpack adoption percentage for the PR base ref, or an empty string when unavailable.
+  backpack-adoption-delta:
+    description: Head minus base Backpack adoption percentage, or an empty string when unavailable.
+
 runs:
   using: node24
   main: dist/index.js

--- a/packages/backpack-adoption-guard/src/action/io.ts
+++ b/packages/backpack-adoption-guard/src/action/io.ts
@@ -23,6 +23,7 @@ export type ActionIO = {
   warning: (message: string) => void;
   error: (message: string) => void;
   setFailed: (message: string) => void;
+  setOutput: (name: string, value: string) => void;
   appendSummary: (markdown: string) => Promise<void>;
 };
 
@@ -37,6 +38,7 @@ export const createGitHubActionsIO = (): ActionIO => ({
   warning: (message) => core.warning(message),
   error: (message) => core.error(message),
   setFailed: (message) => core.setFailed(message),
+  setOutput: (name, value) => core.setOutput(name, value),
   appendSummary: async (markdown) => {
     if (!process.env.GITHUB_STEP_SUMMARY) {
       return;

--- a/packages/backpack-adoption-guard/src/action/outputs.ts
+++ b/packages/backpack-adoption-guard/src/action/outputs.ts
@@ -1,0 +1,22 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const ADOPTION_OUTPUTS = {
+  head: "head-backpack-adoption",
+  base: "base-backpack-adoption",
+  delta: "backpack-adoption-delta",
+} as const;

--- a/packages/backpack-adoption-guard/src/action/run-test.ts
+++ b/packages/backpack-adoption-guard/src/action/run-test.ts
@@ -40,6 +40,7 @@ const createTestIO = (inputs: Record<string, string> = {}): ActionIO => ({
   warning: jest.fn(),
   error: jest.fn(),
   setFailed: jest.fn(),
+  setOutput: jest.fn(),
   appendSummary: jest.fn().mockResolvedValue(undefined),
 });
 
@@ -88,7 +89,8 @@ export const App = () => (
 `,
     );
 
-    const result = await run({ cwd: repoPath, io: createTestIO() });
+    const io = createTestIO();
+    const result = await run({ cwd: repoPath, io });
     const resultsFile = JSON.parse(
       await readFile(join(repoPath, "backpack-adoption-results.json"), "utf8"),
     );
@@ -114,6 +116,15 @@ export const App = () => (
     expect(metrics).not.toHaveProperty("parseErrors");
     expect(metrics).not.toHaveProperty("projects");
     expect(result.guard).not.toHaveProperty("projects");
+    expect(io.setOutput).toHaveBeenCalledWith(
+      "head-backpack-adoption",
+      String(result.comparison.headBackpackPercentage),
+    );
+    expect(io.setOutput).toHaveBeenCalledWith(
+      "base-backpack-adoption",
+      "",
+    );
+    expect(io.setOutput).toHaveBeenCalledWith("backpack-adoption-delta", "");
   });
 
   it("reports NX workspaces as a single repository", async () => {

--- a/packages/backpack-adoption-guard/src/action/run-test.ts
+++ b/packages/backpack-adoption-guard/src/action/run-test.ts
@@ -15,12 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 
 import { run } from "./run";
 import type { ActionIO } from "./io";
+import { ADOPTION_OUTPUTS } from "./outputs";
+
+const execFileAsync = promisify(execFile);
 
 const createRepo = async () => mkdtemp(join(tmpdir(), "bpk-action-test-"));
 
@@ -32,6 +37,22 @@ const writeRepoFile = async (
   const absolutePath = join(repoPath, filePath);
   await mkdir(join(absolutePath, ".."), { recursive: true });
   await writeFile(absolutePath, content, "utf8");
+};
+
+const commitRepository = async (repoPath: string) => {
+  await execFileAsync("git", ["-C", repoPath, "init"]);
+  await execFileAsync("git", ["-C", repoPath, "config", "user.email", "test@example.com"]);
+  await execFileAsync("git", ["-C", repoPath, "config", "user.name", "Test User"]);
+  await execFileAsync("git", ["-C", repoPath, "add", "."]);
+  await execFileAsync("git", ["-C", repoPath, "commit", "-m", "Base"]);
+  const { stdout } = await execFileAsync("git", [
+    "-C",
+    repoPath,
+    "rev-parse",
+    "HEAD",
+  ]);
+
+  return stdout.trim();
 };
 
 const createTestIO = (inputs: Record<string, string> = {}): ActionIO => ({
@@ -117,14 +138,55 @@ export const App = () => (
     expect(metrics).not.toHaveProperty("projects");
     expect(result.guard).not.toHaveProperty("projects");
     expect(io.setOutput).toHaveBeenCalledWith(
-      "head-backpack-adoption",
+      ADOPTION_OUTPUTS.head,
       String(result.comparison.headBackpackPercentage),
     );
-    expect(io.setOutput).toHaveBeenCalledWith(
-      "base-backpack-adoption",
-      "",
+    expect(io.setOutput).toHaveBeenCalledWith(ADOPTION_OUTPUTS.base, "");
+    expect(io.setOutput).toHaveBeenCalledWith(ADOPTION_OUTPUTS.delta, "");
+  });
+
+  it("emits base and delta outputs for pull requests", async () => {
+    await writeRepoFile(
+      repoPath,
+      "src/App.tsx",
+      "export const App = () => <div>Raw HTML</div>;",
     );
-    expect(io.setOutput).toHaveBeenCalledWith("backpack-adoption-delta", "");
+    const baseSha = await commitRepository(repoPath);
+    const eventPath = join(repoPath, "event.json");
+    await writeFile(
+      eventPath,
+      JSON.stringify({ pull_request: { base: { sha: baseSha } } }),
+      "utf8",
+    );
+    await writeRepoFile(
+      repoPath,
+      "src/App.tsx",
+      `
+import BpkButton from '@skyscanner/backpack-web/bpk-component-button';
+
+export const App = () => <BpkButton>Book</BpkButton>;
+`,
+    );
+    process.env = {
+      ...originalEnv,
+      GITHUB_EVENT_NAME: "pull_request",
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_REF: "refs/pull/1/merge",
+    };
+
+    const io = createTestIO();
+    const result = await run({ cwd: repoPath, io });
+
+    expect(result.comparison.baseBackpackPercentage).not.toBeNull();
+    expect(result.comparison.delta).not.toBeNull();
+    expect(io.setOutput).toHaveBeenCalledWith(
+      ADOPTION_OUTPUTS.base,
+      String(result.comparison.baseBackpackPercentage),
+    );
+    expect(io.setOutput).toHaveBeenCalledWith(
+      ADOPTION_OUTPUTS.delta,
+      String(result.comparison.delta),
+    );
   });
 
   it("reports NX workspaces as a single repository", async () => {

--- a/packages/backpack-adoption-guard/src/action/run-test.ts
+++ b/packages/backpack-adoption-guard/src/action/run-test.ts
@@ -137,10 +137,7 @@ export const App = () => (
     expect(metrics).not.toHaveProperty("parseErrors");
     expect(metrics).not.toHaveProperty("projects");
     expect(result.guard).not.toHaveProperty("projects");
-    expect(io.setOutput).toHaveBeenCalledWith(
-      ADOPTION_OUTPUTS.head,
-      String(result.comparison.headBackpackPercentage),
-    );
+    expect(io.setOutput).toHaveBeenCalledWith(ADOPTION_OUTPUTS.head, "66.67");
     expect(io.setOutput).toHaveBeenCalledWith(ADOPTION_OUTPUTS.base, "");
     expect(io.setOutput).toHaveBeenCalledWith(ADOPTION_OUTPUTS.delta, "");
   });
@@ -179,14 +176,9 @@ export const App = () => <BpkButton>Book</BpkButton>;
 
     expect(result.comparison.baseBackpackPercentage).not.toBeNull();
     expect(result.comparison.delta).not.toBeNull();
-    expect(io.setOutput).toHaveBeenCalledWith(
-      ADOPTION_OUTPUTS.base,
-      String(result.comparison.baseBackpackPercentage),
-    );
-    expect(io.setOutput).toHaveBeenCalledWith(
-      ADOPTION_OUTPUTS.delta,
-      String(result.comparison.delta),
-    );
+    expect(io.setOutput).toHaveBeenCalledWith(ADOPTION_OUTPUTS.head, "100.00");
+    expect(io.setOutput).toHaveBeenCalledWith(ADOPTION_OUTPUTS.base, "0.00");
+    expect(io.setOutput).toHaveBeenCalledWith(ADOPTION_OUTPUTS.delta, "100.00");
   });
 
   it("reports NX workspaces as a single repository", async () => {

--- a/packages/backpack-adoption-guard/src/action/run.ts
+++ b/packages/backpack-adoption-guard/src/action/run.ts
@@ -75,6 +75,21 @@ const writeResults = async (
   );
 };
 
+const writeOutputs = (io: ActionIO, result: ActionResult) => {
+  const {
+    baseBackpackPercentage,
+    delta,
+    headBackpackPercentage,
+  } = result.comparison;
+
+  io.setOutput("head-backpack-adoption", String(headBackpackPercentage));
+  io.setOutput(
+    "base-backpack-adoption",
+    baseBackpackPercentage === null ? "" : String(baseBackpackPercentage),
+  );
+  io.setOutput("backpack-adoption-delta", delta === null ? "" : String(delta));
+};
+
 const createActionResult = ({
   baseReport,
   eventName,
@@ -205,6 +220,7 @@ export const run = async ({
   });
 
   await writeResults(cwd, outputPath, result);
+  writeOutputs(io, result);
   await io.appendSummary(buildStepSummary(result));
 
   io.info(`Backpack adoption results written to ${outputPath}`);

--- a/packages/backpack-adoption-guard/src/action/run.ts
+++ b/packages/backpack-adoption-guard/src/action/run.ts
@@ -40,6 +40,7 @@ import {
 } from "../git/base-worktree";
 import { createGitHubActionsIO, getBooleanInput } from "./io";
 import type { ActionIO } from "./io";
+import { ADOPTION_OUTPUTS } from "./outputs";
 import { buildStepSummary } from "./summary";
 
 export type RunOptions = {
@@ -82,12 +83,12 @@ const writeOutputs = (io: ActionIO, result: ActionResult) => {
     headBackpackPercentage,
   } = result.comparison;
 
-  io.setOutput("head-backpack-adoption", String(headBackpackPercentage));
+  io.setOutput(ADOPTION_OUTPUTS.head, String(headBackpackPercentage));
   io.setOutput(
-    "base-backpack-adoption",
+    ADOPTION_OUTPUTS.base,
     baseBackpackPercentage === null ? "" : String(baseBackpackPercentage),
   );
-  io.setOutput("backpack-adoption-delta", delta === null ? "" : String(delta));
+  io.setOutput(ADOPTION_OUTPUTS.delta, delta === null ? "" : String(delta));
 };
 
 const createActionResult = ({

--- a/packages/backpack-adoption-guard/src/action/run.ts
+++ b/packages/backpack-adoption-guard/src/action/run.ts
@@ -76,6 +76,9 @@ const writeResults = async (
   );
 };
 
+const formatOutput = (value: number | null) =>
+  value === null ? "" : value.toFixed(2);
+
 const writeOutputs = (io: ActionIO, result: ActionResult) => {
   const {
     baseBackpackPercentage,
@@ -83,12 +86,9 @@ const writeOutputs = (io: ActionIO, result: ActionResult) => {
     headBackpackPercentage,
   } = result.comparison;
 
-  io.setOutput(ADOPTION_OUTPUTS.head, String(headBackpackPercentage));
-  io.setOutput(
-    ADOPTION_OUTPUTS.base,
-    baseBackpackPercentage === null ? "" : String(baseBackpackPercentage),
-  );
-  io.setOutput(ADOPTION_OUTPUTS.delta, delta === null ? "" : String(delta));
+  io.setOutput(ADOPTION_OUTPUTS.head, formatOutput(headBackpackPercentage));
+  io.setOutput(ADOPTION_OUTPUTS.base, formatOutput(baseBackpackPercentage));
+  io.setOutput(ADOPTION_OUTPUTS.delta, formatOutput(delta));
 };
 
 const createActionResult = ({


### PR DESCRIPTION
## Summary

Expose the adoption comparison already calculated by `backpack-adoption-guard` as GitHub Action outputs:

- `head-backpack-adoption`
- `base-backpack-adoption`
- `backpack-adoption-delta`

This lets consuming workflows publish Head/Base/Delta in a PR comment without checking out the base ref or running the guard a second time. The existing Cortex JSON result schema is unchanged.

## Why

The guard already calculates the comparison for PR evaluation, but previously only persisted the Head metric in its JSON file. Consumers therefore had to duplicate the Base calculation solely for presentation.

## Consumer impact

This is a backwards-compatible, additive action API change. Consumers can use the new outputs after upgrading to the next guard release.

Apply the `minor` label.

## Validation

- [x] Updated `packages/backpack-adoption-guard/README.md`
- [x] Added unit-test coverage for action outputs
- [x] Typecheck passed
- [x] Unit tests passed (5 tests)
- [x] Build passed
- [x] `git diff --check` passed
- [ ] Accessibility tests — not applicable; this is a Node GitHub Action with no UI
- [ ] Storybook examples — not applicable
- [ ] Migration guide — not applicable; the change is additive and backwards compatible

> Note: re-running checks after rebasing onto the latest `main` was blocked by transient npm registry `ECONNRESET` errors during dependency installation. The same cherry-picked change passed typecheck, tests, and build before the rebase.