### PR TITLE
[spike] Fix card-list rail pagination on short final page

### DIFF
--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.stories.tsx
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardList.stories.tsx
@@ -286,6 +286,32 @@ const GridToStackExample = () => (
   </PageContainer>
 );
 
+const RowToRailShortFinalPageExample = () => (
+  <PageContainer>
+    <BpkCardList
+      {...commonProps}
+      cardList={makeList(DestinationCard, 3)}
+      initiallyShownCardsDesktop={2}
+      layoutDesktop={LAYOUTS.row}
+      layoutMobile={LAYOUTS.rail}
+      accessoryDesktop={ACCESSORY_DESKTOP_TYPES.pagination}
+    />
+  </PageContainer>
+);
+
+const RowToRailShortFinalPageWiderExample = () => (
+  <PageContainer>
+    <BpkCardList
+      {...commonProps}
+      cardList={makeList(DestinationCard, 10)}
+      initiallyShownCardsDesktop={4}
+      layoutDesktop={LAYOUTS.row}
+      layoutMobile={LAYOUTS.rail}
+      accessoryDesktop={ACCESSORY_DESKTOP_TYPES.pagination}
+    />
+  </PageContainer>
+);
+
 const RowToStackWithExpandExample = () => {
   const [expandText, setExpandText] = useState('Show more');
 
@@ -433,6 +459,8 @@ export const RowToStackWithExpand = { render: () => <RowToStackWithExpandExample
 export const GridToStackWithExpand = { render: () => <GridToStackWithExpandExample /> };
 export const RowToRailForSnippets = { render: () => <RowToRailForSnippetsExample /> };
 export const RowToRailWithoutTitle = { render: () => <RowToRailWithoutTitleExample /> };
+export const RowToRailShortFinalPage = { render: () => <RowToRailShortFinalPageExample /> };
+export const RowToRailShortFinalPageWider = { render: () => <RowToRailShortFinalPageWiderExample /> };
 
 export const MultiComponentsScrollingTest = { render: () => <MultiComponentsScrollingTestExample /> };
 export const VisualTest = { render: () => <BasicExample /> };

--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListRowRail/utils-test.tsx
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListRowRail/utils-test.tsx
@@ -584,6 +584,47 @@ describe('usePageScrollSync', () => {
       expect(mockSetCurrentIndex).not.toHaveBeenCalled();
     });
 
+    it('should snap to the last page when the final (short) page cannot scroll its first card to the start', () => {
+      // 3 cards, 2 shown per page => page 0 = [0,1], page 1 = [2].
+      // The final page holds fewer cards than initiallyShownCards, so scrolling to
+      // the end leaves card 2 alongside card 1 (firstVisibleIndex stays at 1).
+      // Because the last card is visible, we should still land on page 1.
+      const shortCardRefs = { current: [] as Array<HTMLDivElement | null> };
+      Array.from({ length: 3 }).forEach((_, index) => {
+        const { mockDiv } = makeMockDiv(index);
+        mockDiv.scrollIntoView = jest.fn();
+        shortCardRefs.current.push(mockDiv);
+      });
+
+      const { rerender } = renderHook(
+        ({ visibilityList }) =>
+          usePageScrollSync({
+            cardRefs: shortCardRefs,
+            container: mockContainer,
+            currentIndex: 0,
+            enabled: true,
+            initiallyShownCards: 2,
+            setCurrentIndex: mockSetCurrentIndex,
+            visibilityList,
+          }),
+        {
+          initialProps: {
+            visibilityList: [1, 1, 0],
+          },
+        },
+      );
+
+      // User initiates scroll via wheel
+      act(() => {
+        mockContainer.dispatchEvent(new Event('wheel'));
+      });
+
+      // Scrolled to the end: cards 1 and 2 visible, card 0 out of view
+      rerender({ visibilityList: [0, 1, 1] });
+
+      expect(mockSetCurrentIndex).toHaveBeenCalledWith(1);
+    });
+
     it('should handle partial visibility at page boundaries by using first visible card', () => {
       // When scrolling between pages, the first visible index determines the page.
       // With firstVisibleIndex=2 and initiallyShownCards=3: Math.floor(2/3) = 0

--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListRowRail/utils.tsx
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListRowRail/utils.tsx
@@ -209,17 +209,13 @@ export const usePageScrollSync = ({
     const firstVisibleIndex = visibilityList.indexOf(1);
     if (firstVisibleIndex === -1) return;
 
-    // When the final page holds fewer cards than initiallyShownCards, scrolling to
-    // the end can't bring that page's first card to the start of the viewport, so
-    // firstVisibleIndex still points at the previous page. If the last card is
-    // visible we've reached the end, so snap the indicator to the final page.
-    const totalPages = Math.ceil(visibilityList.length / initiallyShownCards);
-    const isLastCardVisible =
-      visibilityList[visibilityList.length - 1] === 1;
-
-    const newPageIndex = isLastCardVisible
-      ? totalPages - 1
-      : Math.floor(firstVisibleIndex / initiallyShownCards);
+    // A short final page can't scroll its first card to the viewport start, so
+    // firstVisibleIndex stays on the previous page. Treat a visible last card as
+    // the final page.
+    const newPageIndex =
+      visibilityList[visibilityList.length - 1] === 1
+        ? Math.ceil(visibilityList.length / initiallyShownCards) - 1
+        : Math.floor(firstVisibleIndex / initiallyShownCards);
     if (newPageIndex !== currentIndex) {
       setCurrentIndex(newPageIndex);
       lastCurrentIndexRef.current = newPageIndex;

--- a/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListRowRail/utils.tsx
+++ b/packages/backpack-web/src/bpk-component-card-list/src/BpkCardListRowRail/utils.tsx
@@ -209,7 +209,17 @@ export const usePageScrollSync = ({
     const firstVisibleIndex = visibilityList.indexOf(1);
     if (firstVisibleIndex === -1) return;
 
-    const newPageIndex = Math.floor(firstVisibleIndex / initiallyShownCards);
+    // When the final page holds fewer cards than initiallyShownCards, scrolling to
+    // the end can't bring that page's first card to the start of the viewport, so
+    // firstVisibleIndex still points at the previous page. If the last card is
+    // visible we've reached the end, so snap the indicator to the final page.
+    const totalPages = Math.ceil(visibilityList.length / initiallyShownCards);
+    const isLastCardVisible =
+      visibilityList[visibilityList.length - 1] === 1;
+
+    const newPageIndex = isLastCardVisible
+      ? totalPages - 1
+      : Math.floor(firstVisibleIndex / initiallyShownCards);
     if (newPageIndex !== currentIndex) {
       setCurrentIndex(newPageIndex);
       lastCurrentIndexRef.current = newPageIndex;


### PR DESCRIPTION
## Spike

Investigating a pagination bug in `BpkCardList` row/rail mode.

## Problem

When the final page of a rail holds **fewer cards than `initiallyShownCards`** (odd totals — e.g. 3 cards shown 2-wide), physically scrolling to the end does **not** advance the pagination indicator.

Cause: in `usePageScrollSync`, the page index is derived from `Math.floor(firstVisibleIndex / initiallyShownCards)`. On a short final page there isn't enough content to scroll that page's first card to the viewport start, so `firstVisibleIndex` never reaches it and the indicator stays on the previous page.

## Change

- `BpkCardListRowRail/utils.tsx` — in `usePageScrollSync`, if the last card is visible we've reached the end, so snap the indicator to the final page (`totalPages - 1`); otherwise the existing calculation is used.
- `BpkCardListRowRail/utils-test.tsx` — unit test for the short-final-page case.
- `BpkCardList.stories.tsx` — two repro stories:
  - `RowToRailShortFinalPage` (2-wide, 3 cards)
  - `RowToRailShortFinalPageWider` (4-wide, 10 cards)

## How to review

Storybook → `bpk-component-card-list` → the two `RowToRailShortFinalPage*` stories. On desktop, physically scroll to the last card; the indicator now tracks to the final page. `pnpm jest packages/backpack-web/src/bpk-component-card-list` is green (61 tests).

## Notes

Draft / spike — no changelog entry yet, wanted a sanity check on the approach before polishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)