### PR TITLE
[BpkPriceMarkerButton][BD-11103] Fix price marker onClick event type

### DIFF
--- a/packages/backpack-web/src/bpk-component-map/src/BpkPriceMarkerButton-test.tsx
+++ b/packages/backpack-web/src/bpk-component-map/src/BpkPriceMarkerButton-test.tsx
@@ -93,11 +93,24 @@ describe('BpkPriceMarkerButton', () => {
     );
   });
 
-  it('should render correctly with a "onClick" attribute', () => {
-    const mockOnClick = jest.fn();
-    render(<BpkPriceMarkerButton label="£120" onClick={mockOnClick} />);
+  it('should pass the click event to the "onClick" handler', () => {
+    const parentOnClick = jest.fn();
+    let handlerCalled = false;
+    render(
+      <BpkPriceMarkerButton
+        label="£120"
+        onClick={(event) => {
+          handlerCalled = true;
+          event.stopPropagation();
+        }}
+      />,
+    );
+    document.addEventListener('click', parentOnClick);
 
     fireEvent.click(screen.getByRole('button'));
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
+    document.removeEventListener('click', parentOnClick);
+
+    expect(handlerCalled).toBe(true);
+    expect(parentOnClick).not.toHaveBeenCalled();
   });
 });

--- a/packages/backpack-web/src/bpk-component-map/src/BpkPriceMarkerButton-test.tsx
+++ b/packages/backpack-web/src/bpk-component-map/src/BpkPriceMarkerButton-test.tsx
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import type { MouseEvent } from 'react';
+
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import BpkPriceMarkerButton, { MARKER_STATUSES } from './BpkPriceMarkerButton';
@@ -95,22 +97,31 @@ describe('BpkPriceMarkerButton', () => {
 
   it('should pass the click event to the "onClick" handler', () => {
     const parentOnClick = jest.fn();
-    let handlerCalled = false;
-    render(
-      <BpkPriceMarkerButton
-        label="£120"
-        onClick={(event) => {
-          handlerCalled = true;
-          event.stopPropagation();
-        }}
-      />,
+    const onClick = jest.fn((event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+    });
+    const { baseElement } = render(
+      <BpkPriceMarkerButton label="£120" onClick={onClick} />,
     );
-    document.addEventListener('click', parentOnClick);
+    baseElement.addEventListener('click', parentOnClick);
 
     fireEvent.click(screen.getByRole('button'));
-    document.removeEventListener('click', parentOnClick);
+    baseElement.removeEventListener('click', parentOnClick);
 
-    expect(handlerCalled).toBe(true);
+    expect(onClick).toHaveBeenCalledTimes(1);
     expect(parentOnClick).not.toHaveBeenCalled();
+  });
+
+  it('should allow the click event to propagate when it is not stopped', () => {
+    const parentOnClick = jest.fn();
+    const { baseElement } = render(
+      <BpkPriceMarkerButton label="£120" onClick={jest.fn()} />,
+    );
+    baseElement.addEventListener('click', parentOnClick);
+
+    fireEvent.click(screen.getByRole('button'));
+    baseElement.removeEventListener('click', parentOnClick);
+
+    expect(parentOnClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/backpack-web/src/bpk-component-map/src/BpkPriceMarkerButton.tsx
+++ b/packages/backpack-web/src/bpk-component-map/src/BpkPriceMarkerButton.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type { MouseEventHandler, ReactNode } from 'react';
 
 import BpkText, { TEXT_STYLES } from '../../bpk-component-text';
 import { cssModules } from '../../bpk-react-utils';
@@ -37,7 +37,7 @@ export type Props = {
   label: string;
   icon?: ReactNode;
   className?: string | null;
-  onClick?: () => void;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
   buttonProps?: { [key: string]: string };
   status?: Status;
 };


### PR DESCRIPTION
## Changes

- Updated `BpkPriceMarkerButton`'s `onClick` prop from `() => void` to `MouseEventHandler<HTMLButtonElement>`, allowing consumers to access the click event.
- Added coverage showing consumers can stop click propagation with `event.stopPropagation()`.
- Added a control case showing clicks continue to propagate when `stopPropagation()` is not called.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Remember to include the following changes:

- [ ] Ensure the PR title includes the name of the component you are changing so it's clear in the release notes for consumers of the changes in the version e.g `[Clover-123][BpkButton] Updating the colour`
- [ ] `README.md` (If you have created a new component)
- [ ] Component `README.md`
- [ ] Tests
- [ ] Accessibility tests
    - The following checks were performed:
        - [ ] Ability to navigate using a [keyboard only](https://webaim.org/techniques/keyboard/)
        - [ ] Zoom functionality ([Deque University explanation](https://dequeuniversity.com/checklists/web/text)):
            - [ ] The page SHOULD be functional AND readable when only the text is magnified to 200% of its initial size
            - [ ] Pages must reflow as zoom increases up to 400% so that content continues to be presented in only one column i.e. Content MUST NOT require scrolling in two directions (both vertically and horizontally)
        - [ ] Ability to navigate using a [screen reader only](https://webaim.org/articles/screenreader_testing/)
- [ ] Storybook examples created/updated
- [ ] For breaking changes or deprecating components/properties, migration guides added to the description of the PR. If the guide has large changes, consider creating a new Markdown page inside the component's docs folder and link it here
