### PR TITLE
[CLOV-1903] Fix Dependabot alerts - lodash vulnerable to Code Injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@babel/register": "^7.28.3",
-    "@figma/code-connect": "^1.4.3",
+    "@figma/code-connect": "^1.4.9",
     "@figma/rest-api-spec": "^0.37.0",
     "@nx/eslint-plugin": "22.7.1",
     "@nx/jest": "22.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   braces: 3.0.3
+  lodash: ^4.18.1
 
 importers:
 
@@ -8487,9 +8488,6 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -13637,7 +13635,7 @@ snapshots:
       find-up: 5.0.0
       glob: 11.1.0
       jsdom: 24.1.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimatch: 9.0.9
       ora: 5.4.1
       parse5: 7.3.0
@@ -22096,8 +22094,6 @@ snapshots:
   lodash.truncate@4.4.2: {}
 
   lodash.uniq@4.5.0: {}
-
-  lodash@4.17.23: {}
 
   lodash@4.18.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   braces: 3.0.3
-  lodash: ^4.18.1
 
 importers:
 
@@ -46,8 +45,8 @@ importers:
         specifier: ^7.28.3
         version: 7.28.3(@babel/core@7.29.6)
       '@figma/code-connect':
-        specifier: ^1.4.3
-        version: 1.4.3
+        specifier: ^1.4.9
+        version: 1.4.9
       '@figma/rest-api-spec':
         specifier: ^0.37.0
         version: 0.37.0
@@ -1792,8 +1791,8 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@figma/code-connect@1.4.3':
-    resolution: {integrity: sha512-Tj3QMhx3pfBB0I0tgvT82FTVbJb+DnSEE8hTJ0K+d1/8XXgrBzG62I5K8OLG9Vj+OkVmdOnnbC4MDl4DgP5wLA==}
+  '@figma/code-connect@1.4.9':
+    resolution: {integrity: sha512-Ifan9Kb5oXHAh0wXu0BM8Iy+AEhWM8NoJSTBr3oU0vQTwggleK55CUHnh5zEYl6tQjj83mg6mTo4klDgcgDprg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11462,6 +11461,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uglify-js@3.4.10:
     resolution: {integrity: sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==}
     engines: {node: '>=0.8.0'}
@@ -13623,7 +13627,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@figma/code-connect@1.4.3':
+  '@figma/code-connect@1.4.9':
     dependencies:
       boxen: 5.1.1
       chalk: 4.1.2
@@ -13643,7 +13647,7 @@ snapshots:
       prompts: 2.4.2
       strip-ansi: 6.0.1
       ts-morph: 27.0.2
-      typescript: 5.9.3
+      typescript: 6.0.3
       undici: 7.25.0
       zod: 3.25.58
       zod-validation-error: 3.5.3(zod@3.25.58)
@@ -16294,7 +16298,7 @@ snapshots:
     dependencies:
       minimatch: 10.2.5
       path-browserify: 1.0.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -20032,7 +20036,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
-    optional: true
 
   figures@3.2.0:
     dependencies:
@@ -25207,7 +25210,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-    optional: true
 
   tinyrainbow@2.0.0: {}
 
@@ -25436,6 +25438,8 @@ snapshots:
   typedarray@0.0.6: {}
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   uglify-js@3.4.10:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 
 overrides:
   braces: 3.0.3
+  lodash: ^4.18.1
 
 allowBuilds:
   '@parcel/watcher': true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,6 @@ packages:
 
 overrides:
   braces: 3.0.3
-  lodash: ^4.18.1
 
 allowBuilds:
   '@parcel/watcher': true


### PR DESCRIPTION
## What

Addresses Dependabot alert [#562](https://github.com/Skyscanner/backpack/security/dependabot/562) — lodash CVE-2026-4800 (GHSA-r5fr-rjxr-66jc).

`@figma/code-connect@1.4.9` ships `lodash@4.18.1` natively, resolving the vulnerability without a workspace override.

## Changes

- `package.json` — bumped `@figma/code-connect` from `^1.4.3` to `^1.4.9`
- `pnpm-lock.yaml` — updated lockfile; `lodash@4.17.23` is gone, `@figma/code-connect` now resolves `lodash@4.18.1` directly
- `pnpm-workspace.yaml` — no override needed; unchanged from main